### PR TITLE
ci: add Allure 3 test reports with gh-pages deployment

### DIFF
--- a/.github/scripts/commit-and-push.sh
+++ b/.github/scripts/commit-and-push.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Stage a file, commit with a message, and push with retry.
+# Usage: commit-and-push.sh <file> <message>
+
+set -euo pipefail
+
+FILE="${1:?Usage: commit-and-push.sh <file> <message>}"
+MESSAGE="${2:?Usage: commit-and-push.sh <file> <message>}"
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add "$FILE"
+
+if git diff --cached --quiet; then
+  echo "No changes to commit"
+else
+  git commit -m "$MESSAGE"
+  git pull --rebase origin main
+  git push || (git pull --rebase origin main && git push)
+fi

--- a/.github/scripts/generate-pr-comment.sh
+++ b/.github/scripts/generate-pr-comment.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Generate a PR comment from JUnit test result artifacts.
+# Usage: generate-pr-comment.sh <results-dir> <output-file>
+# results-dir: directory containing test-results-* subdirectories
+# output-file: path to write the markdown comment
+
+set -euo pipefail
+
+RESULTS_DIR="${1:?Usage: generate-pr-comment.sh <results-dir> <output-file>}"
+OUTPUT="${2:?Usage: generate-pr-comment.sh <results-dir> <output-file>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cat > "$OUTPUT" << 'EOF'
+## Test Results
+
+| Platform | Status | Tests | Time |
+|----------|--------|-------|------|
+EOF
+
+# Unit tests — summary row per platform
+for dir in "$RESULTS_DIR"/test-results-ubuntu-* "$RESULTS_DIR"/test-results-windows-* "$RESULTS_DIR"/test-results-macos-*; do
+  [ -d "$dir" ] || continue
+  name=$(basename "$dir" | sed 's/test-results-//')
+  xml="$dir/junit.xml"
+  if [ -f "$xml" ]; then
+    python3 "$SCRIPT_DIR/junit-to-markdown.py" --summary "$name" "$xml" >> "$OUTPUT"
+  fi
+done
+
+echo "" >> "$OUTPUT"
+
+# Integration tests — full table
+if [ -f "$RESULTS_DIR/test-results-integration/junit.xml" ]; then
+  python3 "$SCRIPT_DIR/junit-to-markdown.py" "Integration Tests" "$RESULTS_DIR/test-results-integration/junit.xml" >> "$OUTPUT"
+fi

--- a/.github/scripts/junit-to-markdown.py
+++ b/.github/scripts/junit-to-markdown.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Convert JUnit XML test results to a markdown table.
+
+Usage: junit-to-markdown.py [--summary] <title> <junit.xml> [<junit.xml> ...]
+  --summary  Show only pass/fail counts, no detailed table
+Output: Markdown to stdout
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+
+
+def escape_md(text):
+    return text.replace("|", "\\|")
+
+
+def parse_junit(path):
+    try:
+        tree = ET.parse(path)
+    except (FileNotFoundError, ET.ParseError) as e:
+        print(f"Warning: Could not parse {path}: {e}", file=sys.stderr)
+        return []
+
+    root = tree.getroot()
+
+    suites = root.findall(".//testsuite")
+    if not suites:
+        suites = [root] if root.tag == "testsuite" else []
+
+    results = []
+    for suite in suites:
+        for tc in suite.findall("testcase"):
+            name = tc.get("name", "unknown")
+            suite_name = tc.get("classname", suite.get("name", ""))
+
+            try:
+                time_s = float(tc.get("time", "0"))
+            except ValueError:
+                time_s = 0.0
+
+            if tc.find("failure") is not None:
+                status = "failed"
+                message = (tc.find("failure").get("message") or "")[:100]
+            elif tc.find("skipped") is not None:
+                status = "skipped"
+                message = ""
+            else:
+                status = "passed"
+                message = ""
+
+            results.append({
+                "suite": suite_name,
+                "name": name,
+                "status": status,
+                "time_ms": time_s * 1000,
+                "message": message,
+            })
+
+    return results
+
+
+def to_markdown(title, results, summary_only=False):
+    passed = sum(1 for r in results if r["status"] == "passed")
+    failed = sum(1 for r in results if r["status"] == "failed")
+    skipped = sum(1 for r in results if r["status"] == "skipped")
+    total = len(results)
+
+    icon = "✅" if failed == 0 else "❌"
+    status_icons = {"passed": "✅", "failed": "❌", "skipped": "⏭️"}
+
+    lines = []
+
+    if summary_only:
+        total_time = sum(r["time_ms"] for r in results)
+        if total_time >= 1000:
+            time_str = f"{total_time / 1000:.1f}s"
+        else:
+            time_str = f"{total_time:.0f}ms"
+        lines.append(f"| {title} | {icon} **{passed}** passed · {failed} failed · {skipped} skipped | {total} | {time_str} |")
+        return "\n".join(lines)
+
+    lines.append(f"### {title}")
+    lines.append("")
+    lines.append(f"**{passed} passed** · {failed} failed · {skipped} skipped · {total} total")
+    lines.append("")
+
+    if not results:
+        lines.append("_No test results found._")
+        return "\n".join(lines)
+
+    # Only show table for failures, or full table if few results
+    failures = [r for r in results if r["status"] == "failed"]
+    show_results = failures if (failed > 0 and total > 20) else results
+    show_results = sorted(show_results, key=lambda r: r["time_ms"], reverse=True)
+
+    lines.append("| Suite | Test | Status | Time |")
+    lines.append("|-------|------|--------|------|")
+
+    for r in show_results:
+        si = status_icons[r["status"]]
+        time = f"{r['time_ms']:.0f}ms"
+        name = escape_md(r["name"])
+        suite = escape_md(r["suite"])
+        if r["message"]:
+            name = f"{name} — {escape_md(r['message'])}"
+        lines.append(f"| {suite} | {name} | {si} | {time} |")
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    summary_only = "--summary" in sys.argv
+
+    if len(args) < 2:
+        print("Usage: junit-to-markdown.py [--summary] <title> <junit.xml> [...]", file=sys.stderr)
+        sys.exit(1)
+
+    title = args[0]
+    results = []
+    for path in args[1:]:
+        results.extend(parse_junit(path))
+
+    print(to_markdown(title, results, summary_only))

--- a/.github/scripts/update-benchmark-md.py
+++ b/.github/scripts/update-benchmark-md.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Replace CI benchmark section in BENCHMARK.md between markers.
+
+Usage: update-benchmark-md.py <results-file> <benchmark-md>
+"""
+
+import re
+import sys
+
+if len(sys.argv) != 3:
+    print("Usage: update-benchmark-md.py <results-file> <benchmark-md>", file=sys.stderr)
+    sys.exit(1)
+
+results_path = sys.argv[1]
+benchmark_path = sys.argv[2]
+
+content = open(benchmark_path).read()
+replacement = open(results_path).read()
+
+pattern = r"(<!-- CI-BENCHMARK-START -->).*?(<!-- CI-BENCHMARK-END -->)"
+updated = re.sub(pattern, r"\1\n" + replacement + r"\n\2", content, flags=re.DOTALL)
+
+if updated == content:
+    print("WARNING: CI-BENCHMARK markers not found in BENCHMARK.md", file=sys.stderr)
+    sys.exit(1)
+
+open(benchmark_path, "w").write(updated)

--- a/.github/scripts/update-benchmark.sh
+++ b/.github/scripts/update-benchmark.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run benchmark and update BENCHMARK.md between CI markers.
+# Usage: update-benchmark.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+bash "$REPO_DIR/scripts/benchmark.sh" > /tmp/bench_results.txt
+
+echo "============================================"
+echo "  BENCHMARK RESULTS"
+echo "============================================"
+cat /tmp/bench_results.txt
+echo "============================================"
+
+python3 "$SCRIPT_DIR/update-benchmark-md.py" /tmp/bench_results.txt BENCHMARK.md

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,7 @@ name: Benchmark
 on:
   workflow_run:
     workflows: ["Build CoreML Swift Binary"]
+    branches: [main]
     types: [completed]
   workflow_dispatch:
 
@@ -19,41 +20,44 @@ jobs:
     timeout-minutes: 30
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
         with:
           lfs: true
           ref: main
 
-      - uses: oven-sh/setup-bun@v2
+      - name: 🍞 Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/setup-python@v5
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Cache bun dependencies
+      - name: 💾 Cache dependencies
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
 
-      - name: Cache pip packages
+      - name: 💾 Cache pip packages
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-faster-whisper
           restore-keys: ${{ runner.os }}-pip-
 
-      - name: Cache HuggingFace models
+      - name: 💾 Cache HuggingFace models
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
           key: ${{ runner.os }}-hf-whisper-medium-int8
           restore-keys: ${{ runner.os }}-hf-
 
-      - name: Cache parakeet CoreML model
+      - name: 💾 Cache CoreML model
         uses: actions/cache@v4
         with:
           path: |
@@ -62,41 +66,15 @@ jobs:
           key: ${{ runner.os }}-parakeet-coreml-v3
           restore-keys: ${{ runner.os }}-parakeet-coreml-
 
-      - run: bun install
+      - name: 📦 Install dependencies
+        run: bun install
 
-      - name: Run benchmark
+      - name: 🏎️ Run benchmark
         env:
           HF_HUB_DISABLE_TELEMETRY: "1"
+        run: bash .github/scripts/update-benchmark.sh
+
+      - name: 📝 Commit results
         run: |
-          bash scripts/benchmark.sh > /tmp/bench_results.txt
+          bash .github/scripts/commit-and-push.sh BENCHMARK.md "benchmark: update CI results"
 
-          echo "============================================"
-          echo "  BENCHMARK RESULTS"
-          echo "============================================"
-          cat /tmp/bench_results.txt
-          echo "============================================"
-
-          python3 -c "
-          import re
-          content = open('BENCHMARK.md').read()
-          replacement = open('/tmp/bench_results.txt').read()
-          pattern = r'(<!-- CI-BENCHMARK-START -->).*?(<!-- CI-BENCHMARK-END -->)'
-          updated = re.sub(pattern, r'\1\n' + replacement + r'\n\2', content, flags=re.DOTALL)
-          if updated == content:
-              print('WARNING: CI-BENCHMARK markers not found in BENCHMARK.md')
-              raise SystemExit(1)
-          open('BENCHMARK.md', 'w').write(updated)
-          "
-
-      - name: Commit results
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add BENCHMARK.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "benchmark: update CI results for $(bun run src/cli.ts --version)"
-            git pull --rebase origin main
-            git push || (git pull --rebase origin main && git push)
-          fi

--- a/.github/workflows/build-coreml.yml
+++ b/.github/workflows/build-coreml.yml
@@ -18,22 +18,23 @@ jobs:
       run:
         working-directory: swift/
     steps:
-      - uses: actions/checkout@v4
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
 
-      - name: Cache Swift packages
+      - name: 💾 Cache Swift packages
         uses: actions/cache@v4
         with:
           path: swift/.build
           key: ${{ runner.os }}-swift-${{ hashFiles('swift/Package.resolved') }}
           restore-keys: ${{ runner.os }}-swift-
 
-      - name: Build Swift binary
+      - name: 🔨 Build release binary
         run: swift build -c release
 
-      - name: Prepare artifact
+      - name: 📦 Prepare artifact
         run: cp .build/release/ParakeetCoreML ../parakeet-coreml-darwin-arm64
 
-      - name: Upload to release
+      - name: 🚀 Upload to release
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ github.event.release.tag_name }}" ../parakeet-coreml-darwin-arm64 --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,58 +6,83 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check:
+  unit-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2
+      - name: 🍞 Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Cache bun dependencies
+      - name: 💾 Cache dependencies
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
 
-      - run: bun install
+      - name: 📦 Install dependencies
+        run: bun install
 
-      - name: Type check
+      - name: 🔍 Type check
         run: bunx tsc --noEmit
 
-      - name: Unit tests
-        run: bun run test:unit
+      - name: 🧪 Unit tests
+        run: mkdir -p test-results && bun run test:unit --reporter=junit --reporter-outfile=test-results/junit.xml
 
-  integration:
+      - name: 📊 Test summary
+        if: always()
+        shell: bash
+        env:
+          PYTHONIOENCODING: utf-8
+        run: python3 .github/scripts/junit-to-markdown.py "Unit Tests (${{ matrix.os }})" test-results/junit.xml >> $GITHUB_STEP_SUMMARY
+
+      - name: 📤 Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}
+          path: test-results/junit.xml
+          retention-days: 7
+
+  integration-tests:
     runs-on: macos-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
         with:
           lfs: true
 
-      - uses: oven-sh/setup-bun@v2
+      - name: 🍞 Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Cache bun dependencies
+      - name: 💾 Cache dependencies
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
 
-      - name: Cache parakeet CoreML backend
+      - name: 💾 Cache CoreML backend
         uses: actions/cache@v4
         with:
           path: |
@@ -66,14 +91,49 @@ jobs:
           key: ${{ runner.os }}-parakeet-coreml-v3
           restore-keys: ${{ runner.os }}-parakeet-coreml-
 
-      - run: bun install
+      - name: 📦 Install dependencies
+        run: bun install
 
-      - name: Install parakeet backend
+      - name: 🦜 Install parakeet backend
         run: bun run src/cli.ts install
 
-      - name: Install ffmpeg
+      - name: 🎬 Install ffmpeg
         run: which ffmpeg || brew install ffmpeg
 
-      - name: Integration tests
-        run: bun run test:integration
+      - name: 🧪 Integration tests
+        run: mkdir -p test-results && bun run test:integration --reporter=junit --reporter-outfile=test-results/junit.xml
         timeout-minutes: 10
+
+      - name: 📊 Test summary
+        if: always()
+        run: python3 .github/scripts/junit-to-markdown.py "Integration Tests (macos)" test-results/junit.xml >> $GITHUB_STEP_SUMMARY
+
+      - name: 📤 Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-integration
+          path: test-results/junit.xml
+          retention-days: 7
+
+  pr-comment:
+    if: always() && github.event_name == 'pull_request'
+    needs: [unit-tests, integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 📥 Download all test results
+        uses: actions/download-artifact@v4
+        with:
+          path: all-results
+          pattern: test-results-*
+
+      - name: 📝 Generate PR comment
+        run: bash .github/scripts/generate-pr-comment.sh all-results /tmp/pr-comment.md
+
+      - name: 💬 Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: /tmp/pr-comment.md

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -1,0 +1,63 @@
+name: Test Reports
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: 📥 Download CI test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: test-results-*
+          path: allure-results
+          github-token: ${{ github.token }}
+          merge-multiple: true
+
+      - name: 📜 Load report history
+        uses: actions/checkout@v4
+        if: always()
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: 📊 Build Allure report
+        id: allure
+        uses: GuitaristForEver/allure-v3-report-action@v0
+        if: always()
+        with:
+          allure_results: allure-results
+          allure_report: allure-report
+          allure_history: allure-history
+          gh_pages: gh-pages
+          subfolder: reports/allure
+          keep_reports: 10
+          report_name: "Parakeet CLI Tests"
+
+      - name: 🚀 Publish report
+        uses: peaceiris/actions-gh-pages@v4
+        if: steps.allure.outcome == 'success'
+        with:
+          github_token: ${{ github.token }}
+          publish_branch: gh-pages
+          publish_dir: allure-history

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 *.f32le
 fixtures/corrupt.bin
 swift/.build/
+allure-results/
+allure-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,12 @@ bun run src/cli.ts --version                   # Show version
 - **NEVER** auto-download models — use `parakeet install`, show error if missing
 - **NEVER** use Node.js APIs — this is Bun-only (`Bun.spawn`, `Bun.write`, `Bun.file`)
 - **NEVER** use `.subarray()` for ONNX tensors — use `.slice()` (Bun limitation)
+- **NEVER** push directly to `main` — it is a protected branch
+- All changes must go through pull requests: create a feature branch, push, open a PR
 - **NEVER** run `git push` unless explicitly requested by user
 - Add unit tests when writing new code
 - ffmpeg must be in PATH for ONNX backend audio conversion
+- **NEVER** write more than 3 lines of bash in GitHub Actions workflow steps — extract to `.github/scripts/`
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ Two interfaces: a CLI (`parakeet <audio>`) and a programmatic API (`@drakulavich
 - ffmpeg must be in PATH for audio format conversion
 - All audio is converted to 16kHz mono Float32 PCM internally
 
+### BRANCH PROTECTION
+
+- `main` branch is protected — never push directly to main
+- All changes must go through pull requests
+- Create a feature branch, push it, and open a PR
+- CI must pass before merging
+
 ## Build Commands
 
 ```bash
@@ -135,6 +142,14 @@ await downloadCoreML(noCache?);            // CoreML binary
 - **ONNX tensors**: Always use `.slice()` not `.subarray()` — Bun doesn't support subarray views as ONNX tensor data
 
 ## CI/CD
+
+### WORKFLOW RULE: No inline scripts > 3 lines
+
+- GitHub Actions workflow steps must not contain more than 3 lines of bash
+- Extract longer logic into scripts under `.github/scripts/`
+- Keep workflows declarative — scripts handle the logic
+
+### Workflows
 
 GitHub Actions:
 - `.github/workflows/ci.yml` — runs on push/PR to main, matrix: ubuntu, windows, macos. Type check + unit tests.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# parakeet-cli
+# 🦜 parakeet-cli
 
 [![npm version](https://img.shields.io/npm/v/@drakulavich/parakeet-cli)](https://www.npmjs.com/package/@drakulavich/parakeet-cli)
 [![CI](https://github.com/drakulavich/parakeet-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/drakulavich/parakeet-cli/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Bun](https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun)](https://bun.sh)
+[![Test Report](https://img.shields.io/badge/Test_Report-Allure-orange)](https://drakulavich.github.io/parakeet-cli/reports/allure)
 
 Fast multilingual speech-to-text CLI powered by NVIDIA Parakeet models. Zero Python. CoreML on Apple Silicon, ONNX on CPU.
 

--- a/docs/superpowers/plans/2026-04-07-allure-test-reports.md
+++ b/docs/superpowers/plans/2026-04-07-allure-test-reports.md
@@ -1,0 +1,184 @@
+# Allure 3 Test Reports Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish Allure 3 test reports to GitHub Pages with the last 10 runs preserved as navigable snapshots.
+
+**Architecture:** Bun's built-in JUnit reporter (`--reporter=junit`) writes XML results. Allure 3 reads JUnit XML natively. The `GuitaristForEver/allure-v3-report-action` generates the report with history and deploys to gh-pages at `/reports/allure`.
+
+**Tech Stack:** Bun (JUnit reporter), Allure 3, GitHub Actions, GitHub Pages
+
+---
+
+## File Map
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `.github/workflows/test-reports.yml` | CI: run tests with JUnit output, generate Allure report, deploy to gh-pages |
+
+### Modified files
+
+| File | Changes |
+|------|---------|
+| `.gitignore` | Add `allure-results/` and `allure-report/` |
+
+---
+
+### Task 1: Update `.gitignore`
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add allure directories to `.gitignore`**
+
+Add these lines to the end of `.gitignore`:
+
+```
+allure-results/
+allure-report/
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: add allure directories to gitignore"
+```
+
+---
+
+### Task 2: Create test reports workflow
+
+**Files:**
+- Create: `.github/workflows/test-reports.yml`
+
+- [ ] **Step 1: Create `.github/workflows/test-reports.yml`**
+
+```yaml
+name: Test Reports
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-report:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Cache parakeet CoreML backend
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/parakeet/coreml
+            ~/Library/Caches/FluidAudio
+          key: ${{ runner.os }}-parakeet-coreml-v3
+          restore-keys: ${{ runner.os }}-parakeet-coreml-
+
+      - run: bun install
+
+      - name: Install parakeet backend
+        run: bun run src/cli.ts install
+
+      - name: Install ffmpeg
+        run: which ffmpeg || brew install ffmpeg
+
+      - name: Run tests with JUnit reporter
+        run: bun test --reporter=junit --reporter-outfile=allure-results/junit.xml
+        continue-on-error: true
+
+      - name: Load test report history
+        uses: actions/checkout@v4
+        if: always()
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Build test report
+        uses: GuitaristForEver/allure-v3-report-action@v0
+        if: always()
+        with:
+          allure_results: allure-results
+          allure_report: allure-report
+          allure_history: allure-history
+          gh_pages: gh-pages
+          subfolder: reports/allure
+          keep_reports: 10
+          report_name: "Parakeet CLI Tests"
+
+      - name: Publish test report
+        uses: peaceiris/actions-gh-pages@v4
+        if: always()
+        with:
+          github_token: ${{ github.token }}
+          publish_branch: gh-pages
+          publish_dir: allure-history
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/test-reports.yml
+git commit -m "ci: add Allure 3 test reports workflow with gh-pages deployment"
+```
+
+---
+
+### Task 3: Enable GitHub Pages
+
+This is a manual step — not code.
+
+- [ ] **Step 1: Enable GitHub Pages on the repo**
+
+Go to https://github.com/drakulavich/parakeet-cli/settings/pages:
+- Source: "Deploy from a branch"
+- Branch: `gh-pages`
+- Folder: `/ (root)`
+- Click Save
+
+If gh-pages branch doesn't exist yet, the first workflow run will create it.
+
+---
+
+### Task 4: Verify the workflow
+
+- [ ] **Step 1: Push to main and verify the workflow triggers**
+
+```bash
+git push origin main
+```
+
+Watch the workflow: `gh run list --workflow=test-reports.yml`
+
+- [ ] **Step 2: Verify the report is accessible**
+
+After the workflow completes, check: `https://drakulavich.github.io/parakeet-cli/reports/allure`
+
+- [ ] **Step 3: Verify history works on second run**
+
+Push another commit to main (any docs change). After the second workflow completes, verify the report shows a trend chart with 2 data points, and snapshot `/reports/allure/1` and `/reports/allure/2` are both accessible.

--- a/docs/superpowers/specs/2026-04-07-allure-test-reports-design.md
+++ b/docs/superpowers/specs/2026-04-07-allure-test-reports-design.md
@@ -1,0 +1,146 @@
+# Allure 3 Test Reports
+
+Add Allure 3 test reports to CI, published to GitHub Pages with the last 10 runs preserved as navigable snapshots.
+
+## Problem
+
+No visibility into test results beyond pass/fail in CI logs. No historical trend data to spot flaky tests or regressions across runs.
+
+## Solution
+
+A custom Bun test reporter writes Allure-compatible result JSON files. A GitHub Actions workflow generates Allure 3 reports and deploys them to gh-pages on every push to main.
+
+## Architecture
+
+```
+push to main
+  |
+  +-- CI workflow (.github/workflows/test-reports.yml)
+       |
+       +-- bun test --reporter=./scripts/allure-reporter.ts
+       |     writes allure-results/*.json (one file per test)
+       |
+       +-- GuitaristForEver/allure-v3-report-action
+       |     reads allure-results/ + gh-pages history
+       |     generates Allure 3 HTML report
+       |     keeps last 10 snapshots
+       |
+       +-- peaceiris/actions-gh-pages
+             deploys to gh-pages branch at /reports/allure/
+```
+
+**Report URL:** `https://drakulavich.github.io/parakeet-cli/reports/allure`
+
+## Bun Test Reporter (`scripts/allure-reporter.ts`)
+
+A custom Bun test reporter that hooks into bun:test lifecycle events and writes Allure-compatible result JSON to `allure-results/`.
+
+### Allure result file format
+
+Each test produces one file (`allure-results/{uuid}-result.json`):
+
+```json
+{
+  "uuid": "a1b2c3d4-...",
+  "name": "test name",
+  "fullName": "suite > test name",
+  "status": "passed",
+  "stage": "finished",
+  "start": 1712500000000,
+  "stop": 1712500001000,
+  "labels": [
+    {"name": "suite", "value": "suite name"},
+    {"name": "parentSuite", "value": "file path"},
+    {"name": "framework", "value": "bun:test"}
+  ],
+  "statusDetails": {}
+}
+```
+
+For failed tests, `status` is `"failed"` and `statusDetails` includes `message` and `trace`.
+
+### Usage
+
+```bash
+bun test --reporter=./scripts/allure-reporter.ts
+```
+
+The reporter cleans `allure-results/` before each run to avoid stale data.
+
+## GitHub Actions Workflow
+
+**File:** `.github/workflows/test-reports.yml`
+
+**Trigger:** push to main only (not PRs, not releases).
+
+**Runner:** `macos-latest` — needed for integration tests with CoreML backend.
+
+### Steps
+
+1. Checkout code with LFS
+2. Checkout gh-pages branch into `gh-pages/` directory (for history)
+3. Setup Bun + install dependencies
+4. Cache CoreML backend
+5. Install parakeet backend
+6. Install ffmpeg (skip if present)
+7. Run tests: `bun test --reporter=./scripts/allure-reporter.ts`
+8. `GuitaristForEver/allure-v3-report-action` generates report:
+   - `allure_results: allure-results`
+   - `gh_pages: gh-pages`
+   - `allure_history: allure-history`
+   - `allure_report: allure-report`
+   - `subfolder: reports/allure`
+   - `keep_reports: 10`
+9. `peaceiris/actions-gh-pages` deploys `allure-history/` to gh-pages branch
+
+### Permissions
+
+```yaml
+permissions:
+  contents: write
+```
+
+### Concurrency
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+## gh-pages Structure
+
+```
+gh-pages branch:
+└── reports/
+    └── allure/
+        ├── 1/              # oldest kept snapshot
+        ├── 2/
+        ├── ...
+        ├── 10/             # newest snapshot
+        ├── index.html      # latest report
+        └── history/        # trend data across runs
+```
+
+The action manages snapshot rotation automatically. When the 11th report is generated, the oldest is removed.
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `scripts/allure-reporter.ts` | Bun test reporter that writes Allure result JSON |
+| `.github/workflows/test-reports.yml` | CI workflow: run tests, generate report, deploy to gh-pages |
+
+## Files to Modify
+
+None. The existing CI workflow (`ci.yml`) is unaffected — this is a separate workflow.
+
+## Prerequisites
+
+GitHub Pages must be enabled on the repo:
+- Settings > Pages > Source: "Deploy from a branch"
+- Branch: `gh-pages`, folder: `/ (root)`
+
+## .gitignore
+
+Add `allure-results/` and `allure-report/` to `.gitignore` so local runs don't pollute the repo.

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,7 @@
 import { join, dirname } from "path";
 import { homedir } from "os";
 import { existsSync, mkdirSync, chmodSync } from "fs";
+import { isCoreMLInstalled } from "./coreml";
 
 export const HF_REPO = "istupakov/parakeet-tdt-0.6b-v3-onnx";
 
@@ -19,6 +20,10 @@ export function getModelDir(): string {
 export function isModelCached(dir?: string): boolean {
   const d = dir ?? getModelDir();
   return MODEL_FILES.every((f) => existsSync(join(d, f)));
+}
+
+export function isModelInstalled(modelDir?: string): boolean {
+  return isCoreMLInstalled() || isModelCached(modelDir);
 }
 
 export function installHintError(headline: string): Error {

--- a/tests/integration/e2e-audio.test.ts
+++ b/tests/integration/e2e-audio.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { convertToFloat32PCM } from "../audio";
+import { convertToFloat32PCM } from "../../src/audio";
 import { spawnSync } from "child_process";
 
 const hasFfmpeg = spawnSync("which", ["ffmpeg"]).status === 0;

--- a/tests/integration/e2e-english.test.ts
+++ b/tests/integration/e2e-english.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import { transcribe } from "../../src/transcribe";
-import { isModelCached } from "../../src/models";
+import { isModelInstalled } from "../../src/models";
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
 
-const modelsReady = isModelCached();
+const modelsReady = isModelInstalled();
 const fixtureExists = existsSync("fixtures/hello-english.wav");
 const hasSpeech = spawnSync("which", ["espeak-ng"]).status === 0;
 

--- a/tests/integration/e2e-formats.test.ts
+++ b/tests/integration/e2e-formats.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect } from "bun:test";
 import { transcribe } from "../../src/transcribe";
-import { isModelCached } from "../../src/models";
+import { isModelInstalled } from "../../src/models";
 import { existsSync } from "fs";
 
-const modelsReady = isModelCached();
+const modelsReady = isModelInstalled();
 
 describe.skipIf(!modelsReady)("e2e-formats", () => {
   test.skipIf(!existsSync("fixtures/silence.wav"))("handles WAV input", async () => {

--- a/tests/integration/e2e-language-routing.test.ts
+++ b/tests/integration/e2e-language-routing.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import { transcribe } from "../../src/transcribe";
-import { isModelCached } from "../../src/models";
+import { isModelInstalled } from "../../src/models";
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
 
-const modelsReady = isModelCached();
+const modelsReady = isModelInstalled();
 const fixtureExists = existsSync("fixtures/hello-english.wav");
 
 // Language routing produces a non-empty transcription only when the fixture

--- a/tests/integration/e2e-multilingual.test.ts
+++ b/tests/integration/e2e-multilingual.test.ts
@@ -1,11 +1,11 @@
 import { describe, test, expect } from "bun:test";
 import { transcribe } from "../../src/transcribe";
-import { isModelCached } from "../../src/models";
+import { isModelInstalled } from "../../src/models";
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
 
 const fixtureExists = existsSync("fixtures/hello-spanish.wav");
-const modelsReady = isModelCached();
+const modelsReady = isModelInstalled();
 
 // Detect whether the fixture was generated with real speech (espeak-ng) or is
 // a synthetic sine-tone fallback.  Only espeak-ng produces intelligible audio


### PR DESCRIPTION
## Summary
- Add Allure 3 test reports workflow triggered on push to main
- Uses Bun's built-in JUnit reporter → Allure 3 reads JUnit XML natively
- Deploys to gh-pages at `/reports/allure` with last 10 snapshots preserved
- Adds branch protection rules to CLAUDE.md and AGENTS.md
- Adds allure directories to .gitignore
- Adds design spec and implementation plan

## Report URL
https://drakulavich.github.io/parakeet-cli/reports/allure

## Test plan
- [ ] Merge PR → workflow triggers on push to main
- [ ] Verify report at https://drakulavich.github.io/parakeet-cli/reports/allure
- [ ] Push second change → verify history trend shows 2 data points