### PR TITLE
docs: add git worktree instructions for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ fixtures/corrupt.bin
 swift/.build/
 allure-results/
 allure-report/
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,24 @@ bun run src/cli.ts --version                   # Show version
 - ffmpeg must be in PATH for ONNX backend audio conversion
 - **NEVER** write more than 3 lines of bash in GitHub Actions workflow steps — extract to `.github/scripts/`
 
+## Git Worktrees for Big Changes
+
+For multi-file features or refactors, use git worktrees to work in isolation:
+
+```bash
+git worktree add ../parakeet-cli-feature feature/my-feature
+cd ../parakeet-cli-feature
+# work, commit, push, open PR
+# when done:
+cd ../parakeet-cli
+git worktree remove ../parakeet-cli-feature
+```
+
+Use worktrees when:
+- The change touches 5+ files
+- You need to keep main clean while iterating
+- Running long tasks (benchmarks, builds) without blocking the main checkout
+
 ## Code Style
 
 - TypeScript strict mode, ESNext target

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,12 @@ Two interfaces: a CLI (`parakeet <audio>`) and a programmatic API (`@drakulavich
 - Create a feature branch, push it, and open a PR
 - CI must pass before merging
 
+### GIT WORKTREES FOR BIG CHANGES
+
+- Use `git worktree add` for multi-file features or refactors
+- Keeps main checkout clean while iterating on a feature branch
+- Use when the change touches 5+ files or runs long tasks
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
Add worktree usage guidelines to CLAUDE.md and AGENTS.md for multi-file features.