### PR TITLE
ci: remove workflow_dispatch, add release process rules

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,7 +5,6 @@ on:
     workflows: ["Build CoreML Swift Binary"]
     branches: [main]
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -18,7 +17,7 @@ jobs:
   benchmark:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-15, windows-latest]


### PR DESCRIPTION
## Summary
- Remove `workflow_dispatch` trigger from benchmark (runs only on release)
- Add release process rule: agents must ask user to run e2e tests locally before npm publish
- Added to both CLAUDE.md and AGENTS.md