### PR TITLE
feat: add Makefile, smoke test, and release process rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ bun run src/cli.ts --version                   # Show version
 - Add unit tests when writing new code
 - ffmpeg must be in PATH for ONNX backend audio conversion
 - **NEVER** write more than 3 lines of bash in GitHub Actions workflow steps — extract to `.github/scripts/`
+- **BEFORE npm publish**: ask the user to run `make smoke-test`. Do NOT publish without explicit user confirmation that tests pass.
 
 ## Git Worktrees for Big Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ Two interfaces: a CLI (`parakeet <audio>`) and a programmatic API (`@drakulavich
 - ffmpeg must be in PATH for audio format conversion
 - All audio is converted to 16kHz mono Float32 PCM internally
 
+### RELEASE PROCESS
+
+- Before `npm publish`, always ask the user to run e2e tests locally first
+- Suggest: `make smoke-test`
+- Do NOT publish to npm without explicit user confirmation that tests pass
+- Create a GitHub release first, wait for CI to pass, then publish to npm
+
 ### BRANCH PROTECTION
 
 - `main` branch is protected — never push directly to main

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: test unit integration lint smoke-test release publish
+
+test: unit integration
+
+unit:
+	bun run test:unit
+
+integration:
+	bun run test:integration
+
+lint:
+	bunx tsc --noEmit
+
+smoke-test:
+	bun link
+	parakeet install
+	bash scripts/smoke-test.sh
+
+release: lint test smoke-test
+	@echo "All checks passed. Ready to publish."
+
+publish: release
+	npm publish --access public

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Smoke test: run parakeet against benchmark fixtures and verify output.
+# Usage: scripts/smoke-test.sh
+# Exit code 0 if all files produce non-empty transcripts, 1 otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/../fixtures/benchmark"
+FAILED=0
+PASSED=0
+TOTAL=0
+
+echo "Running smoke tests against benchmark fixtures..."
+echo ""
+
+for f in "$FIXTURES_DIR"/*.ogg; do
+  [ -f "$f" ] || continue
+  TOTAL=$((TOTAL + 1))
+  NAME=$(basename "$f")
+
+  RESULT=$(parakeet "$f" 2>/dev/null || true)
+
+  if [ -z "$RESULT" ]; then
+    echo "  FAIL  $NAME — empty transcript"
+    FAILED=$((FAILED + 1))
+  else
+    echo "  PASS  $NAME — ${RESULT:0:60}..."
+    PASSED=$((PASSED + 1))
+  fi
+done
+
+echo ""
+echo "$PASSED/$TOTAL passed, $FAILED failed"
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `Makefile` with development commands: `test`, `lint`, `smoke-test`, `release`, `publish`
- Add `scripts/smoke-test.sh` — runs parakeet against benchmark fixtures, verifies non-empty output
- Add release process rules to CLAUDE.md and AGENTS.md: agents must ask user to run `make smoke-test` before npm publish

## Makefile targets
```
make test          # unit + integration
make lint          # type check
make smoke-test    # link + install backend + verify against fixtures
make release       # lint + test + smoke-test
make publish       # release + npm publish
```

## Test plan
- [ ] `make smoke-test` passes locally