### PR TITLE
chore: bump to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/parakeet-cli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Fast multilingual speech-to-text CLI powered by NVIDIA Parakeet ONNX models",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.6.0

### New
- Allure 3 test reports on gh-pages with 10-run history
- Benchmark matrix (ubuntu/macos/windows) with regression detection (20% threshold)
- PR comments with test result tables
- Makefile (`test`, `lint`, `smoke-test`, `release`, `publish`)
- Smoke test script for pre-release validation
- Git worktree documentation for agents

### Improved
- Slimmed README (-50%), reshuffled by importance
- Extracted all CI bash into `.github/scripts/`
- Test reports workflow consumes CI artifacts (no duplicate test runs)
- Cross-platform benchmark script
- Branch protection enforced