### PR TITLE
fix(ci): fix empty Allure reports and .git permission error

### DIFF
--- a/.github/scripts/generate-pr-comment.sh
+++ b/.github/scripts/generate-pr-comment.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Generate a PR comment from JUnit test result artifacts.
 # Usage: generate-pr-comment.sh <results-dir> <output-file>
-# results-dir: directory containing test-results-* subdirectories
-# output-file: path to write the markdown comment
 
 set -euo pipefail
 
@@ -18,18 +16,16 @@ cat > "$OUTPUT" << 'EOF'
 EOF
 
 # Unit tests — summary row per platform
-for dir in "$RESULTS_DIR"/test-results-ubuntu-* "$RESULTS_DIR"/test-results-windows-* "$RESULTS_DIR"/test-results-macos-*; do
-  [ -d "$dir" ] || continue
-  name=$(basename "$dir" | sed 's/test-results-//')
-  xml="$dir/junit.xml"
-  if [ -f "$xml" ]; then
-    python3 "$SCRIPT_DIR/junit-to-markdown.py" --summary "$name" "$xml" >> "$OUTPUT"
-  fi
+for xml in "$RESULTS_DIR"/test-results-*/unit-*.xml; do
+  [ -f "$xml" ] || continue
+  name=$(basename "$xml" .xml | sed 's/unit-//')
+  python3 "$SCRIPT_DIR/junit-to-markdown.py" --summary "$name" "$xml" >> "$OUTPUT"
 done
 
 echo "" >> "$OUTPUT"
 
 # Integration tests — full table
-if [ -f "$RESULTS_DIR/test-results-integration/junit.xml" ]; then
-  python3 "$SCRIPT_DIR/junit-to-markdown.py" "Integration Tests" "$RESULTS_DIR/test-results-integration/junit.xml" >> "$OUTPUT"
-fi
+for xml in "$RESULTS_DIR"/test-results-*/integration.xml; do
+  [ -f "$xml" ] || continue
+  python3 "$SCRIPT_DIR/junit-to-markdown.py" "Integration Tests" "$xml" >> "$OUTPUT"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,21 +44,21 @@ jobs:
         run: bunx tsc --noEmit
 
       - name: 🧪 Unit tests
-        run: mkdir -p test-results && bun run test:unit --reporter=junit --reporter-outfile=test-results/junit.xml
+        run: mkdir -p test-results && bun run test:unit --reporter=junit --reporter-outfile=test-results/unit-${{ matrix.os }}.xml
 
       - name: 📊 Test summary
         if: always()
         shell: bash
         env:
           PYTHONIOENCODING: utf-8
-        run: python3 .github/scripts/junit-to-markdown.py "Unit Tests (${{ matrix.os }})" test-results/junit.xml >> $GITHUB_STEP_SUMMARY
+        run: python3 .github/scripts/junit-to-markdown.py "Unit Tests (${{ matrix.os }})" test-results/unit-${{ matrix.os }}.xml >> $GITHUB_STEP_SUMMARY
 
       - name: 📤 Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.os }}
-          path: test-results/junit.xml
+          path: test-results/unit-${{ matrix.os }}.xml
           retention-days: 7
 
   integration-tests:
@@ -101,19 +101,19 @@ jobs:
         run: which ffmpeg || brew install ffmpeg
 
       - name: 🧪 Integration tests
-        run: mkdir -p test-results && bun run test:integration --reporter=junit --reporter-outfile=test-results/junit.xml
+        run: mkdir -p test-results && bun run test:integration --reporter=junit --reporter-outfile=test-results/integration.xml
         timeout-minutes: 10
 
       - name: 📊 Test summary
         if: always()
-        run: python3 .github/scripts/junit-to-markdown.py "Integration Tests (macos)" test-results/junit.xml >> $GITHUB_STEP_SUMMARY
+        run: python3 .github/scripts/junit-to-markdown.py "Integration Tests (macos)" test-results/integration.xml >> $GITHUB_STEP_SUMMARY
 
       - name: 📤 Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results-integration
-          path: test-results/junit.xml
+          path: test-results/integration.xml
           retention-days: 7
 
   pr-comment:

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: 🧹 Clean nested .git
         if: steps.allure.outcome == 'success'
-        run: rm -rf allure-history/.git
+        run: sudo rm -rf allure-history/.git
 
       - name: 🚀 Publish report
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Problem
1. Allure reports show 0 results — all JUnit XML files named `junit.xml`, `merge-multiple` overwrites them
2. `rm -rf allure-history/.git` fails with Permission denied

## Fix
1. Unique JUnit filenames: `unit-ubuntu-latest.xml`, `unit-macos-latest.xml`, `integration.xml`
2. `sudo rm -rf` for the nested `.git` directory
3. Updated PR comment script for new filenames