### PR TITLE
fix(ci): use Allure CLI for JUnit XML, ubuntu-only benchmark

### DIFF
--- a/.github/scripts/load-allure-history.sh
+++ b/.github/scripts/load-allure-history.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Manage Allure report snapshots on gh-pages.
+# Keeps last 10 runs under reports/allure/1..10, latest at reports/allure/latest.
+# Expects: allure-report/ directory with the current report.
+# Outputs: deploy/ directory ready for gh-pages publish.
+
+set -euo pipefail
+
+KEEP=10
+
+# Clone gh-pages to get existing reports
+git clone --depth=1 --branch=gh-pages "https://github.com/${GITHUB_REPOSITORY}.git" gh-pages 2>/dev/null || mkdir -p gh-pages
+
+mkdir -p deploy/reports/allure
+
+# Copy existing snapshots
+if [ -d "gh-pages/reports/allure" ]; then
+  cp -r gh-pages/reports/allure/* deploy/reports/allure/ 2>/dev/null || true
+fi
+
+# Find next snapshot number
+LATEST=0
+for d in deploy/reports/allure/*/; do
+  [ -d "$d" ] || continue
+  NUM=$(basename "$d")
+  [[ "$NUM" =~ ^[0-9]+$ ]] && [ "$NUM" -gt "$LATEST" ] && LATEST=$NUM
+done
+NEXT=$((LATEST + 1))
+
+# Copy new report as next snapshot
+cp -r allure-report "deploy/reports/allure/$NEXT"
+
+# Create redirect index.html pointing to latest
+cat > deploy/reports/allure/index.html << EOF
+<!DOCTYPE html><meta http-equiv="refresh" content="0;url=$NEXT/index.html">
+EOF
+
+# Remove old snapshots beyond KEEP
+cd deploy/reports/allure
+for d in */; do
+  NUM=$(basename "$d")
+  [[ "$NUM" =~ ^[0-9]+$ ]] || continue
+  if [ "$NUM" -le "$((NEXT - KEEP))" ]; then
+    rm -rf "$NUM"
+  fi
+done

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,11 +14,8 @@ concurrency:
 
 jobs:
   benchmark:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-15, windows-latest]
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -56,18 +53,7 @@ jobs:
           key: ${{ runner.os }}-hf-whisper-medium-int8
           restore-keys: ${{ runner.os }}-hf-
 
-      - name: 💾 Cache CoreML model
-        if: runner.os == 'macOS'
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/parakeet/coreml
-            ~/Library/Caches/FluidAudio
-          key: ${{ runner.os }}-parakeet-coreml-v3
-          restore-keys: ${{ runner.os }}-parakeet-coreml-
-
       - name: 🎬 Install ffmpeg
-        if: runner.os == 'Linux'
         run: sudo apt-get install -y ffmpeg
 
       - name: 📦 Install dependencies
@@ -82,35 +68,11 @@ jobs:
       - name: 📊 Print results
         run: cat benchmark-results.md
 
-      - name: 📤 Upload results
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-${{ matrix.os }}
-          path: |
-            benchmark-results.md
-            benchmark-summary.json
-          retention-days: 7
-
-  publish:
-    needs: benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: main
-
-      - name: 📥 Download Ubuntu results
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmark-ubuntu-latest
-          path: results
-
       - name: 🔍 Check regression
-        run: python3 .github/scripts/check-regression.py results/benchmark-summary.json BENCHMARK.md
+        run: python3 .github/scripts/check-regression.py benchmark-summary.json BENCHMARK.md
 
       - name: 📝 Update BENCHMARK.md
-        run: python3 .github/scripts/update-benchmark-md.py results/benchmark-results.md BENCHMARK.md
+        run: python3 .github/scripts/update-benchmark-md.py benchmark-results.md BENCHMARK.md
 
       - name: 📝 Commit results
         run: bash .github/scripts/commit-and-push.sh BENCHMARK.md

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -33,34 +33,20 @@ jobs:
           github-token: ${{ github.token }}
           merge-multiple: true
 
-      - name: 📜 Load report history
-        uses: actions/checkout@v6
+      - name: 📋 List downloaded results
+        run: find allure-results -type f
+
+      - name: 📊 Generate Allure report
+        run: bunx allure generate allure-results --output allure-report --report-name "Parakeet CLI Tests"
+
+      - name: 📜 Load previous reports from gh-pages
         continue-on-error: true
-        with:
-          ref: gh-pages
-          path: gh-pages
-
-      - name: 📊 Build Allure report
-        id: allure
-        uses: GuitaristForEver/allure-v3-report-action@v1
-        with:
-          allure_results: allure-results
-          allure_report: allure-report
-          allure_history: allure-history
-          gh_pages: gh-pages
-          subfolder: reports/allure
-          keep_reports: 10
-          report_name: "Parakeet CLI Tests"
-
-      - name: 🧹 Clean nested .git
-        if: steps.allure.outcome == 'success'
-        run: sudo rm -rf allure-history/.git
+        run: bash .github/scripts/load-allure-history.sh
 
       - name: 🚀 Publish report
         uses: peaceiris/actions-gh-pages@v4
-        if: steps.allure.outcome == 'success'
         with:
           github_token: ${{ github.token }}
           publish_branch: gh-pages
-          publish_dir: allure-history
+          publish_dir: deploy
           keep_files: true


### PR DESCRIPTION
## Problem
Allure reports show 0 results — the third-party Docker action doesn't read JUnit XML.

## Fix
- Replace `GuitaristForEver/allure-v3-report-action` with `bunx allure generate` (reads JUnit XML natively)
- Add `load-allure-history.sh` — manages 10 report snapshots on gh-pages with index redirect
- Benchmark simplified to ubuntu-only single job (removed matrix + separate publish job)
- Removed CoreML cache and conditional ffmpeg from benchmark (always Linux now)

## Report URL
https://drakulavich.github.io/parakeet-cli/reports/allure