### PR TITLE
fix(ci): detect empty test artifacts, add manual trigger for test reports

### DIFF
--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["🧪 CI"]
     branches: [main]
     types: [completed]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -17,7 +18,7 @@ jobs:
   test-report:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -33,8 +34,8 @@ jobs:
         run: bun install
 
       - name: 📥 Download CI test artifacts
-        id: download
         uses: actions/download-artifact@v4
+        if: github.event_name == 'workflow_run'
         continue-on-error: true
         with:
           run-id: ${{ github.event.workflow_run.id }}
@@ -43,24 +44,34 @@ jobs:
           github-token: ${{ github.token }}
           merge-multiple: true
 
-      - name: 🚫 Skip if no test results
-        if: steps.download.outcome == 'failure' || !hashFiles('allure-results/**')
-        run: echo "No test artifacts found — skipping report generation" && exit 0
+      - name: 🧪 Run tests (manual trigger)
+        if: github.event_name == 'workflow_dispatch'
+        run: mkdir -p allure-results && bun test --reporter=junit --reporter-outfile=allure-results/all.xml
 
-      - name: 📋 List downloaded results
-        if: steps.download.outcome == 'success'
+      - name: 🔍 Check for results
+        id: check
+        run: |
+          if [ -d allure-results ] && find allure-results -name '*.xml' | grep -q .; then
+            echo "has_results=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_results=false" >> $GITHUB_OUTPUT
+            echo "⚠️ No test results found — skipping report"
+          fi
+
+      - name: 📋 List results
+        if: steps.check.outputs.has_results == 'true'
         run: find allure-results -type f
 
       - name: 📊 Generate Allure report
-        if: steps.download.outcome == 'success'
+        if: steps.check.outputs.has_results == 'true'
         run: bunx allure generate allure-results --output allure-report --report-name "Parakeet CLI Tests"
 
       - name: 📜 Load history and prepare deploy
-        if: steps.download.outcome == 'success'
+        if: steps.check.outputs.has_results == 'true'
         run: bun .github/scripts/load-allure-history.ts
 
       - name: 🚀 Publish report
-        if: steps.download.outcome == 'success'
+        if: steps.check.outputs.has_results == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
## Problem
`download-artifact@v4` returns success even with 0 artifacts (docs-only PRs skip tests). Subsequent steps crash on missing directory.

## Fix
- Check for actual XML files in directory, not step outcome
- All report steps gated on `steps.check.outputs.has_results == 'true'`
- Added `workflow_dispatch` for manual testing — runs `bun test` directly

## Tested
Manual trigger passed: https://github.com/drakulavich/parakeet-cli/actions/runs/24084979344