### PR TITLE
fix(ci): set GH_TOKEN for benchmark PR creation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -76,4 +76,6 @@ jobs:
         run: bun .github/scripts/update-benchmark-md.ts benchmark-results.md BENCHMARK.md
 
       - name: 📝 Commit results
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: bun .github/scripts/commit-and-push.ts BENCHMARK.md


### PR DESCRIPTION
## Summary
- `gh pr create` in GitHub Actions requires `GH_TOKEN` env var
- The benchmark workflow pushed the branch successfully but failed to open the PR

## Test plan
- [ ] Trigger benchmark workflow manually — should create a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)