### PR TITLE
chore: bump to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakulavich/parakeet-cli",
-  "version": "0.6.0",
-  "description": "Fast multilingual speech-to-text CLI powered by NVIDIA Parakeet ONNX models",
+  "version": "0.6.1",
+  "description": "Fast local speech-to-text CLI. CoreML on Apple Silicon, ONNX on CPU. 25 languages.",
   "type": "module",
   "bin": {
     "parakeet": "bin/parakeet.js"


### PR DESCRIPTION
## v0.6.1

### Fix
- Fix ONNX model download on Linux — `Bun.write(dest, response)` silently fails on large fetch responses. Replaced with `FileSink` streaming.
- Proper error handling for model downloads (check response body, verify bytes written)

### Other
- CoreML vs CoreML benchmark (Parakeet ~27x faster than WhisperKit)
- Renamed benchmark fixtures by content
- CONTRIBUTING.md
- CI improvements (paths-filter, progress bars, ONNX cache)