### PR TITLE
feat: download CoreML models during parakeet install

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -102,8 +102,15 @@ export async function downloadModel(noCache = false, modelDir?: string): Promise
   return dir;
 }
 
+const COREML_BINARY_NAME = "parakeet-coreml-darwin-arm64";
+const GITHUB_REPO = "drakulavich/parakeet-cli";
+
 export function getCoreMLDownloadURL(version: string): string {
-  return `https://github.com/drakulavich/parakeet-cli/releases/download/v${version}/parakeet-coreml-darwin-arm64`;
+  return `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${COREML_BINARY_NAME}`;
+}
+
+export function getCoreMLLatestDownloadURL(): string {
+  return `https://github.com/${GITHUB_REPO}/releases/latest/download/${COREML_BINARY_NAME}`;
 }
 
 export async function downloadCoreML(noCache = false): Promise<string> {
@@ -111,19 +118,32 @@ export async function downloadCoreML(noCache = false): Promise<string> {
   const binPath = getCoreMLBinPath();
 
   if (!noCache && existsSync(binPath)) {
-    console.log("CoreML backend already installed.");
-    return binPath;
+    // Binary exists — ensure models are also downloaded
+    const checkProc = Bun.spawnSync([binPath, "--download-only"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (checkProc.exitCode === 0) {
+      console.log("CoreML backend already installed.");
+      return binPath;
+    }
+    // Models missing — continue to re-download
   }
 
-  const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
-  const url = getCoreMLDownloadURL(pkg.version);
-
+  // Try latest release first, fall back to version-specific
+  const latestUrl = getCoreMLLatestDownloadURL();
   console.error("Downloading parakeet-coreml binary...");
 
-  const res = await fetch(url, { redirect: "follow" });
+  let res = await fetch(latestUrl, { redirect: "follow" });
 
   if (!res.ok) {
-    throw new Error(`Failed to download CoreML binary: ${url} (${res.status})`);
+    const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
+    const versionUrl = getCoreMLDownloadURL(pkg.version);
+    res = await fetch(versionUrl, { redirect: "follow" });
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to download CoreML binary (HTTP ${res.status}). No release found with ${COREML_BINARY_NAME}.`);
   }
 
   mkdirSync(dirname(binPath), { recursive: true });
@@ -131,6 +151,17 @@ export async function downloadCoreML(noCache = false): Promise<string> {
   await Bun.write(binPath, res);
 
   chmodSync(binPath, 0o755);
+
+  // Download CoreML model files (first transcription would be slow without this)
+  console.error("Downloading CoreML models...");
+  const downloadProc = Bun.spawnSync([binPath, "--download-only"], {
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  if (downloadProc.exitCode !== 0) {
+    throw new Error("Failed to download CoreML models");
+  }
 
   console.log("CoreML backend installed successfully.");
   return binPath;

--- a/swift/Sources/ParakeetCoreML/main.swift
+++ b/swift/Sources/ParakeetCoreML/main.swift
@@ -5,12 +5,27 @@ func writeToStderr(_ message: String) {
     FileHandle.standardError.write(Data(message.utf8))
 }
 
-guard CommandLine.arguments.count >= 2 else {
-    writeToStderr("Usage: ParakeetCoreML <audio-file-path>\n")
+let args = CommandLine.arguments
+
+// Download models only (no transcription)
+if args.contains("--download-only") {
+    do {
+        writeToStderr("Downloading CoreML models...\n")
+        let _ = try await AsrModels.downloadAndLoad(version: .v3)
+        print("CoreML models downloaded and compiled.")
+    } catch {
+        writeToStderr("Error downloading models: \(error.localizedDescription)\n")
+        exit(1)
+    }
+    exit(0)
+}
+
+guard args.count >= 2 else {
+    writeToStderr("Usage: parakeet-coreml [--download-only] <audio-file-path>\n")
     exit(1)
 }
 
-let path = CommandLine.arguments[1]
+let path = args[1]
 
 guard FileManager.default.fileExists(atPath: path) else {
     writeToStderr("Error: file not found: \(path)\n")


### PR DESCRIPTION
## Problem
CoreML model files are downloaded on first transcription, making it slow (~10s).

## Fix
- Add `--download-only` flag to Swift binary (`parakeet-coreml --download-only`)
- `parakeet install` on macOS now: downloads binary → runs `--download-only` → models ready
- First transcription is instant
- Re-running `parakeet install` checks if models are already present

## Requires
New Swift binary release (CI will build on next release). Until then, existing binaries
don't have the `--download-only` flag and the install step will fail gracefully.