### PR TITLE
fix(ci): tag-driven release flow

### DIFF
--- a/.github/workflows/build-coreml.yml
+++ b/.github/workflows/build-coreml.yml
@@ -1,8 +1,8 @@
 name: 🔨 Build CoreML
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: ['v*']
 
 permissions:
   contents: write
@@ -34,7 +34,11 @@ jobs:
       - name: 📦 Prepare artifact
         run: cp .build/release/ParakeetCoreML ../parakeet-coreml-darwin-arm64
 
-      - name: 🚀 Upload to release
+      - name: 🚀 Create release with binary
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" ../parakeet-coreml-darwin-arm64 --clobber
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            ../parakeet-coreml-darwin-arm64 \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ Two interfaces: a CLI (`parakeet <audio>`) and a programmatic API (`@drakulavich
 - Before `npm publish`, always ask the user to run e2e tests locally first
 - Suggest: `make smoke-test`
 - Do NOT publish to npm without explicit user confirmation that tests pass
-- Create a GitHub release first, wait for CI to pass, then publish to npm
+- Tag and push (`git tag vX.Y.Z && git push --tags`) — CI creates the GitHub release with CoreML binary
+- Wait for CI to pass, then `npm publish --access public`
 
 ### VERIFY BEFORE PUSHING
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,10 +80,11 @@ swift/                # CoreML Swift binary (built by CI)
 
 ## Releases
 
-1. Bump version in `package.json`
-2. `make release` — verify everything passes
-3. Create GitHub release
-4. `npm publish --access public`
+1. Bump version in `package.json` via PR, merge
+2. `make release` — verify locally
+3. Tag and push: `git tag v0.7.0 && git push --tags`
+4. CI builds CoreML binary + creates GitHub release automatically
+5. `npm publish --access public`
 
 ## License
 


### PR DESCRIPTION
## Problem
`release: [published]` trigger → release is immediately immutable → CI can't upload binary → 422 error on every release since v0.6.0.

## Fix
Trigger on tag push instead of release publish. CI creates the release with the binary already attached — never hits immutability.

```
Before: create release → publish (immutable) → build binary → upload fails
After:  push tag → build binary → create release with binary → published
```

## New release process
```bash
git tag v0.7.0 && git push --tags  # CI does the rest
npm publish --access public         # after CI passes
```