### PR TITLE
chore: bump to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/parakeet-cli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Fast local speech-to-text CLI. CoreML on Apple Silicon, ONNX on CPU. 25 languages.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.7.0

### New
- CoreML models downloaded during `parakeet install` (no more slow first transcription)
- Tag-driven release flow (CI creates releases with binary)
- CoreML binary download uses latest release URL

### Fix
- Success messages to stdout instead of stderr
- Fixed immutable release upload failures