### PR TITLE
fix: remove duplicate download message

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -153,7 +153,6 @@ export async function downloadCoreML(noCache = false): Promise<string> {
   chmodSync(binPath, 0o755);
 
   // Download CoreML model files (first transcription would be slow without this)
-  console.error("Downloading CoreML models...");
   const downloadProc = Bun.spawnSync([binPath, "--download-only"], {
     stdout: "inherit",
     stderr: "inherit",


### PR DESCRIPTION
Swift binary already prints 'Downloading CoreML models...' — removed the duplicate from models.ts.