### PR TITLE
feat: add coreml capabilities handshake

### DIFF
--- a/src/__tests__/coreml-install.test.ts
+++ b/src/__tests__/coreml-install.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import {
-  classifyCoreMLInstallCheck,
+  classifyCoreMLInstallProbe,
   getCoreMLDownloadURL,
   getCoreMLInstallState,
   getCoreMLSupportDir,
-  isLegacyCoreMLFlagError,
+  parseCoreMLBinaryCapabilities,
   planCoreMLInstall,
 } from "../coreml-install";
 import { join } from "path";
@@ -100,24 +100,78 @@ describe("coreml-install", () => {
     });
   });
 
-  test("isLegacyCoreMLFlagError detects unsupported command flags", () => {
+  test("parseCoreMLBinaryCapabilities accepts the current protocol payload", () => {
     expect(
-      isLegacyCoreMLFlagError("Error: file not found: --check-install", "--check-install"),
-    ).toBe(true);
-    expect(
-      isLegacyCoreMLFlagError("CoreML models are not installed.", "--check-install"),
-    ).toBe(false);
+      parseCoreMLBinaryCapabilities(
+        JSON.stringify({
+          protocolVersion: 1,
+          installState: "ready",
+          supportedCommands: {
+            checkInstall: true,
+            downloadOnly: true,
+          },
+        }),
+      ),
+    ).toEqual({
+      protocolVersion: 1,
+      installState: "ready",
+      supportedCommands: {
+        checkInstall: true,
+        downloadOnly: true,
+      },
+    });
   });
 
-  test("classifyCoreMLInstallCheck marks legacy binaries as stale", () => {
+  test("parseCoreMLBinaryCapabilities rejects malformed payloads", () => {
     expect(
-      classifyCoreMLInstallCheck(1, "Error: file not found: --check-install"),
+      parseCoreMLBinaryCapabilities("{invalid"),
+    ).toBeNull();
+    expect(
+      parseCoreMLBinaryCapabilities(
+        JSON.stringify({
+          protocolVersion: 2,
+          installState: "ready",
+          supportedCommands: {
+            checkInstall: true,
+            downloadOnly: true,
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("classifyCoreMLInstallProbe classifies capabilities responses", () => {
+    expect(
+      classifyCoreMLInstallProbe(1, ""),
     ).toBe("stale-binary");
     expect(
-      classifyCoreMLInstallCheck(1, "CoreML models are not installed."),
+      classifyCoreMLInstallProbe(
+        0,
+        JSON.stringify({
+          protocolVersion: 1,
+          installState: "models-missing",
+          supportedCommands: {
+            checkInstall: true,
+            downloadOnly: true,
+          },
+        }),
+      ),
     ).toBe("binary-only");
     expect(
-      classifyCoreMLInstallCheck(0, ""),
+      classifyCoreMLInstallProbe(
+        0,
+        JSON.stringify({
+          protocolVersion: 1,
+          installState: "ready",
+          supportedCommands: {
+            checkInstall: true,
+            downloadOnly: true,
+          },
+        }),
+      ),
     ).toBe("ready");
+    expect(
+      classifyCoreMLInstallProbe(0, "{\"protocolVersion\":999}"),
+    ).toBe("stale-binary");
   });
 });

--- a/src/coreml-install.ts
+++ b/src/coreml-install.ts
@@ -7,6 +7,16 @@ const COREML_BINARY_NAME = "parakeet-coreml-darwin-arm64";
 const GITHUB_REPO = "drakulavich/parakeet-cli";
 
 export type CoreMLInstallState = "missing" | "binary-only" | "ready" | "stale-binary";
+export type CoreMLBinaryInstallState = "ready" | "models-missing";
+
+export interface CoreMLBinaryCapabilities {
+  protocolVersion: number;
+  installState: CoreMLBinaryInstallState;
+  supportedCommands: {
+    checkInstall: boolean;
+    downloadOnly: boolean;
+  };
+}
 
 export function getCoreMLSupportDir(): string {
   return join(homedir(), ".cache", "parakeet", "coreml");
@@ -60,20 +70,43 @@ export function planCoreMLInstall(
   }
 }
 
-export function isLegacyCoreMLFlagError(detail: string, flag: string): boolean {
-  return detail.includes(`file not found: ${flag}`);
+export function parseCoreMLBinaryCapabilities(stdout: string): CoreMLBinaryCapabilities | null {
+  try {
+    const parsed = JSON.parse(stdout) as Partial<CoreMLBinaryCapabilities>;
+    if (parsed.protocolVersion !== 1) {
+      return null;
+    }
+    if (parsed.installState !== "ready" && parsed.installState !== "models-missing") {
+      return null;
+    }
+    if (!parsed.supportedCommands) {
+      return null;
+    }
+    if (parsed.supportedCommands.checkInstall !== true || parsed.supportedCommands.downloadOnly !== true) {
+      return null;
+    }
+
+    return {
+      protocolVersion: parsed.protocolVersion,
+      installState: parsed.installState,
+      supportedCommands: parsed.supportedCommands,
+    };
+  } catch {
+    return null;
+  }
 }
 
-export function classifyCoreMLInstallCheck(exitCode: number, stderr: string): CoreMLInstallState {
-  if (exitCode === 0) {
-    return "ready";
-  }
-
-  if (isLegacyCoreMLFlagError(stderr, "--check-install")) {
+export function classifyCoreMLInstallProbe(exitCode: number, stdout: string): CoreMLInstallState {
+  if (exitCode !== 0) {
     return "stale-binary";
   }
 
-  return "binary-only";
+  const capabilities = parseCoreMLBinaryCapabilities(stdout);
+  if (!capabilities) {
+    return "stale-binary";
+  }
+
+  return capabilities.installState === "ready" ? "ready" : "binary-only";
 }
 
 async function fetchCoreMLBinary(): Promise<Response> {
@@ -96,12 +129,12 @@ async function fetchCoreMLBinary(): Promise<Response> {
 }
 
 function getCoreMLInstallStatus(binPath: string): CoreMLInstallState {
-  const checkProc = Bun.spawnSync([binPath, "--check-install"], {
+  const checkProc = Bun.spawnSync([binPath, "--capabilities-json"], {
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  return classifyCoreMLInstallCheck(checkProc.exitCode, checkProc.stderr.toString());
+  return classifyCoreMLInstallProbe(checkProc.exitCode, checkProc.stdout.toString());
 }
 
 async function ensureCoreMLModels(binPath: string): Promise<void> {

--- a/swift/Sources/ParakeetCoreML/main.swift
+++ b/swift/Sources/ParakeetCoreML/main.swift
@@ -5,6 +5,17 @@ func writeToStderr(_ message: String) {
     FileHandle.standardError.write(Data(message.utf8))
 }
 
+struct BinaryCapabilities: Encodable {
+    struct SupportedCommands: Encodable {
+        let checkInstall: Bool
+        let downloadOnly: Bool
+    }
+
+    let protocolVersion: Int
+    let installState: String
+    let supportedCommands: SupportedCommands
+}
+
 func coreMLMarkerPath() -> String {
     let home = FileManager.default.homeDirectoryForCurrentUser
     return home
@@ -27,10 +38,40 @@ func markCoreMLInstalled() throws {
     try contents.write(to: markerURL, atomically: true, encoding: .utf8)
 }
 
+func currentInstallState() -> String {
+    FileManager.default.fileExists(atPath: coreMLMarkerPath()) ? "ready" : "models-missing"
+}
+
+func printCapabilitiesJSON() throws {
+    let capabilities = BinaryCapabilities(
+        protocolVersion: 1,
+        installState: currentInstallState(),
+        supportedCommands: .init(
+            checkInstall: true,
+            downloadOnly: true
+        )
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(capabilities)
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
 let args = CommandLine.arguments
 
+if args.contains("--capabilities-json") {
+    do {
+        try printCapabilitiesJSON()
+        exit(0)
+    } catch {
+        writeToStderr("Error: failed to encode capabilities: \(error.localizedDescription)\n")
+        exit(1)
+    }
+}
+
 if args.contains("--check-install") {
-    if FileManager.default.fileExists(atPath: coreMLMarkerPath()) {
+    if currentInstallState() == "ready" {
         print("ready")
         exit(0)
     }
@@ -54,7 +95,7 @@ if args.contains("--download-only") {
 }
 
 guard args.count >= 2 else {
-    writeToStderr("Usage: parakeet-coreml [--download-only] <audio-file-path>\n")
+    writeToStderr("Usage: parakeet-coreml [--capabilities-json] [--check-install] [--download-only] <audio-file-path>\n")
     exit(1)
 }
 


### PR DESCRIPTION
## Summary
- add a capabilities-json command to the Swift CoreML helper with explicit protocol and install-state data
- switch the TypeScript installer to classify CoreML binary state from that capabilities payload instead of parsing stderr text
- expand install tests to cover protocol parsing, malformed payloads, and stale-binary fallback

## Testing
- bun run test:unit
- bunx tsc --noEmit
- bun test