### PR TITLE
refactor: extract coreml install runner

### DIFF
--- a/src/__tests__/coreml-install.test.ts
+++ b/src/__tests__/coreml-install.test.ts
@@ -1,11 +1,16 @@
 import { describe, test, expect } from "bun:test";
 import {
   classifyCoreMLInstallProbe,
+  createCoreMLBinaryRunner,
+  ensureCoreMLModels,
   getCoreMLDownloadURL,
   getCoreMLInstallState,
+  getCoreMLInstallStatus,
   getCoreMLSupportDir,
   parseCoreMLBinaryCapabilities,
   planCoreMLInstall,
+  type CoreMLBinaryCommandResult,
+  type CoreMLBinaryRunner,
 } from "../coreml-install";
 import { join } from "path";
 import { homedir } from "os";
@@ -173,5 +178,104 @@ describe("coreml-install", () => {
     expect(
       classifyCoreMLInstallProbe(0, "{\"protocolVersion\":999}"),
     ).toBe("stale-binary");
+  });
+
+  test("createCoreMLBinaryRunner runs the expected commands", () => {
+    const calls: string[][] = [];
+    const runner = createCoreMLBinaryRunner((cmd) => {
+      calls.push(Array.isArray(cmd) ? cmd : cmd.cmd);
+      return {
+        exitCode: 0,
+        stdout: Buffer.from("{}"),
+        stderr: Buffer.from(""),
+      } as ReturnType<typeof Bun.spawnSync>;
+    });
+
+    runner.probeCapabilities("/tmp/parakeet-coreml");
+    runner.downloadModels("/tmp/parakeet-coreml");
+
+    expect(calls).toEqual([
+      ["/tmp/parakeet-coreml", "--capabilities-json"],
+      ["/tmp/parakeet-coreml", "--download-only"],
+    ]);
+  });
+
+  test("getCoreMLInstallStatus delegates to the runner probe", () => {
+    const runner: CoreMLBinaryRunner = {
+      probeCapabilities() {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            protocolVersion: 1,
+            installState: "models-missing",
+            supportedCommands: {
+              checkInstall: true,
+              downloadOnly: true,
+            },
+          }),
+          stderr: "",
+        };
+      },
+      downloadModels() {
+        throw new Error("not used");
+      },
+    };
+
+    expect(getCoreMLInstallStatus("/tmp/parakeet-coreml", runner)).toBe("binary-only");
+  });
+
+  test("ensureCoreMLModels streams command output through the writer", async () => {
+    const writes = {
+      stdout: [] as string[],
+      stderr: [] as string[],
+    };
+    const runner: CoreMLBinaryRunner = {
+      probeCapabilities() {
+        throw new Error("not used");
+      },
+      downloadModels() {
+        return {
+          exitCode: 0,
+          stdout: "downloaded\n",
+          stderr: "progress\n",
+        };
+      },
+    };
+
+    await ensureCoreMLModels("/tmp/parakeet-coreml", runner, {
+      stdout(message) {
+        writes.stdout.push(message);
+      },
+      stderr(message) {
+        writes.stderr.push(message);
+      },
+    });
+
+    expect(writes).toEqual({
+      stdout: ["downloaded\n"],
+      stderr: ["progress\n"],
+    });
+  });
+
+  test("ensureCoreMLModels throws a contextual error when download fails", async () => {
+    const runner: CoreMLBinaryRunner = {
+      probeCapabilities() {
+        throw new Error("not used");
+      },
+      downloadModels() {
+        return {
+          exitCode: 2,
+          stdout: "",
+          stderr: "download failed",
+        };
+      },
+    };
+
+    await expect(
+      ensureCoreMLModels("/tmp/parakeet-coreml", runner, {
+        stdout() {},
+        stderr() {},
+      }),
+    ).rejects.toThrow("Failed to download CoreML models: download failed");
   });
 });

--- a/src/coreml-install.ts
+++ b/src/coreml-install.ts
@@ -9,6 +9,22 @@ const GITHUB_REPO = "drakulavich/parakeet-cli";
 export type CoreMLInstallState = "missing" | "binary-only" | "ready" | "stale-binary";
 export type CoreMLBinaryInstallState = "ready" | "models-missing";
 
+export interface CoreMLBinaryCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CoreMLBinaryRunner {
+  probeCapabilities(binPath: string): CoreMLBinaryCommandResult;
+  downloadModels(binPath: string): CoreMLBinaryCommandResult;
+}
+
+export interface CoreMLOutputWriter {
+  stdout(message: string): void;
+  stderr(message: string): void;
+}
+
 export interface CoreMLBinaryCapabilities {
   protocolVersion: number;
   installState: CoreMLBinaryInstallState;
@@ -17,6 +33,43 @@ export interface CoreMLBinaryCapabilities {
     downloadOnly: boolean;
   };
 }
+
+const defaultOutputWriter: CoreMLOutputWriter = {
+  stdout(message) {
+    process.stdout.write(message);
+  },
+  stderr(message) {
+    process.stderr.write(message);
+  },
+};
+
+export function createCoreMLBinaryRunner(
+  spawnSync: typeof Bun.spawnSync = Bun.spawnSync,
+): CoreMLBinaryRunner {
+  function runCommand(binPath: string, flag: string): CoreMLBinaryCommandResult {
+    const proc = spawnSync([binPath, flag], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    return {
+      exitCode: proc.exitCode,
+      stdout: proc.stdout.toString(),
+      stderr: proc.stderr.toString(),
+    };
+  }
+
+  return {
+    probeCapabilities(binPath) {
+      return runCommand(binPath, "--capabilities-json");
+    },
+    downloadModels(binPath) {
+      return runCommand(binPath, "--download-only");
+    },
+  };
+}
+
+const defaultCoreMLBinaryRunner = createCoreMLBinaryRunner();
 
 export function getCoreMLSupportDir(): string {
   return join(homedir(), ".cache", "parakeet", "coreml");
@@ -128,42 +181,47 @@ async function fetchCoreMLBinary(): Promise<Response> {
   return res;
 }
 
-function getCoreMLInstallStatus(binPath: string): CoreMLInstallState {
-  const checkProc = Bun.spawnSync([binPath, "--capabilities-json"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  return classifyCoreMLInstallProbe(checkProc.exitCode, checkProc.stdout.toString());
+export function getCoreMLInstallStatus(
+  binPath: string,
+  runner: CoreMLBinaryRunner = defaultCoreMLBinaryRunner,
+): CoreMLInstallState {
+  const probe = runner.probeCapabilities(binPath);
+  return classifyCoreMLInstallProbe(probe.exitCode, probe.stdout);
 }
 
-async function ensureCoreMLModels(binPath: string): Promise<void> {
-  const downloadProc = Bun.spawnSync([binPath, "--download-only"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+export async function ensureCoreMLModels(
+  binPath: string,
+  runner: CoreMLBinaryRunner = defaultCoreMLBinaryRunner,
+  output: CoreMLOutputWriter = defaultOutputWriter,
+): Promise<void> {
+  const download = runner.downloadModels(binPath);
 
-  const stdout = downloadProc.stdout.toString();
-  const stderr = downloadProc.stderr.toString();
-
-  if (stderr) {
-    process.stderr.write(stderr);
+  if (download.stderr) {
+    output.stderr(download.stderr);
   }
-  if (stdout) {
-    process.stdout.write(stdout);
+  if (download.stdout) {
+    output.stdout(download.stdout);
   }
 
-  if (downloadProc.exitCode !== 0) {
-    const detail = stderr.trim();
+  if (download.exitCode !== 0) {
+    const detail = download.stderr.trim();
     throw new Error(detail ? `Failed to download CoreML models: ${detail}` : "Failed to download CoreML models");
   }
 }
 
-export async function downloadCoreML(noCache = false): Promise<string> {
+export async function downloadCoreML(
+  noCache = false,
+  opts?: {
+    runner?: CoreMLBinaryRunner;
+    output?: CoreMLOutputWriter;
+  },
+): Promise<string> {
   const binPath = getCoreMLBinPath();
+  const runner = opts?.runner ?? defaultCoreMLBinaryRunner;
+  const output = opts?.output ?? defaultOutputWriter;
   const state = getCoreMLInstallState({
     binPath,
-    verifyReady: noCache ? undefined : getCoreMLInstallStatus,
+    verifyReady: noCache ? undefined : (path) => getCoreMLInstallStatus(path, runner),
   });
   const plan = planCoreMLInstall(state, noCache);
 
@@ -181,7 +239,7 @@ export async function downloadCoreML(noCache = false): Promise<string> {
   }
 
   if (plan.downloadModels) {
-    await ensureCoreMLModels(binPath);
+    await ensureCoreMLModels(binPath, runner, output);
   }
 
   console.log("CoreML backend installed successfully.");


### PR DESCRIPTION
## Summary
- extract CoreML helper subprocess calls behind a small runner interface in coreml-install
- route install probing and model download execution through that runner and an injectable output writer
- expand unit coverage for command dispatch, status probing, output forwarding, and download failure handling

## Testing
- bun run test:unit
- bunx tsc --noEmit