### PR TITLE
chore: bump to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/parakeet-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Fast local speech-to-text CLI. CoreML on Apple Silicon, ONNX on CPU. 25 languages.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.7.1

### Fix
- ffmpeg stderr pipe deadlock (concurrent consumption)
- Cross-platform ffmpeg check (`Bun.which` instead of `which` command)
- Duplicate "Downloading CoreML models..." message removed
- Empty stderr fallback in CoreML error messages

### Improved
- CoreML capabilities handshake (`--capabilities`, `--download-only`)
- Extracted `coreml-install.ts` and `onnx-install.ts` for cleaner install logic
- Updated CLAUDE.md and AGENTS.md