### PR TITLE
feat: colored CLI output with picocolors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "parakeet-cli",
       "dependencies": {
         "onnxruntime-node": "^1.24.0",
+        "picocolors": "^1.1.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -62,6 +63,8 @@
     "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.4.0", "", {}, "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "onnxruntime-node": "^1.24.0"
+    "onnxruntime-node": "^1.24.0",
+    "picocolors": "^1.1.1"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { transcribe } from "./lib";
 import { downloadModel } from "./onnx-install";
 import { downloadCoreML } from "./coreml-install";
 import { isMacArm64 } from "./coreml";
+import { log } from "./log";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -24,7 +25,7 @@ async function main(): Promise<void> {
     try {
       if (forceCoreML) {
         if (!isMacArm64()) {
-          console.error("Error: CoreML backend is only available on macOS Apple Silicon.");
+          log.error("CoreML backend is only available on macOS Apple Silicon.");
           process.exit(1);
         }
         await downloadCoreML(noCache);
@@ -37,7 +38,7 @@ async function main(): Promise<void> {
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error(`Error: ${message}`);
+      log.error(message);
       process.exit(1);
     }
     process.exit(0);
@@ -46,8 +47,8 @@ async function main(): Promise<void> {
   const file = positional[0];
 
   if (!file) {
-    console.error("Usage: parakeet [--version] <audio_file>");
-    console.error("       parakeet install [--coreml | --onnx] [--no-cache]");
+    log.info("Usage: parakeet [--version] <audio_file>");
+    log.info("       parakeet install [--coreml | --onnx] [--no-cache]");
     process.exit(1);
   }
 
@@ -56,7 +57,7 @@ async function main(): Promise<void> {
     if (text) process.stdout.write(text + "\n");
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(message);
+    log.error(message);
     process.exit(1);
   }
 }

--- a/src/coreml-install.ts
+++ b/src/coreml-install.ts
@@ -2,6 +2,7 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 import { existsSync, mkdirSync, chmodSync } from "fs";
 import { getCoreMLBinPath } from "./coreml";
+import { log } from "./log";
 
 const COREML_BINARY_NAME = "parakeet-coreml-darwin-arm64";
 const GITHUB_REPO = "drakulavich/parakeet-cli";
@@ -226,12 +227,12 @@ export async function downloadCoreML(
   const plan = planCoreMLInstall(state, noCache);
 
   if (!plan.downloadBinary && !plan.downloadModels) {
-    console.log("CoreML backend already installed.");
+    log.success("CoreML backend already installed.");
     return binPath;
   }
 
   if (plan.downloadBinary) {
-    console.error("Downloading parakeet-coreml binary...");
+    log.progress("Downloading parakeet-coreml binary...");
     const res = await fetchCoreMLBinary();
     mkdirSync(dirname(binPath), { recursive: true });
     await Bun.write(binPath, res);
@@ -242,6 +243,6 @@ export async function downloadCoreML(
     await ensureCoreMLModels(binPath, runner, output);
   }
 
-  console.log("CoreML backend installed successfully.");
+  log.success("CoreML backend installed successfully.");
   return binPath;
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,9 @@
+import pc from "picocolors";
+
+export const log = {
+  info: (msg: string) => console.log(msg),
+  success: (msg: string) => console.log(pc.green(msg)),
+  progress: (msg: string) => console.log(pc.cyan(msg)),
+  warn: (msg: string) => console.error(pc.yellow(msg)),
+  error: (msg: string) => console.error(pc.red(msg)),
+};

--- a/src/onnx-install.ts
+++ b/src/onnx-install.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 import { homedir } from "os";
 import { existsSync, mkdirSync } from "fs";
+import { log } from "./log";
 
 export const HF_REPO = "istupakov/parakeet-tdt-0.6b-v3-onnx";
 
@@ -48,7 +49,7 @@ export async function downloadModel(noCache = false, modelDir?: string): Promise
   const dir = modelDir ?? getModelDir();
 
   if (!noCache && isModelCached(dir)) {
-    console.log("Model already downloaded.");
+    log.success("Model already downloaded.");
     return dir;
   }
 
@@ -60,7 +61,7 @@ export async function downloadModel(noCache = false, modelDir?: string): Promise
 
     if (!noCache && existsSync(dest)) continue;
 
-    console.error(`Downloading ${file}...`);
+    log.progress(`Downloading ${file}...`);
 
     let res: Response;
     try {
@@ -93,6 +94,6 @@ export async function downloadModel(noCache = false, modelDir?: string): Promise
     }
   }
 
-  console.log("Model downloaded successfully.");
+  log.success("Model downloaded successfully.");
   return dir;
 }

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -24,9 +24,9 @@ describe("e2e-cli", () => {
   });
 
   test("no args prints usage and exits 1", async () => {
-    const { stderr, exitCode } = await runCli([]);
+    const { stdout, exitCode } = await runCli([]);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("Usage:");
+    expect(stdout).toContain("Usage:");
   });
 
   test("missing file prints error and exits 1", async () => {

--- a/tests/integration/e2e-coreml-install.test.ts
+++ b/tests/integration/e2e-coreml-install.test.ts
@@ -148,7 +148,7 @@ describe("e2e-coreml-install", () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stderr).toContain("Downloading parakeet-coreml binary...");
+      expect(result.stdout).toContain("Downloading parakeet-coreml binary...");
       expect(result.stdout).toContain("downloaded");
       expect(result.stdout).toContain("CoreML backend installed successfully.");
 


### PR DESCRIPTION
## Problem
All CLI messages were red (stderr) or plain white — no visual distinction between progress, success, and errors.

## Fix
- Add `src/log.ts` using `picocolors` (3KB, zero deps)
- Progress: cyan on stdout ("Downloading...")
- Success: green on stdout ("installed successfully")
- Errors: red on stderr
- Usage: white on stdout