### PR TITLE
feat: OS-specific ffmpeg install instructions

### DIFF
--- a/docs/superpowers/plans/2026-04-09-ffmpeg-error-dx.md
+++ b/docs/superpowers/plans/2026-04-09-ffmpeg-error-dx.md
@@ -1,0 +1,178 @@
+# Improved ffmpeg Error Messages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generic "ffmpeg not found in PATH" error with an OS-aware message that suggests the correct install command.
+
+**Architecture:** Add a `getFfmpegInstallHint()` helper to `src/audio.ts` that checks `process.platform` and probes for package managers via `Bun.which()`. The existing `assertFfmpegExists()` uses the hint in its error message. No new files or dependencies.
+
+**Tech Stack:** TypeScript, Bun (`Bun.which`), picocolors (via existing `src/log.ts` — not used directly; error is thrown, not logged)
+
+**Spec:** `docs/superpowers/specs/2026-04-09-ffmpeg-error-dx-design.md`
+
+---
+
+### Task 1: Add `getFfmpegInstallHint()` with tests
+
+**Files:**
+- Modify: `src/audio.ts:64-70`
+- Create: `src/__tests__/audio.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/__tests__/audio.test.ts`:
+
+```typescript
+import { describe, test, expect } from "bun:test";
+import { getFfmpegInstallHint } from "../audio";
+
+describe("getFfmpegInstallHint", () => {
+  test("returns a non-empty string", () => {
+    const hint = getFfmpegInstallHint();
+    expect(hint).toBeTruthy();
+    expect(typeof hint).toBe("string");
+  });
+
+  test("contains install keyword", () => {
+    const hint = getFfmpegInstallHint();
+    expect(hint).toMatch(/install|ffmpeg\.org/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/__tests__/audio.test.ts`
+Expected: FAIL — `getFfmpegInstallHint` is not exported from `../audio`
+
+- [ ] **Step 3: Implement `getFfmpegInstallHint()`**
+
+In `src/audio.ts`, add this exported function before `assertFfmpegExists`:
+
+```typescript
+export function getFfmpegInstallHint(): string {
+  const platform = process.platform;
+
+  if (platform === "darwin") {
+    if (Bun.which("brew")) return "  brew install ffmpeg";
+    if (Bun.which("port")) return "  sudo port install ffmpeg";
+  }
+
+  if (platform === "linux") {
+    if (Bun.which("apt")) return "  sudo apt install ffmpeg";
+    if (Bun.which("dnf")) return "  sudo dnf install ffmpeg-free";
+    if (Bun.which("pacman")) return "  sudo pacman -S ffmpeg";
+  }
+
+  if (platform === "win32") {
+    if (Bun.which("choco")) return "  choco install ffmpeg";
+    if (Bun.which("scoop")) return "  scoop install ffmpeg";
+    if (Bun.which("winget")) return "  winget install ffmpeg";
+  }
+
+  return "  https://ffmpeg.org/download.html";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/__tests__/audio.test.ts`
+Expected: PASS — both tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/audio.ts src/__tests__/audio.test.ts
+git commit -m "feat: add getFfmpegInstallHint with OS-aware install suggestions"
+```
+
+---
+
+### Task 2: Update `assertFfmpegExists()` to use the hint
+
+**Files:**
+- Modify: `src/audio.ts:64-70`
+
+- [ ] **Step 1: Write a failing test for the error message**
+
+Add to `src/__tests__/audio.test.ts`:
+
+```typescript
+import { assertFfmpegExists } from "../audio";
+
+describe("assertFfmpegExists", () => {
+  test("includes install hint when ffmpeg is missing", () => {
+    // Save and override Bun.which to simulate missing ffmpeg
+    const originalWhich = Bun.which;
+    Bun.which = ((cmd: string) => {
+      if (cmd === "ffmpeg") return null;
+      return originalWhich(cmd);
+    }) as typeof Bun.which;
+
+    // Reset the cached check so assertFfmpegExists re-checks
+    resetFfmpegCheck();
+
+    try {
+      expect(() => assertFfmpegExists()).toThrow(/Install it:/);
+    } finally {
+      Bun.which = originalWhich;
+      resetFfmpegCheck();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/__tests__/audio.test.ts`
+Expected: FAIL — `assertFfmpegExists` is not exported, `resetFfmpegCheck` does not exist, and the error message doesn't match `/Install it:/`
+
+- [ ] **Step 3: Export `assertFfmpegExists`, add `resetFfmpegCheck`, and update the error message**
+
+In `src/audio.ts`, make these changes:
+
+1. Export `assertFfmpegExists`:
+
+```typescript
+export function assertFfmpegExists(): void {
+```
+
+2. Add a `resetFfmpegCheck` export for testing:
+
+```typescript
+export function resetFfmpegCheck(): void {
+  ffmpegChecked = false;
+}
+```
+
+3. Update the error message inside `assertFfmpegExists`:
+
+```typescript
+export function assertFfmpegExists(): void {
+  if (ffmpegChecked) return;
+  if (!Bun.which("ffmpeg")) {
+    const hint = getFfmpegInstallHint();
+    throw new Error(
+      `ffmpeg is required but not found in PATH.\n\nInstall it:\n${hint}`
+    );
+  }
+  ffmpegChecked = true;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/__tests__/audio.test.ts`
+Expected: PASS — all tests green
+
+- [ ] **Step 5: Run full test suite and type check**
+
+Run: `bun test && bunx tsc --noEmit`
+Expected: All tests pass, no type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/audio.ts src/__tests__/audio.test.ts
+git commit -m "feat: show OS-specific ffmpeg install instructions on missing ffmpeg"
+```

--- a/docs/superpowers/specs/2026-04-09-ffmpeg-error-dx-design.md
+++ b/docs/superpowers/specs/2026-04-09-ffmpeg-error-dx-design.md
@@ -1,0 +1,57 @@
+# Improved ffmpeg Error Messages
+
+**Date**: 2026-04-09
+**Status**: Approved
+**Scope**: `src/audio.ts` — `assertFfmpegExists()` function only
+
+## Problem
+
+When ffmpeg is not installed, parakeet shows a generic error:
+```
+ffmpeg not found in PATH
+```
+This gives the user no guidance on how to fix it, especially across different OSes and package managers.
+
+## Solution
+
+Replace the generic error with an OS-aware message that detects available package managers and suggests the correct install command.
+
+### Detection Logic
+
+The function uses `Bun.which()` to probe for package managers (same pattern already used for ffmpeg itself):
+
+| Platform | Package manager check | Suggested command |
+|---|---|---|
+| macOS | `brew` | `brew install ffmpeg` |
+| macOS | `port` (fallback) | `sudo port install ffmpeg` |
+| Linux | `apt` | `sudo apt install ffmpeg` |
+| Linux | `dnf` | `sudo dnf install ffmpeg-free` |
+| Linux | `pacman` | `sudo pacman -S ffmpeg` |
+| Windows | `choco` | `choco install ffmpeg` |
+| Windows | `scoop` | `scoop install ffmpeg` |
+| Windows | `winget` | `winget install ffmpeg` |
+| Any | fallback | `https://ffmpeg.org/download.html` |
+
+### Error Message Format
+
+```
+ffmpeg is required but not found in PATH.
+
+Install it:
+  brew install ffmpeg
+```
+
+Only the first matching package manager is shown (not all of them). If none are found, the fallback URL is shown.
+
+### Implementation
+
+All changes are in `src/audio.ts`:
+- `assertFfmpegExists()` calls a new helper `getFfmpegInstallHint(): string`
+- `getFfmpegInstallHint()` checks `process.platform` and probes for package managers via `Bun.which()`
+- No new files, no new dependencies
+
+## Out of Scope
+
+- No `parakeet install --ffmpeg` auto-installer
+- No native WAV handling to bypass ffmpeg
+- No new dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/parakeet-cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Fast local speech-to-text CLI. CoreML on Apple Silicon, ONNX on CPU. 25 languages.",
   "type": "module",
   "bin": {

--- a/src/__tests__/audio.test.ts
+++ b/src/__tests__/audio.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { getFfmpegInstallHint } from "../audio";
+import { getFfmpegInstallHint, assertFfmpegExists, resetFfmpegCheck } from "../audio";
 
 describe("getFfmpegInstallHint", () => {
   test("returns a non-empty string", () => {
@@ -11,5 +11,26 @@ describe("getFfmpegInstallHint", () => {
   test("contains install keyword", () => {
     const hint = getFfmpegInstallHint();
     expect(hint).toMatch(/install|ffmpeg\.org/i);
+  });
+});
+
+describe("assertFfmpegExists", () => {
+  test("includes install hint when ffmpeg is missing", () => {
+    // Save and override Bun.which to simulate missing ffmpeg
+    const originalWhich = Bun.which;
+    Bun.which = ((cmd: string) => {
+      if (cmd === "ffmpeg") return null;
+      return originalWhich(cmd);
+    }) as typeof Bun.which;
+
+    // Reset the cached check so assertFfmpegExists re-checks
+    resetFfmpegCheck();
+
+    try {
+      expect(() => assertFfmpegExists()).toThrow(/Install it:/);
+    } finally {
+      Bun.which = originalWhich;
+      resetFfmpegCheck();
+    }
   });
 });

--- a/src/__tests__/audio.test.ts
+++ b/src/__tests__/audio.test.ts
@@ -1,0 +1,15 @@
+import { describe, test, expect } from "bun:test";
+import { getFfmpegInstallHint } from "../audio";
+
+describe("getFfmpegInstallHint", () => {
+  test("returns a non-empty string", () => {
+    const hint = getFfmpegInstallHint();
+    expect(hint).toBeTruthy();
+    expect(typeof hint).toBe("string");
+  });
+
+  test("contains install keyword", () => {
+    const hint = getFfmpegInstallHint();
+    expect(hint).toMatch(/install|ffmpeg\.org/i);
+  });
+});

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -84,10 +84,17 @@ export function getFfmpegInstallHint(): string {
   return "  https://ffmpeg.org/download.html";
 }
 
-function assertFfmpegExists(): void {
+export function assertFfmpegExists(): void {
   if (ffmpegChecked) return;
   if (!Bun.which("ffmpeg")) {
-    throw new Error("ffmpeg not found in PATH");
+    const hint = getFfmpegInstallHint();
+    throw new Error(
+      `ffmpeg is required but not found in PATH.\n\nInstall it:\n${hint}`
+    );
   }
   ffmpegChecked = true;
+}
+
+export function resetFfmpegCheck(): void {
+  ffmpegChecked = false;
 }

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -61,6 +61,29 @@ async function convertAudioWithFfmpeg(
   return tmpPath;
 }
 
+export function getFfmpegInstallHint(): string {
+  const platform = process.platform;
+
+  if (platform === "darwin") {
+    if (Bun.which("brew")) return "  brew install ffmpeg";
+    if (Bun.which("port")) return "  sudo port install ffmpeg";
+  }
+
+  if (platform === "linux") {
+    if (Bun.which("apt")) return "  sudo apt install ffmpeg";
+    if (Bun.which("dnf")) return "  sudo dnf install ffmpeg-free";
+    if (Bun.which("pacman")) return "  sudo pacman -S ffmpeg";
+  }
+
+  if (platform === "win32") {
+    if (Bun.which("choco")) return "  choco install ffmpeg";
+    if (Bun.which("scoop")) return "  scoop install ffmpeg";
+    if (Bun.which("winget")) return "  winget install ffmpeg";
+  }
+
+  return "  https://ffmpeg.org/download.html";
+}
+
 function assertFfmpegExists(): void {
   if (ffmpegChecked) return;
   if (!Bun.which("ffmpeg")) {


### PR DESCRIPTION
## Summary
- Add `getFfmpegInstallHint()` that detects OS and available package managers (brew, apt, dnf, pacman, choco, scoop, winget) via `Bun.which()`
- Replace generic "ffmpeg not found in PATH" error with actionable install command
- Add `src/__tests__/audio.test.ts` with 3 tests (hint output + error message integration)
- Add supported audio formats table to README

## Test plan
- [x] `bun test` — 48 tests pass
- [x] `bunx tsc --noEmit` — no type errors
- [x] Verify error message on macOS: uninstall ffmpeg temporarily, run `parakeet audio.ogg`, confirm it shows `brew install ffmpeg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)