### PR TITLE
docs: agent runs smoke-test before publish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ make publish                   # release + npm publish
 - Add unit tests when writing new code
 - ffmpeg must be in PATH for ONNX backend audio conversion
 - **NEVER** write more than 3 lines of bash in GitHub Actions workflow steps — extract to `.github/scripts/`
-- **BEFORE npm publish**: ask the user to run `make smoke-test`. Do NOT publish without explicit user confirmation that tests pass.
+- **BEFORE npm publish**: run `make smoke-test` locally and verify all tests pass. Do NOT publish if smoke tests fail.
 - **BEFORE pushing**: run `bun test && bunx tsc --noEmit` locally and verify all tests pass. Do NOT push broken code.
 - **ALWAYS write proper error handling**: errors must be human-readable with context (what failed, why, what to do). Never swallow errors silently. Never let a function return success when it failed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,8 @@ Two interfaces: a CLI (`parakeet <audio>`) and a programmatic API (`@drakulavich
 
 ### RELEASE PROCESS
 
-- Before `npm publish`, always ask the user to run e2e tests locally first
-- Suggest: `make smoke-test`
-- Do NOT publish to npm without explicit user confirmation that tests pass
+- Before `npm publish`, run `make smoke-test` locally and verify all tests pass
+- Do NOT publish to npm if smoke tests fail
 - Tag and push (`git tag vX.Y.Z && git push --tags`) — CI creates the GitHub release with CoreML binary
 - Wait for CI to pass, then `npm publish --access public`
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ Parakeet (CoreML):      1.9s  ██
 
 Full results with transcripts: [BENCHMARK.md](BENCHMARK.md)
 
+## Supported Audio Formats
+
+Any format that ffmpeg can decode works with parakeet:
+
+| Format | Extension |
+|---|---|
+| WAV | `.wav` |
+| MP3 | `.mp3` |
+| OGG Vorbis | `.ogg` |
+| FLAC | `.flac` |
+| AAC / M4A | `.aac`, `.m4a` |
+| Opus | `.opus` |
+| WMA | `.wma` |
+| WebM | `.webm` |
+| MP4 (audio track) | `.mp4` |
+| AIFF | `.aiff` |
+
+CoreML backend tries native decoding first, falls back to ffmpeg for unsupported formats. ONNX backend always converts via ffmpeg.
+
 ## Supported Languages
 
 :bulgaria: Bulgarian, :croatia: Croatian, :czech_republic: Czech, :denmark: Danish, :netherlands: Dutch, :gb: English, :estonia: Estonian, :finland: Finnish, :fr: French, :de: German, :greece: Greek, :hungary: Hungarian, :it: Italian, :latvia: Latvian, :lithuania: Lithuanian, :malta: Maltese, :poland: Polish, :portugal: Portuguese, :romania: Romanian, :ru: Russian, :slovakia: Slovak, :slovenia: Slovenian, :es: Spanish, :sweden: Swedish, :ukraine: Ukrainian


### PR DESCRIPTION
## Summary
- Update `CLAUDE.md` and `AGENTS.md` release process instructions
- Agent now runs `make smoke-test` directly instead of asking the user to run it
- Removes human-in-the-loop for pre-publish verification

## Test plan
- [x] Review updated instructions in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)