### PR TITLE
chore: bump to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/parakeet-cli",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Fast local speech-to-text CLI. CoreML on Apple Silicon, ONNX on CPU. 25 languages.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Version bump to 0.8.0 for release

## Changes in 0.8.0

- `parakeet status` command — diagnostic view of installed components
- Download progress bar — TTY-aware with percentage and MB counters
- Actionable error messages — every error includes a `Fix:` suggestion
- Short-audio and CoreML fallback warnings (CLI only, silent in API)
- `bin/parakeet.js` fix — entry point now calls `runMain` directly
- Test layout consolidated under `tests/unit/` and `tests/integration/`

## Test plan

- [x] `bun test` — 98 pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)