### PR TITLE
chore: bump to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/parakeet-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Fast local speech-to-text CLI. CoreML on Apple Silicon, ONNX on CPU. 25 languages.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 0.8.1 for patch release

All checks passed locally (`make release`).

After merge: tag `v0.8.1` and push to trigger CoreML build, then `npm publish --access public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)