### PR TITLE
fix(ci): add write permissions to build-engine

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -4,9 +4,13 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-14


### PR DESCRIPTION
Fixes release upload 403 error. Adds `permissions: contents: write` and `fail-fast: false`.