### PR TITLE
feat: add "Did you mean?" command suggestion for typos

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "parakeet-cli",
       "dependencies": {
         "citty": "^0.2.2",
+        "fastest-levenshtein": "^1.0.16",
         "picocolors": "^1.1.1",
         "tinyld": "^1.3.4",
       },
@@ -28,6 +29,8 @@
     "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.5.10", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.1", "strnum": "^2.2.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w=="],
+
+    "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.4.0", "", {}, "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "citty": "^0.2.2",
+    "fastest-levenshtein": "^1.0.16",
     "picocolors": "^1.1.1",
     "tinyld": "^1.3.4"
   }

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -105,7 +105,31 @@ for (const cmd of ["kesha", "parakeet"] as const) {
   }
 }
 
-const total = files.length + 6;
+// E2E: unknown command with typo shows suggestion
+const typoProc = Bun.spawnSync(["kesha", "instal"], { stdout: "pipe", stderr: "pipe" });
+const typoStderr = typoProc.stderr.toString();
+
+if (typoProc.exitCode === 1 && typoStderr.includes("unknown command") && typoStderr.includes("Did you mean")) {
+  console.log(`  PASS  typo "instal" suggests "install"`);
+  passed++;
+} else {
+  console.log(`  FAIL  typo suggestion not shown (stderr: ${typoStderr.slice(0, 80)})`);
+  failed++;
+}
+
+// E2E: unknown command without match shows no suggestion
+const noMatchProc = Bun.spawnSync(["kesha", "xyzxyzxyz"], { stdout: "pipe", stderr: "pipe" });
+const noMatchOut = noMatchProc.stdout.toString() + noMatchProc.stderr.toString();
+
+if (!noMatchOut.includes("Did you mean")) {
+  console.log(`  PASS  gibberish "xyzxyzxyz" shows no suggestion`);
+  passed++;
+} else {
+  console.log(`  FAIL  gibberish unexpectedly matched a command`);
+  failed++;
+}
+
+const total = files.length + 8;
 console.log(`\n${passed}/${total} passed, ${failed} failed`);
 
 if (failed > 0) process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,6 +165,8 @@ export const mainCommand = defineCommand({
   },
 });
 
+const SUBCOMMANDS = ["install", "status"];
+
 export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
   const [firstArg, ...restArgs] = rawArgs;
 
@@ -176,6 +178,17 @@ export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
   if (firstArg === "status") {
     await runMain(statusCommand, { rawArgs: restArgs });
     return;
+  }
+
+  // Check for unknown subcommands (non-flag, non-file-path args)
+  if (firstArg && !firstArg.startsWith("-") && !firstArg.includes(".") && !firstArg.includes("/")) {
+    const { suggestCommand } = await import("./suggest-command");
+    const suggestion = suggestCommand(firstArg, SUBCOMMANDS);
+    if (suggestion && suggestion !== firstArg) {
+      log.error(`unknown command '${firstArg}'`);
+      log.warn(`(Did you mean ${suggestion}?)`);
+      process.exit(1);
+    }
   }
 
   await runMain(mainCommand, { rawArgs });

--- a/src/suggest-command.ts
+++ b/src/suggest-command.ts
@@ -1,0 +1,23 @@
+import { closest, distance } from "fastest-levenshtein";
+
+export function suggestCommand(input: string, commands: string[]): string | null {
+  if (!input || commands.length === 0) return null;
+
+  const lowerInput = input.toLowerCase();
+  const lowerCommands = commands.map((c) => c.toLowerCase());
+
+  // Exact match — return as-is
+  const exactIdx = lowerCommands.indexOf(lowerInput);
+  if (exactIdx !== -1) return commands[exactIdx];
+
+  const match = closest(lowerInput, lowerCommands);
+  const dist = distance(lowerInput, match);
+
+  // Threshold: distance <= 3 AND distance <= 40% of target length
+  const maxDist = Math.min(3, Math.ceil(match.length * 0.4));
+  if (dist > maxDist) return null;
+
+  // Return the original-cased command
+  const idx = lowerCommands.indexOf(match);
+  return commands[idx];
+}

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -2,9 +2,9 @@ import { describe, test, expect } from "bun:test";
 import { parseLangResult, getEngineBinPath } from "../../src/engine";
 
 describe("engine", () => {
-  test("getEngineBinPath returns path under .cache/kesha", () => {
+  test("getEngineBinPath returns path under .cache kesha", () => {
     const path = getEngineBinPath();
-    expect(path).toContain(".cache/kesha");
+    expect(path).toMatch(/\.cache[/\\]kesha/);
     expect(path).toContain("kesha-engine");
   });
 

--- a/tests/unit/suggest-command.test.ts
+++ b/tests/unit/suggest-command.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { suggestCommand } from "../../src/suggest-command";
+
+describe("suggestCommand", () => {
+  const commands = ["help", "test", "run"];
+
+  test("suggests 'help' for 'hlep'", () => {
+    expect(suggestCommand("hlep", commands)).toBe("help");
+  });
+
+  test("suggests 'test' for 'tset'", () => {
+    expect(suggestCommand("tset", commands)).toBe("test");
+  });
+
+  test("suggests 'run' for 'ru'", () => {
+    expect(suggestCommand("ru", commands)).toBe("run");
+  });
+
+  test("returns null for 'xyzabc'", () => {
+    expect(suggestCommand("xyzabc", commands)).toBeNull();
+  });
+
+  test("returns null for empty input", () => {
+    expect(suggestCommand("", commands)).toBeNull();
+  });
+
+  test("returns exact match for 'help'", () => {
+    expect(suggestCommand("help", commands)).toBe("help");
+  });
+
+  test("case-insensitive: 'Help' matches 'help'", () => {
+    expect(suggestCommand("Help", commands)).toBe("help");
+  });
+
+  test("suggests 'test' for 'tes'", () => {
+    expect(suggestCommand("tes", commands)).toBe("test");
+  });
+
+  test("suggests 'run' for 'runx'", () => {
+    expect(suggestCommand("runx", commands)).toBe("run");
+  });
+
+  test("returns null for empty commands list", () => {
+    expect(suggestCommand("foo", [])).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #64

## Changes
- Add `fastest-levenshtein` dependency (3KB, zero deps)
- Add `src/suggest-command.ts` — fuzzy matching with Levenshtein distance
- Integrate into `runCli()` — unknown subcommands show suggestion
- Threshold: distance <= 3 AND <= 40% of target length

## Examples
```
❯ kesha instal
error: unknown command 'instal'
(Did you mean install?)

❯ kesha xyzxyzxyz
(no suggestion — too far from any command)
```

## Tests
- 10 unit tests for `suggestCommand()` (all cases from issue)
- 2 E2E smoke tests (typo with suggestion + gibberish without)
- 59 unit tests total, 18 smoke tests, tsc clean