### PR TITLE
feat: add OpenClaw skill for voice message transcription

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,54 @@
+# Kesha Voice Kit
+
+Local speech-to-text for voice messages. Runs entirely on your machine — no API keys, no cloud.
+
+## What it does
+
+When a voice message arrives (Telegram, WhatsApp, Slack), Kesha transcribes it and returns JSON with the transcript and detected language:
+
+```json
+[{
+  "file": "voice.ogg",
+  "text": "Привет, как дела?",
+  "lang": "ru",
+  "textLanguage": { "code": "ru", "confidence": 0.99 }
+}]
+```
+
+Use the `lang` field to detect which language the user spoke and respond accordingly.
+
+## Setup
+
+After installing the plugin, run once to download the engine and models:
+
+```bash
+kesha install
+```
+
+## Plain text mode
+
+If you don't need language detection, switch to plain text output in your config:
+
+```json
+{
+  "type": "cli",
+  "command": "kesha",
+  "args": ["{{MediaPath}}"]
+}
+```
+
+This returns just the transcript text without JSON wrapping.
+
+## Available flags
+
+- `--json` — JSON output with language detection (default in this plugin)
+- `--verbose` — show language detection details (audio + text language with confidence)
+- `--lang <code>` — warn if detected language differs from expected (e.g. `--lang en`)
+
+## Supported languages
+
+Speech-to-text: Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
+
+## Performance
+
+~19x faster than Whisper on Apple Silicon (CoreML), ~2.5x faster on CPU (ONNX).

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "kesha-voice-kit",
+  "displayName": "Kesha Voice Kit",
+  "description": "Local speech-to-text for voice messages. 25 languages, ~19x faster than Whisper on Apple Silicon. Drop-in replacement for openai-whisper.",
+  "configPatch": {
+    "tools": {
+      "media": {
+        "audio": {
+          "enabled": true,
+          "models": [
+            {
+              "type": "cli",
+              "command": "kesha",
+              "args": ["--json", "{{MediaPath}}"]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "src/",
     "package.json",
     "tsconfig.json",
+    "openclaw.plugin.json",
+    "SKILL.md",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
## Summary
Add OpenClaw skill so users can install Kesha as a drop-in replacement for whisper:

```
openclaw plugins install @drakulavich/kesha-voice-kit
kesha install
```

## Files added
- `openclaw.plugin.json` — manifest with `configPatch` that auto-configures `tools.media.audio` with `kesha --json`
- `SKILL.md` — agent-facing docs: JSON output format, plain text mode, flags, supported languages

## User flow
1. `openclaw plugins install @drakulavich/kesha-voice-kit` — installs + patches config
2. `kesha install` — downloads engine + models
3. Voice messages now transcribed locally with language detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)