### PR TITLE
feat: restore --coreml/--onnx flags for kesha install

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,8 @@ export function checkLanguageMismatch(expected: string | undefined, detected: st
 }
 
 interface InstallCommandArgs {
+  coreml: boolean;
+  onnx: boolean;
   "no-cache": boolean;
 }
 
@@ -33,9 +35,19 @@ interface MainCommandArgs {
 
 const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
 
-async function performInstall(noCache: boolean) {
+function resolveBackendFlag(coreml: boolean, onnx: boolean): string | undefined {
+  if (coreml && onnx) {
+    log.error('Choose only one backend: "--coreml" or "--onnx".');
+    process.exit(1);
+  }
+  if (coreml) return "coreml";
+  if (onnx) return "onnx";
+  return undefined;
+}
+
+async function performInstall(noCache: boolean, backend?: string) {
   try {
-    await downloadEngine(noCache);
+    await downloadEngine(noCache, backend);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     log.error(message);
@@ -49,6 +61,16 @@ export const installCommand = defineCommand({
     description: "Download inference engine and models",
   },
   args: {
+    coreml: {
+      type: "boolean",
+      description: "Force CoreML backend (macOS arm64)",
+      default: false,
+    },
+    onnx: {
+      type: "boolean",
+      description: "Force ONNX backend",
+      default: false,
+    },
     "no-cache": {
       type: "boolean",
       description: "Re-download even if cached",
@@ -56,7 +78,8 @@ export const installCommand = defineCommand({
     },
   },
   async run({ args }: { args: InstallCommandArgs }) {
-    await performInstall(args["no-cache"]);
+    const backend = resolveBackendFlag(args.coreml, args.onnx);
+    await performInstall(args["no-cache"], backend);
   },
 });
 

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -17,7 +17,7 @@ function getEngineBinaryName(): string {
   throw new Error(`Unsupported platform: ${platform} ${arch}`);
 }
 
-export async function downloadEngine(noCache = false): Promise<string> {
+export async function downloadEngine(noCache = false, backend?: string): Promise<string> {
   const binPath = getEngineBinPath();
 
   if (!noCache && existsSync(binPath)) {
@@ -51,7 +51,8 @@ export async function downloadEngine(noCache = false): Promise<string> {
   }
 
   log.progress("Installing models...");
-  const proc = Bun.spawnSync([binPath, "install", ...(noCache ? ["--no-cache"] : [])], {
+  const installArgs = ["install", ...(noCache ? ["--no-cache"] : []), ...(backend ? [`--backend=${backend}`] : [])];
+  const proc = Bun.spawnSync([binPath, ...installArgs], {
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -5,6 +5,9 @@ import { downloadEngine } from "./engine-install";
 export type { TranscribeOptions };
 export { downloadEngine as downloadModel };
 
+/** @deprecated Use `downloadModel` instead. */
+export const downloadCoreML = downloadEngine;
+
 export async function transcribe(
   audioPath: string,
   options: TranscribeOptions = {},

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -9,8 +9,10 @@ describe("CLI help", () => {
     expect(usage).toContain("install");
   });
 
-  test("install help contains --no-cache option", async () => {
+  test("install help contains backend and cache options", async () => {
     const usage = await renderUsage(installCommand);
+    expect(usage).toContain("--coreml");
+    expect(usage).toContain("--onnx");
     expect(usage).toContain("--no-cache");
   });
 


### PR DESCRIPTION
Restore backend override flags removed in the engine migration. Users can force a specific backend:

```bash
kesha install --coreml    # force CoreML (macOS arm64)
kesha install --onnx      # force ONNX
kesha install             # auto-detect (default)
```

Conflicting flags (`--coreml --onnx`) rejected with error. Flag passed through to engine as `--backend=coreml|onnx`.