### PR TITLE
chore: release v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 

--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -148,8 +148,7 @@ fn resample(samples: Vec<f32>, src_rate: u32) -> Result<Vec<f32>> {
         Async::<f32>::new_sinc(ratio, 1.1, &params, chunk_size, channels, FixedAsync::Input)
             .context("failed to create resampler")?;
 
-    // Wrap mono samples in a vec-of-vecs (one channel)
-    let input_data = vec![samples];
+    let input_data = [samples];
     let total_frames = input_data[0].len();
 
     let mut output_mono: Vec<f32> =

--- a/rust/src/capabilities.rs
+++ b/rust/src/capabilities.rs
@@ -9,6 +9,7 @@ pub struct Capabilities {
 }
 
 pub fn get_capabilities() -> Capabilities {
+    #[allow(unused_mut)]
     let mut features = vec!["transcribe", "detect-lang"];
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1
- Ships fixes from #89: OpenClaw plugin install docs, `openclaw.plugin.json` configSchema, removal of broken `--backend` passthrough to `kesha-engine install`, and build-engine matrix switch so darwin-arm64 releases ship the CoreML binary.

## Test plan
- [x] `make lint`
- [x] `make unit`
- [x] `make smoke-test`
- [ ] CI green on PR
- [ ] Tag `v1.0.1` triggers build-engine workflow and release
- [ ] `npm publish --access public`

🤖 Generated with [Claude Code](https://claude.com/claude-code)