### PR TITLE
fix(ci): build coreml engine on macos-15

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
+          - os: macos-15
             target: aarch64-apple-darwin
             features: coreml
             binary: kesha-engine-darwin-arm64


### PR DESCRIPTION
## Summary
- fluidaudio 0.10.0 (via fluidaudio-rs) requires Swift 6.0, but the macos-14 runner ships Swift 5.10.
- Switch darwin-arm64 build job to macos-15 (Xcode 16 / Swift 6).
- Fixes the v1.0.1 tagged release which failed with `package 'fluidaudio' @ 0.10.0 is using Swift tools version 6.0.0 but the installed version is 5.10.0`.

## Test plan
- [ ] CI unit/rust tests green
- [ ] Re-tag v1.0.1 after merge; build-engine workflow succeeds on macos-15

🤖 Generated with [Claude Code](https://claude.com/claude-code)