### PR TITLE
fix(rust): make CoreML backend actually compile

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,8 +6,9 @@ description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 
 [features]
 default = ["onnx"]
+# ASR backend selection. Language detection always uses ONNX regardless.
 coreml = ["dep:fluidaudio-rs"]
-onnx = ["dep:ort", "dep:ndarray"]
+onnx = []
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -24,11 +25,12 @@ rubato = "2"
 ureq = "3"
 dirs = "6"
 
-# ONNX backend (Linux/Windows)
-ort = { version = "2.0.0-rc.12", optional = true }
-ndarray = { version = "0.17", optional = true }
+# ONNX Runtime: always needed for audio language detection (speechbrain);
+# also drives ASR transcription when the `onnx` feature is enabled.
+ort = { version = "2.0.0-rc.12" }
+ndarray = { version = "0.17" }
 
-# CoreML backend (macOS)
+# CoreML backend (macOS): FluidAudio/Apple Neural Engine for ASR.
 fluidaudio-rs = { version = "0.1", optional = true }
 audioadapter-buffers = "3.0.0"
 

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use fluidaudio_rs::FluidAudio;
 
 use super::TranscribeBackend;
@@ -9,15 +9,20 @@ pub struct FluidAudioBackend {
 
 impl FluidAudioBackend {
     pub fn new() -> Result<Self> {
-        let audio = FluidAudio::new()?;
-        audio.init_asr()?;
+        let audio = FluidAudio::new().context("failed to initialize FluidAudio bridge")?;
+        audio
+            .init_asr()
+            .context("failed to initialize FluidAudio ASR (first run compiles models for ANE)")?;
         Ok(Self { audio })
     }
 }
 
 impl TranscribeBackend for FluidAudioBackend {
-    fn transcribe(&mut self, audio_samples: &[f32]) -> Result<String> {
-        let result = self.audio.transcribe_samples(audio_samples)?;
+    fn transcribe(&mut self, audio_path: &str) -> Result<String> {
+        let result = self
+            .audio
+            .transcribe_file(audio_path)
+            .context("FluidAudio transcription failed")?;
         Ok(result.text)
     }
 }

--- a/rust/src/backend/mod.rs
+++ b/rust/src/backend/mod.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 
 #[cfg(feature = "coreml")]
 pub mod fluidaudio;
-#[cfg(feature = "onnx")]
+#[cfg(all(feature = "onnx", not(feature = "coreml")))]
 pub mod onnx;
 
 pub trait TranscribeBackend {
-    fn transcribe(&mut self, audio_samples: &[f32]) -> Result<String>;
+    fn transcribe(&mut self, audio_path: &str) -> Result<String>;
 }
 
 pub fn create_backend(model_dir: &str) -> Result<Box<dyn TranscribeBackend>> {

--- a/rust/src/backend/onnx.rs
+++ b/rust/src/backend/onnx.rs
@@ -5,6 +5,8 @@ use ndarray::{Array1, Array2};
 use ort::session::Session;
 use ort::value::Value;
 
+use crate::audio;
+
 use super::TranscribeBackend;
 
 const DECODER_LAYERS: usize = 2;
@@ -350,7 +352,9 @@ impl OnnxBackend {
 }
 
 impl TranscribeBackend for OnnxBackend {
-    fn transcribe(&mut self, audio_samples: &[f32]) -> Result<String> {
+    fn transcribe(&mut self, audio_path: &str) -> Result<String> {
+        let audio_samples = audio::load_audio(audio_path)?;
+
         if audio_samples.len() < 1600 {
             anyhow::bail!(
                 "Audio too short: {} samples ({:.2}s) — minimum is 0.1s (1600 samples at 16kHz)",
@@ -359,7 +363,7 @@ impl TranscribeBackend for OnnxBackend {
             );
         }
 
-        let (features_data, features_lens) = self.preprocess(audio_samples)?;
+        let (features_data, features_lens) = self.preprocess(&audio_samples)?;
         let (logits_data, logits_shape, encoded_lengths) =
             self.encode(&features_data, &features_lens)?;
 

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 
-use crate::audio;
 use crate::backend;
 use crate::models;
 
@@ -13,6 +12,5 @@ pub fn transcribe(audio_path: &str) -> Result<String> {
         );
     }
     let mut be = backend::create_backend(&model_dir)?;
-    let samples = audio::load_audio(audio_path)?;
-    be.transcribe(&samples)
+    be.transcribe(audio_path)
 }


### PR DESCRIPTION
## Summary
The coreml build path has been broken since before v1.0.0 and only shipped because darwin-arm64 releases used \`features=onnx\`. When v1.0.1 flipped the build matrix to \`features=coreml\`, two pre-existing issues surfaced:

1. \`lang_id.rs\` unconditionally uses \`ort\` and \`ndarray\`, but both crates were gated on the \`onnx\` feature.
2. \`backend/fluidaudio.rs\` called \`FluidAudio::transcribe_samples\`, which does not exist on fluidaudio-rs 0.1.

## Changes
- \`rust/Cargo.toml\`: promote \`ort\` and \`ndarray\` to unconditional deps; \`onnx\` feature becomes a pure marker gating \`backend/onnx.rs\`.
- \`rust/src/backend/mod.rs\`: change \`TranscribeBackend::transcribe\` to take an audio path instead of pre-loaded samples; gate \`backend::onnx\` behind \`not(feature = "coreml")\` so it is excluded from coreml-only builds.
- \`rust/src/backend/fluidaudio.rs\`: rewrite against the actual fluidaudio-rs 0.1 API (\`transcribe_file\`).
- \`rust/src/backend/onnx.rs\`: load samples via \`audio::load_audio\` inside the backend so the existing pipeline keeps working.
- \`rust/src/transcribe.rs\`: hand the path through to the backend.

## Test plan
- [ ] Rust test workflow green on ubuntu/windows (onnx) and macos (coreml)
- [ ] Retag v1.0.1 → build-engine workflow succeeds on all three platforms
- [ ] \`kesha install --coreml\` actually installs a working CoreML binary on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)