### PR TITLE
fix(ci): build CoreML binary on macos-14 with Xcode 16

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -3,6 +3,12 @@ name: "🔨 Build Engine"
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (tag, branch, or SHA)"
+        required: false
+        default: "main"
 
 permissions:
   contents: write
@@ -74,6 +80,7 @@ jobs:
 
   release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15
+          - os: macos-14
             target: aarch64-apple-darwin
             features: coreml
             binary: kesha-engine-darwin-arm64
@@ -29,8 +29,19 @@ jobs:
             features: onnx
             binary: kesha-engine-windows-x64.exe
     runs-on: ${{ matrix.os }}
+    env:
+      # Target macOS 14 so the Swift compiler treats concurrency as
+      # OS-provided and does not emit an explicit @rpath dependency on
+      # libswift_Concurrency.dylib (which no longer ships as a standalone
+      # file on macOS 26+).
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
     steps:
       - uses: actions/checkout@v6
+      - name: Select Xcode 16 (Swift 6)
+        if: matrix.os == 'macos-14'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.0"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -45,6 +56,16 @@ jobs:
           src="rust/target/${{ matrix.target }}/release/kesha-engine"
           if [ "${{ matrix.os }}" = "windows-latest" ]; then src="${src}.exe"; fi
           cp "$src" "${{ matrix.binary }}"
+      - name: Smoke-test binary
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          chmod +x "${{ matrix.binary }}"
+          "./${{ matrix.binary }}" --capabilities-json
+      - name: Inspect macOS dynamic deps
+        if: matrix.os == 'macos-14'
+        shell: bash
+        run: otool -L "${{ matrix.binary }}" && otool -l "${{ matrix.binary }}" | grep -A2 LC_RPATH || true
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -463,6 +463,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "kesha-engine"
+version = "1.0.1"
+dependencies = [
+ "anyhow",
+ "audioadapter-buffers",
+ "clap",
+ "dirs",
+ "fluidaudio-rs",
+ "ndarray",
+ "ort",
+ "rubato",
+ "serde",
+ "serde_json",
+ "symphonia",
+ "symphonia-adapter-libopus",
+ "ureq",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,25 +703,6 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq",
-]
-
-[[package]]
-name = "parakeet-engine"
-version = "1.0.0"
-dependencies = [
- "anyhow",
- "audioadapter-buffers",
- "clap",
- "dirs",
- "fluidaudio-rs",
- "ndarray",
- "ort",
- "rubato",
- "serde",
- "serde_json",
- "symphonia",
- "symphonia-adapter-libopus",
  "ureq",
 ]
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    // The `coreml` feature pulls in fluidaudio-rs, which links against the
+    // macOS Swift runtime (libswift_Concurrency.dylib and friends). Without
+    // an explicit rpath the dynamic linker fails at startup with
+    // `Library not loaded: @rpath/libswift_Concurrency.dylib`. /usr/lib/swift
+    // is the standard location on macOS 13+.
+    #[cfg(feature = "coreml")]
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+    }
+}


### PR DESCRIPTION
## Summary
The v1.0.1 CoreML binary crashes at startup on recent macOS versions:

\`\`\`
dyld: Library not loaded: @rpath/libswift_Concurrency.dylib
      Reason: no LC_RPATH's found
\`\`\`

## Root cause
The linker on macos-15 with the default deployment target emits an explicit dynamic dep on libswift_Concurrency.dylib with no LC_RPATH to resolve it. On macOS 26 (Tahoe) that dylib no longer ships as a standalone file — Swift concurrency is merged into libswiftCore.

## Fixes
1. Switch the darwin-arm64 build back to **macos-14** (matching v1.0.0) and install Xcode 16 via \`maxim-lobanov/setup-xcode\` to get Swift 6 (required by FluidAudio 0.10.0).
2. Set \`MACOSX_DEPLOYMENT_TARGET=14.0\` so the Swift compiler treats concurrency as OS-provided and elides the explicit libswift_Concurrency load command.
3. Add \`rust/build.rs\` emitting \`-Wl,-rpath,/usr/lib/swift\` under the \`coreml\` feature as a safety net.
4. Smoke-test the freshly-built binary with \`--capabilities-json\` inside the build job. \`otool -L\` / \`otool -l\` output is logged so future linker regressions fail the release workflow immediately.
5. Refresh \`rust/Cargo.lock\` (stale \`parakeet-engine\` entry from the rename).

## Test plan
- [ ] build-engine workflow smoke-test passes on macos-14
- [ ] Downloaded binary runs locally on macOS 26 (Tahoe) without dyld errors
- [ ] \`kesha install --coreml\` produces a functioning CoreML backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)