### PR TITLE
fix(ci): pin Xcode to 16.2

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.os == 'macos-14'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.0"
+          xcode-version: "16.2"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
16.0 is not available on the macos-14 runner image — available versions are 16.2, 16.1, and 15.x. Use 16.2 (latest GM) for Swift 6 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)