### PR TITLE
chore: release v1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
## Summary
Bump version to 1.0.2. Skipping v1.0.1 because GitHub's immutable-releases feature permanently reserved that tag name after an earlier broken CoreML release attempt.

Ships:
- Working CoreML binary on Apple Silicon (macos-14 + Xcode 16.2 + \`MACOSX_DEPLOYMENT_TARGET=14.0\`, verified locally on macOS 26)
- OpenClaw plugin install docs
- \`openclaw.plugin.json\` \`configSchema\`
- Removal of broken \`--backend\` passthrough to \`kesha-engine install\` + capability mismatch validation
- Clippy / Cargo.lock hygiene
- Refactored \`TranscribeBackend\` trait to take an audio path so the CoreML backend can use \`FluidAudio.transcribe_file\`

## Test plan
- [x] Rust tests green on PR CI
- [x] Local CoreML build smoke-tested on macOS 26 (Russian + English transcription via downloaded artifact)
- [ ] Tag \`v1.0.2\` triggers build-engine workflow and creates a release
- [ ] \`npm publish --access public\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)