### PR TITLE
chore(docs): apply lessons learned from v1.0.2 release

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -10,8 +10,15 @@ jobs:
       matrix:
         os: [macos-14, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
     steps:
       - uses: actions/checkout@v6
+      - name: Select Xcode 16 (Swift 6)
+        if: matrix.os == 'macos-14'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.2"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -24,3 +31,8 @@ jobs:
       - name: Clippy
         if: matrix.os == 'ubuntu-latest'
         run: cd rust && cargo clippy -- -D warnings
+      # Guard against coreml-backend rot: v1.0.0 shipped with broken
+      # coreml code because no PR CI job ever tried to build it.
+      - name: Check coreml feature
+        if: matrix.os == 'macos-14'
+        run: cd rust && cargo check --features coreml --no-default-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,8 @@
-# parakeet-cli - Agent Development Guide
+# Kesha Voice Kit — Agent Development Guide
+
+> The authoritative reference for engineering rules, architecture, and release
+> workflow is **[CLAUDE.md](./CLAUDE.md)**. This file keeps a shorter,
+> editor-agnostic summary. When they disagree, CLAUDE.md wins.
 
 ## Build & Test Commands
 
@@ -13,48 +17,61 @@ make publish                   # release + npm publish
 
 ## Architecture
 
-- **src/cli.ts**: CLI entry point — argument parsing, install/transcribe commands
-- **src/lib.ts**: Public API — `transcribe`, `downloadModel`, `downloadCoreML`
-- **src/transcribe.ts**: Backend selection — CoreML first, ONNX fallback
-- **src/models.ts**: Thin re-export layer for `onnx-install` + `coreml-install`
-- **src/onnx-install.ts**: ONNX model download, cache check, requireModel
-- **src/coreml-install.ts**: CoreML binary + model download with capabilities handshake
-- **src/coreml.ts**: CoreML backend — detection, subprocess invocation, wav retry
-- **src/audio.ts**: ffmpeg-based audio conversion
-- **src/benchmark-report.ts**: Benchmark markdown generation
-- **src/preprocess.ts → encoder.ts → decoder.ts → tokenizer.ts**: ONNX inference pipeline
-- **swift/**: Swift helper binary wrapping FluidAudio for CoreML transcription
-- **scripts/**: Benchmark + smoke test scripts (TypeScript)
-- **.github/scripts/**: CI helper scripts (TypeScript)
-- **.github/actions/**: Composite actions (setup-bun, install-parakeet-backend)
+- **src/cli.ts** — Bun CLI entry: argument parsing, install/transcribe/status commands
+- **src/lib.ts** — Public API exposed at `@drakulavich/kesha-voice-kit/core`
+- **src/engine.ts** — Wrapper for spawning the `kesha-engine` Rust subprocess + `getEngineCapabilities`
+- **src/engine-install.ts** — Downloads the engine binary from the GitHub release matching the current `package.json` version
+- **src/transcribe.ts** — Thin forwarder to the engine
+- **rust/** — `kesha-engine` Rust binary (ASR + lang-id), single source of truth for inference
+  - `rust/src/main.rs` — clap subcommands: `transcribe`, `detect-lang`, `detect-text-lang`, `install`, `--capabilities-json`
+  - `rust/src/backend/{onnx,fluidaudio}.rs` — feature-gated ASR backends behind a single trait
+  - `rust/src/lang_id.rs` — ONNX speechbrain, always compiled regardless of feature
+  - `rust/build.rs` — emits the Swift rpath under `#[cfg(feature = "coreml")]`
+- **scripts/** — Benchmark + smoke-test TypeScript scripts
+- **.github/workflows/** — `ci.yml`, `rust-test.yml`, `build-engine.yml`, `benchmark.yml`
 
 ## Critical Rules
 
-- **NEVER** auto-download models — use `parakeet install`, show error if missing
-- **NEVER** use Node.js APIs — this is Bun-only (`Bun.spawn`, `Bun.write`, `Bun.file`, `Bun.which`)
-- **NEVER** use `.subarray()` for ONNX tensors — use `.slice()` (Bun limitation)
-- **NEVER** push directly to `main` — it is a protected branch
-- All changes must go through pull requests: create a feature branch, push, open a PR
+- **NEVER** auto-download the engine or models — use `kesha install`, show an actionable error if missing
+- **NEVER** use Node.js APIs in the CLI — it is Bun-only (`Bun.spawn`, `Bun.write`, `Bun.file`, `Bun.which`)
+- **NEVER** push directly to `main` — it is a protected branch; all changes go through PRs
+- **NEVER** run `git push` unless explicitly requested by the user
+- **NEVER** blindly forward CLI flags to `kesha-engine` subcommands — validate against `--capabilities-json` instead. `kesha-engine install` accepts only `--no-cache`.
 - Create a **new PR for each distinct user request** — do not pile unrelated changes into one PR
-- **NEVER** run `git push` unless explicitly requested by user
-- Add unit tests when writing new code
-- ffmpeg must be in PATH for ONNX backend audio conversion
 - **NEVER** write more than 3 lines of bash in GitHub Actions workflow steps — extract to `.github/scripts/`
-- **BEFORE npm publish**: run `make smoke-test` locally and verify all tests pass. Do NOT publish if smoke tests fail.
-- **BEFORE pushing**: run `bun test && bunx tsc --noEmit` locally and verify all tests pass. Do NOT push broken code.
-- **ALWAYS write proper error handling**: errors must be human-readable with context (what failed, why, what to do). Never swallow errors silently. Never let a function return success when it failed.
+- **BEFORE `npm publish`**: run `make smoke-test` against the freshly downloaded engine binary. Do NOT publish if smoke tests fail.
+- **BEFORE pushing TS changes**: run `bun test && bunx tsc --noEmit`
+- **BEFORE pushing Rust changes**: run `cd rust && cargo fmt && cargo clippy -- -D warnings && cargo test` — and if you touched `rust/src/backend/**` or `rust/Cargo.toml`, also run `cargo check --features coreml --no-default-features`
+- **ALWAYS write proper error handling**: human-readable messages with context (what failed, why, what to do). Never swallow errors silently.
+- Add unit tests when writing new code
 
 ## Release Process
 
 ```bash
-# 1. Bump version in package.json via PR, merge
+# 1. Bump version (package.json + rust/Cargo.toml + rust/Cargo.lock) via PR, merge
 # 2. Verify locally
 make release
-# 3. Tag and push — CI builds binary + creates GitHub release
-git tag v0.8.0 && git push --tags
-# 4. Publish to npm after CI passes
+
+# 3. Tag and push — build-engine.yml builds all 3 platform binaries,
+#    smoke-tests each with --capabilities-json, and creates a draft release
+git tag vX.Y.Z && git push origin vX.Y.Z
+
+# 4. Publish the draft and then ship to npm
+gh release edit vX.Y.Z --draft=false
 npm publish --access public
 ```
+
+### Tag names are one-use
+
+GitHub's immutable releases feature permanently reserves a tag as soon as a
+release publishes. **If a release goes out broken, you cannot reuse its tag —
+bump the patch version instead.** v1.0.1 was skipped for exactly this reason.
+
+### Debugging the build-engine workflow without tagging
+
+`build-engine.yml` accepts `workflow_dispatch`. Run `gh workflow run "🔨 Build
+Engine" --ref main` to build + smoke-test all three platforms without creating
+a release — the release job is gated on `startsWith(github.ref, 'refs/tags/v')`.
 
 ## Git Worktrees for Big Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,35 +4,49 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Parakeet CLI is a fast multilingual speech-to-text tool powered by NVIDIA Parakeet TDT 0.6B models. It runs entirely locally with no cloud dependencies. Two backends: CoreML on macOS Apple Silicon (~155x real-time via FluidAudio), ONNX on all platforms (via onnxruntime-node). Built on Bun runtime.
+Kesha Voice Kit is a fast multilingual voice toolkit: speech-to-text (NVIDIA Parakeet TDT 0.6B) plus audio- and text-based language detection. It runs entirely locally with no cloud dependencies.
 
-Two interfaces: a CLI (`parakeet <audio>`) and a programmatic API (`@drakulavich/parakeet-cli/core`).
+The CLI (`kesha`, with `parakeet` as a backward-compatible alias) is a thin Bun/TypeScript wrapper around a single Rust binary, `kesha-engine`, which is downloaded from GitHub Releases during `kesha install`. The Rust engine has two build-time backends for ASR:
+- **CoreML** (Apple Silicon): uses FluidAudio / Apple Neural Engine via the `fluidaudio-rs` crate. Built on `macos-14` with Xcode 16.2 and `MACOSX_DEPLOYMENT_TARGET=14.0`.
+- **ONNX** (Linux / Windows / fallback): uses `ort` + the `istupakov/parakeet-tdt-0.6b-v3-onnx` models.
+
+Language detection (`lang_id.rs`) is always ONNX (`speechbrain/lang-id-voxlingua107-ecapa`), regardless of which ASR backend is active. Text language detection uses macOS `NLLanguageRecognizer` (macOS only).
+
+Two interfaces: the CLI and a programmatic API exported from `@drakulavich/kesha-voice-kit/core`.
 
 ## Critical Development Rules
 
-### NEVER AUTO-DOWNLOAD MODELS
+### NEVER AUTO-DOWNLOAD MODELS OR THE ENGINE
 
-- Models are downloaded explicitly via `parakeet install`, never on first transcription run
-- If a model is missing, show a Playwright-style error directing the user to run install
+- The engine binary and models are downloaded explicitly via `kesha install`, never on first transcription run
+- If either is missing, surface an actionable error directing the user to run `kesha install`
 - This is a deliberate design decision to avoid surprising multi-GB downloads
 
-### BUN-ONLY RUNTIME
+### BUN-ONLY RUNTIME FOR THE CLI
 
-- This project runs on Bun, not Node.js. Use Bun-native APIs (`Bun.spawn`, `Bun.write`, `Bun.file`, `Bun.which`)
+- The CLI and library run on Bun, not Node.js. Use Bun-native APIs (`Bun.spawn`, `Bun.write`, `Bun.file`, `Bun.which`)
 - TypeScript is executed directly by Bun — no build step
-- The `ort-backend-fix.ts` workaround is required for onnxruntime-node CJS/ESM bridge under Bun
-
-### EXTERNAL DEPENDENCY: ffmpeg
-
-- ffmpeg must be in PATH for audio format conversion (ONNX backend only)
-- Use `Bun.which("ffmpeg")` to check — not `which` command (cross-platform)
+- The engine itself is a Rust binary (`rust/`), invoked as a subprocess — not linked in-process
 
 ### RELEASE PROCESS
 
-- Before `npm publish`, run `make smoke-test` locally and verify all tests pass
+- Before `npm publish`, run `make smoke-test` locally against the just-downloaded engine binary and verify all tests pass
 - Do NOT publish to npm if smoke tests fail
-- Tag and push (`git tag vX.Y.Z && git push --tags`) — CI creates the GitHub release with CoreML binary
-- Wait for CI to pass, then `npm publish --access public`
+- Tag and push (`git tag vX.Y.Z && git push origin vX.Y.Z`) — CI builds all three platform binaries, smoke-tests each one, and creates a draft GitHub release
+- Wait for the workflow to finish, publish the draft (`gh release edit vX.Y.Z --draft=false`), then `npm publish --access public`
+
+### TAG NAMES ARE ONE-USE UNDER IMMUTABLE RELEASES
+
+- GitHub's "immutable releases" feature permanently reserves a tag name as soon as the release has been published, even after the release is deleted. Attempts to re-push the same tag fail with `Cannot create ref due to creations being restricted` / `tag_name was used by an immutable release`.
+- **If a release goes out broken, you cannot reuse its tag.** Bump the patch version and cut a new tag (e.g. `v1.0.1` → `v1.0.2`).
+- Corollary: never tag-and-push "just to test". Dispatch the `🔨 Build Engine` workflow manually on `main` instead (it skips the release job when not triggered by a tag push).
+
+### VERIFY BEFORE PUSHING
+
+- Run `bun test && bunx tsc --noEmit` locally before every push
+- When changing Rust code (`rust/`), run `cd rust && cargo fmt` and `cargo clippy --all-features -- -D warnings` before every commit
+- When changing Rust code that touches the backend modules, also run `cd rust && cargo check --features coreml --no-default-features` — the Rust test workflow only exercises the default feature set by default, and the CoreML backend has previously rotted silently because no CI job built it
+- Do NOT push broken code — fix locally first
 
 ### VERIFY BEFORE PUSHING
 
@@ -59,6 +73,19 @@ Two interfaces: a CLI (`parakeet <audio>`) and a programmatic API (`@drakulavich
 - Keeps main checkout clean while iterating on a feature branch
 - Use when the change touches 5+ files or runs long tasks
 
+### DO NOT BLINDLY FORWARD CLI FLAGS TO SUBCOMMANDS
+
+- The Bun CLI wraps `kesha-engine`. If a flag is meant for the CLI (e.g. `--coreml` selecting a backend), validate it against `kesha-engine --capabilities-json` instead of passing it through as a subprocess argument — `kesha-engine install` only accepts `--no-cache`.
+- Past regression: `kesha install --coreml` forwarded `--backend=coreml` to the engine and crashed with a clap parse error. Always round-trip new flags end to end (`kesha install --coreml` on a machine without a CoreML build must fail gracefully, not crash).
+
+### COREML BACKEND LIVES OR DIES BY ITS LINKER CONFIG
+
+- The `coreml` feature links against the macOS Swift runtime via `fluidaudio-rs`. Three things must all be true for the released binary to run on end-user machines:
+  1. `macos-14` runner with `maxim-lobanov/setup-xcode@v1` pinned to an **actually available** Xcode version (check the runner image catalog — `16.0` is not on `macos-14`, `16.2` is)
+  2. `MACOSX_DEPLOYMENT_TARGET=14.0` in the build job env, so the linker treats Swift concurrency as OS-provided and does not emit `@rpath/libswift_Concurrency.dylib`
+  3. `rust/build.rs` emits `cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift` under `#[cfg(feature = "coreml")]` as a belt-and-suspenders fallback
+- The build-engine workflow smoke-tests every freshly built binary with `--capabilities-json` before uploading the artifact. **Never remove that step** — it is the only check that catches dyld / rpath regressions before a release ships.
+
 ## Build Commands
 
 ```bash
@@ -74,90 +101,93 @@ make benchmark-coreml          # CoreML vs WhisperKit (local, macOS only)
 ## Project Structure
 
 ```
-parakeet-cli/
+kesha-voice-kit/
 ├── bin/
-│   └── parakeet.js               # Shebang entry point
-├── src/
-│   ├── cli.ts                    # CLI argument parsing, install/transcribe commands
-│   ├── lib.ts                    # Public API (transcribe, downloadModel, downloadCoreML)
-│   ├── transcribe.ts             # Backend selection: CoreML first, ONNX fallback
-│   ├── models.ts                 # Thin re-export layer (onnx-install + coreml-install)
-│   ├── onnx-install.ts           # ONNX model download, cache check, requireModel
-│   ├── coreml-install.ts         # CoreML binary + model download with capabilities handshake
-│   ├── coreml.ts                 # CoreML backend: detection, subprocess invocation, wav retry
-│   ├── audio.ts                  # ffmpeg-based audio conversion to Float32 PCM
-│   ├── benchmark-report.ts       # Benchmark markdown report generation
-│   ├── preprocess.ts             # Mel-spectrogram extraction (nemo128.onnx)
-│   ├── encoder.ts                # FastConformer encoder (encoder-model.onnx)
-│   ├── decoder.ts                # RNN-T joint decoder + beam search (decoder_joint-model.onnx)
-│   ├── tokenizer.ts              # Vocab loading and detokenization
-│   ├── ort-backend-fix.ts        # Bun CJS/ESM workaround for onnxruntime-node
+│   └── kesha.js                  # Shebang entry point (aliased as `parakeet` too)
+├── src/                          # Bun/TypeScript CLI + library
+│   ├── cli.ts                    # Argument parsing, install/transcribe/status commands
+│   ├── lib.ts                    # Public API exported at `@drakulavich/kesha-voice-kit/core`
+│   ├── engine.ts                 # Engine subprocess wrapper + `getEngineCapabilities`
+│   ├── engine-install.ts         # Engine binary download from GitHub Releases
+│   ├── transcribe.ts             # Thin forwarder to the engine
+│   ├── log.ts, progress.ts       # Stderr progress reporting
+│   ├── suggest-command.ts        # "Did you mean?" typo suggester
 │   └── __tests__/                # Unit tests
+├── rust/                         # kesha-engine (Rust)
+│   ├── Cargo.toml                # `onnx` (default) and `coreml` features
+│   ├── build.rs                  # Emits swift rpath under the `coreml` feature
+│   └── src/
+│       ├── main.rs               # clap CLI: transcribe / detect-lang / detect-text-lang / install
+│       ├── audio.rs              # symphonia decode + rubato resample to 16kHz mono f32
+│       ├── models.rs             # HF download + cache handling for ASR and lang-id models
+│       ├── lang_id.rs            # ONNX speechbrain audio language detection (always built)
+│       ├── text_lang.rs          # macOS NLLanguageRecognizer wrapper (macOS only)
+│       ├── capabilities.rs       # `--capabilities-json` output struct
+│       ├── transcribe.rs         # Backend dispatch → TranscribeBackend::transcribe(path)
+│       └── backend/
+│           ├── mod.rs            # `TranscribeBackend` trait (audio_path → String)
+│           ├── onnx.rs           # ORT pipeline: nemo128 → encoder → decoder_joint (beam=4)
+│           └── fluidaudio.rs     # fluidaudio-rs 0.1 via `transcribe_file` (coreml feature)
 ├── tests/
-│   └── integration/              # E2E tests (require backend + ffmpeg)
+│   ├── unit/                     # bun test — TS unit tests
+│   └── integration/              # bun test — E2E against the installed engine
 ├── scripts/
-│   ├── benchmark.ts              # CI benchmark (faster-whisper vs parakeet)
-│   ├── benchmark-coreml.ts       # Local CoreML benchmark (WhisperKit vs parakeet)
+│   ├── benchmark.ts              # faster-whisper vs Kesha benchmark (CI, ubuntu)
 │   └── smoke-test.ts             # Pre-release fixture verification
-├── .github/
-│   ├── scripts/                  # CI helper scripts (TypeScript)
-│   ├── actions/                  # Composite actions (setup-bun, install-parakeet-backend)
-│   └── workflows/                # CI, benchmark, build-coreml
-├── swift/                        # CoreML Swift binary (built by CI)
+├── .github/workflows/
+│   ├── ci.yml                    # PR CI: unit tests + integration tests + type check
+│   ├── rust-test.yml             # PR CI: cargo test / fmt / clippy (runs on rust/** changes)
+│   └── build-engine.yml          # Tag push OR manual dispatch; builds 3 binaries, smoke-tests, creates draft release
 ├── Makefile                      # Development commands
-└── package.json
+├── openclaw.plugin.json          # OpenClaw plugin manifest (configSchema + configPatch)
+└── package.json                  # @drakulavich/kesha-voice-kit
 ```
 
 ## Architecture Overview
 
-### Backend Selection
+### Request flow
 
 ```
-transcribe(audioPath)
-  ├── CoreML installed? → spawn parakeet-coreml subprocess → stdout
-  ├── ONNX cached?     → existing ONNX pipeline
-  └── Neither?         → error: run "parakeet install"
+kesha audio.ogg
+  → src/cli.ts parses args
+  → src/transcribe.ts → spawn kesha-engine transcribe <path>
+                     → rust: backend::create_backend() → TranscribeBackend::transcribe(path)
+                         ├── coreml: fluidaudio_rs::FluidAudio::transcribe_file
+                         └── onnx:   symphonia load → nemo128 → encoder → decoder_joint
+  → stdout: transcript; stderr: progress/errors
 ```
 
-### CoreML Backend (macOS Apple Silicon)
+### Rust engine — feature flags
 
-A pre-built Swift binary (`~/.cache/parakeet/coreml/bin/parakeet-coreml`) wraps [FluidAudio](https://github.com/FluidInference/FluidAudio) for CoreML inference on Apple Neural Engine. Invoked as a subprocess. `parakeet install` downloads both the binary and CoreML model files.
-
-### ONNX Backend (cross-platform)
-
-```
-Audio file (any format)
-  → [audio.ts] ffmpeg → Float32Array (16kHz mono)
-  → [preprocess.ts] nemo128.onnx → Mel-spectrogram [1, 128, T]
-  → [encoder.ts] encoder-model.onnx → Encoded features [1, D, T]
-  → [decoder.ts] decoder_joint-model.onnx → Token IDs (beam search)
-  → [tokenizer.ts] vocab.txt → Transcript text
-```
+- `default = ["onnx"]`. The `onnx` feature is a pure marker gating `backend/onnx.rs`; `ort` and `ndarray` are **unconditional dependencies** because `lang_id.rs` always uses them.
+- `coreml = ["dep:fluidaudio-rs"]` — mutually exclusive with `onnx` at backend-module level: when `coreml` is on, `backend::onnx` is gated out via `#[cfg(all(feature = "onnx", not(feature = "coreml")))]`.
+- `backend::create_backend` selects the right implementation at compile time. There is no runtime "CoreML-first, ONNX fallback" behavior in the binary itself — the binary has exactly one ASR backend baked in. The capability check happens in the TypeScript layer.
 
 ### Key Constants
 
-- Decoder: 2 RNN layers, 640 hidden units
+- Decoder: 2 RNN layers, 640 hidden units (ONNX backend)
 - Beam width: 4 (default)
 - Min audio: 0.1s (1600 samples at 16kHz)
-- Model source: `istupakov/parakeet-tdt-0.6b-v3-onnx` on HuggingFace
+- ASR model source: `istupakov/parakeet-tdt-0.6b-v3-onnx` on HuggingFace
+- Lang-ID model source: `drakulavich/SpeechBrain-coreml` on HuggingFace
 
 ### Public API (`./core` export)
 
 ```typescript
-import { transcribe, downloadModel, downloadCoreML } from "@drakulavich/parakeet-cli/core";
+import { transcribe, downloadEngine, getEngineCapabilities } from "@drakulavich/kesha-voice-kit/core";
 
-const text = await transcribe("audio.wav", { modelDir?, beamWidth? });
-await downloadModel(noCache?, modelDir?);  // ONNX models
-await downloadCoreML(noCache?);            // CoreML binary + models
+const text = await transcribe("audio.ogg");
+await downloadEngine({ noCache, backend });  // "coreml" | "onnx" | undefined (auto)
+const caps = await getEngineCapabilities();  // { protocolVersion, backend, features }
 ```
 
 ## Code Style
 
 - **TypeScript**: Strict mode, ESNext target
 - **No build step**: Bun runs `.ts` directly
-- **Imports**: Use relative paths (`./models`, not `src/models`)
-- **Progress/errors**: `console.error()` — **Success messages**: `console.log()`
-- **ONNX tensors**: Always use `.slice()` not `.subarray()` — Bun doesn't support subarray views as ONNX tensor data
+- **Imports**: Use relative paths (`./engine`, not `src/engine`)
+- **Progress/errors**: `console.error()` — **Success messages**: `console.log()` (stdout stays pipe-friendly for transcripts)
+- **Rust**: `cargo fmt` before every commit; `cargo clippy -- -D warnings` must pass
 
 ## CI/CD
 
@@ -169,24 +199,19 @@ await downloadCoreML(noCache?);            // CoreML binary + models
 
 ### Workflows
 
-- `.github/workflows/ci.yml` — runs on PRs to main. Unit tests (ubuntu/windows/macos) + integration tests (macos). Type check on ubuntu only.
-- `.github/workflows/build-coreml.yml` — triggers on tag push (`v*`). Builds Swift binary, creates GitHub release with binary attached.
-- `.github/workflows/benchmark.yml` — manual benchmark workflow. Runs faster-whisper vs parakeet on ubuntu and publishes results in the workflow summary and artifacts.
+- `.github/workflows/ci.yml` — PRs to main. Unit tests (ubuntu/windows/macos) + integration tests (macos-14) + type check (ubuntu).
+- `.github/workflows/rust-test.yml` — PRs touching `rust/**`. `cargo test` on all three OSes, `cargo fmt --check` and `cargo clippy -- -D warnings` on ubuntu. **Also runs `cargo check --features coreml --no-default-features` on macos-14** to catch backend rot.
+- `.github/workflows/build-engine.yml` — triggers on tag push (`v*`) OR manual `workflow_dispatch`. Builds three platform binaries in parallel, **smoke-tests each one with `--capabilities-json`**, uploads artifacts, and (on tag push only) creates a draft GitHub release.
+- `.github/workflows/benchmark.yml` — manual. Runs faster-whisper vs Kesha on ubuntu and publishes results in the workflow summary and artifacts.
 
 ### Composite Actions
 
 - `.github/actions/setup-bun/` — setup Bun with dependency caching
-- `.github/actions/install-parakeet-backend/` — install backend with CoreML/ffmpeg caching
-
-## Swift Binary (`swift/`)
-
-A minimal Swift package wrapping FluidAudio. Built by CI on tag push, not by end users.
-- `swift/Package.swift` — depends on FluidAudio
-- `swift/Sources/ParakeetCoreML/main.swift` — supports `--download-only`, `--capabilities`, and audio transcription
+- `.github/actions/install-parakeet-backend/` — install engine with cache
 
 ## Platform Requirements
 
-- **Runtime**: Bun >= 1.3.0
-- **System**: ffmpeg in PATH (ONNX backend only; CoreML handles conversion internally)
-- **CoreML backend**: macOS 14+, Apple Silicon (arm64)
-- **ONNX backend**: macOS, Linux, Windows (anywhere Bun + onnxruntime-node runs)
+- **Runtime**: Bun >= 1.3.0 (CLI only; the engine is a standalone Rust binary)
+- **CoreML engine binary**: macOS 14+, Apple Silicon (arm64)
+- **ONNX engine binary**: macOS, Linux, Windows (anywhere a recent glibc / msvcrt is available)
+- `ffmpeg` is **no longer required** — the Rust engine uses symphonia for decode and rubato for resample

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -64,20 +64,23 @@ describe.skipIf(!engineInstalled)("e2e-engine", () => {
     expect(result.confidence).toBeGreaterThan(0);
   }, 60_000);
 
+  // Cold-start of macOS NLLanguageRecognizer can exceed Bun's 5s default
+  // test timeout on the CI runner; give it the same 60s budget as the
+  // audio-based tests above.
   test("engine detect-text-lang identifies Russian text", async () => {
     const { stdout, exitCode } = await runEngine(["detect-text-lang", "Привет мир как дела"]);
     expect(exitCode).toBe(0);
     const result = JSON.parse(stdout);
     expect(result.code).toBe("ru");
     expect(result.confidence).toBeGreaterThan(0.5);
-  });
+  }, 60_000);
 
   test("engine detect-text-lang identifies English text", async () => {
     const { stdout, exitCode } = await runEngine(["detect-text-lang", "Hello world how are you doing today"]);
     expect(exitCode).toBe(0);
     const result = JSON.parse(stdout);
     expect(result.code).toBe("en");
-  });
+  }, 60_000);
 });
 
 describe.skipIf(!engineInstalled)("e2e-transcribe", () => {


### PR DESCRIPTION
Capture the gotchas that burned roundtrips during the v1.0.1 → v1.0.2 release cycle so future sessions don't re-discover them.

## CLAUDE.md / AGENTS.md
- New critical rules: tag-name reservation under GitHub's immutable-releases, CoreML linker triple (macos-14 + Xcode 16.2 + \`MACOSX_DEPLOYMENT_TARGET=14.0\` + build.rs rpath), don't blindly forward CLI flags to \`kesha-engine\` subcommands, and \`cargo check --features coreml\` before pushing backend changes.
- Release-process section now documents \`workflow_dispatch\` for debugging \`build-engine\` without creating a release.
- Project overview, project structure, and architecture sections rewritten to reflect the current Rust engine layout (were still describing the pre-engine in-process \`onnxruntime-node\` pipeline with nonexistent TS modules).

## \`.github/workflows/rust-test.yml\`
- Adds \`cargo check --features coreml --no-default-features\` on macos-14 with Xcode 16.2 and \`MACOSX_DEPLOYMENT_TARGET=14.0\`. This is the missing PR-time guard that let the coreml backend rot silently from v0.x — the default \`cargo test\` invocation never exercised that feature combination.

## \`tests/integration/e2e-engine.test.ts\`
- \`detect-text-lang\` tests now have a 60s timeout matching the audio tests. Cold-start of macOS \`NLLanguageRecognizer\` on the CI runner regularly exceeds Bun's 5s default and has been intermittently failing integration runs.

## Test plan
- [x] \`bunx tsc --noEmit\`
- [x] \`bun test tests/unit/\`
- [x] \`cd rust && cargo fmt --check\`
- [ ] PR CI green (including the new coreml-feature check step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)