### PR TITLE
fix(openclaw): drop child_process from postinstall (v1.0.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,12 +1,25 @@
 #!/usr/bin/env node
-const { execSync } = require("child_process");
+// Warn if Bun is not on PATH. Uses fs-only probing instead of
+// child_process.execSync("bun --version") so that OpenClaw's
+// dangerous-code scanner does not flag the plugin install.
+const fs = require("fs");
+const path = require("path");
 
-try {
-  execSync("bun --version", { stdio: "ignore" });
-} catch {
+const exe = process.platform === "win32" ? "bun.exe" : "bun";
+const dirs = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+
+const found = dirs.some((dir) => {
+  try {
+    return fs.existsSync(path.join(dir, exe));
+  } catch {
+    return false;
+  }
+});
+
+if (!found) {
   console.warn(
     "\n⚠️  Kesha Voice Kit requires Bun runtime.\n" +
-    "   Install Bun: curl -fsSL https://bun.sh/install | bash\n" +
-    "   Then run:    kesha install\n"
+      "   Install Bun: curl -fsSL https://bun.sh/install | bash\n" +
+      "   Then run:    kesha install\n",
   );
 }


### PR DESCRIPTION
OpenClaw's dangerous-code scanner blocks plugin install on any `child_process` usage. `scripts/postinstall.cjs` only uses it to check that Bun is on PATH so it can print a friendly warning if Bun is missing — benign, but the scanner can't tell the difference.

Replace the check with pure `fs` probing: walk `process.env.PATH` and `fs.existsSync(join(dir, "bun"))`. Same UX, no `child_process`, no scanner trigger.

CLI-only patch — engine binaries from v1.0.2 unchanged.

## Test plan
- [x] `node scripts/postinstall.cjs` is silent with Bun on PATH
- [x] `env -i PATH=/tmp node scripts/postinstall.cjs` prints the warning
- [x] `bunx tsc --noEmit && bun test tests/unit/`
- [ ] PR CI green
- [ ] `openclaw plugins install @drakulavich/kesha-voice-kit` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)