### PR TITLE
fix(openclaw): remove trigger-phrase from postinstall comment (v1.0.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Warn if Bun is not on PATH. Uses fs-only probing instead of
-// child_process.execSync("bun --version") so that OpenClaw's
-// dangerous-code scanner does not flag the plugin install.
+// Warn if Bun is not on PATH. Probes PATH via fs only — no subprocess
+// APIs — so OpenClaw's dangerous-code scanner does not flag the plugin
+// install.
 const fs = require("fs");
 const path = require("path");
 


### PR DESCRIPTION
OpenClaw's dangerous-code scanner does a literal string match on `child_process` — including in comments. v1.0.4's `postinstall.cjs` dropped the actual subprocess call but still had the word in a comment explaining the change, so the scanner still blocked the plugin install.

Rephrase the comment to describe what the script does ("probes PATH via fs only — no subprocess APIs") without naming the forbidden module.

CLI-only patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)