### PR TITLE
fix(openclaw): add required 'id' field to plugin manifest (v1.0.6)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,4 +1,5 @@
 {
+  "id": "kesha-voice-kit",
   "name": "kesha-voice-kit",
   "displayName": "Kesha Voice Kit",
   "description": "Local speech-to-text for voice messages. 25 languages, ~19x faster than Whisper on Apple Silicon. Drop-in replacement for openai-whisper.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
OpenClaw's plugin installer rejects our manifest with:

```
Config validation failed: plugins: plugin: plugin manifest requires id
```

Add `id: "kesha-voice-kit"` to `openclaw.plugin.json`.

CLI-only patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)