### PR TITLE
chore: support CLI-only marker releases with -cli tag suffix

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -2,7 +2,14 @@ name: "🔨 Build Engine"
 
 on:
   push:
-    tags: ["v*"]
+    # Match real engine-release tags ("v1.0.2") but skip CLI-only marker
+    # tags ("v1.0.8-cli"). CLI-only patches do not rebuild the Rust
+    # engine — a separate marker release is created manually via
+    # `gh release create v<X.Y.Z>-cli --notes-file ...` without
+    # triggering this workflow. See CLAUDE.md → RELEASE PROCESS.
+    tags:
+      - "v*"
+      - "!v*-cli"
   workflow_dispatch:
     inputs:
       ref:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,15 @@ until the matching GitHub release existed.
 #    rust/Cargo.toml at the current engine version.
 # 2. Verify locally
 make smoke-test
-# 3. Open PR, merge. No git tag. No build-engine run.
+# 3. Open PR, merge. No Rust rebuild needed.
 # 4. Publish
 npm publish --access public
+# 5. Cut a CLI-only marker release on GitHub. The -cli suffix is
+#    excluded from build-engine.yml's tag filter, so pushing the tag
+#    does NOT trigger a Rust rebuild or a conflicting release job.
+gh release create vX.Y.Z-cli \
+  --title "vX.Y.Z (CLI-only patch)" \
+  --notes "CLI-only release. Engine binary: v<keshaEngine.version> (unchanged)."
 ```
 
 ### Engine release (anything under rust/, or a coreml/onnx change)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,14 @@ This split exists because CLI-only patches would otherwise require a full engine
 
 1. Open a PR that bumps only `package.json#version`. Leave `keshaEngine.version` and `rust/Cargo.toml` alone.
 2. PR CI runs against the existing published engine binary — integration tests pass because the `v${keshaEngine.version}` release already exists.
-3. Merge, then `npm publish --access public`. No git tag, no build-engine run, no GitHub release.
+3. Merge, then `npm publish --access public`.
+4. **Cut a marker release** so the npm version is visible on the GitHub releases page:
+   ```bash
+   gh release create vX.Y.Z-cli \
+     --title "v<X.Y.Z> (CLI-only patch)" \
+     --notes "CLI-only release. Engine binary: v<keshaEngine.version> (unchanged). See <npm link> for the tarball."
+   ```
+   The `-cli` suffix is excluded from `build-engine.yml`'s tag filter, so pushing the tag **does not** trigger a Rust rebuild or create a second (conflicting) GitHub release. Marker tags are never re-used — bump the npm version first if you need a new marker.
 
 **Engine release** (any change under `rust/`, or bumping `keshaEngine.version`):
 


### PR DESCRIPTION
CLI-only patches (v1.0.3–v1.0.8) did not cut a GitHub release because `build-engine.yml` fires on any `v*` tag and would build+release a full engine bundle the tag doesn't need. Result: npm at v1.0.8, GitHub releases stuck at v1.0.2.

Fix the visibility gap with a lightweight marker-release convention:

- `build-engine.yml` tag filter now excludes `v*-cli` tags, so pushing a marker tag does not trigger the Rust rebuild or a second release.
- CLAUDE.md and AGENTS.md document: after `npm publish` on a CLI-only patch, run `gh release create vX.Y.Z-cli --title ... --notes ...` to create a changelog-only release pointing at the already-published npm tarball and the unchanged engine binary.

Real engine releases (`v1.0.2`, `v1.1.0`, …) keep their existing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)