### PR TITLE
feat: add --format flag with transcript and json modes (v1.0.9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ interface MainCommandArgs {
   _: string[];
   json: boolean;
   verbose: boolean;
+  format?: string;
   lang?: string;
 }
 
@@ -113,6 +114,10 @@ export const mainCommand = defineCommand({
       description: "Show language detection details",
       default: false,
     },
+    format: {
+      type: "string",
+      description: "Output format: transcript (enriched text with lang/confidence)",
+    },
     lang: {
       type: "string",
       description: "Expected language code (ISO 639-1), warn if mismatch",
@@ -129,7 +134,7 @@ export const mainCommand = defineCommand({
     let hasError = false;
     const results: TranscribeResult[] = [];
 
-    const wantsLangId = !!(args.lang || args.verbose || args.json);
+    const wantsLangId = !!(args.lang || args.verbose || args.json || args.format === "transcript" || args.format === "json");
 
     for (const file of files) {
       try {
@@ -178,8 +183,10 @@ export const mainCommand = defineCommand({
       }
     }
 
-    if (args.json) {
+    if (args.json || args.format === "json") {
       process.stdout.write(formatJsonOutput(results));
+    } else if (args.format === "transcript") {
+      process.stdout.write(formatTranscriptOutput(results));
     } else if (args.verbose) {
       process.stdout.write(formatVerboseOutput(results));
     } else {
@@ -253,6 +260,23 @@ export function formatVerboseOutput(results: TranscribeResult[]): string {
       }
       lines.push("---");
       lines.push(r.text);
+      return lines.join("\n");
+    })
+    .join("\n") + "\n";
+}
+
+export function formatTranscriptOutput(results: TranscribeResult[]): string {
+  return results
+    .map((r, i) => {
+      const lines: string[] = [];
+      if (results.length > 1) {
+        if (i > 0) lines.push("");
+        lines.push(`=== ${r.file} ===`);
+      }
+      lines.push(r.text);
+      const lang = r.textLanguage?.code || r.audioLanguage?.code || r.lang;
+      const confidence = r.textLanguage?.confidence ?? r.audioLanguage?.confidence;
+      if (lang) lines.push(`[lang: ${lang}${confidence != null ? `, confidence: ${confidence.toFixed(2)}` : ""}]`);
       return lines.join("\n");
     })
     .join("\n") + "\n";


### PR DESCRIPTION
## Summary

Add a `--format` flag that accepts `transcript` or `json`:

```bash
kesha --format transcript audio.ogg
# Раз, два, три, четыре, пять.
# [lang: ru, confidence: 1.00]

kesha --format json audio.ogg
# (same as --json)
```

**`--format transcript`** is the recommended mode for OpenClaw's `type: "cli"` audio config. The agent sees enriched context (language + confidence) as a compact metadata line after the transcript, and OpenClaw's `runCliEntry` treats stdout as the transcript verbatim. No JSON parsing needed.

Recommended OpenClaw config:
```json
{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}
```

## Test plan
- [x] `kesha --format transcript fixtures/benchmark/01-*.ogg` — Russian text + `[lang: ru, confidence: 1.00]`
- [x] `kesha --format transcript fixtures/benchmark-en/01-*.ogg` — English text + `[lang: en, confidence: 1.00]`
- [x] `kesha --format json fixtures/benchmark-en/01-*.ogg` — full JSON with lang fields populated
- [x] `bunx tsc --noEmit && bun test tests/unit/`
- [ ] PR CI green
- [ ] Merge, `npm publish`, cut `v1.0.9-cli` marker release

🤖 Generated with [Claude Code](https://claude.com/claude-code)