### PR TITLE
docs: update benchmark SVG and README for M3 Pro results

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center"><b>Open-source voice toolkit.</b> Optimized for Apple Silicon (CoreML), works on any platform (ONNX fallback).<br>A collection of small, fast, open-source audio models — packaged as CLI tools and an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill for LLM agents.</p>
 
-- **Speech-to-text** — 25 languages, ~19x faster than Whisper on Apple Silicon, ~2.5x on CPU
+- **Speech-to-text** — 25 languages, ~15x faster than Whisper on Apple Silicon, ~2.5x on CPU
 - **Language detection** — 107 languages from audio, text language via NLLanguageRecognizer
 - **Rust engine** — single 20MB binary, no ffmpeg, no Python, no native Node addons
 - **OpenClaw-ready** — plug into your LLM agent as a voice processing skill
@@ -92,7 +92,7 @@ All models run through `kesha-engine` — a Rust binary using [FluidAudio](https
 
 ## Performance
 
-> **~19x faster than Whisper** on Apple Silicon, **~2.5x faster** on CPU
+> **~15x faster than Whisper** on Apple Silicon (M3 Pro), **~2.5x faster** on CPU
 
 Compared against Whisper `large-v3-turbo` — all engines auto-detect language.
 

--- a/assets/benchmark.svg
+++ b/assets/benchmark.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ec618677cd18f70cdc4d33145b53b6a86ce1ca1fcab02b36c04ad20b3323984
-size 2750
+oid sha256:927c8b1f4318d1b9f9ec6600d40af26723f726aa0c0bba8fa529b209207663cd
+size 2329


### PR DESCRIPTION
Update the benchmark chart and performance claims to reflect the M3 Pro results (~15x faster, not ~19x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)