### PR TITLE
feat: bidirectional voice M3 (part 1 of 3) — Piper engine + dispatch

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -161,8 +161,14 @@ fn run_say(a: SayArgs) -> i32 {
         }
     };
 
-    let (model_path, voice_path, espeak_lang) = match (a.model, a.voice_file) {
-        (Some(m), Some(v)) => (m, v, a.lang.clone().unwrap_or_else(|| "en-us".to_string())),
+    // `--model` + `--voice-file` are Kokoro-specific testing overrides.
+    // Pinned model/voice paths bypass the cache lookup.
+    let resolved = match (a.model, a.voice_file) {
+        (Some(model_path), Some(voice_path)) => tts::voices::ResolvedVoice::Kokoro {
+            model_path,
+            voice_path,
+            espeak_lang: "en-us",
+        },
         (Some(_), None) | (None, Some(_)) => {
             eprintln!("error: pass both --model and --voice-file or neither");
             return 2;
@@ -170,10 +176,7 @@ fn run_say(a: SayArgs) -> i32 {
         (None, None) => {
             let id = a.voice.as_deref().unwrap_or(tts::voices::DEFAULT_VOICE_ID);
             match tts::voices::resolve_voice(&models::cache_dir(), id) {
-                Ok(r) => {
-                    let lang = a.lang.clone().unwrap_or_else(|| r.espeak_lang.to_string());
-                    (r.model_path, r.voice_path, lang)
-                }
+                Ok(r) => r,
                 Err(e) => {
                     eprintln!("error: {e}");
                     return 1;
@@ -182,12 +185,34 @@ fn run_say(a: SayArgs) -> i32 {
         }
     };
 
+    let espeak_lang = a
+        .lang
+        .clone()
+        .unwrap_or_else(|| resolved.espeak_lang().to_string());
+    let engine = match &resolved {
+        tts::voices::ResolvedVoice::Kokoro {
+            model_path,
+            voice_path,
+            ..
+        } => tts::EngineChoice::Kokoro {
+            model_path,
+            voice_path,
+            speed: a.rate,
+        },
+        tts::voices::ResolvedVoice::Piper {
+            model_path,
+            config_path,
+            ..
+        } => tts::EngineChoice::Piper {
+            model_path,
+            config_path,
+        },
+    };
+
     let wav = match tts::say(tts::SayOptions {
         text: &text_joined,
         lang: &espeak_lang,
-        speed: a.rate,
-        model_path: &model_path,
-        voice_path: &voice_path,
+        engine,
     }) {
         Ok(w) => w,
         Err(e) => {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -206,6 +206,7 @@ fn run_say(a: SayArgs) -> i32 {
         } => tts::EngineChoice::Piper {
             model_path,
             config_path,
+            speed: a.rate,
         },
     };
 

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -1,15 +1,16 @@
-//! Text-to-speech via Kokoro ONNX.
+//! Text-to-speech dispatch across per-engine modules.
 
 use std::path::Path;
 
 pub mod g2p;
 pub mod kokoro;
+pub mod piper;
 pub mod tokenizer;
 pub mod voices;
 pub mod wav;
 
 /// Soft limit on input text length. Rejects absurdly long inputs that would
-/// spend minutes on synthesis with poor quality (Kokoro context is 512 tokens).
+/// spend minutes on synthesis with poor quality.
 pub const MAX_TEXT_CHARS: usize = 5000;
 
 #[derive(Debug, thiserror::Error)]
@@ -22,54 +23,103 @@ pub enum TtsError {
     SynthesisFailed(String),
 }
 
-pub struct SayOptions<'a> {
-    pub text: &'a str,
-    /// espeak language code, e.g. `en-us`.
-    pub lang: &'a str,
-    pub speed: f32,
-    pub model_path: &'a Path,
-    pub voice_path: &'a Path,
+/// Which TTS engine to run. Voice ids determine this via `voices::resolve_voice`.
+pub enum EngineChoice<'a> {
+    /// Kokoro-82M: separate model + per-voice style embedding + rate.
+    Kokoro {
+        model_path: &'a Path,
+        voice_path: &'a Path,
+        speed: f32,
+    },
+    /// Piper VITS: model + per-voice .onnx.json config.
+    Piper {
+        model_path: &'a Path,
+        config_path: &'a Path,
+    },
 }
 
-/// Synthesize speech and return WAV bytes (24kHz mono float32).
+pub struct SayOptions<'a> {
+    pub text: &'a str,
+    /// espeak language code, e.g. `en-us`, `ru`.
+    pub lang: &'a str,
+    pub engine: EngineChoice<'a>,
+}
+
+/// Synthesize speech and return WAV bytes (mono float32; sample rate depends on engine).
 ///
-/// Loads the Kokoro ONNX session fresh on each call (~200-800ms cold). Fine for
-/// one-shot CLI usage; callers that synthesize in a loop should hold a [`kokoro::Kokoro`]
-/// instance directly and drive it via [`kokoro::Kokoro::infer`].
+/// Loads the ONNX session fresh on each call (~100-800ms). Fine for one-shot CLI
+/// usage; callers that synthesize in a loop should hold a [`kokoro::Kokoro`] or
+/// [`piper::Piper`] instance and drive it via its `infer` method.
 pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
     if opts.text.is_empty() {
         return Err(TtsError::EmptyText);
     }
-    if opts.text.chars().count() > MAX_TEXT_CHARS {
+    let len = opts.text.chars().count();
+    if len > MAX_TEXT_CHARS {
         return Err(TtsError::TextTooLong {
             max: MAX_TEXT_CHARS,
-            actual: opts.text.chars().count(),
+            actual: len,
         });
     }
 
     let ipa = g2p::text_to_ipa(opts.text, opts.lang)
         .map_err(|e| TtsError::SynthesisFailed(format!("g2p: {e}")))?;
+    if ipa.trim().is_empty() {
+        return Err(TtsError::SynthesisFailed(
+            "no phonemes produced for input (empty after G2P)".into(),
+        ));
+    }
+
+    match opts.engine {
+        EngineChoice::Kokoro {
+            model_path,
+            voice_path,
+            speed,
+        } => say_with_kokoro(&ipa, model_path, voice_path, speed),
+        EngineChoice::Piper {
+            model_path,
+            config_path,
+        } => say_with_piper(&ipa, model_path, config_path),
+    }
+}
+
+fn say_with_kokoro(
+    ipa: &str,
+    model_path: &Path,
+    voice_path: &Path,
+    speed: f32,
+) -> Result<Vec<u8>, TtsError> {
     let tok = tokenizer::Tokenizer::load()
         .map_err(|e| TtsError::SynthesisFailed(format!("tokenizer load: {e}")))?;
-    let ids = tok.encode(&ipa);
+    let ids = tok.encode(ipa);
     if ids.is_empty() {
         return Err(TtsError::SynthesisFailed(
             "no recognizable phonemes in input".into(),
         ));
     }
-    let active_count = ids.len();
+    let active = ids.len();
     let padded = tokenizer::Tokenizer::pad_to_context(ids);
 
-    let voice = voices::load_voice(opts.voice_path)
+    let voice = voices::load_voice(voice_path)
         .map_err(|e| TtsError::SynthesisFailed(format!("voice load: {e}")))?;
-    let style = voices::select_style(&voice, active_count);
+    let style = voices::select_style(&voice, active);
 
-    let mut k = kokoro::Kokoro::load(opts.model_path)
+    let mut k = kokoro::Kokoro::load(model_path)
         .map_err(|e| TtsError::SynthesisFailed(format!("kokoro load: {e}")))?;
     let audio = k
-        .infer(&padded, style, opts.speed)
+        .infer(&padded, style, speed)
         .map_err(|e| TtsError::SynthesisFailed(format!("infer: {e}")))?;
-    let wav = wav::encode_wav(&audio, kokoro::SAMPLE_RATE)
-        .map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))?;
-    Ok(wav)
+    wav::encode_wav(&audio, kokoro::SAMPLE_RATE)
+        .map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))
+}
+
+fn say_with_piper(ipa: &str, model_path: &Path, config_path: &Path) -> Result<Vec<u8>, TtsError> {
+    let mut p = piper::Piper::load(model_path, config_path)
+        .map_err(|e| TtsError::SynthesisFailed(format!("piper load: {e}")))?;
+    let ids = p.encode(ipa);
+    let audio = p
+        .infer(&ids)
+        .map_err(|e| TtsError::SynthesisFailed(format!("infer: {e}")))?;
+    wav::encode_wav(&audio, p.sample_rate())
+        .map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))
 }

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -35,6 +35,9 @@ pub enum EngineChoice<'a> {
     Piper {
         model_path: &'a Path,
         config_path: &'a Path,
+        /// Speed multiplier: 1.0 = voice default, 2.0 = twice as fast, 0.5 = half speed.
+        /// Mapped to Piper's `length_scale = 1 / speed`.
+        speed: f32,
     },
 }
 
@@ -79,7 +82,8 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         EngineChoice::Piper {
             model_path,
             config_path,
-        } => say_with_piper(&ipa, model_path, config_path),
+            speed,
+        } => say_with_piper(&ipa, model_path, config_path, speed),
     }
 }
 
@@ -113,12 +117,24 @@ fn say_with_kokoro(
         .map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))
 }
 
-fn say_with_piper(ipa: &str, model_path: &Path, config_path: &Path) -> Result<Vec<u8>, TtsError> {
+fn say_with_piper(
+    ipa: &str,
+    model_path: &Path,
+    config_path: &Path,
+    speed: f32,
+) -> Result<Vec<u8>, TtsError> {
     let mut p = piper::Piper::load(model_path, config_path)
         .map_err(|e| TtsError::SynthesisFailed(format!("piper load: {e}")))?;
     let ids = p.encode(ipa);
+    // `encode` always emits BOS + EOS; anything beyond the empty-input baseline means
+    // at least one phoneme matched. Parallel guard to the one in `say_with_kokoro`.
+    if ids.len() <= p.encode("").len() {
+        return Err(TtsError::SynthesisFailed(
+            "no recognizable phonemes in input".into(),
+        ));
+    }
     let audio = p
-        .infer(&ids)
+        .infer_with_speed(&ids, speed)
         .map_err(|e| TtsError::SynthesisFailed(format!("infer: {e}")))?;
     wav::encode_wav(&audio, p.sample_rate())
         .map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))

--- a/rust/src/tts/piper.rs
+++ b/rust/src/tts/piper.rs
@@ -1,0 +1,173 @@
+//! Piper VITS ONNX inference session.
+//!
+//! Inputs:
+//!   `input`         int64 [1, N]   phoneme IDs (BOS + pad-interleaved + EOS)
+//!   `input_lengths` int64 [1]      == N
+//!   `scales`        f32   [3]      [noise_scale, length_scale, noise_w]
+//! Output:
+//!   `output`        f32   [1, 1, 1, T]   mono audio — sample rate varies per voice
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use ndarray::{Array1, Array2};
+use ort::session::Session;
+use ort::value::Value;
+use serde::Deserialize;
+
+pub struct Piper {
+    session: Session,
+    config: PiperConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiperConfig {
+    pub audio: AudioConfig,
+    pub inference: InferenceConfig,
+    pub phoneme_id_map: HashMap<String, Vec<i64>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AudioConfig {
+    pub sample_rate: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct InferenceConfig {
+    pub noise_scale: f32,
+    pub length_scale: f32,
+    pub noise_w: f32,
+}
+
+/// Special symbols in Piper's phoneme vocabulary.
+const BOS: &str = "^";
+const EOS: &str = "$";
+const PAD: &str = "_";
+
+/// Encode IPA phonemes to Piper token IDs: `BOS + (phoneme + PAD)* + EOS`.
+/// Unknown characters are dropped (matches upstream).
+pub fn encode_phonemes(map: &HashMap<String, Vec<i64>>, ipa: &str) -> Vec<i64> {
+    let bos = map.get(BOS).cloned().unwrap_or_default();
+    let pad = map.get(PAD).cloned().unwrap_or_default();
+    let eos = map.get(EOS).cloned().unwrap_or_default();
+
+    let mut ids: Vec<i64> = bos;
+    for c in ipa.chars() {
+        if let Some(entry) = map.get(&c.to_string()) {
+            ids.extend(entry);
+            ids.extend(&pad);
+        }
+    }
+    ids.extend(eos);
+    ids
+}
+
+impl Piper {
+    pub fn load(model_path: &Path, config_path: &Path) -> anyhow::Result<Self> {
+        let session = Session::builder()?.commit_from_file(model_path)?;
+        let raw = std::fs::read_to_string(config_path)?;
+        let config: PiperConfig = serde_json::from_str(&raw)?;
+        Ok(Self { session, config })
+    }
+
+    pub fn sample_rate(&self) -> u32 {
+        self.config.audio.sample_rate
+    }
+
+    pub fn encode(&self, ipa: &str) -> Vec<i64> {
+        encode_phonemes(&self.config.phoneme_id_map, ipa)
+    }
+
+    /// Run synthesis on pre-encoded phoneme IDs. Returns mono f32 audio at [`Self::sample_rate`].
+    pub fn infer(&mut self, phoneme_ids: &[i64]) -> anyhow::Result<Vec<f32>> {
+        anyhow::ensure!(!phoneme_ids.is_empty(), "phoneme_ids must be non-empty");
+        let n = phoneme_ids.len();
+
+        let input =
+            Value::from_array(Array2::<i64>::from_shape_vec((1, n), phoneme_ids.to_vec())?)?;
+        let input_lengths = Value::from_array(Array1::<i64>::from_vec(vec![n as i64]))?;
+        let scales = Value::from_array(Array1::<f32>::from_vec(vec![
+            self.config.inference.noise_scale,
+            self.config.inference.length_scale,
+            self.config.inference.noise_w,
+        ]))?;
+
+        let outputs = self.session.run(ort::inputs![
+            "input"         => input,
+            "input_lengths" => input_lengths,
+            "scales"        => scales,
+        ])?;
+
+        // Piper output is rank-4 [1, 1, 1, T]; the underlying buffer is contiguous,
+        // so collecting the iterator flattens it.
+        let (_shape, data) = outputs["output"].try_extract_tensor::<f32>()?;
+        Ok(data.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn simple_map() -> HashMap<String, Vec<i64>> {
+        let mut m = HashMap::new();
+        m.insert(BOS.to_string(), vec![1]);
+        m.insert(EOS.to_string(), vec![2]);
+        m.insert(PAD.to_string(), vec![0]);
+        m.insert("a".to_string(), vec![10]);
+        m.insert("b".to_string(), vec![11]);
+        m
+    }
+
+    #[test]
+    fn encode_wraps_with_bos_eos_and_pad_interleave() {
+        // "ab" -> BOS(1), a(10), PAD(0), b(11), PAD(0), EOS(2)
+        assert_eq!(
+            encode_phonemes(&simple_map(), "ab"),
+            vec![1, 10, 0, 11, 0, 2]
+        );
+    }
+
+    #[test]
+    fn encode_skips_unknown_characters() {
+        assert_eq!(
+            encode_phonemes(&simple_map(), "aXb"),
+            vec![1, 10, 0, 11, 0, 2]
+        );
+    }
+
+    #[test]
+    fn encode_handles_empty_input() {
+        assert_eq!(encode_phonemes(&simple_map(), ""), vec![1, 2]);
+    }
+
+    #[test]
+    fn encode_handles_multi_id_mappings() {
+        // Some real Piper configs map a single phoneme to multiple IDs.
+        let mut m = simple_map();
+        m.insert("c".to_string(), vec![20, 21]);
+        // "c" -> 20, 21, PAD(0)
+        assert_eq!(encode_phonemes(&m, "c"), vec![1, 20, 21, 0, 2]);
+    }
+
+    /// Gated on PIPER_MODEL + PIPER_CONFIG env vars.
+    #[test]
+    fn infer_produces_non_silent_audio_when_model_available() {
+        let (model, config) = match (
+            std::env::var_os("PIPER_MODEL"),
+            std::env::var_os("PIPER_CONFIG"),
+        ) {
+            (Some(m), Some(c)) => (m, c),
+            _ => {
+                eprintln!("PIPER_MODEL/PIPER_CONFIG not set; skipping");
+                return;
+            }
+        };
+        let mut p = Piper::load(Path::new(&model), Path::new(&config)).unwrap();
+        // Hand-picked IDs in [10, 80] for shape/wiring check only.
+        let ids: Vec<i64> = vec![1, 0, 20, 0, 30, 0, 40, 0, 50, 0, 60, 0, 70, 0, 2];
+        let audio = p.infer(&ids).unwrap();
+        assert!(audio.len() > 1000, "audio too short: {}", audio.len());
+        assert_eq!(p.sample_rate(), 22_050);
+    }
+}

--- a/rust/src/tts/piper.rs
+++ b/rust/src/tts/piper.rs
@@ -78,17 +78,25 @@ impl Piper {
         encode_phonemes(&self.config.phoneme_id_map, ipa)
     }
 
-    /// Run synthesis on pre-encoded phoneme IDs. Returns mono f32 audio at [`Self::sample_rate`].
-    pub fn infer(&mut self, phoneme_ids: &[i64]) -> anyhow::Result<Vec<f32>> {
+    /// Run synthesis with a speed multiplier: `length_scale = voice_default / speed`.
+    /// speed > 1.0 speaks faster; speed < 1.0 speaks slower. speed == 1.0 is the
+    /// voice's config default.
+    pub fn infer_with_speed(
+        &mut self,
+        phoneme_ids: &[i64],
+        speed: f32,
+    ) -> anyhow::Result<Vec<f32>> {
         anyhow::ensure!(!phoneme_ids.is_empty(), "phoneme_ids must be non-empty");
+        anyhow::ensure!(speed > 0.0, "speed must be > 0 (got {speed})");
         let n = phoneme_ids.len();
+        let length_scale = self.config.inference.length_scale / speed;
 
         let input =
             Value::from_array(Array2::<i64>::from_shape_vec((1, n), phoneme_ids.to_vec())?)?;
         let input_lengths = Value::from_array(Array1::<i64>::from_vec(vec![n as i64]))?;
         let scales = Value::from_array(Array1::<f32>::from_vec(vec![
             self.config.inference.noise_scale,
-            self.config.inference.length_scale,
+            length_scale,
             self.config.inference.noise_w,
         ]))?;
 
@@ -166,8 +174,14 @@ mod tests {
         let mut p = Piper::load(Path::new(&model), Path::new(&config)).unwrap();
         // Hand-picked IDs in [10, 80] for shape/wiring check only.
         let ids: Vec<i64> = vec![1, 0, 20, 0, 30, 0, 40, 0, 50, 0, 60, 0, 70, 0, 2];
-        let audio = p.infer(&ids).unwrap();
+        let audio = p.infer_with_speed(&ids, 1.0).unwrap();
         assert!(audio.len() > 1000, "audio too short: {}", audio.len());
-        assert_eq!(p.sample_rate(), 22_050);
+        // Piper voices ship at different sample rates (e.g. 16k for small, 22.05k for medium);
+        // assert a permissive range rather than pinning a single value.
+        assert!(
+            p.sample_rate() >= 16_000 && p.sample_rate() <= 48_000,
+            "unexpected sample rate: {}",
+            p.sample_rate()
+        );
     }
 }

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -39,29 +39,47 @@ pub fn select_style(voice: &[f32], token_count: usize) -> &[f32] {
 /// Default voice id used when neither `--voice` nor auto-routing resolves one.
 pub const DEFAULT_VOICE_ID: &str = "en-af_heart";
 
-/// Resolved paths + language for a given voice id, looked up against the cache.
+/// Resolved engine + paths for a given voice id.
 #[derive(Debug)]
-pub struct ResolvedVoice {
-    pub voice_path: std::path::PathBuf,
-    pub model_path: std::path::PathBuf,
-    pub espeak_lang: &'static str,
+pub enum ResolvedVoice {
+    Kokoro {
+        model_path: std::path::PathBuf,
+        voice_path: std::path::PathBuf,
+        espeak_lang: &'static str,
+    },
+    Piper {
+        model_path: std::path::PathBuf,
+        config_path: std::path::PathBuf,
+        espeak_lang: &'static str,
+    },
 }
 
-/// Parse a voice id like `en-af_heart` into espeak language + filesystem paths.
-/// Returns an error if the voice is not installed at `<cache>/models/kokoro-82m/voices/<name>.bin`.
-/// Only English voices are supported currently; Silero (ru, uk) lands in a later milestone.
+impl ResolvedVoice {
+    pub fn espeak_lang(&self) -> &'static str {
+        match self {
+            Self::Kokoro { espeak_lang, .. } | Self::Piper { espeak_lang, .. } => espeak_lang,
+        }
+    }
+}
+
+/// Parse a voice id like `en-af_heart` or `ru-denis` into engine + paths.
+/// Voice id is `<lang>-<name>`; lang picks the engine and espeak language code.
 pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<ResolvedVoice> {
     let (lang, name) = voice_id.split_once('-').ok_or_else(|| {
         anyhow::anyhow!("voice id must be in 'lang-name' form (got '{voice_id}')")
     })?;
-    let espeak_lang: &'static str = match lang {
-        "en" => "en-us",
-        other => anyhow::bail!("language '{other}' not supported (use 'en-*')"),
-    };
+    match lang {
+        "en" => resolve_kokoro(cache_dir, voice_id, name),
+        "ru" => resolve_piper_ru(cache_dir, voice_id, name),
+        other => anyhow::bail!("language '{other}' not supported (use 'en-*' or 'ru-*')"),
+    }
+}
+
+fn resolve_kokoro(cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Result<ResolvedVoice> {
+    let model_path = cache_dir.join("models/kokoro-82m/model.onnx");
     let voice_path = cache_dir
         .join("models/kokoro-82m/voices")
         .join(format!("{name}.bin"));
-    let model_path = cache_dir.join("models/kokoro-82m/model.onnx");
     if !voice_path.exists() {
         anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
     }
@@ -71,10 +89,27 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
             model_path.display()
         );
     }
-    Ok(ResolvedVoice {
-        voice_path,
+    Ok(ResolvedVoice::Kokoro {
         model_path,
-        espeak_lang,
+        voice_path,
+        espeak_lang: "en-us",
+    })
+}
+
+fn resolve_piper_ru(cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Result<ResolvedVoice> {
+    // Piper filenames follow the upstream convention `ru_RU-<name>-medium.*`.
+    let base = cache_dir
+        .join("models/piper-ru")
+        .join(format!("ru_RU-{name}-medium"));
+    let model_path = base.with_extension("onnx");
+    let config_path = base.with_extension("onnx.json");
+    if !model_path.exists() || !config_path.exists() {
+        anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+    }
+    Ok(ResolvedVoice::Piper {
+        model_path,
+        config_path,
+        espeak_lang: "ru",
     })
 }
 
@@ -140,13 +175,48 @@ mod tests {
     }
 
     #[test]
-    fn resolve_installed_voice() {
+    fn resolve_installed_kokoro_voice() {
         let tmp = tempfile::tempdir().unwrap();
         populate_cache(tmp.path());
         let r = resolve_voice(tmp.path(), "en-af_heart").unwrap();
-        assert!(r.voice_path.ends_with("af_heart.bin"));
-        assert!(r.model_path.ends_with("model.onnx"));
-        assert_eq!(r.espeak_lang, "en-us");
+        match r {
+            ResolvedVoice::Kokoro {
+                voice_path,
+                model_path,
+                espeak_lang,
+            } => {
+                assert!(voice_path.ends_with("af_heart.bin"));
+                assert!(model_path.ends_with("model.onnx"));
+                assert_eq!(espeak_lang, "en-us");
+            }
+            other => panic!("expected Kokoro, got {other:?}"),
+        }
+    }
+
+    fn populate_piper_ru(cache: &Path) {
+        let dir = cache.join("models/piper-ru");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("ru_RU-denis-medium.onnx"), b"dummy").unwrap();
+        std::fs::write(dir.join("ru_RU-denis-medium.onnx.json"), b"{}").unwrap();
+    }
+
+    #[test]
+    fn resolve_installed_piper_voice() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_piper_ru(tmp.path());
+        let r = resolve_voice(tmp.path(), "ru-denis").unwrap();
+        match r {
+            ResolvedVoice::Piper {
+                model_path,
+                config_path,
+                espeak_lang,
+            } => {
+                assert!(model_path.ends_with("ru_RU-denis-medium.onnx"));
+                assert!(config_path.ends_with("ru_RU-denis-medium.onnx.json"));
+                assert_eq!(espeak_lang, "ru");
+            }
+            other => panic!("expected Piper, got {other:?}"),
+        }
     }
 
     #[test]
@@ -178,7 +248,7 @@ mod tests {
     #[test]
     fn resolve_unsupported_language() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = resolve_voice(tmp.path(), "ru-something").unwrap_err();
+        let err = resolve_voice(tmp.path(), "fr-something").unwrap_err();
         assert!(err.to_string().contains("not supported"), "msg: {err}");
     }
 }

--- a/rust/tests/tts_e2e.rs
+++ b/rust/tests/tts_e2e.rs
@@ -1,12 +1,14 @@
 //! End-to-end TTS: real model, real voice, real espeak-ng → produces real WAV bytes.
-//! Gated on KOKORO_MODEL + KOKORO_VOICE env vars so default CI without models stays fast.
+//! Gated on engine-specific env vars so default CI without models stays fast.
 
 #![cfg(feature = "tts")]
 
 use std::path::Path;
 
+use kesha_engine::tts::{self, EngineChoice, SayOptions, TtsError};
+
 #[test]
-fn hello_world_produces_wav() {
+fn kokoro_hello_world_produces_wav() {
     let (model, voice) = match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
         (Ok(m), Ok(v)) => (m, v),
         _ => {
@@ -14,12 +16,14 @@ fn hello_world_produces_wav() {
             return;
         }
     };
-    let wav = kesha_engine::tts::say(kesha_engine::tts::SayOptions {
+    let wav = tts::say(SayOptions {
         text: "Hello, world",
         lang: "en-us",
-        speed: 1.0,
-        model_path: Path::new(&model),
-        voice_path: Path::new(&voice),
+        engine: EngineChoice::Kokoro {
+            model_path: Path::new(&model),
+            voice_path: Path::new(&voice),
+            speed: 1.0,
+        },
     })
     .unwrap();
     assert_eq!(&wav[..4], b"RIFF", "not a WAV");
@@ -31,29 +35,56 @@ fn hello_world_produces_wav() {
 }
 
 #[test]
+fn piper_russian_produces_wav() {
+    let (model, config) = match (std::env::var("PIPER_MODEL"), std::env::var("PIPER_CONFIG")) {
+        (Ok(m), Ok(c)) => (m, c),
+        _ => {
+            eprintln!("skipping: set PIPER_MODEL + PIPER_CONFIG");
+            return;
+        }
+    };
+    let wav = tts::say(SayOptions {
+        text: "Привет, мир",
+        lang: "ru",
+        engine: EngineChoice::Piper {
+            model_path: Path::new(&model),
+            config_path: Path::new(&config),
+        },
+    })
+    .unwrap();
+    assert_eq!(&wav[..4], b"RIFF");
+    assert!(
+        wav.len() > 44 + 1000 * 4,
+        "audio too short: {} bytes",
+        wav.len()
+    );
+}
+
+#[test]
 fn empty_text_errors() {
-    let res = kesha_engine::tts::say(kesha_engine::tts::SayOptions {
+    let res = tts::say(SayOptions {
         text: "",
         lang: "en-us",
-        speed: 1.0,
-        model_path: Path::new("/nonexistent"),
-        voice_path: Path::new("/nonexistent"),
+        engine: EngineChoice::Kokoro {
+            model_path: Path::new("/nonexistent"),
+            voice_path: Path::new("/nonexistent"),
+            speed: 1.0,
+        },
     });
-    assert!(matches!(res, Err(kesha_engine::tts::TtsError::EmptyText)));
+    assert!(matches!(res, Err(TtsError::EmptyText)));
 }
 
 #[test]
 fn too_long_errors() {
     let huge = "a".repeat(10_000);
-    let res = kesha_engine::tts::say(kesha_engine::tts::SayOptions {
+    let res = tts::say(SayOptions {
         text: &huge,
         lang: "en-us",
-        speed: 1.0,
-        model_path: Path::new("/nonexistent"),
-        voice_path: Path::new("/nonexistent"),
+        engine: EngineChoice::Kokoro {
+            model_path: Path::new("/nonexistent"),
+            voice_path: Path::new("/nonexistent"),
+            speed: 1.0,
+        },
     });
-    assert!(matches!(
-        res,
-        Err(kesha_engine::tts::TtsError::TextTooLong { .. })
-    ));
+    assert!(matches!(res, Err(TtsError::TextTooLong { .. })));
 }

--- a/rust/tests/tts_e2e.rs
+++ b/rust/tests/tts_e2e.rs
@@ -49,6 +49,7 @@ fn piper_russian_produces_wav() {
         engine: EngineChoice::Piper {
             model_path: Path::new(&model),
             config_path: Path::new(&config),
+            speed: 1.0,
         },
     })
     .unwrap();


### PR DESCRIPTION
## Summary

First part of M3 (bidirectional-voice for Russian). Adds the **Piper VITS** engine alongside Kokoro and a voice-id-based dispatch so `tts::say()` picks the right engine based on the voice id prefix.

```rust
tts::say(SayOptions {
    text: "Привет, мир",
    lang: "ru",
    engine: EngineChoice::Piper { model_path, config_path },
})
```

`en-*` voice ids resolve to Kokoro; `ru-*` voice ids resolve to Piper. The existing Kokoro path is unchanged externally — only its ownership of `SayOptions` moved behind the `EngineChoice` enum.

## Pivot from the original M3 plan

The original spec (2026-04-16) called for **Silero TTS** for Russian. Empirical finding during the M3 spike: Silero ships PyTorch-only, no public ONNX export. **Pivoted to Piper** (Rhasspy's VITS-based TTS, ONNX-native, active project, uses the espeak-ng we already bundle). 63MB RU model, MIT license. See discussion in the conversation transcript.

## What's in this PR (Phases A + B of 5)

1. **`rust/src/tts/piper.rs`** — new module mirroring `kokoro.rs`: loads `.onnx` + `.onnx.json`, encodes IPA phonemes via the config's `phoneme_id_map` (BOS + pad-interleave + EOS), runs inference, handles rank-4 `[1,1,1,T]` output tensor.
2. **`rust/src/tts/mod.rs`** — `SayOptions` now takes an `EngineChoice` enum; `say()` branches to `say_with_kokoro` or `say_with_piper`.
3. **`rust/src/tts/voices.rs`** — `ResolvedVoice` is an enum with per-engine variants; `resolve_voice` dispatches on voice-id prefix.
4. **`rust/src/main.rs`** — dispatch refactor: `ResolvedVoice` → `EngineChoice` before `tts::say()`.
5. **`rust/tests/tts_e2e.rs`** — new `piper_russian_produces_wav` test (gated on `PIPER_MODEL`/`PIPER_CONFIG`).

## Still ahead (Phases C/D/E — follow-up PRs)

- **Phase C:** extend `download_tts_kokoro` to unified `download_tts` covering Piper RU + manifest entries (`ru_RU-denis-medium.onnx`, sha256 pinned to `15fab56e...`).
- **Phase D:** TS auto-routing — call `NLLanguageRecognizer` on input text when `--voice` is omitted; pick voice accordingly.
- **Phase E:** README Russian demo + CLAUDE.md updates + smoke-test-tts RU case.

## Test plan

- [x] 77 Rust tests green (29 bin + 31 lib + 4 integration + 13 smoke)
- [x] Real Piper RU inference: \"Привет, мир\" → valid RIFF WAV @ 22050Hz (via `tts_e2e::piper_russian_produces_wav`)
- [x] Existing Kokoro path unchanged (`tts_e2e::kokoro_hello_world_produces_wav` still passes)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] CI green on macOS + ubuntu (rust-test.yml)

## Breaking changes

**Internal only:** `SayOptions` field shape changed (now `engine: EngineChoice` instead of flat fields). The public API (`kesha say` CLI + TypeScript `say()` from `./core`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)