### PR TITLE
docs: add 🥤 energy to README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-Made with 💛🩵 Published under MIT License.
+Made with 💛🩵 and 🥤 energy under MIT License


### PR DESCRIPTION
One-line README footer tweak:

```diff
-Made with 💛🩵 Published under MIT License.
+Made with 💛🩵 and 🥤 energy under MIT License
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)