### PR TITLE
feat: bidirectional voice M3 (part 2 of 2) — Piper RU install + auto-routing + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,22 @@ Don't add struct fields, enum variants, or constants "for later." Clippy's `dead
 - `main` is protected — all changes go through PRs
 - CI must pass before merging
 
+### VERIFY THIRD-PARTY MODEL FORMATS WITH A SPIKE
+
+Any plan that names a specific upstream artifact ("Silero via ONNX", "statically-linked espeak-ng", "FluidAudio CoreML Kokoro") MUST be validated with a throwaway spike BEFORE the implementation phase commits to it.
+
+- The spike downloads / builds the thing and runs it end-to-end — not just "checks if the repo exists."
+- Past pivots this rule would have prevented earlier: espeak-ng turned out to be dynamic-link-only in `espeakng-sys` (→ pivoted to system-dep + issue #124); Silero TTS ships PyTorch-only and has no public ONNX export (→ pivoted to Piper in M3).
+- Spike artifacts go in `/tmp/<name>-spike/` and are deleted after the finding is recorded in the plan doc.
+
+### GREPTILE PR REVIEW IS A GATE
+
+PRs receive automated review from Greptile (as a PR comment on each push). Treat P1/P2 findings as merge blockers — address them before marking the PR ready-for-review.
+
+- Pattern: push → Greptile reviews → fix → push → merge.
+- Past incidents caught this way: `--backend=` forwarded to an engine that didn't accept it (#125 P1); `--rate` silently discarded for Piper voices (#126 P1); hard-coded 22050 Hz assertion that would break on other Piper voices (#126 P2).
+- Exception: findings that are clearly false positives can be dismissed with a PR comment explaining why — but that's rare in practice.
+
 ### DO NOT BLINDLY FORWARD CLI FLAGS TO SUBCOMMANDS
 
 Validate flags against `kesha-engine --capabilities-json` instead of forwarding to the engine subprocess. `kesha-engine install` only accepts `--no-cache`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,15 +216,22 @@ const text = await transcribe("audio.ogg");
 
 ## TTS
 
-Text-to-speech via Kokoro-82M (English only). Opt-in via `kesha install --tts`.
+Text-to-speech via two engines selected by voice id prefix:
 
-- TTS models are **never auto-downloaded** — same rule as ASR. `kesha say` fails loudly with a `kesha install --tts` hint when models are missing.
-- `kesha say` writes WAV (24 kHz mono f32) to stdout unless `--out` is given. Stderr is progress/errors only.
-- G2P uses the `espeakng-sys` crate, dynamically linked against the system `libespeak-ng`.
-- Kokoro ONNX interface: `input_ids` (int64 `[1,N]`), `style` (f32 `[1,256]` — rank-2), `speed` (f32 `[1]`). Output tensor name is `"waveform"`. Voice file is 510 rows × 256 cols.
-- `KESHA_ENGINE_BIN` — override the default engine-binary path (useful when iterating on `rust/target/release/kesha-engine`).
+- `en-*` → **Kokoro-82M**. Separate model + per-voice style embedding. Output 24 kHz.
+- `ru-*` → **Piper VITS** (`rhasspy/piper-voices`). Per-voice `.onnx` + `.onnx.json`. Output depends on voice (22.05 kHz for medium tier).
+
+Opt-in via `kesha install --tts` (downloads both engines, ~390 MB).
+
+- TTS models are **never auto-downloaded** — `kesha say` fails loudly with a `kesha install --tts` hint when models are missing.
+- `kesha say` writes WAV mono f32 to stdout unless `--out` is given. Stderr is progress/errors only.
+- G2P uses `espeakng-sys` (dynamic link against system `libespeak-ng`) for both engines.
+- **Auto-routing:** when `--voice` is omitted, the TS CLI calls `NLLanguageRecognizer` on the input text and picks `en-af_heart` or `ru-denis`. Confidence < 0.5 or unmapped language falls through to the engine default. `pickVoiceForLang` in `src/cli.ts` is the routing table — add a language by adding a match arm.
+- Kokoro ONNX: `input_ids` (int64 `[1,N]`), `style` (f32 `[1,256]` — rank-2), `speed` (f32 `[1]`). Output name `"waveform"`. Voice file 510 rows × 256 cols.
+- Piper ONNX: `input` (int64 `[1,N]` — BOS + pad-interleaved phoneme IDs + EOS), `input_lengths` (int64 `[1]`), `scales` (f32 `[3]` = `[noise_scale, length_scale, noise_w]`). Output name `"output"`, rank-4 `[1,1,1,T]`. `--rate` is mapped to Piper via `length_scale = voice_default / speed`.
+- `KESHA_ENGINE_BIN` — override the engine-binary path (useful when iterating on `rust/target/release/kesha-engine`).
 - `KESHA_CACHE_DIR` — isolated test cache.
 - macOS dev runtime: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`. Release binaries fix up via `install_name_tool`.
 - macOS build env: `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`, `RUSTFLAGS="-L /opt/homebrew/lib"`.
 
-Russian (Silero) and auto-routing via `NLLanguageRecognizer` are future milestones. See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.
+Original spec assumed Silero TTS; pivoted to Piper during M3 spike (Silero ships PyTorch-only, no public ONNX). See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.

--- a/README.md
+++ b/README.md
@@ -78,21 +78,26 @@ $ kesha freedom.ogg tahiti.ogg
 
 Stdout: transcript. Stderr: errors. Pipe-friendly. Also available as `parakeet` command (backward-compatible alias).
 
-## Text-to-Speech (preview, M1)
+## Text-to-Speech
 
-Kesha can also *speak back* via Kokoro-82M. English only in M1 — Russian and auto-routing land in M3.
+Kesha speaks back via Kokoro-82M (English) and Piper (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Piper. Pass `--voice` to override.
 
 ```bash
 brew install espeak-ng              # one-time system dep (macOS — apt/choco elsewhere)
-kesha install --tts                 # ~326MB download (opt-in — default install unchanged)
-kesha say "Hello, world" > reply.wav
+kesha install --tts                 # ~390MB (Kokoro + Piper RU, opt-in)
+kesha say "Hello, world" > hello.wav
+kesha say "Привет, мир" > privet.wav    # auto-routes to ru-denis
 echo "long text" | kesha say > reply.wav
 kesha say --out reply.wav "text"
-kesha say --voice en-af_heart "text"
+kesha say --voice en-af_heart "text"    # explicit voice overrides auto-routing
 kesha say --list-voices
 ```
 
-Output: WAV 24kHz mono float32. OGG/Opus, MP3, and SSML are tracked in follow-up issues ([#122](https://github.com/drakulavich/kesha-voice-kit/issues/122)). Static-linking of `espeak-ng` to remove the system dep is [#124](https://github.com/drakulavich/kesha-voice-kit/issues/124).
+Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Opus, MP3, and SSML are tracked in follow-up issues ([#122](https://github.com/drakulavich/kesha-voice-kit/issues/122)). Static-linking of `espeak-ng` to remove the system dep is [#124](https://github.com/drakulavich/kesha-voice-kit/issues/124).
+
+**Supported voices:**
+- English: `en-af_heart` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/`
+- Russian: `ru-denis` (default). More speakers (dmitri, irina, ruslan) are ready to drop in once needed.
 
 ## What's Inside
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -264,7 +264,7 @@ fn main() -> Result<()> {
             #[cfg(feature = "tts")]
             if tts {
                 ensure_espeak_available()?;
-                models::download_tts_kokoro(no_cache)?;
+                models::download_tts(no_cache)?;
                 eprintln!("TTS models installed.");
             }
             eprintln!("Install complete.");

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -44,7 +44,7 @@ enum Commands {
         /// Re-download even if cached
         #[arg(long)]
         no_cache: bool,
-        /// Also install Kokoro TTS models (~326MB). Requires `espeak-ng` on PATH.
+        /// Also install TTS models (Kokoro EN + Piper RU, ~390MB). Requires `espeak-ng` on PATH.
         #[cfg(feature = "tts")]
         #[arg(long)]
         tts: bool,
@@ -108,6 +108,45 @@ fn ensure_espeak_available() -> anyhow::Result<()> {
     }
 }
 
+#[cfg(feature = "tts")]
+fn list_kokoro_voices(cache: &std::path::Path) -> Vec<String> {
+    let dir = cache.join("models/kokoro-82m/voices");
+    std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().and_then(|s| s.to_str()) == Some("bin") {
+                p.file_stem().map(|s| format!("en-{}", s.to_string_lossy()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(feature = "tts")]
+fn list_piper_ru_voices(cache: &std::path::Path) -> Vec<String> {
+    // Piper RU files follow `ru_RU-<name>-<quality>.onnx`; report just the <name>.
+    let dir = cache.join("models/piper-ru");
+    std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().and_then(|s| s.to_str()) != Some("onnx") {
+                return None;
+            }
+            let stem = p.file_stem()?.to_string_lossy().into_owned();
+            // stem like "ru_RU-denis-medium" → "denis"
+            let name = stem.strip_prefix("ru_RU-")?.split('-').next()?;
+            Some(format!("ru-{name}"))
+        })
+        .collect()
+}
+
 /// Map a TTS error to the documented exit code for `kesha say`.
 /// 2 = bad input, 4 = synthesis failure, 5 = text too long.
 /// (Voice-not-installed exits 1 directly from the resolver path.)
@@ -125,25 +164,17 @@ fn run_say(a: SayArgs) -> i32 {
     use std::io::{Read, Write};
 
     if a.list_voices {
-        let voices_dir = models::cache_dir().join("models/kokoro-82m/voices");
-        let names: Vec<String> = std::fs::read_dir(&voices_dir)
+        let cache = models::cache_dir();
+        let mut voice_ids: Vec<String> = list_kokoro_voices(&cache)
             .into_iter()
-            .flatten()
-            .filter_map(|e| e.ok())
-            .filter_map(|e| {
-                let p = e.path();
-                if p.extension().and_then(|s| s.to_str()) == Some("bin") {
-                    p.file_stem().map(|s| s.to_string_lossy().into_owned())
-                } else {
-                    None
-                }
-            })
+            .chain(list_piper_ru_voices(&cache))
             .collect();
-        if names.is_empty() {
+        voice_ids.sort();
+        if voice_ids.is_empty() {
             println!("No voices installed. Run: kesha install --tts");
         } else {
-            for name in names {
-                println!("en-{name}");
+            for id in voice_ids {
+                println!("{id}");
             }
         }
         return 0;

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -44,6 +44,23 @@ pub fn kokoro_manifest() -> Vec<ModelFile> {
     ]
 }
 
+/// Piper Russian voice (denis, medium quality). See [rhasspy/piper-voices].
+#[cfg(feature = "tts")]
+pub fn piper_ru_manifest() -> Vec<ModelFile> {
+    vec![
+        ModelFile {
+            rel_path: "models/piper-ru/ru_RU-denis-medium.onnx",
+            url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx",
+            sha256: "15fab56e11a097858ee115545d0f697fc2a316c41a291a5362349fb870411b0a",
+        },
+        ModelFile {
+            rel_path: "models/piper-ru/ru_RU-denis-medium.onnx.json",
+            url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx.json",
+            sha256: "831c860dac0b5073eaa81610a0a638ec23d90a6cf8e5f871b4485c2cec3767c8",
+        },
+    ]
+}
+
 pub fn cache_dir() -> PathBuf {
     if let Ok(p) = std::env::var("KESHA_CACHE_DIR") {
         return PathBuf::from(p);
@@ -119,6 +136,21 @@ mod tts_tests {
     }
 
     #[test]
+    fn piper_ru_manifest_has_expected_files() {
+        let m = piper_ru_manifest();
+        assert!(m
+            .iter()
+            .any(|f| f.rel_path.ends_with("ru_RU-denis-medium.onnx")));
+        assert!(m
+            .iter()
+            .any(|f| f.rel_path.ends_with("ru_RU-denis-medium.onnx.json")));
+        for f in &m {
+            assert_eq!(f.sha256.len(), 64, "{:?} sha256 not 64 hex chars", f);
+            assert!(f.url.starts_with("https://"), "{f:?} url not https");
+        }
+    }
+
+    #[test]
     fn cache_dir_honors_env_var() {
         let guard = EnvGuard::set("KESHA_CACHE_DIR", "/tmp/kesha-test-xyz");
         assert_eq!(cache_dir(), PathBuf::from("/tmp/kesha-test-xyz"));
@@ -174,33 +206,42 @@ fn download_hf_files(repo: &str, files: &[&str], dest_dir: &str) -> Result<()> {
     Ok(())
 }
 
-/// Kokoro TTS install. Downloads model.onnx + af_heart voice, verifies SHA256.
+/// Download every TTS model file: Kokoro English + Piper Russian.
+/// Each file is streamed to disk, then SHA256-verified.
 #[cfg(feature = "tts")]
-pub fn download_tts_kokoro(no_cache: bool) -> Result<()> {
+pub fn download_tts(no_cache: bool) -> Result<()> {
     let cache = cache_dir();
-    for f in kokoro_manifest() {
-        let target = cache.join(f.rel_path);
-        if !no_cache && target.exists() && verify_sha256(&target, f.sha256)? {
-            eprintln!("OK  {} (cached)", f.rel_path);
-            continue;
-        }
-        if let Some(parent) = target.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        eprintln!("GET {}", f.rel_path);
-        let response = ureq::get(f.url)
-            .call()
-            .with_context(|| format!("download {}", f.rel_path))?;
-        let mut reader = response.into_body().into_reader();
-        let mut out =
-            fs::File::create(&target).with_context(|| format!("create {}", target.display()))?;
-        io::copy(&mut reader, &mut out)?;
-        drop(out);
-        if !verify_sha256(&target, f.sha256)? {
-            anyhow::bail!("sha256 mismatch for {}", f.rel_path);
-        }
-        eprintln!("OK  {}", f.rel_path);
+    let mut manifest = kokoro_manifest();
+    manifest.extend(piper_ru_manifest());
+    for f in manifest {
+        download_verified(&cache, &f, no_cache)?;
     }
+    Ok(())
+}
+
+#[cfg(feature = "tts")]
+fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> {
+    let target = cache.join(f.rel_path);
+    if !no_cache && target.exists() && verify_sha256(&target, f.sha256)? {
+        eprintln!("OK  {} (cached)", f.rel_path);
+        return Ok(());
+    }
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    eprintln!("GET {}", f.rel_path);
+    let response = ureq::get(f.url)
+        .call()
+        .with_context(|| format!("download {}", f.rel_path))?;
+    let mut reader = response.into_body().into_reader();
+    let mut out =
+        fs::File::create(&target).with_context(|| format!("create {}", target.display()))?;
+    io::copy(&mut reader, &mut out)?;
+    drop(out);
+    if !verify_sha256(&target, f.sha256)? {
+        anyhow::bail!("sha256 mismatch for {}", f.rel_path);
+    }
+    eprintln!("OK  {}", f.rel_path);
     Ok(())
 }
 

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -67,22 +67,28 @@ check("typo suggestion works", typoProc.exitCode === 1 && typoProc.stderr.toStri
 
 // 6. TTS smoke (opt-in via --tts flag; requires `kesha install --tts` + espeak-ng)
 if (process.argv.includes("--tts")) {
-  const tmpWav = "/tmp/kesha-smoke.wav";
-  const sayProc = Bun.spawnSync(["kesha", "say", "Hello", "--out", tmpWav], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const wavExists = Bun.file(tmpWav).size > 10_000;
-  const header = wavExists
-    ? new TextDecoder().decode(
-        new Uint8Array((await Bun.file(tmpWav).arrayBuffer()).slice(0, 4)),
-      )
-    : "";
-  check(
-    "kesha say produces WAV",
-    sayProc.exitCode === 0 && wavExists && header === "RIFF",
-    `exit=${sayProc.exitCode} header=${header}`,
-  );
+  for (const [label, text] of [
+    ["en (Kokoro)", "Hello, world"],
+    ["ru (Piper, auto-routed)", "Привет, мир"],
+  ] as const) {
+    const tmpWav = `/tmp/kesha-smoke-${label.split(" ")[0]}.wav`;
+    const sayProc = Bun.spawnSync(["kesha", "say", text, "--out", tmpWav], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const wavSize = Bun.file(tmpWav).size;
+    const header =
+      wavSize > 0
+        ? new TextDecoder().decode(
+            new Uint8Array((await Bun.file(tmpWav).arrayBuffer()).slice(0, 4)),
+          )
+        : "";
+    check(
+      `kesha say ${label} produces WAV`,
+      sayProc.exitCode === 0 && wavSize > 10_000 && header === "RIFF",
+      `exit=${sayProc.exitCode} header=${header} size=${wavSize}`,
+    );
+  }
 }
 
 const total = passed + failed;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -122,15 +122,6 @@ export const sayCommand = defineCommand({
     "list-voices": { type: "boolean", description: "List installed voices and exit" },
   },
   async run({ args }) {
-    const text = typeof args.text === "string" ? args.text : undefined;
-    const opts = {
-      text,
-      voice: typeof args.voice === "string" ? args.voice : undefined,
-      lang: typeof args.lang === "string" ? args.lang : undefined,
-      out: typeof args.out === "string" ? args.out : undefined,
-      rate: args.rate ? Number(args.rate) : undefined,
-    };
-
     if (args["list-voices"]) {
       // The engine prints the list directly — just relay its stdout + exit code.
       const { getEngineBinPath } = await import("./engine");
@@ -141,9 +132,21 @@ export const sayCommand = defineCommand({
       process.exit(await proc.exited);
     }
 
+    const inlineText = typeof args.text === "string" ? args.text : undefined;
+    const text = await resolveText(inlineText);
+    const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
+    const voice = explicitVoice ?? (await autoRouteVoice(text));
+
+    const opts = {
+      text,
+      voice,
+      lang: typeof args.lang === "string" ? args.lang : undefined,
+      out: typeof args.out === "string" ? args.out : undefined,
+      rate: args.rate ? Number(args.rate) : undefined,
+    };
+
     try {
-      // If no text and no stdin, engine reads empty and exits 2. Pipe stdin through.
-      const wav = await sayCliPassthrough(opts, text);
+      const wav = await say(opts);
       if (!opts.out) {
         process.stdout.write(wav);
       }
@@ -159,23 +162,9 @@ export const sayCommand = defineCommand({
   },
 });
 
-/**
- * When the CLI user omits the positional text, they may be piping into stdin
- * (e.g. `echo hi | kesha say > out.wav`). `say()` in src/say.ts already handles
- * the stdin case, but we must not close stdin prematurely — forward the terminal's
- * stdin to the engine. Currently `say()` only writes a provided string; for stdin
- * piping we'd duplicate that here. For M1, require the text arg or stdin via pipe
- * that the user set up on the engine directly; keep `say()` the primary path.
- */
-async function sayCliPassthrough(
-  opts: Parameters<typeof say>[0],
-  inlineText: string | undefined,
-): Promise<Uint8Array> {
-  // If inline text given, use the normal say() helper.
-  if (inlineText !== undefined && inlineText.length > 0) {
-    return say(opts);
-  }
-  // Otherwise, read stdin in the CLI process, hand to engine via stdin.
+/** Resolve the text to synthesize: inline positional, else read from stdin. */
+async function resolveText(inline: string | undefined): Promise<string> {
+  if (inline !== undefined && inline.length > 0) return inline;
   const chunks: Uint8Array[] = [];
   for await (const chunk of Bun.stdin.stream()) {
     chunks.push(chunk);
@@ -187,8 +176,30 @@ async function sayCliPassthrough(
     merged.set(c, offset);
     offset += c.byteLength;
   }
-  const stdinText = new TextDecoder().decode(merged).trim();
-  return say({ ...opts, text: stdinText });
+  return new TextDecoder().decode(merged).trim();
+}
+
+/** Map a detected language code to a default voice id. Unknown / low-confidence → undefined. */
+export function pickVoiceForLang(
+  code: string | undefined,
+  confidence: number,
+): string | undefined {
+  if (!code || confidence < 0.5) return undefined;
+  switch (code) {
+    case "en":
+      return "en-af_heart";
+    case "ru":
+      return "ru-denis";
+    default:
+      return undefined;
+  }
+}
+
+/** Run NLLanguageRecognizer (via engine) on the text and pick a default voice. */
+async function autoRouteVoice(text: string): Promise<string | undefined> {
+  if (!text) return undefined;
+  const detected = await detectTextLanguageEngine(text);
+  return pickVoiceForLang(detected?.code, detected?.confidence ?? 0);
 }
 
 export const statusCommand = defineCommand({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,7 +98,7 @@ export const installCommand = defineCommand({
     },
     tts: {
       type: "boolean",
-      description: "Also install Kokoro TTS models (~326MB, requires espeak-ng on PATH)",
+      description: "Also install TTS models (Kokoro EN + Piper RU, ~390MB, requires espeak-ng on PATH)",
       default: false,
     },
   },

--- a/src/status.ts
+++ b/src/status.ts
@@ -61,12 +61,27 @@ function kesheCacheDir(): string {
 }
 
 function listInstalledVoices(): string[] {
-  const voicesDir = join(kesheCacheDir(), "models", "kokoro-82m", "voices");
+  const cache = kesheCacheDir();
+  const voices: string[] = [];
   try {
-    return readdirSync(voicesDir)
-      .filter((f) => f.endsWith(".bin"))
-      .map((f) => `en-${f.replace(/\.bin$/, "")}`);
+    const kokoro = readdirSync(join(cache, "models", "kokoro-82m", "voices"));
+    for (const f of kokoro) {
+      if (f.endsWith(".bin")) voices.push(`en-${f.replace(/\.bin$/, "")}`);
+    }
   } catch {
-    return [];
+    /* Kokoro not installed */
   }
+  try {
+    // Piper RU files follow `ru_RU-<name>-<quality>.onnx` — report just `<name>`.
+    const piper = readdirSync(join(cache, "models", "piper-ru"));
+    for (const f of piper) {
+      if (!f.endsWith(".onnx")) continue;
+      const stem = f.replace(/\.onnx$/, "");
+      const name = stem.replace(/^ru_RU-/, "").split("-")[0];
+      if (name) voices.push(`ru-${name}`);
+    }
+  } catch {
+    /* Piper not installed */
+  }
+  return voices.sort();
 }

--- a/tests/unit/say.test.ts
+++ b/tests/unit/say.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { buildSayArgs } from "../../src/say";
+import { pickVoiceForLang } from "../../src/cli";
 
 describe("buildSayArgs", () => {
   it("starts with the 'say' subcommand", () => {
@@ -53,5 +54,29 @@ describe("buildSayArgs", () => {
     const langIdx = args.indexOf("--lang");
     expect(textIdx).toBeGreaterThan(voiceIdx);
     expect(textIdx).toBeGreaterThan(langIdx);
+  });
+});
+
+describe("pickVoiceForLang (auto-routing)", () => {
+  it("returns en-af_heart for English with high confidence", () => {
+    expect(pickVoiceForLang("en", 0.95)).toBe("en-af_heart");
+  });
+
+  it("returns ru-denis for Russian with high confidence", () => {
+    expect(pickVoiceForLang("ru", 0.95)).toBe("ru-denis");
+  });
+
+  it("returns undefined below 0.5 confidence (too ambiguous)", () => {
+    expect(pickVoiceForLang("ru", 0.3)).toBeUndefined();
+  });
+
+  it("returns undefined for unsupported languages", () => {
+    expect(pickVoiceForLang("fr", 0.95)).toBeUndefined();
+    expect(pickVoiceForLang("de", 0.95)).toBeUndefined();
+  });
+
+  it("returns undefined when code is missing", () => {
+    expect(pickVoiceForLang(undefined, 0.95)).toBeUndefined();
+    expect(pickVoiceForLang("", 0.95)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes out M3 by landing the remaining phases on top of #126 (Piper engine + dispatch):

- **Phase C — install flow:** `kesha install --tts` now downloads **both** Kokoro (EN) and Piper Russian (`ru_RU-denis-medium`, 63 MB, SHA256-pinned) via a unified `download_tts()` helper.
- **Phase D — auto-routing:** `kesha say "Привет"` (no `--voice`) detects the input text's language via `NLLanguageRecognizer` and picks `ru-denis`; English text picks `en-af_heart`. Confidence < 0.5 or unmapped language falls through to the engine default. Explicit `--voice` always wins. Matrix lives in `pickVoiceForLang` (pure, unit-tested).
- **Phase E — docs + smoke:** README TTS section updated for multi-engine + auto-routing (with the Russian demo the project was originally designed around); CLAUDE.md TTS section documents Piper tensor wiring + the Silero→Piper pivot; `make smoke-test-tts` now checks both English and Russian WAV output.

## Developer-guide additions (CLAUDE.md)

Two new rules captured from M1+M3 lessons learned:

- **VERIFY THIRD-PARTY MODEL FORMATS WITH A SPIKE** — plans naming specific upstream artifacts need a throwaway spike that actually downloads + runs the thing before implementation starts.
- **GREPTILE PR REVIEW IS A GATE** — P1/P2 findings block merge.

## Test plan

- [x] 78 Rust tests green (including `piper_ru_manifest_has_expected_files`, full `tts_e2e` suite with real Kokoro + Piper models)
- [x] 100 TS tests green (including 5 new `pickVoiceForLang` unit tests covering high/low confidence, supported/unsupported langs, undefined code)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `bunx tsc --noEmit` clean
- [x] Manual: `kesha say \"Hello\"` → Kokoro EN WAV; `kesha say \"Привет, мир\"` → Piper RU WAV (no `--voice` flag used)
- [ ] CI green on macOS + ubuntu (rust-test.yml + ci.yml)

## Follow-ups (not in this PR)

- **#128** — VAD preprocessing for long-audio transcription (filed during this session; orthogonal to TTS).

## Breaking changes

**Internal:** `models::download_tts_kokoro` → `models::download_tts` (now also downloads Piper RU). No external API impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)