### PR TITLE
release: v1.1.0 — bidirectional voice (Kokoro EN + Piper RU)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {
@@ -29,7 +29,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.0.2"
+    "version": "1.1.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
Version bump for the first release that includes the bidirectional-voice feature landed over #125, #126, and #129.

## Bumps

| | from | to |
|---|---|---|
| \`package.json#version\` | 1.0.10 | **1.1.0** |
| \`package.json#keshaEngine.version\` | 1.0.2 | **1.1.0** |
| \`rust/Cargo.toml#version\` | 1.0.2 | **1.1.0** |

## What shipped since 1.0.10

- **\`kesha say \"...\"\`** — new TTS subcommand
- **Kokoro-82M** for English voices (\`en-af_heart\` default)
- **Piper VITS** for Russian (\`ru-denis\` default)
- **Auto-routing** by detected text language via NLLanguageRecognizer
- **\`kesha install --tts\`** — opt-in TTS model download (~390MB: Kokoro EN + Piper RU)
- **\`kesha say --list-voices\`** — enumerates both engines' installed voices
- Public API: \`say()\`, \`SayOptions\`, \`SayError\`, \`downloadTts()\` exported from \`./core\`

No breaking changes. Default ASR install flow is unchanged.

## Release flow (per CLAUDE.md)

- [x] Bump versions in lockstep (this PR)
- [ ] Merge to main
- [ ] \`git tag v1.1.0 && git push origin v1.1.0\` — triggers \`build-engine.yml\` → 3 platform binaries → draft release
- [ ] \`gh release edit v1.1.0 --draft=false\`
- [ ] Local \`make smoke-test\` + \`make smoke-test-tts\`
- [ ] \`npm publish --access public\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)