### PR TITLE
release: v1.1.1 — fix engine build missing tts feature

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -31,12 +31,14 @@ jobs:
         include:
           - os: macos-14
             target: aarch64-apple-darwin
-            features: coreml
+            features: coreml,tts
             binary: kesha-engine-darwin-arm64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            features: onnx
+            features: onnx,tts
             binary: kesha-engine-linux-x64
+          # Windows ships without TTS pending `choco install espeak-ng` path
+          # verification (see rust-test.yml matrix note).
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             features: onnx
@@ -61,7 +63,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+      - name: Install espeak-ng (macOS)
+        if: matrix.os == 'macos-14'
+        run: brew install espeak-ng
+      - name: Install espeak-ng (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y espeak-ng libespeak-ng-dev
       - name: Build release binary
+        env:
+          # macOS needs bindgen + linker flags for the espeak-ng crate.
+          LIBCLANG_PATH: ${{ matrix.os == 'macos-14' && '/Library/Developer/CommandLineTools/usr/lib' || '' }}
+          RUSTFLAGS: ${{ matrix.os == 'macos-14' && '-L /opt/homebrew/lib' || '' }}
         run: cd rust && cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --no-default-features
       - name: Prepare artifact
         shell: bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {
@@ -29,7 +29,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
## Why v1.1.0 is burned

v1.1.0 shipped engine binaries built with `cargo build --features ${{ matrix.features }} --no-default-features` where matrix features were `coreml` or `onnx` only. That excluded `tts`, so the released binaries have no `say` subcommand and no `--tts` install flag — even though the source tree at the v1.1.0 tag fully supported them.

Per CLAUDE.md: "Tag names are one-use. Broken release → bump patch version, cut new tag."

## Fix

- \`build-engine.yml\`: matrix features now include \`tts\` on macOS (\`coreml,tts\`) and Linux (\`onnx,tts\`)
- Install \`espeak-ng\` on the build runners (brew on macOS, apt on Linux)
- Set \`LIBCLANG_PATH\` + \`RUSTFLAGS\` on macOS for \`espeakng-sys\` bindgen
- Windows ships without TTS for now (matches \`rust-test.yml\` which defers Windows TTS pending \`choco install espeak-ng\` path verification)

## Version bumps

| | 1.1.0 | **1.1.1** |
|---|---|---|
| \`package.json#version\` | 1.1.0 | 1.1.1 |
| \`package.json#keshaEngine.version\` | 1.1.0 | 1.1.1 |
| \`rust/Cargo.toml#version\` | 1.1.0 | 1.1.1 |

## Release flow

- [ ] Admin-merge (release PRs fail integration-tests by design — they try to fetch the binary that doesn't exist yet)
- [ ] Tag v1.1.1 → triggers build-engine.yml → builds 3 binaries now with TTS
- [ ] Publish draft release
- [ ] Local smoke-test + smoke-test-tts → verify \`kesha say\` now works
- [ ] \`npm publish --access public\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)