### PR TITLE
release: v1.1.2 — fix Linux engine build (libclang)

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Install espeak-ng (macOS)
         if: matrix.os == 'macos-14'
         run: brew install espeak-ng
-      - name: Install espeak-ng (Linux)
+      - name: Install espeak-ng + libclang (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y espeak-ng libespeak-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y espeak-ng libespeak-ng-dev libclang-dev
       - name: Build release binary
         env:
           # macOS needs bindgen + linker flags for the espeak-ng crate.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {
@@ -29,7 +29,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
v1.1.1 Linux build failed: bindgen (espeakng-sys build dep) needs libclang. macOS + Windows built fine. This PR adds `libclang-dev` to the Linux apt install and bumps versions per CLAUDE.md.