### PR TITLE
release: v1.1.3 — LIBCLANG_PATH on Linux build

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -68,12 +68,16 @@ jobs:
         run: brew install espeak-ng
       - name: Install espeak-ng + libclang (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y espeak-ng libespeak-ng-dev libclang-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y espeak-ng libespeak-ng-dev libclang-dev llvm-dev
+          echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
+      - name: Set build env (macOS)
+        if: matrix.os == 'macos-14'
+        run: |
+          echo "LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-L /opt/homebrew/lib" >> $GITHUB_ENV
       - name: Build release binary
-        env:
-          # macOS needs bindgen + linker flags for the espeak-ng crate.
-          LIBCLANG_PATH: ${{ matrix.os == 'macos-14' && '/Library/Developer/CommandLineTools/usr/lib' || '' }}
-          RUSTFLAGS: ${{ matrix.os == 'macos-14' && '-L /opt/homebrew/lib' || '' }}
         run: cd rust && cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --no-default-features
       - name: Prepare artifact
         shell: bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {
@@ -29,7 +29,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.1.2"
+    "version": "1.1.3"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
Fixes v1.1.2 Linux build: bindgen/clang-runtime needs explicit LIBCLANG_PATH on Linux. Use `llvm-config --libdir` to locate libclang after apt-installing libclang-dev + llvm-dev. Also moved macOS env setup from YAML ternary into a run step for consistency.