### PR TITLE
feat(cli): processingTimeMs in transcription output (#139)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ rust/target/
 tmp-lang-id-output/
 .venv/
 benchmark-results.json
+.omc/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -299,7 +299,7 @@ export const mainCommand = defineCommand({
           lang,
           audioLanguage,
           textLanguage: textLanguage ?? (tinyldLang ? { code: tinyldLang, confidence: 0 } : undefined),
-          processingTimeMs: Math.round(performance.now() - startedAt),
+          sttTimeMs: Math.round(performance.now() - startedAt),
         });
       } catch (err: unknown) {
         hasError = true;
@@ -362,7 +362,7 @@ export type TranscribeResult = {
   audioLanguage?: LangDetectResult;
   textLanguage?: LangDetectResult;
   /** Wall-clock time around the engine subprocess calls for this file, ms. See #139. */
-  processingTimeMs?: number;
+  sttTimeMs?: number;
 };
 
 export function formatTextOutput(results: TranscribeResult[]): string {
@@ -390,8 +390,8 @@ export function formatVerboseOutput(results: TranscribeResult[]): string {
         const confStr = textLang.confidence > 0 ? ` (confidence: ${textLang.confidence.toFixed(2)})` : "";
         lines.push(`Text language: ${textLang.code}${confStr}`);
       }
-      if (r.processingTimeMs !== undefined) {
-        lines.push(`Processing time: ${r.processingTimeMs}ms`);
+      if (r.sttTimeMs !== undefined) {
+        lines.push(`STT time: ${r.sttTimeMs}ms`);
       }
       lines.push("---");
       lines.push(r.text);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -260,6 +260,7 @@ export const mainCommand = defineCommand({
     const wantsLangId = !!(args.lang || args.verbose || args.json || args.format === "transcript" || args.format === "json");
 
     for (const file of files) {
+      const startedAt = performance.now();
       try {
         // Run audio lang-id and transcription concurrently
         const [audioResult, text] = await Promise.all([
@@ -298,6 +299,7 @@ export const mainCommand = defineCommand({
           lang,
           audioLanguage,
           textLanguage: textLanguage ?? (tinyldLang ? { code: tinyldLang, confidence: 0 } : undefined),
+          processingTimeMs: Math.round(performance.now() - startedAt),
         });
       } catch (err: unknown) {
         hasError = true;
@@ -359,6 +361,8 @@ export type TranscribeResult = {
   lang: string;
   audioLanguage?: LangDetectResult;
   textLanguage?: LangDetectResult;
+  /** Wall-clock time around the engine subprocess calls for this file, ms. See #139. */
+  processingTimeMs?: number;
 };
 
 export function formatTextOutput(results: TranscribeResult[]): string {
@@ -385,6 +389,9 @@ export function formatVerboseOutput(results: TranscribeResult[]): string {
       if (textLang) {
         const confStr = textLang.confidence > 0 ? ` (confidence: ${textLang.confidence.toFixed(2)})` : "";
         lines.push(`Text language: ${textLang.code}${confStr}`);
+      }
+      if (r.processingTimeMs !== undefined) {
+        lines.push(`Processing time: ${r.processingTimeMs}ms`);
       }
       lines.push("---");
       lines.push(r.text);

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -165,32 +165,32 @@ describe("verbose output formatting", () => {
   });
 });
 
-describe("processingTimeMs field (#139)", () => {
-  test("JSON output preserves processingTimeMs when set", () => {
-    const results = [{ file: "a.ogg", text: "Hello", lang: "en", processingTimeMs: 427 }];
+describe("sttTimeMs field (#139)", () => {
+  test("JSON output preserves sttTimeMs when set", () => {
+    const results = [{ file: "a.ogg", text: "Hello", lang: "en", sttTimeMs: 427 }];
     const parsed = JSON.parse(formatJsonOutput(results));
-    expect(parsed[0].processingTimeMs).toBe(427);
+    expect(parsed[0].sttTimeMs).toBe(427);
   });
 
-  test("JSON output omits processingTimeMs when undefined", () => {
+  test("JSON output omits sttTimeMs when undefined", () => {
     const parsed = JSON.parse(formatJsonOutput([{ file: "a.ogg", text: "Hello", lang: "en" }]));
-    expect(parsed[0].processingTimeMs).toBeUndefined();
+    expect(parsed[0].sttTimeMs).toBeUndefined();
   });
 
   test("verbose output prints processing time line when set", () => {
-    const results = [{ file: "a.ogg", text: "Hello", lang: "en", processingTimeMs: 427 }];
+    const results = [{ file: "a.ogg", text: "Hello", lang: "en", sttTimeMs: 427 }];
     const output = formatVerboseOutput(results);
-    expect(output).toContain("Processing time: 427ms");
+    expect(output).toContain("STT time: 427ms");
   });
 
   test("verbose output omits processing time line when undefined", () => {
     const results = [{ file: "a.ogg", text: "Hello", lang: "en" }];
     const output = formatVerboseOutput(results);
-    expect(output).not.toContain("Processing time:");
+    expect(output).not.toContain("STT time:");
   });
 
-  test("plain-text output is unchanged by processingTimeMs", () => {
-    const results = [{ file: "a.ogg", text: "Hello", lang: "en", processingTimeMs: 427 }];
+  test("plain-text output is unchanged by sttTimeMs", () => {
+    const results = [{ file: "a.ogg", text: "Hello", lang: "en", sttTimeMs: 427 }];
     expect(formatTextOutput(results)).toBe("Hello\n");
   });
 });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -165,6 +165,36 @@ describe("verbose output formatting", () => {
   });
 });
 
+describe("processingTimeMs field (#139)", () => {
+  test("JSON output preserves processingTimeMs when set", () => {
+    const results = [{ file: "a.ogg", text: "Hello", lang: "en", processingTimeMs: 427 }];
+    const parsed = JSON.parse(formatJsonOutput(results));
+    expect(parsed[0].processingTimeMs).toBe(427);
+  });
+
+  test("JSON output omits processingTimeMs when undefined", () => {
+    const parsed = JSON.parse(formatJsonOutput([{ file: "a.ogg", text: "Hello", lang: "en" }]));
+    expect(parsed[0].processingTimeMs).toBeUndefined();
+  });
+
+  test("verbose output prints processing time line when set", () => {
+    const results = [{ file: "a.ogg", text: "Hello", lang: "en", processingTimeMs: 427 }];
+    const output = formatVerboseOutput(results);
+    expect(output).toContain("Processing time: 427ms");
+  });
+
+  test("verbose output omits processing time line when undefined", () => {
+    const results = [{ file: "a.ogg", text: "Hello", lang: "en" }];
+    const output = formatVerboseOutput(results);
+    expect(output).not.toContain("Processing time:");
+  });
+
+  test("plain-text output is unchanged by processingTimeMs", () => {
+    const results = [{ file: "a.ogg", text: "Hello", lang: "en", processingTimeMs: 427 }];
+    expect(formatTextOutput(results)).toBe("Hello\n");
+  });
+});
+
 describe("JSON output with lang-id fields", () => {
   test("JSON includes audioLanguage and textLanguage when present", () => {
     const results = [{


### PR DESCRIPTION
Closes #139.

## What

Adds `processingTimeMs: number` to each `TranscribeResult`. Appears in `--json`/`--format json` output and in `--verbose` as `Processing time: 427ms`. Plain text/transcript output unchanged.

## Why

Per-file, real-world timing that users and agents can log into a ledger — spot regressions like \"M3 Pro went from ~300ms to ~800ms, what changed?\" — without running a separate benchmark script.

## Scope

**TS-only**, no Rust change. The `transcribe` subcommand in the engine emits a plain string; the JSON shape is assembled in `src/cli.ts`. Measuring there wraps engine spawn + lang-id fan-out, matching the issue's AC #2 (\"around the engine subprocess call, not just the Rust-side pipeline — captures cold-start + I/O\").

## Changes

- `TranscribeResult.processingTimeMs?: number` (optional — preserves back-compat).
- `performance.now()` around the per-file block in the main transcribe loop; `Math.round()` the delta.
- `formatVerboseOutput`: emits `Processing time: ${ms}ms` between language lines and `---`.
- `formatJsonOutput`: no change — `JSON.stringify` drops undefined, so existing consumers stay compatible.
- `formatTextOutput` / `formatTranscriptOutput`: untouched (pipe-friendly).
- `.gitignore`: `.omc/` (local agent-state dir).

## Tests

5 new formatter tests (JSON round-trip on/off, verbose on/off, text untouched). 82/82 unit tests green, typecheck clean.

## Acceptance criteria

- [x] `kesha --json file.ogg` includes `processingTimeMs` as a positive integer.
- [x] Measured around the engine subprocess (cold-start + I/O included).
- [x] Multi-file output shows per-file timing.
- [x] `--verbose` prints it in a human-readable format.
- [x] Existing JSON consumers unaffected (field is additive + optional).