### PR TITLE
feat(say): --verbose emits TTS time on stderr (symmetric to #139)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -124,6 +124,11 @@ export const sayCommand = defineCommand({
       type: "boolean",
       description: "Parse input as SSML (supports <speak>, <break>; strips unknown tags)",
     },
+    verbose: {
+      type: "boolean",
+      description: "Log TTS synthesis time to stderr",
+      default: false,
+    },
   },
   async run({ args }) {
     if (args["list-voices"]) {
@@ -151,7 +156,13 @@ export const sayCommand = defineCommand({
     };
 
     try {
+      const startedAt = performance.now();
       const wav = await say(opts);
+      const ttsTimeMs = Math.round(performance.now() - startedAt);
+      if (args.verbose) {
+        // stderr — stdout may carry raw WAV bytes when --out is omitted.
+        console.error(`TTS time: ${ttsTimeMs}ms`);
+      }
       if (!opts.out) {
         process.stdout.write(wav);
       }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
-import { mainCommand, installCommand, statusCommand, formatTextOutput, formatJsonOutput, formatVerboseOutput, detectLanguage, checkLanguageMismatch } from "../../src/cli";
+import { mainCommand, installCommand, statusCommand, sayCommand, formatTextOutput, formatJsonOutput, formatVerboseOutput, detectLanguage, checkLanguageMismatch } from "../../src/cli";
 
 describe("CLI help", () => {
   test("main help contains usage and install info", async () => {
@@ -162,6 +162,18 @@ describe("verbose output formatting", () => {
     expect(output).not.toContain("Audio language:");
     expect(output).toContain("Text language: en");
     expect(output).toContain("Hello");
+  });
+});
+
+describe("say --verbose (TTS time, parallel to #139)", () => {
+  test("say help advertises --verbose", async () => {
+    const usage = await renderUsage(sayCommand);
+    expect(usage).toContain("--verbose");
+  });
+
+  test("say help explains --verbose prints TTS time", async () => {
+    const usage = await renderUsage(sayCommand);
+    expect(usage).toMatch(/TTS|synthesis time/i);
   });
 });
 


### PR DESCRIPTION
Sibling of #142 (`sttTimeMs`). Adds `--verbose` to `kesha say`; when set, logs \`TTS time: Xms\` to stderr after synthesis.

## Why

- Same motivation as #139: real-world per-call timing that users and agents can log to spot regressions (\"Piper RU used to run ~300ms, now 800ms on the same M3 Pro — what changed?\").
- Stays symmetric with transcribe's `sttTimeMs` field — future dashboards can line the two up.

## Why stderr, not JSON

`kesha say` writes raw WAV bytes to stdout (when `--out` is omitted). Inlining timing into stdout would corrupt the audio stream. Stderr matches the convention already used by `log.warn`/`log.error` in this codebase.

## Changes

- `sayCommand.args.verbose: boolean` — default false.
- Wrap `await say(opts)` with `performance.now()`; `Math.round()` the delta.
- On `--verbose`, `console.error(\`TTS time: \${ms}ms\`)` (stderr — comment explains why).
- Tests: 2 usage-string checks on sayCommand.

## What this DOES NOT do

- No JSON output for `say` (intentional — WAV and JSON don't share stdout).
- No sub-ms resolution (`Math.round` mirrors sttTimeMs; sub-ms is noise for end-to-end measurement).
- No change to default behavior — pipelines that `kesha say "hi" > out.wav` stay byte-identical.

## Tests

33/33 unit tests green, typecheck clean.

## Related

- #139 sttTimeMs (merged as #142)
- #141 AVSpeechSynthesizer backend (stacked — will measure via this same timer)