### PR TITLE
feat(tts): system_tts feature + AVSpeech helper infrastructure (#141 part 1)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,6 +18,10 @@ default = ["onnx", "tts"]
 coreml = ["dep:fluidaudio-rs"]
 onnx = []
 tts = ["dep:hound", "dep:espeakng-sys", "dep:thiserror", "dep:sha2", "dep:ssml-parser"]
+# macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
+# Opt-in — builds a Swift sidecar via swiftc in build.rs. Silently no-op on
+# non-macOS targets even when enabled.
+system_tts = ["tts"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -8,4 +8,44 @@ fn main() {
     {
         println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
     }
+
+    // `system_tts` (#141): compile the AVSpeechSynthesizer helper on macOS.
+    // Writes the sidecar binary to $OUT_DIR/say-avspeech. Silently no-op on
+    // other targets so `--features system_tts` works in cross-platform builds.
+    #[cfg(all(feature = "system_tts", target_os = "macos"))]
+    build_avspeech_helper();
+}
+
+#[cfg(all(feature = "system_tts", target_os = "macos"))]
+fn build_avspeech_helper() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let src = manifest_dir.join("swift/say-avspeech.swift");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_bin = out_dir.join("say-avspeech");
+
+    println!("cargo:rerun-if-changed={}", src.display());
+
+    let status = Command::new("swiftc")
+        .arg("-O")
+        .arg("-o")
+        .arg(&out_bin)
+        .arg(&src)
+        .status()
+        .expect(
+            "swiftc not found — install Xcode command-line tools or disable --features system_tts",
+        );
+    assert!(
+        status.success(),
+        "swiftc failed to build say-avspeech from {}",
+        src.display()
+    );
+
+    // Expose the path to runtime code via env!("KESHA_AVSPEECH_HELPER").
+    println!(
+        "cargo:rustc-env=KESHA_AVSPEECH_HELPER={}",
+        out_bin.display()
+    );
 }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -44,6 +44,13 @@ fn build_avspeech_helper() {
     );
 
     // Expose the path to runtime code via env!("KESHA_AVSPEECH_HELPER").
+    //
+    // KNOWN LIMITATION: $OUT_DIR is ephemeral and machine-specific. After
+    // `cargo clean` or when kesha-engine is moved off this machine (installed,
+    // distributed, or zipped in a release), this baked-in path becomes stale.
+    // Part 3 of #141 replaces this with "look up a sibling `say-avspeech`
+    // next to the current executable" for deployed binaries, keeping this
+    // path as the fallback for `cargo run` / `cargo test`.
     println!(
         "cargo:rustc-env=KESHA_AVSPEECH_HELPER={}",
         out_bin.display()

--- a/rust/src/tts/avspeech.rs
+++ b/rust/src/tts/avspeech.rs
@@ -1,0 +1,123 @@
+//! AVSpeechSynthesizer backend (#141) — macOS-only, behind the `system_tts` feature.
+//!
+//! Shells out to a Swift sidecar (`swift/say-avspeech.swift`, compiled by
+//! `build.rs` into `$OUT_DIR/say-avspeech`). The Rust side pipes UTF-8 text on
+//! stdin, passes the voice identifier as argv\[1\], and reads a complete WAV
+//! (mono IEEE-float @ 22050 Hz) from stdout. Stderr is surfaced in the error
+//! message when synthesis fails.
+//!
+//! This module is infrastructure only for this PR — callers (voice routing,
+//! `say()` dispatch) land in a follow-up. See issue #141.
+
+#![cfg(all(feature = "system_tts", target_os = "macos"))]
+// Infrastructure-only in this PR (#141). The follow-up wires helper_path()
+// and synthesize() into tts::voices::resolve_voice + the say() dispatch;
+// without those call sites, clippy would otherwise block CI on dead_code.
+#![allow(dead_code)]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Path to the sidecar `say-avspeech` binary, baked in at build time by `build.rs`.
+pub fn helper_path() -> PathBuf {
+    PathBuf::from(env!("KESHA_AVSPEECH_HELPER"))
+}
+
+/// Synthesize `text` with the macOS voice identified by `voice_id`.
+///
+/// `voice_id` is forwarded verbatim to `AVSpeechSynthesisVoice(identifier:)` and
+/// falls back to `AVSpeechSynthesisVoice(language:)` inside the helper. Accepts
+/// either a full identifier (`com.apple.voice.compact.en-US.Samantha`) or a
+/// language code (`en-US`, `ru-RU`).
+///
+/// Returns complete WAV bytes. `helper` defaults to [`helper_path()`] when `None`
+/// — tests inject a fake helper to verify the subprocess contract without needing
+/// the real Swift binary.
+pub fn synthesize(text: &str, voice_id: &str, helper: Option<&Path>) -> anyhow::Result<Vec<u8>> {
+    if text.is_empty() {
+        anyhow::bail!("avspeech: text is empty");
+    }
+    let bin = helper.map(PathBuf::from).unwrap_or_else(helper_path);
+
+    let mut child = Command::new(&bin)
+        .arg(voice_id)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("spawn {}: {e}", bin.display()))?;
+
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("avspeech: stdin unavailable"))?
+        .write_all(text.as_bytes())?;
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "avspeech helper exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fake_helper(tmp: &TempDir, script: &str) -> PathBuf {
+        let path = tmp.path().join("fake-helper.sh");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "{script}").unwrap();
+        drop(f);
+        // chmod +x
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path
+    }
+
+    #[test]
+    fn empty_text_errors() {
+        let err = synthesize("", "en-US", Some(Path::new("/bin/true")))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("empty"), "msg: {err}");
+    }
+
+    #[test]
+    fn helper_stdout_is_returned_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        let helper = fake_helper(&tmp, r#"cat >/dev/null; printf 'RIFFmock'"#);
+        let bytes = synthesize("hello", "en-US", Some(&helper)).unwrap();
+        assert_eq!(&bytes, b"RIFFmock");
+    }
+
+    #[test]
+    fn helper_nonzero_exit_surfaces_stderr() {
+        let tmp = TempDir::new().unwrap();
+        let helper = fake_helper(&tmp, r#"echo 'voice not found: xyz' >&2; exit 2"#);
+        let err = synthesize("hello", "xyz", Some(&helper))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("voice not found"), "msg: {err}");
+        assert!(err.contains("exited"), "msg: {err}");
+    }
+
+    #[test]
+    fn text_is_piped_on_stdin() {
+        let tmp = TempDir::new().unwrap();
+        // `cat` echoes stdin to stdout, so the result should be exactly the input text.
+        let helper = fake_helper(&tmp, "cat");
+        let bytes = synthesize("Hello, kesha!", "en-US", Some(&helper)).unwrap();
+        assert_eq!(String::from_utf8(bytes).unwrap(), "Hello, kesha!");
+    }
+}

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -10,6 +10,9 @@ pub mod tokenizer;
 pub mod voices;
 pub mod wav;
 
+#[cfg(all(feature = "system_tts", target_os = "macos"))]
+pub mod avspeech;
+
 /// Soft limit on input text length. Rejects absurdly long inputs that would
 /// spend minutes on synthesis with poor quality.
 pub const MAX_TEXT_CHARS: usize = 5000;

--- a/rust/swift/say-avspeech.swift
+++ b/rust/swift/say-avspeech.swift
@@ -1,0 +1,105 @@
+// CLI helper for kesha-engine (#141): text on stdin / argv → WAV on stdout.
+//
+// Invoked by the Rust `avspeech` backend when a `macos-*` voice is selected.
+// Emits mono float32 WAV (IEEE_FLOAT) at the voice's native sample rate
+// (22050 Hz on every macOS voice we've tested). Stderr carries progress + errors.
+//
+// Usage: say-avspeech <voiceId> [text]  (stdin if text is omitted)
+//
+// Key gotcha: AVSpeechSynthesizer.write(_:toBufferCallback:) delivers buffers
+// on the main dispatch queue, so the CLI MUST pump the run loop. Semaphores
+// hang. CFRunLoopRun / CFRunLoopStop is the only working pattern.
+
+import AVFoundation
+import Foundation
+
+let args = CommandLine.arguments
+guard args.count >= 2 else {
+  FileHandle.standardError.write("usage: say-avspeech <voiceID> [text — else stdin]\n".data(using: .utf8)!)
+  exit(2)
+}
+let voiceId = args[1]
+let text: String
+if args.count >= 3 {
+  text = args[2]
+} else {
+  let data = FileHandle.standardInput.readDataToEndOfFile()
+  text = String(data: data, encoding: .utf8) ?? ""
+}
+guard !text.isEmpty else {
+  FileHandle.standardError.write("empty text\n".data(using: .utf8)!)
+  exit(2)
+}
+
+let synth = AVSpeechSynthesizer()
+let utt = AVSpeechUtterance(string: text)
+utt.voice = AVSpeechSynthesisVoice(identifier: voiceId) ?? AVSpeechSynthesisVoice(language: voiceId)
+if utt.voice == nil {
+  FileHandle.standardError.write("voice not found: \(voiceId)\n".data(using: .utf8)!)
+  exit(2)
+}
+
+var samples: [Float] = []
+var sampleRate: Double = 0
+var channels: AVAudioChannelCount = 0
+
+synth.write(utt) { buffer in
+  guard let pcm = buffer as? AVAudioPCMBuffer else { return }
+  if pcm.frameLength == 0 {
+    CFRunLoopStop(CFRunLoopGetMain())
+    return
+  }
+  sampleRate = pcm.format.sampleRate
+  channels = pcm.format.channelCount
+  guard let floatPtr = pcm.floatChannelData?[0] else { return }
+  let count = Int(pcm.frameLength)
+  samples.append(contentsOf: UnsafeBufferPointer(start: floatPtr, count: count))
+}
+
+// 15s wall-clock watchdog on a background queue.
+DispatchQueue.global().asyncAfter(deadline: .now() + 15) {
+  FileHandle.standardError.write("timeout waiting for synthesis\n".data(using: .utf8)!)
+  CFRunLoopStop(CFRunLoopGetMain())
+}
+CFRunLoopRun()
+
+guard !samples.isEmpty, sampleRate > 0 else {
+  FileHandle.standardError.write("no samples produced\n".data(using: .utf8)!)
+  exit(4)
+}
+
+// Minimal WAV-float32 encoder (mono). IEEE_FLOAT (wFormatTag = 3) so downstream
+// consumers can read the stream without re-quantization. Matches the shape
+// emitted by `tts::wav::encode_wav` in the Rust engine.
+func appendLE32(_ v: UInt32, to data: inout Data) {
+  var le = v.littleEndian
+  withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }
+}
+func appendLE16(_ v: UInt16, to data: inout Data) {
+  var le = v.littleEndian
+  withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }
+}
+
+let bitsPerSample: UInt16 = 32
+let bytesPerSample: UInt16 = bitsPerSample / 8
+let dataSize = UInt32(samples.count) * UInt32(bytesPerSample) * UInt32(channels)
+var wav = Data()
+wav.append("RIFF".data(using: .ascii)!)
+appendLE32(36 + dataSize, to: &wav)
+wav.append("WAVE".data(using: .ascii)!)
+wav.append("fmt ".data(using: .ascii)!)
+appendLE32(16, to: &wav)
+appendLE16(3, to: &wav)  // IEEE_FLOAT
+appendLE16(UInt16(channels), to: &wav)
+appendLE32(UInt32(sampleRate), to: &wav)
+appendLE32(UInt32(sampleRate) * UInt32(channels) * UInt32(bytesPerSample), to: &wav)
+appendLE16(UInt16(channels) * bytesPerSample, to: &wav)
+appendLE16(bitsPerSample, to: &wav)
+wav.append("data".data(using: .ascii)!)
+appendLE32(dataSize, to: &wav)
+
+samples.withUnsafeBytes { raw in
+  wav.append(raw.bindMemory(to: UInt8.self))
+}
+
+FileHandle.standardOutput.write(wav)

--- a/rust/swift/say-avspeech.swift
+++ b/rust/swift/say-avspeech.swift
@@ -42,6 +42,7 @@ if utt.voice == nil {
 var samples: [Float] = []
 var sampleRate: Double = 0
 var channels: AVAudioChannelCount = 0
+var timedOut = false
 
 synth.write(utt) { buffer in
   guard let pcm = buffer as? AVAudioPCMBuffer else { return }
@@ -56,14 +57,21 @@ synth.write(utt) { buffer in
   samples.append(contentsOf: UnsafeBufferPointer(start: floatPtr, count: count))
 }
 
-// 15s wall-clock watchdog on a background queue.
+// 15s wall-clock watchdog on a background queue. Setting `timedOut = true`
+// before stopping the run loop lets the post-loop check exit non-zero even
+// if some buffers arrived first — partial WAV on stdout is worse than none,
+// because the Rust caller would treat it as success.
 DispatchQueue.global().asyncAfter(deadline: .now() + 15) {
   FileHandle.standardError.write("timeout waiting for synthesis\n".data(using: .utf8)!)
+  timedOut = true
   CFRunLoopStop(CFRunLoopGetMain())
 }
 CFRunLoopRun()
 
-guard !samples.isEmpty, sampleRate > 0 else {
+if timedOut {
+  exit(3)
+}
+guard !samples.isEmpty, sampleRate > 0, channels > 0 else {
   FileHandle.standardError.write("no samples produced\n".data(using: .utf8)!)
   exit(4)
 }


### PR DESCRIPTION
First slice of #141. Ships the **infrastructure** for an AVSpeechSynthesizer backend; the follow-up PR wires it into `say()` + voice routing.

Split per plan C (smaller review chunks):
- **Part 1 (this PR):** Swift helper + build.rs + Rust module + feature + tests.
- **Part 2 (next PR):** `EngineChoice::AVSpeech`, `ResolvedVoice::AVSpeech`, \`macos-*\` voice prefix, `--list-voices` enumeration.
- **Part 3 (later):** CI builds on release, README docs.

## Spike findings (committed as 1ed5916)

- `AVSpeechSynthesizer.write(_:toBufferCallback:)` **works** from CLI Swift — verified on Samantha (en-US) and Milena (ru-RU).
- **MUST pump `CFRunLoopRun()`** — semaphores hang (callbacks dispatch on main queue). Comment in `swift/say-avspeech.swift` warns future readers.
- Output is mono float32 IEEE_FLOAT @ 22050 Hz on every tested voice — conveniently identical to Piper's rate, so downstream consumers don't branch.
- `swiftc -O` binary is ~63 KB for the whole helper.

## What this PR adds

1. `rust/swift/say-avspeech.swift` — standalone helper: text on argv/stdin → WAV on stdout, errors/progress on stderr.
2. `rust/Cargo.toml` — new `system_tts` feature (opt-in, not in default).
3. `rust/build.rs` — under `system_tts` + macOS, compiles the Swift file via `swiftc` into `$OUT_DIR/say-avspeech` and exposes it via the `KESHA_AVSPEECH_HELPER` rustc-env.
4. `rust/src/tts/avspeech.rs` — `synthesize(text, voice_id, helper=None)` that spawns the sidecar, pipes text, returns WAV bytes. Tests inject a fake `sh` helper for isolation (no dependency on the real Swift binary in default CI).

## What this PR does NOT do

- No wiring into `say()` or `voices::resolve_voice` yet — functions carry `#![allow(dead_code)]` with a comment explaining the temporary status. Removed in Part 2.
- No \`macos-*\` voice parsing.
- No `--list-voices` macOS enumeration.
- No release integration (build-engine.yml unchanged).

## Tests

4 new unit tests on `cargo test --features system_tts`:
- empty text errors
- helper stdout flows through verbatim
- nonzero exit surfaces stderr
- text is piped on stdin (not argv)

Total 46/46 lib tests green with the feature; default build unaffected; clippy clean under `-D warnings` on both feature matrices.

**Local E2E sanity:** `cargo build --features system_tts`, then `echo "hello" | $OUT_DIR/say-avspeech com.apple.voice.compact.en-US.Samantha > /tmp/out.wav` → `file` reports valid `RIFF WAVE IEEE Float mono 22050 Hz`.

## Why feature-gate instead of adding to defaults?

- Swift runtime is only present on macOS; swiftc isn't on Linux CI.
- `system_tts` staying opt-in means Linux/Windows builds don't need special handling.
- Once Part 2 lands and the release pipeline ships the sidecar, we reconsider promoting to default on macOS.

## Related

- Closes part of #141 (infrastructure)
- #124 (espeak-ng static-link) — orthogonal