### PR TITLE
feat(tts): wire AVSpeech + macos-* voice routing (#141 part 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,12 +269,13 @@ const text = await transcribe("audio.ogg");
 
 ## TTS
 
-Text-to-speech via two engines selected by voice id prefix:
+Text-to-speech via three engines selected by voice id prefix:
 
 - `en-*` → **Kokoro-82M**. Separate model + per-voice style embedding. Output 24 kHz.
 - `ru-*` → **Piper VITS** (`rhasspy/piper-voices`). Per-voice `.onnx` + `.onnx.json`. Output depends on voice (22.05 kHz for medium tier).
+- `macos-*` → **AVSpeechSynthesizer** via a Swift sidecar (#141, opt-in `--features system_tts` for now). Zero model download, notification-grade quality. Release integration is Part 3.
 
-Opt-in via `kesha install --tts` (downloads both engines, ~390 MB).
+Opt-in via `kesha install --tts` (downloads Kokoro + Piper, ~390 MB). `macos-*` voices need no install — they use voices already on macOS.
 
 - TTS models are **never auto-downloaded** — `kesha say` fails loudly with a `kesha install --tts` hint when models are missing.
 - `kesha say` writes WAV mono f32 to stdout unless `--out` is given. Stderr is progress/errors only.
@@ -283,6 +284,7 @@ Opt-in via `kesha install --tts` (downloads both engines, ~390 MB).
 - **SSML** (opt-in via `--ssml`): uses the `ssml-parser` crate; supports `<speak>` root and `<break time="...">` for silence. Unknown tags (`<emphasis>`, `<prosody>`, `<phoneme>`, `<say-as>`) warn to stderr once per name and are stripped, but contained text is still synthesized. Hardening: required `<speak>` root, `<!DOCTYPE>` rejected anywhere in input. `tts::ssml::parse` returns `Vec<Segment>`; `tts::say()` loads the engine once and concatenates f32 samples for text vs silence for breaks before a single `wav::encode_wav`. See issue #122 for the full scope matrix and future tag support.
 - Kokoro ONNX: `input_ids` (int64 `[1,N]`), `style` (f32 `[1,256]` — rank-2), `speed` (f32 `[1]`). Output name `"waveform"`. Voice file 510 rows × 256 cols.
 - Piper ONNX: `input` (int64 `[1,N]` — BOS + pad-interleaved phoneme IDs + EOS), `input_lengths` (int64 `[1]`), `scales` (f32 `[3]` = `[noise_scale, length_scale, noise_w]`). Output name `"output"`, rank-4 `[1,1,1,T]`. `--rate` is mapped to Piper via `length_scale = voice_default / speed`.
+- **AVSpeech** (#141, opt-in `system_tts`): `kesha-engine` spawns `$OUT_DIR/say-avspeech` (Swift, compiled by `build.rs`). UTF-8 text on stdin, voice id as argv[1]. Swift writes a complete mono f32 IEEE_FLOAT WAV @ 22050 Hz to stdout. Gotcha: AVSpeechSynthesizer callbacks dispatch on the main queue, so the helper MUST pump `CFRunLoopRun()` — `DispatchSemaphore` hangs. `--rate` not wired yet (AVSpeechUtterance has its own `.rate`, mapping TBD). SSML + AVSpeech explicitly rejected in v1.
 - `KESHA_ENGINE_BIN` — override the engine-binary path (useful when iterating on `rust/target/release/kesha-engine`).
 - `KESHA_CACHE_DIR` — isolated test cache.
 - macOS dev runtime: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`. Release binaries fix up via `install_name_tool`.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Op
 **Supported voices:**
 - English: `en-af_heart` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/`
 - Russian: `ru-denis` (default). More speakers (dmitri, irina, ruslan) are ready to drop in once needed.
+- macOS system voices (preview — dev builds only, see below): `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
+
+### macOS system voices (preview)
+
+`kesha say --voice macos-*` routes through `AVSpeechSynthesizer` on macOS, so you get voice synthesis for free — no 390 MB TTS bundle, no `espeak-ng` dep. Currently gated behind the `system_tts` cargo feature; release-binary integration is tracked as part of [#141](https://github.com/drakulavich/kesha-voice-kit/issues/141).
+
+```bash
+# From a dev build: `cargo build --release --features system_tts` in rust/.
+kesha say --voice macos-com.apple.voice.compact.en-US.Samantha "Hello from system TTS" > out.wav
+kesha say --voice macos-ru-RU "Привет, мир" > hello-ru.wav   # language-code fallback
+```
+
+Voice id format: `macos-<id>` where `<id>` is either a full Apple identifier (`com.apple.voice.compact.en-US.Samantha`) or a language code (`en-US`, `ru-RU`) — the Swift helper tries the identifier first and falls back to the language. Output is mono float32 @ 22050 Hz, structurally identical to Piper.
+
+Quality tradeoff is honest: macOS system voices are notification-grade. Use them when you want zero-install TTS on macOS; keep Kokoro/Piper for anything that needs to sound good.
 
 ### SSML (preview)
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -244,6 +244,10 @@ fn run_say(a: SayArgs) -> i32 {
             config_path,
             speed: a.rate,
         },
+        #[cfg(all(feature = "system_tts", target_os = "macos"))]
+        tts::voices::ResolvedVoice::AVSpeech { voice_id } => {
+            tts::EngineChoice::AVSpeech { voice_id }
+        }
     };
 
     let wav = match tts::say(tts::SayOptions {

--- a/rust/src/tts/avspeech.rs
+++ b/rust/src/tts/avspeech.rs
@@ -10,10 +10,6 @@
 //! `say()` dispatch) land in a follow-up. See issue #141.
 
 #![cfg(all(feature = "system_tts", target_os = "macos"))]
-// Infrastructure-only in this PR (#141). The follow-up wires helper_path()
-// and synthesize() into tts::voices::resolve_voice + the say() dispatch;
-// without those call sites, clippy would otherwise block CI on dead_code.
-#![allow(dead_code)]
 
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/rust/src/tts/avspeech.rs
+++ b/rust/src/tts/avspeech.rs
@@ -6,8 +6,8 @@
 //! (mono IEEE-float @ 22050 Hz) from stdout. Stderr is surfaced in the error
 //! message when synthesis fails.
 //!
-//! This module is infrastructure only for this PR — callers (voice routing,
-//! `say()` dispatch) land in a follow-up. See issue #141.
+//! Wired into `tts::say()` dispatch via `EngineChoice::AVSpeech` and selected
+//! by the `macos-*` voice-id prefix in `tts::voices::resolve_voice`.
 
 #![cfg(all(feature = "system_tts", target_os = "macos"))]
 

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -35,6 +35,10 @@ pub enum EngineChoice<'a> {
         voice_path: &'a Path,
         speed: f32,
     },
+    /// macOS AVSpeechSynthesizer via the Swift sidecar (#141).
+    /// `voice_id` is forwarded verbatim (an Apple identifier or a language code).
+    #[cfg(all(feature = "system_tts", target_os = "macos"))]
+    AVSpeech { voice_id: &'a str },
     /// Piper VITS: model + per-voice .onnx.json config.
     Piper {
         model_path: &'a Path,
@@ -72,6 +76,18 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         });
     }
 
+    // AVSpeech does its own G2P + synthesis inside Swift; skip espeak G2P entirely.
+    #[cfg(all(feature = "system_tts", target_os = "macos"))]
+    if let EngineChoice::AVSpeech { voice_id } = &opts.engine {
+        if opts.ssml {
+            return Err(TtsError::SynthesisFailed(
+                "SSML is not yet supported with macos-* voices (#141 follow-up)".into(),
+            ));
+        }
+        return avspeech::synthesize(opts.text, voice_id, None)
+            .map_err(|e| TtsError::SynthesisFailed(format!("avspeech: {e}")));
+    }
+
     if opts.ssml {
         return say_ssml(&opts);
     }
@@ -95,6 +111,10 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
             config_path,
             speed,
         } => say_with_piper(&ipa, model_path, config_path, speed),
+        // The AVSpeech arm is handled by the early-return above. Keep a guard
+        // arm so the match stays exhaustive when the feature is enabled.
+        #[cfg(all(feature = "system_tts", target_os = "macos"))]
+        EngineChoice::AVSpeech { .. } => unreachable!("handled by early return above"),
     }
 }
 
@@ -120,6 +140,11 @@ fn say_ssml(opts: &SayOptions) -> Result<Vec<u8>, TtsError> {
             config_path,
             speed,
         } => synth_segments_piper(&segments, opts.lang, model_path, config_path, *speed),
+        // AVSpeech + SSML is rejected up-front in `say()`; this arm keeps the match exhaustive.
+        #[cfg(all(feature = "system_tts", target_os = "macos"))]
+        EngineChoice::AVSpeech { .. } => {
+            unreachable!("AVSpeech + SSML rejected in say() early return")
+        }
     }
 }
 

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -52,18 +52,28 @@ pub enum ResolvedVoice {
         config_path: std::path::PathBuf,
         espeak_lang: &'static str,
     },
+    /// macOS system TTS via AVSpeechSynthesizer (#141). The voice id is
+    /// whatever the user passed after the `macos-` prefix — forwarded to the
+    /// Swift helper, which tries `AVSpeechSynthesisVoice(identifier:)` first
+    /// and falls back to `AVSpeechSynthesisVoice(language:)`.
+    #[cfg(all(feature = "system_tts", target_os = "macos"))]
+    AVSpeech { voice_id: String },
 }
 
 impl ResolvedVoice {
     pub fn espeak_lang(&self) -> &'static str {
         match self {
             Self::Kokoro { espeak_lang, .. } | Self::Piper { espeak_lang, .. } => espeak_lang,
+            // AVSpeech does its own G2P; the espeak language tag is unused.
+            #[cfg(all(feature = "system_tts", target_os = "macos"))]
+            Self::AVSpeech { .. } => "",
         }
     }
 }
 
 /// Parse a voice id like `en-af_heart` or `ru-denis` into engine + paths.
 /// Voice id is `<lang>-<name>`; lang picks the engine and espeak language code.
+/// The special `macos-*` prefix routes to AVSpeechSynthesizer on supported builds.
 pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<ResolvedVoice> {
     let (lang, name) = voice_id.split_once('-').ok_or_else(|| {
         anyhow::anyhow!("voice id must be in 'lang-name' form (got '{voice_id}')")
@@ -71,7 +81,17 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
     match lang {
         "en" => resolve_kokoro(cache_dir, voice_id, name),
         "ru" => resolve_piper_ru(cache_dir, voice_id, name),
-        other => anyhow::bail!("language '{other}' not supported (use 'en-*' or 'ru-*')"),
+        #[cfg(all(feature = "system_tts", target_os = "macos"))]
+        "macos" => Ok(ResolvedVoice::AVSpeech {
+            voice_id: name.to_string(),
+        }),
+        #[cfg(not(all(feature = "system_tts", target_os = "macos")))]
+        "macos" => anyhow::bail!(
+            "'macos-*' voices require a macOS build with --features system_tts (got '{voice_id}')"
+        ),
+        other => {
+            anyhow::bail!("language '{other}' not supported (use 'en-*', 'ru-*', or 'macos-*')")
+        }
     }
 }
 
@@ -198,6 +218,39 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("ru_RU-denis-medium.onnx"), b"dummy").unwrap();
         std::fs::write(dir.join("ru_RU-denis-medium.onnx.json"), b"{}").unwrap();
+    }
+
+    #[cfg(all(feature = "system_tts", target_os = "macos"))]
+    #[test]
+    fn resolve_macos_voice_returns_avspeech() {
+        let tmp = tempfile::tempdir().unwrap();
+        let r = resolve_voice(tmp.path(), "macos-com.apple.voice.compact.en-US.Samantha").unwrap();
+        match r {
+            ResolvedVoice::AVSpeech { voice_id } => {
+                // Prefix stripped; the rest (including embedded dashes) passes through.
+                assert_eq!(voice_id, "com.apple.voice.compact.en-US.Samantha");
+            }
+            other => panic!("expected AVSpeech, got {other:?}"),
+        }
+    }
+
+    #[cfg(all(feature = "system_tts", target_os = "macos"))]
+    #[test]
+    fn resolve_macos_short_voice_id_works() {
+        let tmp = tempfile::tempdir().unwrap();
+        let r = resolve_voice(tmp.path(), "macos-en-US").unwrap();
+        match r {
+            ResolvedVoice::AVSpeech { voice_id } => assert_eq!(voice_id, "en-US"),
+            other => panic!("expected AVSpeech, got {other:?}"),
+        }
+    }
+
+    #[cfg(not(all(feature = "system_tts", target_os = "macos")))]
+    #[test]
+    fn resolve_macos_voice_errors_without_feature() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_voice(tmp.path(), "macos-en-US").unwrap_err().to_string();
+        assert!(err.contains("system_tts"), "msg: {err}");
     }
 
     #[test]

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -82,9 +82,16 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
         "en" => resolve_kokoro(cache_dir, voice_id, name),
         "ru" => resolve_piper_ru(cache_dir, voice_id, name),
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
-        "macos" => Ok(ResolvedVoice::AVSpeech {
-            voice_id: name.to_string(),
-        }),
+        "macos" => {
+            if name.is_empty() {
+                anyhow::bail!(
+                    "'macos-' voice id requires a suffix (identifier or language code, e.g. macos-en-US)"
+                );
+            }
+            Ok(ResolvedVoice::AVSpeech {
+                voice_id: name.to_string(),
+            })
+        }
         #[cfg(not(all(feature = "system_tts", target_os = "macos")))]
         "macos" => anyhow::bail!(
             "'macos-*' voices require a macOS build with --features system_tts (got '{voice_id}')"
@@ -236,6 +243,16 @@ mod tests {
 
     #[cfg(all(feature = "system_tts", target_os = "macos"))]
     #[test]
+    fn resolve_macos_empty_suffix_errors() {
+        // `macos-` alone would forward an empty string to the Swift helper,
+        // which then fails with an unhelpful "voice not found". Reject early.
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_voice(tmp.path(), "macos-").unwrap_err().to_string();
+        assert!(err.contains("requires a suffix"), "msg: {err}");
+    }
+
+    #[cfg(all(feature = "system_tts", target_os = "macos"))]
+    #[test]
     fn resolve_macos_short_voice_id_works() {
         let tmp = tempfile::tempdir().unwrap();
         let r = resolve_voice(tmp.path(), "macos-en-US").unwrap();
@@ -249,7 +266,9 @@ mod tests {
     #[test]
     fn resolve_macos_voice_errors_without_feature() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = resolve_voice(tmp.path(), "macos-en-US").unwrap_err().to_string();
+        let err = resolve_voice(tmp.path(), "macos-en-US")
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("system_tts"), "msg: {err}");
     }
 


### PR DESCRIPTION
Part 2 of #141 — stacks on #144 (infrastructure, merged as \`8ccb326\`). Turns the scaffolding into an actual voice.

## Shape

\`kesha say --voice macos-<id>\` now synthesizes through the Swift sidecar from #144 instead of erroring.

Voice id syntax: everything after \`macos-\` is forwarded verbatim to the Swift helper, which tries \`AVSpeechSynthesisVoice(identifier:)\` first and falls back to \`AVSpeechSynthesisVoice(language:)\`. So both of these work:

\`\`\`bash
kesha say --voice macos-com.apple.voice.compact.en-US.Samantha \"Hello\"
kesha say --voice macos-ru-RU \"Привет\"   # language-code fallback; Milena default on macOS 14
\`\`\`

## Changes

- \`voices::ResolvedVoice::AVSpeech { voice_id: String }\` — cfg-gated.
- \`voices::resolve_voice\` matches \`macos\` prefix, strips it, stores the rest.
- \`tts::EngineChoice::AVSpeech { voice_id: &str }\` — cfg-gated.
- \`tts::say()\` short-circuits to \`avspeech::synthesize\` **before** the espeak G2P path (AVSpeech does its own phonemizer).
- \`tts::say()\` explicitly rejects SSML + AVSpeech with a clear error — v1 scope per #141, SSML-on-system-TTS is a follow-up concern.
- \`main.rs\` adds the new \`ResolvedVoice\` arm.
- \`avspeech.rs\` drops \`#![allow(dead_code)]\` — the module is live now.

## What happens without \`--features system_tts\` / on non-macOS

Instead of a generic \"language 'macos' not supported\", users get:

> \`'macos-*' voices require a macOS build with --features system_tts\`

## What this PR does NOT do (tracked as Part 3)

- No release-binary integration — the sidecar still lives in \`$OUT_DIR\` (baked-in path, known limitation documented in \`build.rs\`).
- No \`--list-voices\` enumeration for macOS voices.
- No README / CLAUDE.md mention — docs land after Part 3 ships the release binary.

## Tests

- \`voices::tests::resolve_macos_voice_returns_avspeech\` — full Apple identifier passthrough.
- \`voices::tests::resolve_macos_short_voice_id_works\` — language code fallback.
- \`voices::tests::resolve_macos_voice_errors_without_feature\` — clear error on non-macOS / no-feature builds.

Both feature matrices green, clippy clean under \`-D warnings\`, 13 voices tests with \`system_tts\`, 12 without.

## E2E verified on Apple Silicon

\`\`\`bash
echo \"hello from macos\" | ./target/release/kesha-engine say \\
    --voice macos-com.apple.voice.compact.en-US.Samantha > out.wav
file out.wav
# out.wav: RIFF (little-endian) data, WAVE audio, IEEE Float, mono 22050 Hz

echo \"привет мир\" | ./target/release/kesha-engine say --voice macos-ru-RU > ru.wav
file ru.wav
# ru.wav: RIFF (little-endian) data, WAVE audio, IEEE Float, mono 22050 Hz
\`\`\`

## Related

- Parts 1 (#144, merged): infrastructure + Swift helper
- Part 3 (upcoming): release-binary distribution, \`--list-voices\` macOS enumeration, docs