### PR TITLE
release: v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {
@@ -29,7 +29,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.1.3"
+    "version": "1.2.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
Bump to v1.2.0. Versions in \`package.json\`, \`package.json#keshaEngine.version\`, and \`rust/Cargo.toml\` (+ lockfile) all move in lockstep per CLAUDE.md's engine-release protocol.

## Highlights since v1.1.3

- **SSML preview** (#140) — \`kesha say --ssml '<speak>Hi <break time=\"500ms\"/> world</speak>'\`. \`<speak>\` root required, \`<break>\` inserts silence, unknown tags (\`<emphasis>\`, \`<prosody>\`, \`<phoneme>\`, \`<say-as>\`) stripped with a stderr warning. DOCTYPE rejected.
- **Performance telemetry** — \`sttTimeMs\` in \`--json\` / \`--verbose\` (#139, #142); \`kesha say --verbose\` emits \`TTS time: Xms\` on stderr (#143). Matched pair across transcription and synthesis so agents and humans can log real-world latency without a separate benchmark script.
- **macOS AVSpeechSynthesizer** (#141 parts 1 + 2) — opt-in \`system_tts\` cargo feature. \`kesha say --voice macos-<identifier-or-language>\` routes to a Swift sidecar, zero model download. Part 3 (release-binary integration) is deferred per user call — dev builds only.
- **Debug mode** (#148) — \`--debug\` flag and \`KESHA_DEBUG=1\` env. Trace lines on stderr around every engine subprocess call in the TS wrapper, plus \`[debug/engine]\` trace at model-load and inference boundaries inside \`kesha-engine\`.
- **CI fix** — \`integration-tests\` job now installs \`espeak-ng\` on the macOS runner (v1.1.3 engine dynamically links \`libespeak-ng.1.dylib\`; without it the install step died with dyld error).

## Expected CI behavior

\`integration-tests\` will FAIL on this PR — it downloads the released binary for the version in \`package.json#keshaEngine.version\`, which doesn't exist yet (the tag push triggers the binary build, which happens after merge). **Admin-merge is the standard flow for release PRs** per CLAUDE.md.

## Shipped PRs

- #140 SSML
- #142 sttTimeMs
- #143 ttsTimeMs (\`kesha say --verbose\`)
- #144 AVSpeech infra
- #147 AVSpeech wire + docs
- #149 --debug / KESHA_DEBUG

## Follow-ups tracked

- #138 TOON output
- #141 Part 3 (release binary ships the sidecar, \`--list-voices\` macOS enumeration) — deferred until there's a concrete user need
- #145 Raycast integration
- #146 Clawhub skill