### PR TITLE
fix(install): detect stale cached engine after CLI upgrade (#151)

### DIFF
--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -17,13 +17,11 @@ export function getVersionMarkerPath(binPath: string): string {
 
 /** Read the recorded version for the installed binary, or null if missing / empty. */
 export function readInstalledEngineVersion(binPath: string): string | null {
-  const markerPath = getVersionMarkerPath(binPath);
-  if (!existsSync(markerPath)) return null;
   try {
-    const v = readFileSync(markerPath, "utf-8").trim();
+    const v = readFileSync(getVersionMarkerPath(binPath), "utf-8").trim();
     return v.length > 0 ? v : null;
   } catch {
-    // Unreadable marker → treat as missing so we re-download.
+    // Missing, unreadable, or permission-denied → treat as no marker so we re-download.
     return null;
   }
 }

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -1,10 +1,36 @@
 import { dirname } from "path";
-import { existsSync, mkdirSync, chmodSync } from "fs";
+import { existsSync, mkdirSync, chmodSync, readFileSync, writeFileSync } from "fs";
 import { getEngineBinPath, getEngineCapabilities } from "./engine";
 import { log } from "./log";
 import { streamResponseToFile } from "./progress";
 
 const GITHUB_REPO = "drakulavich/kesha-voice-kit";
+
+/**
+ * Version-marker file written next to the engine binary on download (#151).
+ * Lets `kesha install` detect a stale cached engine after a CLI upgrade and
+ * re-download without requiring `--no-cache`.
+ */
+export function getVersionMarkerPath(binPath: string): string {
+  return `${binPath}.version`;
+}
+
+/** Read the recorded version for the installed binary, or null if missing / empty. */
+export function readInstalledEngineVersion(binPath: string): string | null {
+  const markerPath = getVersionMarkerPath(binPath);
+  if (!existsSync(markerPath)) return null;
+  try {
+    const v = readFileSync(markerPath, "utf-8").trim();
+    return v.length > 0 ? v : null;
+  } catch {
+    // Unreadable marker → treat as missing so we re-download.
+    return null;
+  }
+}
+
+export function writeInstalledEngineVersion(binPath: string, version: string): void {
+  writeFileSync(getVersionMarkerPath(binPath), `${version}\n`);
+}
 
 function getEngineBinaryName(): string {
   const platform = process.platform;
@@ -28,21 +54,31 @@ export async function downloadEngine(
   options: InstallOptions = {},
 ): Promise<string> {
   const binPath = getEngineBinPath();
-
-  if (!noCache && existsSync(binPath)) {
-    log.success("Engine binary already installed.");
-  } else {
-    const binaryName = getEngineBinaryName();
-    const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
-    // The engine version is tracked separately from the CLI version so
-    // CLI-only patch releases don't require cutting a new GitHub release
-    // + Rust rebuild. Fall back to the CLI version for backwards compat.
-    const engineVersion =
-      typeof pkg.keshaEngine?.version === "string"
-        ? pkg.keshaEngine.version
-        : typeof pkg.version === "string"
+  const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
+  // The engine version is tracked separately from the CLI version so
+  // CLI-only patch releases don't require cutting a new GitHub release
+  // + Rust rebuild. Fall back to the CLI version for backwards compat.
+  const engineVersion =
+    typeof pkg.keshaEngine?.version === "string"
+      ? pkg.keshaEngine.version
+      : typeof pkg.version === "string"
         ? pkg.version
         : "unknown";
+
+  const installedVersion = readInstalledEngineVersion(binPath);
+  const cacheValid =
+    !noCache && existsSync(binPath) && installedVersion === engineVersion;
+
+  if (cacheValid) {
+    log.success(`Engine binary already installed (v${engineVersion}).`);
+  } else {
+    // Log why we're downloading — helps diagnose surprising re-downloads.
+    if (existsSync(binPath) && installedVersion && installedVersion !== engineVersion) {
+      log.progress(
+        `Upgrading engine v${installedVersion} → v${engineVersion}...`,
+      );
+    }
+    const binaryName = getEngineBinaryName();
     const url = `https://github.com/${GITHUB_REPO}/releases/download/v${engineVersion}/${binaryName}`;
 
     mkdirSync(dirname(binPath), { recursive: true });
@@ -64,7 +100,8 @@ export async function downloadEngine(
 
     await streamResponseToFile(res, binPath, "kesha-engine binary");
     chmodSync(binPath, 0o755);
-    log.success("Engine binary downloaded.");
+    writeInstalledEngineVersion(binPath, engineVersion);
+    log.success(`Engine binary downloaded (v${engineVersion}).`);
   }
 
   if (backend) {

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test";
+import {
+  getVersionMarkerPath,
+  readInstalledEngineVersion,
+  writeInstalledEngineVersion,
+} from "../../src/engine-install";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+function mkTmpBinPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-install-test-"));
+  return join(dir, "kesha-engine");
+}
+
+describe("engine-install version marker (#151)", () => {
+  test("getVersionMarkerPath appends .version alongside binary", () => {
+    expect(getVersionMarkerPath("/bin/kesha-engine")).toBe("/bin/kesha-engine.version");
+    expect(getVersionMarkerPath("/tmp/foo/x")).toBe("/tmp/foo/x.version");
+  });
+
+  test("reads back what was written", () => {
+    const binPath = mkTmpBinPath();
+    writeInstalledEngineVersion(binPath, "1.2.0");
+    expect(readInstalledEngineVersion(binPath)).toBe("1.2.0");
+    rmSync(binPath + ".version");
+  });
+
+  test("returns null when marker missing", () => {
+    const binPath = mkTmpBinPath();
+    expect(readInstalledEngineVersion(binPath)).toBeNull();
+  });
+
+  test("returns null for empty marker (corrupted file treated as missing)", () => {
+    const binPath = mkTmpBinPath();
+    writeFileSync(binPath + ".version", "");
+    expect(readInstalledEngineVersion(binPath)).toBeNull();
+    rmSync(binPath + ".version");
+  });
+
+  test("returns null for whitespace-only marker", () => {
+    const binPath = mkTmpBinPath();
+    writeFileSync(binPath + ".version", "  \n  ");
+    expect(readInstalledEngineVersion(binPath)).toBeNull();
+    rmSync(binPath + ".version");
+  });
+
+  test("trims trailing newlines on read", () => {
+    const binPath = mkTmpBinPath();
+    writeInstalledEngineVersion(binPath, "1.2.0");
+    expect(readInstalledEngineVersion(binPath)).toBe("1.2.0");
+    rmSync(binPath + ".version");
+  });
+
+  test("overwrite replaces previous version", () => {
+    const binPath = mkTmpBinPath();
+    writeInstalledEngineVersion(binPath, "1.1.3");
+    writeInstalledEngineVersion(binPath, "1.2.0");
+    expect(readInstalledEngineVersion(binPath)).toBe("1.2.0");
+    rmSync(binPath + ".version");
+  });
+});

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -45,9 +45,12 @@ describe("engine-install version marker (#151)", () => {
     rmSync(binPath + ".version");
   });
 
-  test("trims trailing newlines on read", () => {
+  test("trims surrounding whitespace on read (hand-written marker)", () => {
+    // Test via writeFileSync so the trim path is actually exercised —
+    // writeInstalledEngineVersion only appends one \n, which String.trim
+    // would strip regardless of our handling.
     const binPath = mkTmpBinPath();
-    writeInstalledEngineVersion(binPath, "1.2.0");
+    writeFileSync(binPath + ".version", "  1.2.0\n\n\n");
     expect(readInstalledEngineVersion(binPath)).toBe("1.2.0");
     rmSync(binPath + ".version");
   });


### PR DESCRIPTION
Closes #151. Caught live during the v1.2.0 release: after upgrading the CLI to 1.2.0, plain \`kesha install\` kept the v1.1.3 engine because \`existsSync(binPath)\` short-circuits without a version check.

## Fix

Version-marker file written next to the engine binary on download:

```
~/.cache/kesha/engine/bin/kesha-engine
~/.cache/kesha/engine/bin/kesha-engine.version    ← new, single line "1.2.0"
```

On install, compare \`package.json#keshaEngine.version\` against the marker:

| Marker state | Behavior |
|---|---|
| Matches expected | Skip download (fast path, zero regression). |
| Mismatch | Re-download + log \`Upgrading engine vX.Y.Z → vA.B.C...\`. |
| Missing | Re-download. |
| Empty / whitespace / unreadable | Treated as missing → re-download. |

## Log messages

Before:
```
Engine binary already installed.
```

After — matches expected:
```
Engine binary already installed (v1.2.0).
```

After — mismatch (the bug path):
```
Upgrading engine v1.1.3 → v1.2.0...
Engine binary downloaded (v1.2.0).
```

Surprising re-downloads become explicit.

## Public surface

Keeps \`downloadEngine\` signature. Exports three helpers for unit tests:

- \`getVersionMarkerPath(binPath) → string\`
- \`readInstalledEngineVersion(binPath) → string | null\`
- \`writeInstalledEngineVersion(binPath, version) → void\`

## Tests

7 new unit tests with tmpdir fixtures:
- marker path derivation
- round-trip (write then read)
- missing marker returns null
- empty marker returns null
- whitespace-only marker returns null
- trailing newline trimmed
- overwrite replaces

98/98 total unit tests green, typecheck clean.

## Edge cases

- First install: no marker → download path fires, marker written. ✓
- \`KESHA_ENGINE_BIN\` override: already bypasses this code path entirely. ✓
- Downgrade (1.2.0 → 1.1.0 CLI): mismatch path → correct, re-download older. ✓
- Marker deleted manually: re-download. ✓
- Binary deleted but marker present: \`existsSync(binPath)\` gates, cache invalid → re-download. ✓

## Related

- v1.2.0 release notes flagged this workflow gap
- CLAUDE.md's \"NEVER AUTO-DOWNLOAD\" rule still holds — \`kesha install\` is explicit; this makes it actually do what users expect when they run it.