### PR TITLE
release: v1.2.1 (CLI-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
CLI-only patch per CLAUDE.md. Only \`package.json#version\` bumped (1.2.0 → 1.2.1); \`keshaEngine.version\` and \`rust/Cargo.toml\` unchanged — engine stays on v1.2.0.

## What ships

- #152: stale-engine detection via \`.version\` marker file alongside the cached binary. Users upgrading the CLI across engine-version bumps no longer need \`--no-cache\` to pick up the new engine. Fixes #151.

## Engine

v1.2.0 (unchanged). No Rust rebuild, no new GitHub-release binaries.

## CI expectation

Unlike engine-release PRs, \`integration-tests\` pass here because the engine artifact for \`keshaEngine.version: 1.2.0\` already exists on GitHub.