### PR TITLE
release: v1.2.2 (CLI-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
CLI-only patch per CLAUDE.md. Only `package.json#version` bumped (1.2.1 → 1.2.2); `keshaEngine.version` and `rust/Cargo.toml` unchanged — engine stays on v1.2.0.

## What ships

- #154: star-prompt now fires only on first install or major/minor CLI bump. No more per-install nag. Marker file `kesha-engine.star-seen` beside the engine binary.

## Engine

v1.2.0 (unchanged). No Rust rebuild, no new GitHub-release binaries.