### PR TITLE
ci(windows): rust-test Windows onnx path (#136 WIP)

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -47,6 +47,8 @@ jobs:
           key: kokoro-spike-v1-${{ runner.os }}
 
       - name: Download Kokoro model (if cache miss)
+        # Skip on Windows — TTS tests are gated out there (#136).
+        if: runner.os != 'Windows'
         shell: bash
         run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-latest]  # Windows follows after M2 (choco install espeak-ng path verification)
+        os: [macos-14, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
@@ -33,6 +33,29 @@ jobs:
       - name: Install espeak-ng (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y espeak-ng libespeak-ng-dev
+
+      - name: Install espeak-ng + LLVM (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Chocolatey packages both espeak-ng (runtime + dev files) and llvm
+          # (libclang for bindgen). LLVM is normally on windows-latest runners
+          # already, but we install anyway so LIBCLANG_PATH is predictable.
+          choco install -y --no-progress espeak-ng llvm
+          # Espeak-ng install path — choco drops it in Program Files.
+          $espeak = "C:\Program Files\eSpeak NG"
+          if (-not (Test-Path "$espeak\libespeak-ng.dll")) {
+            Write-Error "espeak-ng DLL not found at $espeak"
+            exit 1
+          }
+          Write-Host "espeak-ng contents:"
+          Get-ChildItem $espeak | Select-Object Name, Length | Format-Table
+          # Tell the MSVC linker where to find libespeak-ng.lib.
+          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$espeak;$env:LIB"
+          # Tell the runtime loader where to find libespeak-ng.dll.
+          Add-Content -Path $env:GITHUB_PATH -Value $espeak
+          # bindgen (via espeakng-sys `clang-runtime`) needs LIBCLANG_PATH.
+          Add-Content -Path $env:GITHUB_ENV -Value "LIBCLANG_PATH=C:\Program Files\LLVM\bin"
 
       - name: Cache Kokoro spike models
         uses: actions/cache@v4

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -34,28 +34,11 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y espeak-ng libespeak-ng-dev
 
-      - name: Install espeak-ng + LLVM (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # Chocolatey packages both espeak-ng (runtime + dev files) and llvm
-          # (libclang for bindgen). LLVM is normally on windows-latest runners
-          # already, but we install anyway so LIBCLANG_PATH is predictable.
-          choco install -y --no-progress espeak-ng llvm
-          # Espeak-ng install path — choco drops it in Program Files.
-          $espeak = "C:\Program Files\eSpeak NG"
-          if (-not (Test-Path "$espeak\libespeak-ng.dll")) {
-            Write-Error "espeak-ng DLL not found at $espeak"
-            exit 1
-          }
-          Write-Host "espeak-ng contents:"
-          Get-ChildItem $espeak | Select-Object Name, Length | Format-Table
-          # Tell the MSVC linker where to find libespeak-ng.lib.
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$espeak;$env:LIB"
-          # Tell the runtime loader where to find libespeak-ng.dll.
-          Add-Content -Path $env:GITHUB_PATH -Value $espeak
-          # bindgen (via espeakng-sys `clang-runtime`) needs LIBCLANG_PATH.
-          Add-Content -Path $env:GITHUB_ENV -Value "LIBCLANG_PATH=C:\Program Files\LLVM\bin"
+      # Windows TTS support is blocked on generating an import lib for
+      # libespeak-ng — the choco package ships the DLL but no .lib, and
+      # espeakng-sys links dynamically via `cargo:rustc-link-lib=espeak-ng`,
+      # so MSVC linker hits LNK1181. Tracked in #136. Until that's sorted,
+      # Windows CI tests the ASR / lang-id path only (onnx feature).
 
       - name: Cache Kokoro spike models
         uses: actions/cache@v4
@@ -69,7 +52,13 @@ jobs:
 
       - name: Run tests (with real Kokoro + espeak)
         shell: bash
-        run: bash rust/ci/run-cargo-test.sh "$KOKORO_CACHE" "${{ runner.os }}"
+        # Windows skips tts — see #136 note in the install step above.
+        run: |
+          EXTRA=""
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA="--no-default-features --features onnx"
+          fi
+          bash rust/ci/run-cargo-test.sh "$KOKORO_CACHE" "${{ runner.os }}" "$EXTRA"
 
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'

--- a/rust/ci/run-cargo-test.sh
+++ b/rust/ci/run-cargo-test.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # Run `cargo test` with platform-specific env vars for espeak-ng linking
 # and Kokoro-model paths. Skips the real-inference tests if the cache is empty.
+# Optional $3 = extra cargo args (e.g. `--no-default-features --features onnx`
+# on Windows where TTS isn't yet linkable — see #136).
 set -euo pipefail
 
-KOKORO_CACHE="${1:?usage: run-cargo-test.sh <kokoro_cache> <runner_os>}"
+KOKORO_CACHE="${1:?usage: run-cargo-test.sh <kokoro_cache> <runner_os> [extra_cargo_args]}"
 RUNNER_OS="${2:?}"
+EXTRA_CARGO_ARGS="${3:-}"
 
 cd rust
 
@@ -19,8 +22,8 @@ case "$RUNNER_OS" in
     :
     ;;
   Windows)
-    # LIB / PATH / LIBCLANG_PATH are set in the workflow step before this
-    # script runs — choco install espeak-ng lands at C:\Program Files\eSpeak NG.
+    # LIBCLANG_PATH is set in the workflow step for bindgen. No TTS libs on
+    # Windows yet — caller should pass --no-default-features --features onnx.
     :
     ;;
   *)
@@ -37,4 +40,5 @@ else
   echo "Kokoro cache empty — gated tests will skip"
 fi
 
-cargo test --verbose
+# shellcheck disable=SC2086  # deliberate word-splitting of EXTRA_CARGO_ARGS
+cargo test --verbose $EXTRA_CARGO_ARGS

--- a/rust/ci/run-cargo-test.sh
+++ b/rust/ci/run-cargo-test.sh
@@ -22,8 +22,9 @@ case "$RUNNER_OS" in
     :
     ;;
   Windows)
-    # LIBCLANG_PATH is set in the workflow step for bindgen. No TTS libs on
-    # Windows yet — caller should pass --no-default-features --features onnx.
+    # No TTS libs on Windows yet (espeak-ng import library — #136).
+    # Caller passes --no-default-features --features onnx via $EXTRA_CARGO_ARGS
+    # so nothing platform-specific needs to be exported here.
     :
     ;;
   *)

--- a/rust/ci/run-cargo-test.sh
+++ b/rust/ci/run-cargo-test.sh
@@ -18,6 +18,11 @@ case "$RUNNER_OS" in
     # apt-installed libespeak-ng is discovered via pkg-config / default lib paths
     :
     ;;
+  Windows)
+    # LIB / PATH / LIBCLANG_PATH are set in the workflow step before this
+    # script runs — choco install espeak-ng lands at C:\Program Files\eSpeak NG.
+    :
+    ;;
   *)
     echo "unsupported runner: $RUNNER_OS" >&2
     exit 1

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -21,6 +21,7 @@ const LANG_ID_FILES: &[&str] = &[
 
 /// A file in a model manifest. SHA256 is optional for legacy models; new
 /// TTS downloads verify it.
+#[cfg(feature = "tts")]
 #[derive(Debug, Clone)]
 pub struct ModelFile {
     pub rel_path: &'static str,

--- a/rust/tests/tts_smoke.rs
+++ b/rust/tests/tts_smoke.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "tts")]
+
 use std::process::Command;
 
 #[test]
@@ -184,8 +186,10 @@ fn resolves_from_cache_when_installed() {
     let tmp = tempfile::tempdir().unwrap();
     let voices_dir = tmp.path().join("models/kokoro-82m/voices");
     std::fs::create_dir_all(&voices_dir).unwrap();
-    std::os::unix::fs::symlink(&model, tmp.path().join("models/kokoro-82m/model.onnx")).unwrap();
-    std::os::unix::fs::symlink(&voice, voices_dir.join("af_heart.bin")).unwrap();
+    // Copy instead of symlink so the test works cross-platform (Windows symlink
+    // creation requires elevated privileges and the os::unix API is not available).
+    std::fs::copy(&model, tmp.path().join("models/kokoro-82m/model.onnx")).unwrap();
+    std::fs::copy(&voice, voices_dir.join("af_heart.bin")).unwrap();
 
     let bin = env!("CARGO_BIN_EXE_kesha-engine");
     let out = Command::new(bin)


### PR DESCRIPTION
Partial progress on #136. Full Windows TTS support turned out to be bigger than one PR — documented the specific blocker and shipping what's doable now.

## What this PR does

Restores `windows-latest` in the `rust-test.yml` matrix for the **non-TTS** code path (ASR / language detection). Matches the current Windows row in `build-engine.yml` which already ships without TTS.

- Matrix gets `windows-latest` back.
- Windows branch runs `cargo test --no-default-features --features onnx` (skipping all TTS compilation).
- `run-cargo-test.sh` accepts an optional 3rd arg for extra cargo flags.
- `tests/tts_smoke.rs`: module gated on `#[cfg(feature = "tts")]` and the stray `std::os::unix::fs::symlink` calls replaced with cross-platform `fs::copy`.
- `src/models.rs`: `ModelFile` struct gated on tts feature so onnx-only builds don't hit dead_code.

## What this PR does NOT do (tracked for follow-up on #136)

Actual Windows TTS is blocked on the import-library problem:

- Chocolatey's espeak-ng package ships only `libespeak-ng.dll` — no `.lib` file. MSVC linker errors with `LNK1181: cannot open input file 'espeak-ng.lib'`.
- espeakng-sys dynamically links via `cargo:rustc-link-lib=espeak-ng`, which requires the import library at link time.

Real solutions (any of):

1. Generate import lib from DLL: `dumpbin /exports` → parse to `.def` → `lib /def /out:espeak-ng.lib`. Needs MSVC dev env on the runner (via `ilammy/msvc-dev-cmd`).
2. Switch to `vcpkg install espeak-ng` — ships a proper import lib. Slower install but cleaner.
3. Build espeak-ng from source in CI. Heavy.
4. Vendor a prebuilt `.lib` in the repo. Gross.

Also needs:
- Fix-up for bindgen `LIBCLANG_PATH` on Windows (tried `C:\Program Files\LLVM\bin` — unverified).
- README + CLAUDE.md docs update once it works.
- `build-engine.yml` Windows matrix flip to `onnx,tts`.

## Local verification

- `cargo clippy --all-targets -- -D warnings` clean under default features.
- `cargo clippy --no-default-features --features onnx --all-targets -- -D warnings` clean.
- `cargo test --no-default-features --features onnx --no-run` builds cleanly (the only test binaries produced are the lib + main unittests; tts_smoke + tts_e2e stubbed out by the feature gate).

## Acceptance for this slice

- [ ] `test (windows-latest)` job in rust-test.yml green on the onnx+lang-id path.
- [ ] macOS + Linux rust-test rows unaffected (still exercise default features incl. TTS).

## Related

- Parent issue #136 — Windows TTS support. Stays open for the import-lib + TTS enable work.
- #124 — static-link espeak-ng, orthogonal vendoring.
