### PR TITLE
chore(deps): refresh dependabot.yml (cargo + grouping)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,50 @@
 version: 2
 updates:
+  # CLI / TS deps
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      npm-dev:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      npm-prod:
+        dependency-type: production
+        update-types:
+          - patch
 
+  # Rust engine deps (kesha-engine). Added in the dependabot refresh — the
+  # crate has 70+ transitive deps and no previous tracking.
+  - package-ecosystem: cargo
+    directory: "/rust"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - rust
+    groups:
+      cargo-patch:
+        update-types:
+          - patch
+
+  # Workflow action versions across .github/workflows/*.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-
-  - package-ecosystem: swift
-    directory: "/swift"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Independent of the #136 Windows work.

## What changed

1. **Drop stale `/swift` entry** — directory doesn't exist. The only Swift source file (rust/swift/say-avspeech.swift from #141) is a single freestanding file with no Package.swift; dependabot's swift ecosystem has nothing to track.
2. **Add `cargo` ecosystem for `/rust`** — the engine has 70+ transitive deps and wasn't being tracked until now.
3. **Labels** — every dependabot PR now gets `dependencies`; cargo PRs also get `rust`, github-actions PRs also get `ci`. Filter-friendly.
4. **Groups** — batch minor/patch bumps so reviews are one PR instead of N. Keeps prod-npm-minor ungrouped (higher blast radius) but groups the rest.

## Not changed

- Review cadence stays weekly.
- PR limits: npm 10, github-actions 5. New cargo ecosystem also capped at 10.

## Verified

- Dependabot YAML is schema-valid (matches the options documented at github.com/dependabot/dependabot-core/tree/main/updater).
- Labels `dependencies`, `rust`, `ci` exist in the repo (created/confirmed).