### PR TITLE
release: v1.3.0 — AVSpeech release-binary integration + Windows TTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {
@@ -29,7 +29,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
## Summary

Engine + CLI lockstep bump **v1.2.0 → v1.3.0**. Two headline changes since v1.2.0:

- **macOS AVSpeechSynthesizer backend ships in release binaries** (#141). The Swift sidecar is staged next to the engine in the darwin-arm64 release archive; \`kesha install\` fetches it alongside the engine; \`kesha say --list-voices\` now enumerates installed macos-* voices. Zero model download, ~180 voices already on the Mac.
- **Windows TTS enabled in release binaries** (#136). \`kesha-engine-windows-x64.exe\` now ships with the \`tts\` feature via an espeak-ng import lib synthesized from the choco-shipped DLL. Runtime prereq: \`choco install espeak-ng\`.

## Version bumps

- \`rust/Cargo.toml\`: 1.2.0 → 1.3.0
- \`rust/Cargo.lock\`: bumped via \`cargo check\`
- \`package.json#version\`: 1.2.2 → 1.3.0
- \`package.json#keshaEngine.version\`: 1.2.0 → 1.3.0

## Shipped PRs since v1.2.0

- #159 / #162 — Windows TTS release binaries (#136)
- #163 — test-suite cleanup per Rossi framework (#161)
- #164 — rule: link PRs to issues, auto-close on merge
- #166 — AVSpeech release integration + \`--list-voices\` for macos-* (#141)

## Test plan

- [ ] PR CI green (unit + integration + build check on macOS/Linux/Windows)
- [ ] After merge: tag \`v1.3.0\`, push, build-engine.yml produces 4 artifacts (engine x3 + say-avspeech-darwin-arm64)
- [ ] Release notes written before publishing (build-engine draft is empty)
- [ ] \`make smoke-test\` locally against downloaded binaries
- [ ] \`npm publish --access public\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)