### PR TITLE
chore(deps): drop cargo from dependabot.yml (#165)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,20 +19,14 @@ updates:
         update-types:
           - patch
 
-  # Rust engine deps (kesha-engine). Added in the dependabot refresh — the
-  # crate has 70+ transitive deps and no previous tracking.
-  - package-ecosystem: cargo
-    directory: "/rust"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - rust
-    groups:
-      cargo-patch:
-        update-types:
-          - patch
+  # Rust (cargo) deliberately NOT tracked by Dependabot (#165).
+  # Every cargo update attempt fails with curl error [8] "Weird server line"
+  # against the crates.io sparse index (https://index.crates.io) — the
+  # Dependabot runner image ships a libcurl that mishandles the sparse
+  # HTTP framing, and no cargo PR has ever merged successfully since we
+  # added the ecosystem in PR #160.
+  # Workaround: run `cd rust && cargo update` manually and open a PR.
+  # Revisit once Dependabot ships a fix upstream.
 
   # Workflow action versions across .github/workflows/*.
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

Per #165 option (B): remove cargo from \`.github/dependabot.yml\`.

Every cargo Dependabot run since PR #160 added the ecosystem has failed with:

\`\`\`
error: failed to get \`<crate>\` as a dependency of package \`kesha-engine ...\`
Caused by: download of <path> failed
Caused by: [8] Weird server reply (Invalid status line)
\`\`\`

Origin is libcurl inside the Dependabot runner image vs. the crates.io sparse index — not actionable on our end. Filtered the Dependabot PR history: every merged Dependabot PR is \`github-actions\`; zero successful cargo PRs on this repo.

Rust deps on this project move slowly (clap, serde, ort, fluidaudio-rs, espeakng-sys) and major bumps get reviewed deliberately anyway — automated weekly cargo PRs weren't adding much even before the breakage. Manual \`cd rust && cargo update\` + a PR when needed.

**Closes #165.**

## Test plan

- [ ] YAML still parses (\`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"\` locally — clean)
- [ ] No CI-impacting change; the \`rust\` label is still usable for manual PRs if we re-add the ecosystem later

🤖 Generated with [Claude Code](https://claude.com/claude-code)