### PR TITLE
docs(skill): rewrite SKILL.md for Clawhub registry + vector search (#146)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -71,7 +71,7 @@ Output: WAV mono float32. `--out <path>` writes to a file instead of stdout.
 ## Install
 
 ```bash
-bun add --global @drakulavich/kesha-voice-kit    # or: npm i -g
+bun add --global @drakulavich/kesha-voice-kit    # or: npm i -g @drakulavich/kesha-voice-kit
 kesha install                                    # downloads engine (~350 MB)
 kesha install --tts                              # adds Kokoro + Piper RU (~390 MB more, for TTS)
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,54 +1,105 @@
-# Kesha Voice Kit
+---
+name: kesha-voice-kit
+description: Local voice toolkit — speech-to-text (STT), text-to-speech (TTS), and language detection. Runs entirely offline on Apple Silicon, Linux, and Windows. No API keys, no cloud. NVIDIA Parakeet TDT for STT across 25 languages (English, Russian, Spanish, German, French, Ukrainian, etc.), Kokoro-82M + Piper VITS for TTS (English + Russian), plus macOS AVSpeechSynthesizer for 180+ system voices with zero install.
+emoji: 🎙️
 
-Local speech-to-text for voice messages. Runs entirely on your machine — no API keys, no cloud.
+requires:
+  bins: [kesha]
 
-## What it does
+install:
+  - kind: npm
+    packages: [@drakulavich/kesha-voice-kit]
+    flags: [--global]
+  - kind: bash
+    cmd: kesha install
+---
 
-When a voice message arrives (Telegram, WhatsApp, Slack), Kesha transcribes it and returns JSON with the transcript and detected language:
+# kesha-voice-kit
+
+Local voice toolkit: transcribe voice messages to text, synthesize speech, detect language of audio or text. Fully offline after `kesha install`. No API keys, no per-minute billing.
+
+**Trigger keywords for when to use this skill:** voice message, voice memo, .ogg, .wav, .mp3, audio file, transcribe, transcription, speech-to-text, STT, text-to-speech, TTS, synthesize speech, say, Russian speech, multilingual ASR, language detection, offline voice, privacy, Apple Silicon, CoreML.
+
+## When to use
+
+- **Voice memo arrived** (Telegram, WhatsApp, Slack, Signal .ogg/.opus/.m4a): transcribe with `kesha --json <path>` and branch on the detected language.
+- **Need to reply with audio**: synthesize with `kesha say "<text>" > reply.wav`. Routes English to Kokoro-82M and Russian to Piper automatically; `--voice macos-*` uses the 180+ voices already installed on macOS (zero model download).
+- **Need to detect what language a file is in** before choosing a pipeline: `kesha --json audio.ogg` returns both audio-based and text-based language detection with confidence scores.
+
+## STT: transcribe audio
+
+```bash
+# JSON output with language detection (recommended for automation)
+kesha --json voice.ogg
+```
 
 ```json
 [{
   "file": "voice.ogg",
   "text": "Привет, как дела?",
   "lang": "ru",
+  "audioLanguage": { "code": "ru", "confidence": 0.98 },
   "textLanguage": { "code": "ru", "confidence": 0.99 }
 }]
 ```
 
-Use the `lang` field to detect which language the user spoke and respond accordingly.
+Use `lang` (or the more detailed `audioLanguage`/`textLanguage`) to decide how to respond.
 
-## Setup
+**Formats:** .ogg, .opus, .mp3, .m4a, .wav, .flac, .webm — decoded via symphonia, no ffmpeg required.
 
-After installing the plugin, run once to download the engine and models:
+**Other output modes:**
+- `kesha audio.ogg` — plain transcript on stdout
+- `kesha --format transcript audio.ogg` — transcript + `[lang: ru, confidence: 0.99]` footer
+- `kesha --verbose audio.ogg` — human-readable with language info
+- `kesha --lang en audio.ogg` — warn if detected language differs (useful sanity check)
+
+## TTS: synthesize speech
 
 ```bash
-kesha install
+kesha say "Hello, world" > hello.wav              # auto-routes en → Kokoro-82M
+kesha say "Привет, мир" > privet.wav              # auto-routes ru → Piper
+kesha say --voice macos-en-US "Hi" > out.wav       # zero-install macOS system voice
+kesha say --list-voices                            # Kokoro + Piper + 180+ macos-* voices
 ```
 
-## Plain text mode
+Output: WAV mono float32. `--out <path>` writes to a file instead of stdout.
 
-If you don't need language detection, switch to plain text output in your config:
+## Language detection standalone
 
-```json
-{
-  "type": "cli",
-  "command": "kesha",
-  "args": ["{{MediaPath}}"]
-}
+`kesha --json audio.ogg` includes both audio-based (`audioLanguage`) and text-based (`textLanguage`) detection. Use audio detection to identify the language before running language-specific logic.
+
+## Install
+
+```bash
+bun add --global @drakulavich/kesha-voice-kit    # or: npm i -g
+kesha install                                    # downloads engine (~350 MB)
+kesha install --tts                              # adds Kokoro + Piper RU (~390 MB more, for TTS)
 ```
 
-This returns just the transcript text without JSON wrapping.
+One-time runtime prereq for TTS on each platform:
+- macOS: `brew install espeak-ng`
+- Linux: `sudo apt install espeak-ng`
+- Windows: `choco install espeak-ng`
 
-## Available flags
-
-- `--json` — JSON output with language detection (default in this plugin)
-- `--verbose` — show language detection details (audio + text language with confidence)
-- `--lang <code>` — warn if detected language differs from expected (e.g. `--lang en`)
+`macos-*` voices need no install — they use voices already on the Mac.
 
 ## Supported languages
 
-Speech-to-text: Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
+**Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, **English**, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, **Russian**, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
+
+**Text-to-speech:** English (Kokoro-82M, ~70 voices), Russian (Piper `ru-denis`), plus any macOS system voice via `--voice macos-*`.
 
 ## Performance
 
-~19x faster than Whisper on Apple Silicon (CoreML), ~2.5x faster on CPU (ONNX).
+- ASR: ~19× faster than OpenAI Whisper on Apple Silicon (CoreML via FluidAudio), ~2.5× on CPU (ONNX via `ort`).
+- TTS: sub-second latency for short utterances on Apple Silicon.
+
+## Why local
+
+No API keys to manage. No per-minute billing. Voice data never leaves the machine — important for regulated industries, personal messaging, and anything that shouldn't be in a third-party log.
+
+## Links
+
+- Source: https://github.com/drakulavich/kesha-voice-kit
+- npm: https://www.npmjs.com/package/@drakulavich/kesha-voice-kit
+- Releases: https://github.com/drakulavich/kesha-voice-kit/releases


### PR DESCRIPTION
## Summary

Prepares \`SKILL.md\` for publishing to the [Clawhub registry](https://clawhub.ai) per #146.

### Registry sanity check (per the issue's own gate)

Issue #146 explicitly flagged that Clawhub might be AI-confabulated. Verified 30s before scaffolding:

- \`npm view clawhub\` → \`clawhub@0.9.0\`, maintained by [steipete](https://github.com/steipete), 700 KB package with CLI entry points. **Real.**
- \`clawhub.ai\` → HTTP 200.
- All 4 awesome-list repos referenced in the issue → HTTP 200.
- Peer skills (\`tg-voice-whisper\`, \`voice-transcribe\`, \`mac-tts\`) inspected via \`clawhub inspect <slug> --file SKILL.md\` to learn the actual schema.

### Schema correction vs. the issue body

The issue's \"Files to add\" section says a separate \`clawhub.json\` is needed. After inspecting several published peer skills, the actual schema is **YAML frontmatter at the top of \`SKILL.md\`** — \`name\`, \`description\`, \`emoji\`, \`requires\`, \`install\`. No \`clawhub.json\`. This PR reflects that.

## What changed in SKILL.md

- **YAML frontmatter added.** Description is the primary vector-search field, loaded with trigger keywords (voice, TTS, STT, audio, speech, transcription, Russian, offline, Apple Silicon, multilingual, privacy).
- **Expanded from STT-only to full v1.3.0 surface:** STT (25 languages), TTS via Kokoro/Piper/AVSpeech, standalone language detection. Each section leads with a \"when to use\" hint so agents can match trigger → command.
- **Added \`--voice macos-*\` coverage** (new in v1.3.0) and refreshed install instructions (\`bun add --global\`, \`kesha install\`, \`kesha install --tts\`).
- **Retained** the voice-message-in-JSON example — it's the highest-leverage trigger pattern for agent automation.

## Publish plan (post-merge, manual — auth-gated)

CLI requires GitHub OAuth; can't be done from CI. After merge:

\`\`\`bash
npm i -g clawhub
clawhub login                  # opens browser
clawhub whoami                 # verify handle
clawhub publish . --slug kesha-voice-kit
clawhub inspect kesha-voice-kit    # verify it landed
\`\`\`

Then open awesome-list PRs the same day (issue lists 4 targets):
- \`VoltAgent/awesome-openclaw-skills\` → \`categories/speech-and-transcription.md\`
- \`ANVEAI/awesome-openclaw-skills\`
- \`vincentkoc/awesome-openclaw\`
- \`sundial-org/awesome-openclaw-skills\`

Pitch angle per the issue: **local inference, no API keys, Russian STT/TTS, Apple Silicon optimized via FluidAudio/CoreML** — what \`elevenlabs-tts\` and friends don't do.

## Follow-up if bundle size is a problem

Root \`SKILL.md\` is intentionally at the repo root because the issue specifies that and because the OpenClaw npm-plugin flow also reads it from there. If \`clawhub publish .\` ends up shipping too much repo content, fall back to \`clawhub publish skills/kesha-voice-kit\` with a subfolder copy — but try the simpler root-publish path first.

Refs #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)