### PR TITLE
chore(clawhub): narrow publish bundle + add workdir marker (#146 follow-up)

### DIFF
--- a/.clawhubignore
+++ b/.clawhubignore
@@ -1,0 +1,11 @@
+# Clawhub skill bundle — publish only skill-facing files.
+#
+# Without this, `clawhub publish .` ships all 96 text files in the repo
+# (CLAUDE.md, docs/superpowers/, src/**, tests/**, rust/**, etc.) as one
+# skill package. Peer skills (tg-voice-whisper, voice-transcribe) ship
+# just SKILL.md.
+
+*
+!SKILL.md
+!README.md
+!LICENSE


### PR DESCRIPTION
## Summary

Two post-publish fixes discovered during yesterday's \`clawhub publish\` session.

### 1. Bundle was 96 files (should be ~2)

\`clawhub publish .\` with no \`.clawhubignore\` ships every text file in the repo. Published **kesha-voice-kit@1.3.0** included: \`CLAUDE.md\`, \`docs/superpowers/plans/*\`, \`src/**/*.ts\`, \`rust/src/**/*.rs\`, \`tests/**\` — 96 files in one skill. Peer skills (\`tg-voice-whisper\`, \`voice-transcribe\`, \`mac-tts\`) ship exactly one: \`SKILL.md\`.

Fix: \`.clawhubignore\` allowlist.

\`\`\`
*
!SKILL.md
!README.md
!LICENSE
\`\`\`

Verified against the same \`listTextFiles\` function the publish command uses — bundle shrinks from **96 → 2 files**.

### 2. \`--workdir\` fallback kept resolving to clawdbot's default workspace

First \`clawhub publish .\` attempt failed with \`Error: SKILL.md required\` even though the file was right there in cwd. Tracked down via \`clawhub/dist/cli.js::resolveWorkdir\` (line 56-68): when \`--workdir\` is absent AND cwd has no \`.clawhub/\` marker, clawhub calls \`resolveClawdbotDefaultWorkspace()\` which returns something like \`~/clawdbot/skills\`. \`resolve(thatPath, ".")\` ≠ cwd → SKILL.md not found.

Workaround yesterday: \`clawhub --workdir "$(pwd)" publish "$(pwd)" ...\` (explicit override).

Proper fix: \`.clawhub/.gitkeep\` so \`hasClawhubMarker\` returns true at the repo root. Future \`clawhub publish .\` works without the \`--workdir\` override.

## What changes

- \`.clawhubignore\` — allowlist narrowing the bundle
- \`.clawhub/.gitkeep\` — keeps the marker dir in git

Neither affects any existing CI, test, or runtime path — both files are only read by the \`clawhub\` CLI.

## Verify after merge

\`\`\`bash
cd /path/to/kesha-voice-kit
git pull
node --input-type=module -e '
  import(\"/opt/homebrew/lib/node_modules/clawhub/dist/skills.js\").then(async ({ listTextFiles }) => {
    const files = await listTextFiles(\".\");
    console.log(\"files:\", files.map(f => f.relPath));
  });
'
# Expected: ["README.md", "SKILL.md"]

clawhub publish . --version 1.3.1 --slug kesha-voice-kit
# Should succeed without the --workdir override, and ship only 2 files.
\`\`\`

Refs #146. The on-registry \`kesha-voice-kit@1.3.0\` bundle stays oversized — a \`1.3.1\` republish with this branch merged supersedes it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)