### PR TITLE
docs(skill): reframe SKILL.md as multilingual, de-emphasize Russian

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kesha-voice-kit
-description: Local voice toolkit — speech-to-text (STT), text-to-speech (TTS), and language detection. Runs entirely offline on Apple Silicon, Linux, and Windows. No API keys, no cloud. NVIDIA Parakeet TDT for STT across 25 languages (English, Russian, Spanish, German, French, Ukrainian, etc.), Kokoro-82M + Piper VITS for TTS (English + Russian), plus macOS AVSpeechSynthesizer for 180+ system voices with zero install.
+description: Local multilingual voice toolkit — speech-to-text (STT), text-to-speech (TTS), and language detection. Runs entirely offline on Apple Silicon, Linux, and Windows. No API keys, no cloud. NVIDIA Parakeet TDT for STT across 25 European languages, Kokoro-82M + Piper VITS for TTS, plus macOS AVSpeechSynthesizer for ~180 system voices with zero install.
 emoji: 🎙️
 
 requires:
@@ -18,12 +18,12 @@ install:
 
 Local voice toolkit: transcribe voice messages to text, synthesize speech, detect language of audio or text. Fully offline after `kesha install`. No API keys, no per-minute billing.
 
-**Trigger keywords for when to use this skill:** voice message, voice memo, .ogg, .wav, .mp3, audio file, transcribe, transcription, speech-to-text, STT, text-to-speech, TTS, synthesize speech, say, Russian speech, multilingual ASR, language detection, offline voice, privacy, Apple Silicon, CoreML.
+**Trigger keywords for when to use this skill:** voice message, voice memo, .ogg, .wav, .mp3, audio file, transcribe, transcription, speech-to-text, STT, text-to-speech, TTS, synthesize speech, say, multilingual voice, multilingual ASR, language detection, offline voice, privacy, Apple Silicon, CoreML.
 
 ## When to use
 
 - **Voice memo arrived** (Telegram, WhatsApp, Slack, Signal .ogg/.opus/.m4a): transcribe with `kesha --json <path>` and branch on the detected language.
-- **Need to reply with audio**: synthesize with `kesha say "<text>" > reply.wav`. Routes English to Kokoro-82M and Russian to Piper automatically; `--voice macos-*` uses the 180+ voices already installed on macOS (zero model download).
+- **Need to reply with audio**: synthesize with `kesha say "<text>" > reply.wav`. Auto-routes by detected language (Kokoro-82M for English, Piper for Russian). For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
 - **Need to detect what language a file is in** before choosing a pipeline: `kesha --json audio.ogg` returns both audio-based and text-based language detection with confidence scores.
 
 ## STT: transcribe audio
@@ -56,10 +56,10 @@ Use `lang` (or the more detailed `audioLanguage`/`textLanguage`) to decide how t
 ## TTS: synthesize speech
 
 ```bash
-kesha say "Hello, world" > hello.wav              # auto-routes en → Kokoro-82M
+kesha say "Hello, world" > hello.wav               # auto-routes en → Kokoro-82M
 kesha say "Привет, мир" > privet.wav              # auto-routes ru → Piper
-kesha say --voice macos-en-US "Hi" > out.wav       # zero-install macOS system voice
-kesha say --list-voices                            # Kokoro + Piper + 180+ macos-* voices
+kesha say --voice macos-de-DE "Guten Tag" > de.wav # any macOS system voice — German, French, Italian, ...
+kesha say --list-voices                            # Kokoro + Piper + ~180 macos-* voices
 ```
 
 Output: WAV mono float32. `--out <path>` writes to a file instead of stdout.
@@ -85,7 +85,7 @@ One-time runtime prereq for TTS on each platform:
 
 ## Supported languages
 
-**Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, **English**, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, **Russian**, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
+**Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
 
 **Text-to-speech:** English (Kokoro-82M, ~70 voices), Russian (Piper `ru-denis`), plus any macOS system voice via `--voice macos-*`.
 


### PR DESCRIPTION
## Summary

Corrects positioning in \`SKILL.md\`. The prior version leaned on Russian as the differentiator when Parakeet STT covers 25 European languages equally and AVSpeech covers many more. Russian stays accurate where it's a factual description (Piper IS the ru pipeline), drops it from marquee positioning.

## Diff highlights

| Location | Before | After |
|---|---|---|
| Frontmatter description | \"25 languages (English, **Russian**, Spanish, German, French, Ukrainian, etc.), ... TTS (English + **Russian**)\" | \"25 European languages, ... Kokoro-82M + Piper VITS for TTS\" |
| Trigger keywords | \"**Russian speech**, multilingual ASR\" | \"multilingual voice, multilingual ASR\" |
| When-to-use TTS hint | \"Routes English to Kokoro-82M and **Russian** to Piper\" | \"Auto-routes by detected language (Kokoro-82M for English, Piper for Russian)\" |
| TTS example block | \`macos-en-US \"Hi\"\` (duplicate of the English line above) | \`macos-de-DE \"Guten Tag\"\` — shows AVSpeech isn't English-only |
| Supported-languages list | **English**, ..., **Russian**, ... (bolded) | English, ..., Russian, ... (neutral alphabetical) |

Piper's Russian specificity stays in \"Text-to-speech\" and \"Piper RU\" callouts — that's factual, not positioning.

## Why it matters

Vector search will still match Russian queries — Russian is listed in the supported-languages section, and the frontmatter mentions \"25 European languages\". What changes: Russian is no longer framed as the headline feature in the primary search-index field.

## Follow-up after merge

\`\`\`bash
clawhub publish . --version 1.3.2 --slug kesha-voice-kit
\`\`\`

Supersedes \`kesha-voice-kit@1.3.1\` with the refined positioning.

Refs #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)