### PR TITLE
chore(permissions): allow clawhub inspect (less-permission-prompts sweep)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,7 @@
       "Bash(bun install)",
       "Bash(bun link)",
       "Bash(bunx tsc*)",
+      "Bash(clawhub inspect *)",
       "Bash(cat *)",
       "Bash(ls *)",
       "Bash(head *)",


### PR DESCRIPTION
Adds \`Bash(clawhub inspect *)\` to \`.claude/settings.json\` — observed 11 times across recent transcripts. Read-only registry metadata lookups; other high-frequency commands (bun test, bunx tsc, gh run, gh pr, gh api) are already covered by existing allowlist entries or auto-allowed by Claude Code's built-in rules, so this is the only net-new entry from the sweep.

Docs-only change, no CI surface touched.