### PR TITLE
feat(vad): auto-enable preprocessing for audio ≥ 120 s (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,12 @@ For meetings, lectures, and podcasts, enable Silero VAD so Parakeet only sees th
 
 ```bash
 kesha install --vad                   # one-time, ~2.3MB
-kesha --vad lecture.m4a               # VAD segments → per-segment ASR → stitched transcript
+kesha lecture.m4a                     # auto-on when audio ≥ 120s and VAD installed
+kesha --vad short-clip.ogg            # force VAD on any input
+kesha --no-vad meeting.m4a            # force VAD off even on long audio
 ```
 
-Opt-in by design — voice messages (<30s of near-pure speech) don't benefit. Defaults: threshold 0.5, min-speech 250ms, min-silence 100ms, 30ms edge padding. See issue #128.
+Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. If you have long audio without VAD installed, Kesha prints a one-time stderr hint. Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues #128 (base) and #187 (auto-trigger).
 
 ## Text-to-Speech
 

--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -5,9 +5,9 @@ use rubato::{
     SincInterpolationType, WindowFunction,
 };
 use symphonia::core::audio::SampleBuffer;
-use symphonia::core::codecs::{CodecRegistry, DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::codecs::{CodecParameters, CodecRegistry, DecoderOptions, CODEC_TYPE_NULL};
 use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::FormatOptions;
+use symphonia::core::formats::{FormatOptions, FormatReader};
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::{Hint, Probe};
@@ -24,11 +24,11 @@ fn get_codec_registry() -> CodecRegistry {
     registry
 }
 
-/// Decode audio file to raw f32 mono samples at the native sample rate.
-/// Returns (samples, sample_rate, channels).
-fn decode_audio(path: &str) -> Result<(Vec<f32>, u32, usize)> {
+/// Open `path`, probe format + select the first supported audio track.
+/// Shared by `decode_audio` and `probe_duration_seconds` so container
+/// detection + error messages live in one place.
+fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameters)> {
     let src = std::fs::File::open(path).with_context(|| format!("file not found: {path}"))?;
-
     let mss = MediaSourceStream::new(Box::new(src), Default::default());
 
     let mut hint = Hint::new();
@@ -51,26 +51,32 @@ fn decode_audio(path: &str) -> Result<(Vec<f32>, u32, usize)> {
         )
         .with_context(|| format!("unsupported audio format: {path}"))?;
 
-    let mut format = probed.format;
-
-    let track = format
+    let track = probed
+        .format
         .tracks()
         .iter()
         .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
         .with_context(|| format!("no supported audio tracks in: {path}"))?;
 
-    let sample_rate = track
-        .codec_params
+    let track_id = track.id;
+    let codec_params = track.codec_params.clone();
+    Ok((probed.format, track_id, codec_params))
+}
+
+/// Decode audio file to raw f32 mono samples at the native sample rate.
+/// Returns (samples, sample_rate, channels).
+fn decode_audio(path: &str) -> Result<(Vec<f32>, u32, usize)> {
+    let (mut format, track_id, codec_params) = open_format(path)?;
+
+    let sample_rate = codec_params
         .sample_rate
         .with_context(|| format!("unknown sample rate in: {path}"))?;
+    let channels = codec_params.channels.map(|c| c.count()).unwrap_or(1);
 
-    let channels = track.codec_params.channels.map(|c| c.count()).unwrap_or(1);
-
-    let track_id = track.id;
     let dec_opts = DecoderOptions::default();
     let codec_registry = get_codec_registry();
     let mut decoder = codec_registry
-        .make(&track.codec_params, &dec_opts)
+        .make(&codec_params, &dec_opts)
         .with_context(|| format!("unsupported codec in: {path}"))?;
 
     let mut all_samples: Vec<f32> = Vec::new();
@@ -231,37 +237,8 @@ pub fn load_audio_truncated(path: &str, max_seconds: f32) -> Result<Vec<f32>> {
 /// falling back to a decode-and-measure, which would defeat the purpose of a
 /// cheap probe.
 pub fn probe_duration_seconds(path: &str) -> Result<Option<f32>> {
-    let src = std::fs::File::open(path).with_context(|| format!("file not found: {path}"))?;
-    let mss = MediaSourceStream::new(Box::new(src), Default::default());
-
-    let mut hint = Hint::new();
-    if let Some(ext) = std::path::Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-    {
-        hint.with_extension(ext);
-    }
-
-    let mut probe = Probe::default();
-    symphonia::default::register_enabled_formats(&mut probe);
-
-    let probed = probe
-        .format(
-            &hint,
-            mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
-        )
-        .with_context(|| format!("unsupported audio format: {path}"))?;
-
-    let track = probed
-        .format
-        .tracks()
-        .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
-        .with_context(|| format!("no supported audio tracks in: {path}"))?;
-
-    match (track.codec_params.n_frames, track.codec_params.sample_rate) {
+    let (_format, _track_id, codec_params) = open_format(path)?;
+    match (codec_params.n_frames, codec_params.sample_rate) {
         (Some(n), Some(sr)) if sr > 0 => Ok(Some(n as f32 / sr as f32)),
         _ => Ok(None),
     }

--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -224,3 +224,45 @@ pub fn load_audio_truncated(path: &str, max_seconds: f32) -> Result<Vec<f32>> {
     let max_samples = (max_seconds * TARGET_SAMPLE_RATE as f32) as usize;
     Ok(samples.into_iter().take(max_samples).collect())
 }
+
+/// Probe audio duration in seconds without decoding. Returns `None` when the
+/// container doesn't report a frame count (some streaming Ogg/Opus files);
+/// callers should treat `None` as "unknown — skip auto-trigger" rather than
+/// falling back to a decode-and-measure, which would defeat the purpose of a
+/// cheap probe.
+pub fn probe_duration_seconds(path: &str) -> Result<Option<f32>> {
+    let src = std::fs::File::open(path).with_context(|| format!("file not found: {path}"))?;
+    let mss = MediaSourceStream::new(Box::new(src), Default::default());
+
+    let mut hint = Hint::new();
+    if let Some(ext) = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+    {
+        hint.with_extension(ext);
+    }
+
+    let mut probe = Probe::default();
+    symphonia::default::register_enabled_formats(&mut probe);
+
+    let probed = probe
+        .format(
+            &hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .with_context(|| format!("unsupported audio format: {path}"))?;
+
+    let track = probed
+        .format
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .with_context(|| format!("no supported audio tracks in: {path}"))?;
+
+    match (track.codec_params.n_frames, track.codec_params.sample_rate) {
+        (Some(n), Some(sr)) if sr > 0 => Ok(Some(n as f32 / sr as f32)),
+        _ => Ok(None),
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -30,11 +30,15 @@ enum Commands {
     Transcribe {
         /// Path to audio file
         audio_path: String,
-        /// Run Silero VAD first; transcribe each detected speech segment
-        /// and stitch the results. Requires the VAD model to be installed
-        /// (`kesha install --vad`).
-        #[arg(long)]
+        /// Force Silero VAD preprocessing. Requires the VAD model to be
+        /// installed (`kesha install --vad`). Mutually exclusive with
+        /// `--no-vad`. Without either flag, VAD auto-engages on audio
+        /// ≥ 120 s when the model is installed (#187).
+        #[arg(long, conflicts_with = "no_vad")]
         vad: bool,
+        /// Disable VAD preprocessing regardless of duration or install state.
+        #[arg(long = "no-vad")]
+        no_vad: bool,
     },
     /// Detect spoken language from audio
     DetectLang {
@@ -299,12 +303,17 @@ fn main() -> Result<()> {
     }
 
     match cli.command {
-        Some(Commands::Transcribe { audio_path, vad }) => {
-            let text = if vad {
-                transcribe::transcribe_with_vad(&audio_path, vad::VadConfig::default())?
-            } else {
-                transcribe::transcribe(&audio_path)?
+        Some(Commands::Transcribe {
+            audio_path,
+            vad,
+            no_vad,
+        }) => {
+            let mode = match (vad, no_vad) {
+                (true, _) => transcribe::VadMode::On,
+                (_, true) => transcribe::VadMode::Off,
+                _ => transcribe::VadMode::Auto,
             };
+            let text = transcribe::transcribe(&audio_path, mode)?;
             println!("{}", text);
         }
         Some(Commands::DetectLang { audio_path }) => {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -308,11 +308,7 @@ fn main() -> Result<()> {
             vad,
             no_vad,
         }) => {
-            let mode = match (vad, no_vad) {
-                (true, _) => transcribe::VadMode::On,
-                (_, true) => transcribe::VadMode::Off,
-                _ => transcribe::VadMode::Auto,
-            };
+            let mode = transcribe::VadMode::from_flags(vad, no_vad);
             let text = transcribe::transcribe(&audio_path, mode)?;
             println!("{}", text);
         }

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -9,9 +9,16 @@ use crate::models;
 use crate::vad::{VadConfig, VadDetector, SAMPLE_RATE as VAD_SAMPLE_RATE};
 
 /// Duration at which the `Auto` VAD mode flips to VAD preprocessing.
-/// Chosen to match the discussion in #128: voice messages (<30 s) and short
-/// clips don't benefit, meetings and lectures (>2 min) do.
-pub const AUTO_VAD_MIN_SECONDS: f32 = 120.0;
+/// Voice messages (<30 s) and short clips don't benefit; meetings and
+/// lectures (>2 min) do.
+const AUTO_VAD_MIN_SECONDS: f32 = 120.0;
+
+/// File-size floor below which `Auto` mode skips the duration probe entirely.
+/// Any audio <120 s at a plausible bitrate weighs well over this threshold;
+/// the guard keeps the hot path cheap for voice messages and bounds MP3
+/// worst-case probe cost (symphonia scans the file when a Xing header is
+/// absent — can reach seconds on large CBR files).
+const AUTO_VAD_MIN_FILE_SIZE: u64 = 200_000;
 
 /// Caller-requested VAD behaviour.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,6 +31,19 @@ pub enum VadMode {
     On,
     /// Force VAD off regardless of duration or install state.
     Off,
+}
+
+impl VadMode {
+    /// Derive the mode from the two mutually-exclusive CLI flags. `(true, true)`
+    /// should be caught by clap's `conflicts_with` before we get here; we still
+    /// resolve it deterministically (prefer `On`) rather than panicking.
+    pub fn from_flags(vad: bool, no_vad: bool) -> Self {
+        match (vad, no_vad) {
+            (true, _) => Self::On,
+            (_, true) => Self::Off,
+            _ => Self::Auto,
+        }
+    }
 }
 
 /// Pure decision function so the auto-trigger rules can be unit-tested
@@ -55,7 +75,7 @@ pub fn transcribe(audio_path: &str, mode: VadMode) -> Result<String> {
 
     // `Auto` needs a duration probe first. `On`/`Off` are deterministic.
     let duration = match mode {
-        VadMode::Auto => audio::probe_duration_seconds(audio_path).unwrap_or(None),
+        VadMode::Auto => probe_duration_if_plausible(audio_path),
         _ => None,
     };
     let decision = decide(mode, duration, vad_installed);
@@ -177,6 +197,25 @@ fn transcribe_via_vad(
     }
 
     Ok(transcripts.join(" "))
+}
+
+/// Probe audio duration for the `Auto` decision, gated on a cheap
+/// file-size floor. Files too small to plausibly be ≥ 120 s skip the
+/// probe entirely. Probe failures log via `dtrace!` and return `None`
+/// — the decode path will surface the real error, if any, shortly.
+fn probe_duration_if_plausible(path: &str) -> Option<f32> {
+    if let Ok(meta) = std::fs::metadata(path) {
+        if meta.len() < AUTO_VAD_MIN_FILE_SIZE {
+            return None;
+        }
+    }
+    match audio::probe_duration_seconds(path) {
+        Ok(d) => d,
+        Err(e) => {
+            dtrace!("asr::probe_failed path={path} err={e}");
+            None
+        }
+    }
 }
 
 /// Returns the cached ASR model dir or bails with the install hint.

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -8,11 +8,80 @@ use crate::dtrace;
 use crate::models;
 use crate::vad::{VadConfig, VadDetector, SAMPLE_RATE as VAD_SAMPLE_RATE};
 
-pub fn transcribe(audio_path: &str) -> Result<String> {
+/// Duration at which the `Auto` VAD mode flips to VAD preprocessing.
+/// Chosen to match the discussion in #128: voice messages (<30 s) and short
+/// clips don't benefit, meetings and lectures (>2 min) do.
+pub const AUTO_VAD_MIN_SECONDS: f32 = 120.0;
+
+/// Caller-requested VAD behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VadMode {
+    /// Use VAD when the audio looks long enough and the model is installed,
+    /// otherwise skip it silently (with a one-time stderr hint if it would
+    /// have helped but the model is missing).
+    Auto,
+    /// Force VAD on. Errors if the model isn't installed.
+    On,
+    /// Force VAD off regardless of duration or install state.
+    Off,
+}
+
+/// Pure decision function so the auto-trigger rules can be unit-tested
+/// without ONNX, disk, or symphonia in the loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VadDecision {
+    Vad,
+    Plain,
+    PlainWithHint,
+}
+
+fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDecision {
+    match mode {
+        VadMode::On => VadDecision::Vad,
+        VadMode::Off => VadDecision::Plain,
+        VadMode::Auto => match duration_s {
+            Some(d) if d >= AUTO_VAD_MIN_SECONDS && vad_installed => VadDecision::Vad,
+            Some(d) if d >= AUTO_VAD_MIN_SECONDS => VadDecision::PlainWithHint,
+            // Unknown duration or short clip → plain, no hint.
+            _ => VadDecision::Plain,
+        },
+    }
+}
+
+pub fn transcribe(audio_path: &str, mode: VadMode) -> Result<String> {
     let model_dir = ensure_asr_installed()?;
-    dtrace!("asr::model_dir {}", model_dir);
+    let vad_dir = models::vad_model_dir();
+    let vad_installed = models::is_vad_cached(&vad_dir);
+
+    // `Auto` needs a duration probe first. `On`/`Off` are deterministic.
+    let duration = match mode {
+        VadMode::Auto => audio::probe_duration_seconds(audio_path).unwrap_or(None),
+        _ => None,
+    };
+    let decision = decide(mode, duration, vad_installed);
+    dtrace!(
+        "asr::mode={mode:?} duration={:?} vad_installed={vad_installed} decision={decision:?}",
+        duration
+    );
+
+    match decision {
+        VadDecision::Vad => {
+            transcribe_via_vad(audio_path, &model_dir, &vad_dir, VadConfig::default())
+        }
+        VadDecision::Plain => transcribe_plain(audio_path, &model_dir),
+        VadDecision::PlainWithHint => {
+            let secs = duration.unwrap_or(0.0);
+            eprintln!(
+                "hint: audio is {secs:.0}s; `kesha install --vad` would improve long-audio accuracy"
+            );
+            transcribe_plain(audio_path, &model_dir)
+        }
+    }
+}
+
+fn transcribe_plain(audio_path: &str, model_dir: &str) -> Result<String> {
     let t0 = Instant::now();
-    let mut be = backend::create_backend(&model_dir)?;
+    let mut be = backend::create_backend(model_dir)?;
     dtrace!("asr::backend_loaded dt={}ms", t0.elapsed().as_millis());
     let t1 = Instant::now();
     let out = be.transcribe(audio_path)?;
@@ -29,10 +98,13 @@ pub fn transcribe(audio_path: &str) -> Result<String> {
 ///
 /// All-silence inputs fall back to a single full-file pass (with a stderr
 /// warning) so a misconfigured threshold never silently drops input.
-pub fn transcribe_with_vad(audio_path: &str, cfg: VadConfig) -> Result<String> {
-    let model_dir = ensure_asr_installed()?;
-    let vad_dir = models::vad_model_dir();
-    if !models::is_vad_cached(&vad_dir) {
+fn transcribe_via_vad(
+    audio_path: &str,
+    model_dir: &str,
+    vad_dir: &str,
+    cfg: VadConfig,
+) -> Result<String> {
+    if !models::is_vad_cached(vad_dir) {
         anyhow::bail!(
             "Error: VAD model not installed\n\n\
              Please run: kesha install --vad"
@@ -48,7 +120,7 @@ pub fn transcribe_with_vad(audio_path: &str, cfg: VadConfig) -> Result<String> {
     );
 
     let t_vad = Instant::now();
-    let vad_path = Path::new(&vad_dir).join("silero_vad.onnx");
+    let vad_path = Path::new(vad_dir).join("silero_vad.onnx");
     let mut vad = VadDetector::load(&vad_path).context("load Silero VAD")?;
     let segments = vad.detect_segments(&samples, cfg)?;
     dtrace!(
@@ -57,12 +129,9 @@ pub fn transcribe_with_vad(audio_path: &str, cfg: VadConfig) -> Result<String> {
         segments.len()
     );
 
-    let mut be = backend::create_backend(&model_dir)?;
+    let mut be = backend::create_backend(model_dir)?;
 
     if segments.is_empty() {
-        // Audio shorter than the configured min_speech window can't ever
-        // produce a segment — fall back silently. Only warn when a real
-        // threshold miss / unexpected silence triggered the empty result.
         let min_speech_samples =
             (cfg.min_speech_ms as u64 * VAD_SAMPLE_RATE as u64 / 1000) as usize;
         if samples.len() >= min_speech_samples {
@@ -111,7 +180,6 @@ pub fn transcribe_with_vad(audio_path: &str, cfg: VadConfig) -> Result<String> {
 }
 
 /// Returns the cached ASR model dir or bails with the install hint.
-/// Shared by the plain and VAD-preprocessed paths.
 fn ensure_asr_installed() -> Result<String> {
     let model_dir = models::asr_model_dir();
     if !models::is_asr_cached(&model_dir) {
@@ -121,4 +189,52 @@ fn ensure_asr_installed() -> Result<String> {
         );
     }
     Ok(model_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_mode_always_uses_vad_regardless_of_other_inputs() {
+        assert_eq!(decide(VadMode::On, None, false), VadDecision::Vad);
+        assert_eq!(decide(VadMode::On, Some(5.0), false), VadDecision::Vad);
+        assert_eq!(decide(VadMode::On, Some(300.0), true), VadDecision::Vad);
+    }
+
+    #[test]
+    fn off_mode_always_uses_plain_regardless_of_other_inputs() {
+        assert_eq!(decide(VadMode::Off, None, true), VadDecision::Plain);
+        assert_eq!(decide(VadMode::Off, Some(3600.0), true), VadDecision::Plain);
+    }
+
+    #[test]
+    fn auto_short_audio_uses_plain_with_no_hint() {
+        assert_eq!(decide(VadMode::Auto, Some(30.0), true), VadDecision::Plain);
+        assert_eq!(decide(VadMode::Auto, Some(119.9), true), VadDecision::Plain);
+    }
+
+    #[test]
+    fn auto_long_audio_with_vad_installed_routes_through_vad() {
+        assert_eq!(
+            decide(VadMode::Auto, Some(AUTO_VAD_MIN_SECONDS), true),
+            VadDecision::Vad
+        );
+        assert_eq!(decide(VadMode::Auto, Some(3600.0), true), VadDecision::Vad);
+    }
+
+    #[test]
+    fn auto_long_audio_without_vad_prints_hint() {
+        assert_eq!(
+            decide(VadMode::Auto, Some(300.0), false),
+            VadDecision::PlainWithHint
+        );
+    }
+
+    #[test]
+    fn auto_unknown_duration_skips_trigger_silently() {
+        // Unknown duration → treat as short, never surprise the user with VAD.
+        assert_eq!(decide(VadMode::Auto, None, true), VadDecision::Plain);
+        assert_eq!(decide(VadMode::Auto, None, false), VadDecision::Plain);
+    }
 }

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -233,6 +233,100 @@ fn ensure_asr_installed() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    /// Write a 16-bit PCM mono WAV of `seconds` silence. Symphonia's probe
+    /// reads `n_frames` from the WAV data-chunk size, so these files produce
+    /// real durations without needing an audio-generation crate. The actual
+    /// samples are zeros — a proper file, not a spoofed header, so the
+    /// file-size guard in `probe_duration_if_plausible` sees real bytes.
+    fn write_silent_pcm16_wav(
+        path: &std::path::Path,
+        seconds: u32,
+        sample_rate: u32,
+    ) -> std::io::Result<()> {
+        let n_samples = (seconds as u64) * (sample_rate as u64);
+        let data_bytes = (n_samples * 2) as u32;
+        let mut f = std::fs::File::create(path)?;
+        f.write_all(b"RIFF")?;
+        f.write_all(&(36u32 + data_bytes).to_le_bytes())?;
+        f.write_all(b"WAVE")?;
+        f.write_all(b"fmt ")?;
+        f.write_all(&16u32.to_le_bytes())?;
+        f.write_all(&1u16.to_le_bytes())?;
+        f.write_all(&1u16.to_le_bytes())?;
+        f.write_all(&sample_rate.to_le_bytes())?;
+        f.write_all(&(sample_rate * 2).to_le_bytes())?;
+        f.write_all(&2u16.to_le_bytes())?;
+        f.write_all(&16u16.to_le_bytes())?;
+        f.write_all(b"data")?;
+        f.write_all(&data_bytes.to_le_bytes())?;
+        let zeros = vec![0u8; (n_samples * 2) as usize];
+        f.write_all(&zeros)?;
+        Ok(())
+    }
+
+    #[test]
+    fn auto_mode_long_wav_routes_to_vad_when_installed() {
+        // End-to-end test of the auto-trigger: 121-second WAV → probe reads
+        // duration → `decide()` picks VAD (when installed) or hint path.
+        let tmp = tempfile::Builder::new()
+            .prefix("kesha-auto-vad-long-")
+            .suffix(".wav")
+            .tempfile()
+            .unwrap();
+        write_silent_pcm16_wav(tmp.path(), 121, 16_000).unwrap();
+        let duration = probe_duration_if_plausible(tmp.path().to_str().unwrap());
+        let secs = duration.expect("long WAV should probe to Some duration");
+        assert!((120.0..122.0).contains(&secs), "expected ~121s, got {secs}");
+        assert_eq!(
+            decide(VadMode::Auto, duration, true),
+            VadDecision::Vad,
+            "long audio + installed → Vad"
+        );
+        assert_eq!(
+            decide(VadMode::Auto, duration, false),
+            VadDecision::PlainWithHint,
+            "long audio + not installed → Plain + hint"
+        );
+    }
+
+    #[test]
+    fn probe_skipped_for_files_below_size_guard() {
+        // 1 s of 16 kHz mono 16-bit PCM = ~32 KB, well below the 200 KB guard.
+        // The probe should short-circuit and return None without touching
+        // symphonia at all.
+        let tmp = tempfile::Builder::new()
+            .prefix("kesha-auto-vad-tiny-")
+            .suffix(".wav")
+            .tempfile()
+            .unwrap();
+        write_silent_pcm16_wav(tmp.path(), 1, 16_000).unwrap();
+        assert!(std::fs::metadata(tmp.path()).unwrap().len() < AUTO_VAD_MIN_FILE_SIZE);
+        assert_eq!(
+            probe_duration_if_plausible(tmp.path().to_str().unwrap()),
+            None,
+        );
+    }
+
+    #[test]
+    fn probe_returns_none_for_missing_or_invalid_file() {
+        // Missing file → metadata fails, probe fails, returns None (decide
+        // then treats as Auto/short → Plain).
+        assert_eq!(
+            probe_duration_if_plausible("/nonexistent/path/to/audio.wav"),
+            None
+        );
+    }
+
+    #[test]
+    fn from_flags_maps_cli_arguments_to_modes() {
+        assert_eq!(VadMode::from_flags(true, false), VadMode::On);
+        assert_eq!(VadMode::from_flags(false, true), VadMode::Off);
+        assert_eq!(VadMode::from_flags(false, false), VadMode::Auto);
+        // Should-be-unreachable (clap rejects), but resolve deterministically.
+        assert_eq!(VadMode::from_flags(true, true), VadMode::On);
+    }
 
     #[test]
     fn on_mode_always_uses_vad_regardless_of_other_inputs() {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -22,6 +22,7 @@ interface MainCommandArgs {
   verbose: boolean;
   debug: boolean;
   vad: boolean;
+  "no-vad": boolean;
   format?: string;
   lang?: string;
 }
@@ -76,7 +77,12 @@ export const mainCommand = defineCommand({
     },
     vad: {
       type: "boolean",
-      description: "Run Silero VAD preprocessing for long/silence-heavy audio (opt-in; kesha install --vad first)",
+      description: "Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.",
+      default: false,
+    },
+    "no-vad": {
+      type: "boolean",
+      description: "Disable VAD preprocessing regardless of duration or install state",
       default: false,
     },
   },
@@ -88,6 +94,12 @@ export const mainCommand = defineCommand({
       log.error("--json and --toon are mutually exclusive (pick one output format).");
       process.exit(2);
     }
+
+    if (args.vad && args["no-vad"]) {
+      log.error("--vad and --no-vad are mutually exclusive.");
+      process.exit(2);
+    }
+    const vadMode: boolean | undefined = args.vad ? true : args["no-vad"] ? false : undefined;
 
     if (files.length === 0) {
       log.info("Usage: kesha <audio_file> [audio_file ...]\n       kesha install [--no-cache]\n       kesha status");
@@ -105,7 +117,7 @@ export const mainCommand = defineCommand({
         // Run audio lang-id and transcription concurrently
         const [audioResult, text] = await Promise.all([
           wantsLangId ? detectAudioLanguageEngine(file) : Promise.resolve(null),
-          transcribe(file, { vad: args.vad }),
+          transcribe(file, { vad: vadMode }),
         ]);
 
         let audioLanguage: LangDetectResult | undefined;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -99,7 +99,7 @@ export const mainCommand = defineCommand({
       log.error("--vad and --no-vad are mutually exclusive.");
       process.exit(2);
     }
-    const vadMode: boolean | undefined = args.vad ? true : args["no-vad"] ? false : undefined;
+    const vadMode = args.vad ? "on" : args["no-vad"] ? "off" : "auto";
 
     if (files.length === 0) {
       log.info("Usage: kesha <audio_file> [audio_file ...]\n       kesha install [--no-cache]\n       kesha status");

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -42,11 +42,15 @@ async function runEngine(args: string[]): Promise<{ stdout: string; stderr: stri
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 
+/** VAD preprocessing selector.
+ *  - `"auto"` (default): engine decides — VAD when audio ≥ 120 s and model installed
+ *  - `"on"`: force VAD (requires `kesha install --vad`)
+ *  - `"off"`: force full-file pass regardless of duration or install state
+ */
+export type VadMode = "auto" | "on" | "off";
+
 export interface TranscribeEngineOptions {
-  /** Silero VAD preprocessing mode. `true` forces on, `false` forces off,
-   *  `undefined` lets the engine decide (auto-on for audio ≥ 120 s when the
-   *  VAD model is installed — see #187). */
-  vad?: boolean;
+  vad?: VadMode;
 }
 
 export async function transcribeEngine(
@@ -54,8 +58,8 @@ export async function transcribeEngine(
   opts: TranscribeEngineOptions = {},
 ): Promise<string> {
   const args = ["transcribe", audioPath];
-  if (opts.vad === true) args.push("--vad");
-  else if (opts.vad === false) args.push("--no-vad");
+  if (opts.vad === "on") args.push("--vad");
+  else if (opts.vad === "off") args.push("--no-vad");
   const { stdout, stderr, exitCode } = await runEngine(args);
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -43,7 +43,9 @@ async function runEngine(args: string[]): Promise<{ stdout: string; stderr: stri
 }
 
 export interface TranscribeEngineOptions {
-  /** Run Silero VAD preprocessing and transcribe each speech segment. */
+  /** Silero VAD preprocessing mode. `true` forces on, `false` forces off,
+   *  `undefined` lets the engine decide (auto-on for audio ≥ 120 s when the
+   *  VAD model is installed — see #187). */
   vad?: boolean;
 }
 
@@ -52,7 +54,8 @@ export async function transcribeEngine(
   opts: TranscribeEngineOptions = {},
 ): Promise<string> {
   const args = ["transcribe", audioPath];
-  if (opts.vad) args.push("--vad");
+  if (opts.vad === true) args.push("--vad");
+  else if (opts.vad === false) args.push("--no-vad");
   const { stdout, stderr, exitCode } = await runEngine(args);
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -2,9 +2,11 @@ import { isEngineInstalled, transcribeEngine } from "./engine";
 
 export interface TranscribeOptions {
   silent?: boolean;
-  /** Run Silero VAD preprocessing: segment the audio first, then transcribe
-   *  each speech span and stitch results. Opt-in — requires the VAD model
-   *  to be installed (`kesha install --vad`). */
+  /** Silero VAD preprocessing mode:
+   *  - `true` — force on (requires `kesha install --vad`)
+   *  - `false` — force off, even for long audio
+   *  - `undefined` (default) — auto-on when audio ≥ 120 s and VAD is installed
+   *  See #187. */
   vad?: boolean;
 }
 

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -1,13 +1,11 @@
-import { isEngineInstalled, transcribeEngine } from "./engine";
+import { isEngineInstalled, transcribeEngine, type VadMode } from "./engine";
+
+export type { VadMode };
 
 export interface TranscribeOptions {
   silent?: boolean;
-  /** Silero VAD preprocessing mode:
-   *  - `true` — force on (requires `kesha install --vad`)
-   *  - `false` — force off, even for long audio
-   *  - `undefined` (default) — auto-on when audio ≥ 120 s and VAD is installed
-   *  See #187. */
-  vad?: boolean;
+  /** Silero VAD preprocessing selector. Defaults to `"auto"`. */
+  vad?: VadMode;
 }
 
 export async function transcribe(audioPath: string, opts: TranscribeOptions = {}): Promise<string> {


### PR DESCRIPTION
## Summary

Follow-up to #128. Users no longer need to remember `--vad` for long audio — Kesha routes through VAD automatically when the audio is ≥ 120 s and the model is installed.

```bash
kesha audio.wav              # auto: VAD when ≥120s AND installed
kesha --vad short.ogg        # force on (unchanged)
kesha --no-vad long.m4a      # force off, new escape hatch
kesha --vad --no-vad f.wav   # clap conflict → exit 2
```

## Behaviour matrix

| condition | path | stderr |
|---|---|---|
| `--vad` explicit | VAD | (unchanged) |
| `--no-vad` explicit | plain | (silent) |
| auto + audio < 120 s | plain | (silent) |
| auto + audio ≥ 120 s + VAD cached | VAD | (silent) |
| auto + audio ≥ 120 s + VAD missing | plain | `hint: audio is NNNs; \`kesha install --vad\` would improve long-audio accuracy` |
| auto + duration unknown (OGG/Opus) | plain | (silent) |

## Implementation

- **Duration probe** (`rust/src/audio.rs::probe_duration_seconds`) — reads symphonia `codec_params.n_frames` / `sample_rate` without decoding. Returns `None` when the container doesn't report frame counts; callers treat `None` as "unknown → skip auto-trigger" rather than falling back to a full decode, which would defeat the purpose.
- **`VadMode { Auto, On, Off }`** in `rust/src/transcribe.rs` threaded from `main.rs`. Pure `decide(mode, duration, installed) → VadDecision` — fully unit-tested (6 tests covering all branches) without touching ONNX, disk, or symphonia.
- **`--no-vad` flag** with `conflicts_with = "vad"` at the clap layer — mutual exclusion enforced before any logic runs.
- **TS side**: `TranscribeEngineOptions.vad?: boolean` is now tri-state (`true` → `--vad`, `false` → `--no-vad`, `undefined` → no flag, engine defaults to Auto).

## Test plan

- [x] 6 new Rust unit tests for `decide()` — all matrix branches covered
- [x] `cargo test --lib --bin kesha-engine` → 75 pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` → 137 pass
- [x] E2E: auto mode on short OGG (Opus, `n_frames=None`) → plain path, no hint
- [x] E2E: `--vad` on same short OGG → VAD path, 2 segments
- [x] E2E: `--no-vad` → plain path
- [x] E2E: `--vad --no-vad` → clap conflict, exit 2
- [ ] Long (≥120 s) WAV auto-trigger — needs a long fixture (not in repo); manual test
- [ ] CI matrix across all 3 platforms

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)