### PR TITLE
feat(tts): Phase 2a of #123 — ONNX G2P hard swap (deletes espeak-ng)

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -41,11 +41,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             features: onnx,tts
             binary: kesha-engine-linux-x64
-          # Windows links espeak-ng at build time via an import lib
-          # synthesized from the choco-shipped DLL (see Windows block below
-          # and the matching recipe in rust-test.yml). Runtime prereq:
-          # users must `choco install espeak-ng` so libespeak-ng.dll is on
-          # PATH — we do not bundle the DLL in the release archive.
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             features: onnx,tts
@@ -70,42 +65,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-      - name: Install espeak-ng (macOS)
-        if: matrix.os == 'macos-14'
-        run: brew install espeak-ng
-      - name: Install espeak-ng + libclang (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y espeak-ng libespeak-ng-dev libclang-dev llvm-dev
-          echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
-      - name: Set build env (macOS)
-        if: matrix.os == 'macos-14'
-        run: |
-          echo "LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib" >> $GITHUB_ENV
-          echo "RUSTFLAGS=-L /opt/homebrew/lib" >> $GITHUB_ENV
-
-      # Windows TTS setup (#136) mirrors rust-test.yml: chocolatey ships
-      # the DLL only, so we synthesize an import lib from the DLL's export
-      # table using MSVC's dumpbin + lib tools, then point cargo at it for
-      # the linker step. espeakng-sys ships its own C headers in the
-      # crate, so nothing to install for bindgen other than LLVM's libclang.
-      - name: Install espeak-ng + LLVM (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: choco install -y --no-progress espeak-ng llvm
-
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
 
       - name: Pin MSVC linker (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
-        # Windows runners ship Git for Windows with a `link` binary (GNU
-        # coreutils) on PATH via /c/Program Files/Git/usr/bin. When `shell:
-        # bash` is used, it shadows MSVC's link.exe and rustc invokes the
-        # wrong tool. Pin the MSVC linker explicitly via cargo's env knob so
-        # PATH ordering doesn't matter.
+        # Git for Windows ships a GNU `link.exe` under /c/Program Files/Git/usr/bin
+        # that shadows MSVC's link.exe under `shell: bash`. Pin via cargo's env
+        # knob so PATH ordering doesn't matter.
         run: |
           $linkPath = (Get-Command link.exe |
             Where-Object { $_.Source -notlike "*Git*usr*" } |
@@ -113,51 +81,6 @@ jobs:
           if (-not $linkPath) { Write-Error "MSVC link.exe not found"; exit 1 }
           Write-Host "MSVC linker: $linkPath"
           Add-Content -Path $env:GITHUB_ENV -Value "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linkPath"
-
-      - name: Generate libespeak-ng import lib from DLL (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          $espeakDir = "C:\Program Files\eSpeak NG"
-          $dll = "$espeakDir\libespeak-ng.dll"
-          if (-not (Test-Path $dll)) {
-            Write-Error "espeak-ng DLL not found at $dll"
-            exit 1
-          }
-          # dumpbin / lib require the MSVC dev environment — activated above.
-          $libDir = "$env:RUNNER_TEMP\espeak-lib"
-          New-Item -ItemType Directory -Force -Path $libDir | Out-Null
-          $def = "$libDir\espeak-ng.def"
-          # LIBRARY must match the DLL filename (libespeak-ng.dll); OUT name
-          # must match `cargo:rustc-link-lib=espeak-ng` (no `lib` prefix on MSVC).
-          "LIBRARY libespeak-ng`r`nEXPORTS" | Set-Content -Encoding ASCII $def
-          # dumpbin /exports rows look like:
-          #     1    0 00001A20 espeak_Cancel
-          # — grab just the symbol name (4th column). Hex is case-insensitive
-          # in case a future toolchain flips output style.
-          $exports = dumpbin /exports $dll |
-            Select-String '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)' |
-            ForEach-Object { $_.Matches.Groups[1].Value }
-          # Zero/near-zero exports means the regex drifted from dumpbin's
-          # output; fail loudly here instead of letting lib.exe produce a
-          # valid-looking empty .lib that breaks later in the cargo link step.
-          if ($exports.Count -lt 10) {
-            Write-Error "dumpbin produced $($exports.Count) exports — regex drift? Raw output:"
-            dumpbin /exports $dll | Select-Object -First 30 | Write-Host
-            exit 1
-          }
-          $exports | Add-Content -Encoding ASCII $def
-          Write-Host "Generated .def with $($exports.Count) exports"
-          lib /def:$def /machine:x64 /out:"$libDir\espeak-ng.lib"
-          if (-not (Test-Path "$libDir\espeak-ng.lib")) {
-            Write-Error "lib.exe failed to produce espeak-ng.lib"
-            exit 1
-          }
-          # Linker path (build time) + DLL path (build- AND runtime for the
-          # smoke-test step below) + libclang for bindgen.
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$libDir;$env:LIB"
-          Add-Content -Path $env:GITHUB_PATH -Value $espeakDir
-          Add-Content -Path $env:GITHUB_ENV -Value "LIBCLANG_PATH=C:\Program Files\LLVM\bin"
 
       - name: Build release binary
         run: cd rust && cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,14 @@ jobs:
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
+      # BRIDGE: integration-tests downloads the released `kesha-engine`
+      # binary, which still dynamic-links libespeak-ng because Phase 2a
+      # (ONNX G2P hard swap, #123) hasn't cut a new release yet. Once a
+      # fresh engine release ships, remove this step — the new binary
+      # has no espeak dep.
+      - name: Install espeak-ng (bridge for released engine binary)
+        run: brew install espeak-ng
+
       - name: 🔊 Setup integration backend
         uses: ./.github/actions/install-parakeet-backend
         with:
@@ -151,6 +159,9 @@ jobs:
         env:
           KOKORO_MODEL: ${{ env.KOKORO_CACHE }}/model.onnx
           KOKORO_VOICE: ${{ env.KOKORO_CACHE }}/af_heart.bin
+          # G2P + Piper live under this dir (see rust/ci/download-kokoro.sh)
+          # — runtime loader resolves them via `models::cache_dir()`.
+          KESHA_CACHE_DIR: ${{ env.KOKORO_CACHE }}
           KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/kesha-engine
           DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib
         run: bun test tests/integration/say-e2e.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-v1-${{ runner.os }}
+          key: kokoro-spike-v2-${{ runner.os }}
 
       - name: 📥 Download Kokoro models (if cache miss)
         run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,6 @@ jobs:
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
-      - name: Install espeak-ng
-        run: brew install espeak-ng
-
       - name: 🔊 Setup integration backend
         uses: ./.github/actions/install-parakeet-backend
         with:
@@ -134,9 +131,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-
-      - name: Install espeak-ng
-        run: brew install espeak-ng
 
       - name: 💾 Cache Kokoro models
         uses: actions/cache@v5

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-v1-${{ runner.os }}
+          key: kokoro-spike-v2-${{ runner.os }}
 
       - name: Download Kokoro model (if cache miss)
         shell: bash

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -26,35 +26,15 @@ jobs:
         with:
           workspaces: rust
 
-      - name: Install espeak-ng (macOS)
-        if: runner.os == 'macOS'
-        run: brew install espeak-ng
-
-      - name: Install espeak-ng (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y espeak-ng libespeak-ng-dev
-
-      # Windows TTS setup (#136): chocolatey ships the DLL only, so we
-      # synthesize an import lib from the DLL's export table using MSVC's
-      # dumpbin + lib tools, then point cargo at it for the linker step.
-      # espeakng-sys ships its own C headers in the crate, so nothing to
-      # install for bindgen other than LLVM's libclang.
-      - name: Install espeak-ng + LLVM (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: choco install -y --no-progress espeak-ng llvm
-
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
 
       - name: Pin MSVC linker (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        # Windows runners ship Git for Windows with a `link` binary (GNU
-        # coreutils) on PATH via /c/Program Files/Git/usr/bin. When `shell:
-        # bash` is used, it shadows MSVC's link.exe and rustc invokes the
-        # wrong tool. Pin the MSVC linker explicitly via cargo's env knob so
-        # PATH ordering doesn't matter.
+        # Git for Windows ships a GNU `link.exe` under /c/Program Files/Git/usr/bin
+        # that shadows MSVC's link.exe under `shell: bash`. Pin via cargo's env
+        # knob so PATH ordering doesn't matter.
         run: |
           $linkPath = (Get-Command link.exe |
             Where-Object { $_.Source -notlike "*Git*usr*" } |
@@ -62,50 +42,6 @@ jobs:
           if (-not $linkPath) { Write-Error "MSVC link.exe not found"; exit 1 }
           Write-Host "MSVC linker: $linkPath"
           Add-Content -Path $env:GITHUB_ENV -Value "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linkPath"
-
-      - name: Generate libespeak-ng import lib from DLL (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $espeakDir = "C:\Program Files\eSpeak NG"
-          $dll = "$espeakDir\libespeak-ng.dll"
-          if (-not (Test-Path $dll)) {
-            Write-Error "espeak-ng DLL not found at $dll"
-            exit 1
-          }
-          # dumpbin / lib require the MSVC dev environment — activated above.
-          $libDir = "$env:RUNNER_TEMP\espeak-lib"
-          New-Item -ItemType Directory -Force -Path $libDir | Out-Null
-          $def = "$libDir\espeak-ng.def"
-          # LIBRARY must match the DLL filename (libespeak-ng.dll); OUT name
-          # must match `cargo:rustc-link-lib=espeak-ng` (no `lib` prefix on MSVC).
-          "LIBRARY libespeak-ng`r`nEXPORTS" | Set-Content -Encoding ASCII $def
-          # dumpbin /exports rows look like:
-          #     1    0 00001A20 espeak_Cancel
-          # — grab just the symbol name (4th column). Hex is case-insensitive
-          # in case a future toolchain flips output style.
-          $exports = dumpbin /exports $dll |
-            Select-String '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)' |
-            ForEach-Object { $_.Matches.Groups[1].Value }
-          # Zero/near-zero exports means the regex drifted from dumpbin's
-          # output; fail loudly here instead of letting lib.exe produce a
-          # valid-looking empty .lib that breaks later in the cargo link step.
-          if ($exports.Count -lt 10) {
-            Write-Error "dumpbin produced $($exports.Count) exports — regex drift? Raw output:"
-            dumpbin /exports $dll | Select-Object -First 30 | Write-Host
-            exit 1
-          }
-          $exports | Add-Content -Encoding ASCII $def
-          Write-Host "Generated .def with $($exports.Count) exports"
-          lib /def:$def /machine:x64 /out:"$libDir\espeak-ng.lib"
-          if (-not (Test-Path "$libDir\espeak-ng.lib")) {
-            Write-Error "lib.exe failed to produce espeak-ng.lib"
-            exit 1
-          }
-          # Linker path (build time) + DLL path (runtime) + libclang for bindgen.
-          Add-Content -Path $env:GITHUB_ENV -Value "LIB=$libDir;$env:LIB"
-          Add-Content -Path $env:GITHUB_PATH -Value $espeakDir
-          Add-Content -Path $env:GITHUB_ENV -Value "LIBCLANG_PATH=C:\Program Files\LLVM\bin"
 
       - name: Cache Kokoro spike models
         uses: actions/cache@v5
@@ -117,7 +53,7 @@ jobs:
         shell: bash
         run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"
 
-      - name: Run tests (with real Kokoro + espeak)
+      - name: Run tests (with real Kokoro)
         shell: bash
         run: bash rust/ci/run-cargo-test.sh "$KOKORO_CACHE" "${{ runner.os }}"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ const text = await transcribe("audio.ogg");
 - **CoreML engine**: macOS 14+, Apple Silicon (arm64)
 - **ONNX engine**: macOS, Linux, Windows
 - `ffmpeg` is **not required** — the Rust engine uses symphonia + rubato
-- **TTS**: `espeak-ng` on PATH (`brew install espeak-ng` / `apt install espeak-ng` / `choco install espeak-ng`). Vendoring tracked in [#124](https://github.com/drakulavich/kesha-voice-kit/issues/124).
+- **TTS**: no system deps. G2P runs as ONNX (CharsiuG2P ByT5-tiny, #123) alongside Kokoro/Piper.
 
 ## TTS
 
@@ -319,11 +319,11 @@ Text-to-speech via three engines selected by voice id prefix:
 - `ru-*` → **Piper VITS** (`rhasspy/piper-voices`). Per-voice `.onnx` + `.onnx.json`. Output depends on voice (22.05 kHz for medium tier).
 - `macos-*` → **AVSpeechSynthesizer** via a Swift sidecar (#141). Zero model download, notification-grade quality. Enabled on darwin-arm64 release binaries (`--features coreml,tts,system_tts` in build-engine.yml). `kesha install` fetches `say-avspeech-darwin-arm64` next to the engine; runtime lookup is sibling-first (see `rust/src/tts/avspeech.rs::helper_path`).
 
-Opt-in via `kesha install --tts` (downloads Kokoro + Piper, ~390 MB). `macos-*` voices need no install — they use voices already on macOS.
+Opt-in via `kesha install --tts` (downloads Kokoro + Piper + ONNX G2P, ~490 MB). `macos-*` voices need no install — they use voices already on macOS.
 
 - TTS models are **never auto-downloaded** — `kesha say` fails loudly with a `kesha install --tts` hint when models are missing.
 - `kesha say` writes WAV mono f32 to stdout unless `--out` is given. Stderr is progress/errors only.
-- G2P uses `espeakng-sys` (dynamic link against system `libespeak-ng`) for both engines.
+- G2P uses CharsiuG2P ByT5-tiny ONNX (`rust/src/tts/g2p.rs`, FP32, ~100 MB), shared across Kokoro and Piper pipelines. See [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123) and `docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md`.
 - **Auto-routing:** when `--voice` is omitted, the TS CLI calls `NLLanguageRecognizer` on the input text and picks `en-af_heart` or `ru-denis`. Confidence < 0.5 or unmapped language falls through to the engine default. `pickVoiceForLang` in `src/cli.ts` is the routing table — add a language by adding a match arm.
 - **SSML** (opt-in via `--ssml`): uses the `ssml-parser` crate; supports `<speak>` root and `<break time="...">` for silence. Unknown tags (`<emphasis>`, `<prosody>`, `<phoneme>`, `<say-as>`) warn to stderr once per name and are stripped, but contained text is still synthesized. Hardening: required `<speak>` root, `<!DOCTYPE>` rejected anywhere in input. `tts::ssml::parse` returns `Vec<Segment>`; `tts::say()` loads the engine once and concatenates f32 samples for text vs silence for breaks before a single `wav::encode_wav`. See issue #122 for the full scope matrix and future tag support.
 - Kokoro ONNX: `input_ids` (int64 `[1,N]`), `style` (f32 `[1,256]` — rank-2), `speed` (f32 `[1]`). Output name `"waveform"`. Voice file 510 rows × 256 cols.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ smoke-test: ## Run smoke tests against fixtures
 	kesha install
 	bun scripts/smoke-test.ts
 
-smoke-test-tts: ## Run smoke tests with TTS (requires espeak-ng)
+smoke-test-tts: ## Run smoke tests with TTS
 	bun link @drakulavich/kesha-voice-kit
 	kesha install --tts
 	bun scripts/smoke-test.ts --tts

--- a/README.md
+++ b/README.md
@@ -110,10 +110,7 @@ Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on th
 Kesha speaks back via Kokoro-82M (English) and Piper (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Piper. Pass `--voice` to override.
 
 ```bash
-brew install espeak-ng              # one-time system dep — macOS
-# Linux:   sudo apt install espeak-ng
-# Windows: choco install espeak-ng  (puts libespeak-ng.dll on PATH)
-kesha install --tts                 # ~390MB (Kokoro + Piper RU, opt-in)
+kesha install --tts                 # ~490MB (Kokoro + Piper RU + ONNX G2P, opt-in)
 kesha say "Hello, world" > hello.wav
 kesha say "Привет, мир" > privet.wav    # auto-routes to ru-denis
 echo "long text" | kesha say > reply.wav
@@ -122,7 +119,7 @@ kesha say --voice en-af_heart "text"    # explicit voice overrides auto-routing
 kesha say --list-voices
 ```
 
-Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Opus and MP3 are tracked in follow-up issues. Static-linking of `espeak-ng` to remove the system dep is [#124](https://github.com/drakulavich/kesha-voice-kit/issues/124).
+Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Opus and MP3 are tracked in follow-up issues. Grapheme-to-phoneme runs entirely through ONNX (CharsiuG2P ByT5-tiny, [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123)) — no `espeak-ng` system dep.
 
 **Supported voices:**
 - English: `en-af_heart` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/`
@@ -131,7 +128,7 @@ Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Op
 
 ### macOS system voices
 
-`kesha say --voice macos-*` routes through `AVSpeechSynthesizer` on macOS, so you get voice synthesis for free — no 390 MB TTS bundle, no `espeak-ng` dep. The sidecar binary ships alongside `kesha-engine` on darwin-arm64 releases (#141); `kesha install` places both in `~/.cache/kesha/bin/`.
+`kesha say --voice macos-*` routes through `AVSpeechSynthesizer` on macOS, so you get voice synthesis for free — no 490 MB TTS bundle. The sidecar binary ships alongside `kesha-engine` on darwin-arm64 releases (#141); `kesha install` places both in `~/.cache/kesha/bin/`.
 
 ```bash
 kesha say --list-voices | grep ^macos-                                       # discover installed voices

--- a/SKILL.md
+++ b/SKILL.md
@@ -73,15 +73,10 @@ Output: WAV mono float32. `--out <path>` writes to a file instead of stdout.
 ```bash
 bun add --global @drakulavich/kesha-voice-kit    # or: npm i -g @drakulavich/kesha-voice-kit
 kesha install                                    # downloads engine (~350 MB)
-kesha install --tts                              # adds Kokoro + Piper RU (~390 MB more, for TTS)
+kesha install --tts                              # adds Kokoro + Piper RU + ONNX G2P (~490 MB more, for TTS)
 ```
 
-One-time runtime prereq for TTS on each platform:
-- macOS: `brew install espeak-ng`
-- Linux: `sudo apt install espeak-ng`
-- Windows: `choco install espeak-ng`
-
-`macos-*` voices need no install — they use voices already on the Mac.
+No system deps — G2P runs as ONNX alongside Kokoro/Piper. `macos-*` voices need no install either — they use voices already on the Mac.
 
 ## Supported languages
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -135,24 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,30 +184,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
 
 [[package]]
 name = "clap"
@@ -490,15 +452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "espeakng-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37752ac02bee1c42754254fa81c568dd42c4959da9d353dfee4cf4dbddc4653"
-dependencies = [
- "bindgen",
-]
-
-[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,12 +548,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -709,15 +656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,7 +669,6 @@ dependencies = [
  "audioadapter-buffers",
  "clap",
  "dirs",
- "espeakng-sys",
  "fluidaudio-rs",
  "hound",
  "ndarray",
@@ -766,16 +703,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
 
 [[package]]
 name = "libredox"
@@ -827,12 +754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,16 +793,6 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1204,12 +1115,6 @@ dependencies = [
  "visibility",
  "windowfunctions",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustfft"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ default = ["onnx", "tts"]
 # a temp WAV per VAD segment (`fluidaudio-rs 0.1.0` lacks transcribe_samples).
 coreml = ["dep:fluidaudio-rs", "dep:tempfile"]
 onnx = []
-tts = ["dep:hound", "dep:espeakng-sys", "dep:thiserror", "dep:ssml-parser"]
+tts = ["dep:hound", "dep:thiserror", "dep:ssml-parser"]
 # macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
 # Opt-in — builds a Swift sidecar via swiftc in build.rs. Silently no-op on
 # non-macOS targets even when enabled.
@@ -52,9 +52,8 @@ ndarray = { version = "0.17" }
 fluidaudio-rs = { version = "0.1", optional = true }
 audioadapter-buffers = "3.0.0"
 
-# TTS (Kokoro + espeak-ng + SSML parser)
+# TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)
 hound = { version = "3.5", optional = true }
-espeakng-sys = { version = "0.3", features = ["clang-runtime"], optional = true }
 thiserror = { version = "1", optional = true }
 sha2 = "0.10"
 ssml-parser = { version = "0.1", optional = true }

--- a/rust/ci/download-kokoro.sh
+++ b/rust/ci/download-kokoro.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-# Download Kokoro model + af_heart voice for CI tests.
+# Download Kokoro + CharsiuG2P ONNX models for CI tts_e2e tests.
 # Called by rust-test.yml; cache warms on subsequent runs.
+#
+# Kokoro files land directly in $DEST (legacy layout — the test env vars
+# KOKORO_MODEL / KOKORO_VOICE take direct paths). G2P files land under
+# $DEST/models/g2p/byt5-tiny/, matching `models::cache_dir()` so the
+# runtime loader finds them when KESHA_CACHE_DIR=$DEST is set by the
+# test runner.
 set -euo pipefail
 
 DEST="${1:?usage: download-kokoro.sh <dest_dir>}"
@@ -18,4 +24,28 @@ if [[ ! -f "$DEST/af_heart.bin" ]]; then
     https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/af_heart.bin
 fi
 
+G2P_DIR="$DEST/models/g2p/byt5-tiny"
+mkdir -p "$G2P_DIR"
+for f in encoder_model.onnx decoder_model.onnx decoder_with_past_model.onnx; do
+  if [[ ! -f "$G2P_DIR/$f" ]]; then
+    echo "Downloading G2P $f..."
+    curl -fL -o "$G2P_DIR/$f" \
+      "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/$f"
+  fi
+done
+
+# Piper RU is needed by piper_russian_produces_wav in tts_e2e.rs — runs
+# under the same KESHA_CACHE_DIR layout.
+PIPER_DIR="$DEST/models/piper-ru"
+mkdir -p "$PIPER_DIR"
+for f in ru_RU-denis-medium.onnx ru_RU-denis-medium.onnx.json; do
+  if [[ ! -f "$PIPER_DIR/$f" ]]; then
+    echo "Downloading Piper $f..."
+    curl -fL -o "$PIPER_DIR/$f" \
+      "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/$f"
+  fi
+done
+
 ls -lh "$DEST"
+ls -lh "$G2P_DIR"
+ls -lh "$PIPER_DIR"

--- a/rust/ci/run-cargo-test.sh
+++ b/rust/ci/run-cargo-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Run `cargo test` with Kokoro-model env vars pointing at the workflow's
-# cached spike assets. Skips the real-inference tests if the cache is empty.
+# Run `cargo test` with Kokoro env vars + KESHA_CACHE_DIR pointing at the
+# workflow's warm model cache. Skips the real-inference tests if the cache
+# is empty.
 set -euo pipefail
 
 KOKORO_CACHE="${1:?usage: run-cargo-test.sh <kokoro_cache> <runner_os>}"
@@ -22,6 +23,15 @@ if [[ -f "$KOKORO_CACHE/model.onnx" && -f "$KOKORO_CACHE/af_heart.bin" ]]; then
   echo "Running with real Kokoro models from $KOKORO_CACHE"
 else
   echo "Kokoro cache empty — gated tests will skip"
+fi
+
+# G2P + Piper live under $KOKORO_CACHE/models/... matching the
+# runtime `models::cache_dir()` layout (see download-kokoro.sh).
+if [[ -d "$KOKORO_CACHE/models/g2p/byt5-tiny" ]]; then
+  export KESHA_CACHE_DIR="$KOKORO_CACHE"
+  export PIPER_MODEL="$KOKORO_CACHE/models/piper-ru/ru_RU-denis-medium.onnx"
+  export PIPER_CONFIG="$KOKORO_CACHE/models/piper-ru/ru_RU-denis-medium.onnx.json"
+  echo "KESHA_CACHE_DIR=$KESHA_CACHE_DIR (G2P + Piper gated tests enabled)"
 fi
 
 cargo test --verbose

--- a/rust/ci/run-cargo-test.sh
+++ b/rust/ci/run-cargo-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Run `cargo test` with platform-specific env vars for espeak-ng linking
-# and Kokoro-model paths. Skips the real-inference tests if the cache is empty.
+# Run `cargo test` with Kokoro-model env vars pointing at the workflow's
+# cached spike assets. Skips the real-inference tests if the cache is empty.
 set -euo pipefail
 
 KOKORO_CACHE="${1:?usage: run-cargo-test.sh <kokoro_cache> <runner_os>}"
@@ -9,20 +9,7 @@ RUNNER_OS="${2:?}"
 cd rust
 
 case "$RUNNER_OS" in
-  macOS)
-    export LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib
-    export RUSTFLAGS="-L /opt/homebrew/lib"
-    export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
-    ;;
-  Linux)
-    # apt-installed libespeak-ng is discovered via pkg-config / default lib paths
-    :
-    ;;
-  Windows)
-    # LIB / PATH / LIBCLANG_PATH are set in the workflow step that generates
-    # the espeak-ng import lib from the DLL (see rust-test.yml #136 block).
-    :
-    ;;
+  macOS|Linux|Windows) ;;
   *)
     echo "unsupported runner: $RUNNER_OS" >&2
     exit 1

--- a/rust/src/backend/onnx.rs
+++ b/rust/src/backend/onnx.rs
@@ -6,6 +6,7 @@ use ort::session::Session;
 use ort::value::Value;
 
 use crate::audio;
+use crate::util::argmax;
 
 use super::TranscribeBackend;
 
@@ -379,18 +380,6 @@ impl TranscribeBackend for OnnxBackend {
 
         Ok(text)
     }
-}
-
-fn argmax(arr: &[f32]) -> usize {
-    let mut best = 0;
-    let mut best_val = f32::NEG_INFINITY;
-    for (i, &v) in arr.iter().enumerate() {
-        if v > best_val {
-            best_val = v;
-            best = i;
-        }
-    }
-    best
 }
 
 fn top_k_indices(arr: &[f32], k: usize, exclude: usize) -> Vec<usize> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,7 @@
 //! `kesha-engine` binary — cargo handles the dual targets.
 
 pub mod debug;
+pub mod models;
 
 #[cfg(feature = "tts")]
 pub mod tts;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod debug;
 pub mod models;
+pub mod util;
 
 #[cfg(feature = "tts")]
 pub mod tts;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -55,7 +55,7 @@ enum Commands {
         /// Re-download even if cached
         #[arg(long)]
         no_cache: bool,
-        /// Also install TTS models (Kokoro EN + Piper RU, ~390MB). Requires `espeak-ng` on PATH.
+        /// Also install TTS models (Kokoro EN + Piper RU + ONNX G2P, ~490MB).
         #[cfg(feature = "tts")]
         #[arg(long)]
         tts: bool,
@@ -71,7 +71,7 @@ enum Commands {
         /// Voice id, e.g. `en-af_heart`
         #[arg(long)]
         voice: Option<String>,
-        /// Override the voice's default espeak language code, e.g. `en-gb`
+        /// Override the voice's default BCP 47 language code, e.g. `en-gb`
         #[arg(long)]
         lang: Option<String>,
         /// Output file (default: stdout)
@@ -107,24 +107,6 @@ struct SayArgs {
     ssml: bool,
     model: Option<std::path::PathBuf>,
     voice_file: Option<std::path::PathBuf>,
-}
-
-#[cfg(feature = "tts")]
-fn ensure_espeak_available() -> anyhow::Result<()> {
-    use std::process::Command;
-    let check = Command::new("espeak-ng").arg("--version").output();
-    match check {
-        Ok(o) if o.status.success() => Ok(()),
-        _ => {
-            anyhow::bail!(
-                "espeak-ng not found on PATH.\n\
-                 Install it and retry:\n\
-                   macOS:   brew install espeak-ng\n\
-                   Linux:   apt install espeak-ng  (or your distro equivalent)\n\
-                   Windows: choco install espeak-ng"
-            )
-        }
-    }
 }
 
 #[cfg(feature = "tts")]
@@ -329,7 +311,6 @@ fn main() -> Result<()> {
             models::install(no_cache)?;
             #[cfg(feature = "tts")]
             if tts {
-                ensure_espeak_available()?;
                 models::download_tts(no_cache)?;
                 eprintln!("TTS models installed.");
             }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -11,6 +11,7 @@ mod text_lang;
 mod transcribe;
 #[cfg(feature = "tts")]
 mod tts;
+mod util;
 mod vad;
 
 #[derive(Parser)]

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -1,14 +1,8 @@
-//! Grapheme-to-phoneme via CharsiuG2P ByT5-tiny ONNX (#123 — replaces
-//! espeak-ng). Three ORT sessions (encoder, decoder, decoder-with-past)
-//! plus greedy decoding with explicit KV-cache management.
-//!
-//! The ByT5 tokenizer is byte-level with a `+3` offset (PAD=0, EOS=1,
-//! UNK=2 reserved; actual byte tokens start at 3). Prompts look like
-//! `"<{lang}>: {word}"` where `{lang}` is a CharsiuG2P code (e.g. `eng-us`).
-//!
-//! Session lifetime: loaded once per `text_to_ipa` call, reused across
-//! all words in the input. This matches the Kokoro/Piper/VAD pattern —
-//! per-call load amortized over all words in one synthesis.
+//! Grapheme-to-phoneme via CharsiuG2P ByT5-tiny ONNX (#123). Three ORT
+//! sessions (encoder, decoder, decoder-with-past) plus greedy decoding
+//! with explicit KV-cache management. Byte-level tokenizer adds 3 to each
+//! UTF-8 byte (PAD=0, EOS=1, UNK=2 reserved). Prompt format is
+//! `<{lang}>: {word}` where `{lang}` is a CharsiuG2P code.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -19,6 +13,7 @@ use ort::session::Session;
 use ort::value::Value;
 
 use crate::models;
+use crate::util::argmax;
 
 const PAD: i64 = 0;
 const EOS: i64 = 1;
@@ -54,25 +49,19 @@ impl G2pSessions {
 }
 
 fn build_session(path: &Path) -> Result<Session> {
-    // `ort::Error<SessionBuilder>` isn't Send in 2.0.0-rc.12 so it can't
-    // convert through `?` into `anyhow::Error`. Inline `map_err` at each
-    // boundary — see the spike doc's "ort API gotchas" section.
     Session::builder()
-        .map_err(|e| anyhow::anyhow!("ort session builder: {e}"))?
+        .context("create g2p session builder")?
         .commit_from_file(path)
         .with_context(|| format!("open {}", path.display()))
 }
 
-/// Map espeak-style language codes to CharsiuG2P prompt codes.
-///
-/// The upstream checkpoint uses non-standard ISO-ish suffixes — Portuguese
-/// is `por-bz` (Brazilian) / `por-po` (European) rather than `-br`/`-pt`,
-/// per the training dictionary names in
-/// <https://github.com/lingjzhu/CharsiuG2P/tree/main/dicts>. Every code in
-/// this table is verified against that directory listing; "ISO-looking"
-/// substitutions (e.g. `por-br`) would silently produce garbage because
-/// the model has never seen that prompt.
-pub fn charsiu_lang(espeak: &str) -> Result<&'static str> {
+/// Map espeak-style language codes to CharsiuG2P prompt codes. The
+/// upstream training corpus uses non-standard suffixes — notably
+/// Portuguese is `por-bz` / `por-po` (not `-br`/`-pt`) per the dict
+/// filenames at <https://github.com/lingjzhu/CharsiuG2P/tree/main/dicts>.
+/// "ISO-looking" substitutions would silently produce garbage since the
+/// model has never seen that prompt.
+fn charsiu_lang(espeak: &str) -> Result<&'static str> {
     Ok(match espeak.to_ascii_lowercase().as_str() {
         "en-us" => "eng-us",
         "en" | "en-gb" | "en-uk" => "eng-uk",
@@ -90,9 +79,7 @@ pub fn charsiu_lang(espeak: &str) -> Result<&'static str> {
     })
 }
 
-/// Byte-level tokenization: UTF-8 bytes + 3 (ByT5 reserves 0/1/2), with
-/// trailing EOS. The prompt format (`<lang>: word`) is what the CharsiuG2P
-/// checkpoint was trained on; matches the Python reference exactly.
+/// Byte-level tokenization: `<{lang}>: {word}` → UTF-8 bytes + 3, EOS.
 fn tokenize(charsiu_code: &str, word: &str) -> Vec<i64> {
     let prompt = format!("<{charsiu_code}>: {word}");
     let mut ids: Vec<i64> = prompt.bytes().map(|b| b as i64 + BYTE_OFFSET).collect();
@@ -100,8 +87,7 @@ fn tokenize(charsiu_code: &str, word: &str) -> Vec<i64> {
     ids
 }
 
-/// Decode a run of token IDs back to UTF-8. IDs below `BYTE_OFFSET` are
-/// special tokens (PAD/EOS/UNK) and are dropped silently.
+/// Invert the byte+3 encoding. Special tokens (< `BYTE_OFFSET`) drop silently.
 fn detokenize(ids: &[i64]) -> String {
     let bytes: Vec<u8> = ids
         .iter()
@@ -116,16 +102,9 @@ fn detokenize(ids: &[i64]) -> String {
     String::from_utf8_lossy(&bytes).into_owned()
 }
 
-fn argmax(logits: &[f32]) -> usize {
-    let mut best = 0usize;
-    let mut best_v = f32::NEG_INFINITY;
-    for (i, &v) in logits.iter().enumerate() {
-        if v > best_v {
-            best_v = v;
-            best = i;
-        }
-    }
-    best
+/// Build all 16 KV name keys: `{prefix}.{layer}.{place}.{kv}`.
+fn kv_names(prefix: &str, layer: usize, place: &str, kv: &str) -> String {
+    format!("{prefix}.{layer}.{place}.{kv}")
 }
 
 /// Convert one word to IPA. Sessions are passed in so the caller can amortize
@@ -137,9 +116,7 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
     // --- Encoder ---
     let enc_ids = Array2::<i64>::from_shape_vec((1, n_in), input_ids.clone())?;
     // `Value::from_array` consumes its input, so the attention mask is a
-    // fresh all-ones Array2 at each boundary (encoder, step 0, and every
-    // decode step below). `Array2::ones` is an inline allocation rather
-    // than a clone of an outer binding — same memory, clearer intent.
+    // fresh all-ones Array2 at each boundary.
     let enc_out = sess.encoder.run(ort::inputs![
         "input_ids" => Value::from_array(enc_ids)?,
         "attention_mask" => Value::from_array(Array2::<i64>::ones((1, n_in)))?,
@@ -165,17 +142,21 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
     );
     let next = argmax(&logits0[..VOCAB_SIZE]) as i64;
 
-    // Harvest all 16 "present" KV entries (4 layers × {decoder, encoder} × {key, value}).
-    let mut present_kv: HashMap<String, Array4<f32>> = HashMap::with_capacity(16);
+    // KV is split two ways: encoder-side entries are constants (the model
+    // never re-emits them), so we build them once and reuse by reference.
+    // Decoder-side entries update every step and are kept in a separate
+    // map we clone each iteration.
+    let mut encoder_kv: HashMap<String, Array4<f32>> = HashMap::with_capacity(8);
+    let mut decoder_kv: HashMap<String, Array4<f32>> = HashMap::with_capacity(8);
     for layer in 0..NUM_DECODER_LAYERS {
-        for place in ["decoder", "encoder"] {
-            for kv in ["key", "value"] {
-                let name = format!("present.{layer}.{place}.{kv}");
+        for kv in ["key", "value"] {
+            for (place, target) in [("encoder", &mut encoder_kv), ("decoder", &mut decoder_kv)] {
+                let name = kv_names("present", layer, place, kv);
                 let (shape, data) = step0[name.as_str()].try_extract_tensor::<f32>()?;
                 let sv: Vec<usize> = shape.iter().map(|&x| x as usize).collect();
                 let arr =
                     Array4::<f32>::from_shape_vec((sv[0], sv[1], sv[2], sv[3]), data.to_vec())?;
-                present_kv.insert(name, arr);
+                target.insert(name, arr);
             }
         }
     }
@@ -195,11 +176,11 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
             "encoder_attention_mask" => Value::from_array(Array2::<i64>::ones((1, n_in)))?,
         ];
         for layer in 0..NUM_DECODER_LAYERS {
-            for place in ["decoder", "encoder"] {
-                for kv in ["key", "value"] {
-                    let present_name = format!("present.{layer}.{place}.{kv}");
-                    let past_name = format!("past_key_values.{layer}.{place}.{kv}");
-                    let arr = present_kv
+            for kv in ["key", "value"] {
+                for (place, source) in [("encoder", &encoder_kv), ("decoder", &decoder_kv)] {
+                    let past_name = kv_names("past_key_values", layer, place, kv);
+                    let present_name = kv_names("present", layer, place, kv);
+                    let arr = source
                         .get(&present_name)
                         .expect("present KV missing — step 0 must have populated all 16 entries")
                         .clone();
@@ -223,15 +204,15 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
         output_ids.push(next);
 
         // decoder_with_past only emits *decoder*-side presents; encoder KV
-        // stays constant across steps, so we leave those entries untouched.
+        // stays constant across steps, so we leave `encoder_kv` alone.
         for layer in 0..NUM_DECODER_LAYERS {
             for kv in ["key", "value"] {
-                let present_name = format!("present.{layer}.decoder.{kv}");
+                let present_name = kv_names("present", layer, "decoder", kv);
                 let (shape, data) = out[present_name.as_str()].try_extract_tensor::<f32>()?;
                 let sv: Vec<usize> = shape.iter().map(|&x| x as usize).collect();
                 let arr =
                     Array4::<f32>::from_shape_vec((sv[0], sv[1], sv[2], sv[3]), data.to_vec())?;
-                present_kv.insert(present_name, arr);
+                decoder_kv.insert(present_name, arr);
             }
         }
     }
@@ -280,7 +261,6 @@ mod tests {
 
     #[test]
     fn detokenize_drops_specials() {
-        // EOS + PAD + byte('h') + byte('i') → "hi"
         let ids = vec![
             EOS,
             PAD,
@@ -302,6 +282,8 @@ mod tests {
         assert_eq!(charsiu_lang("en-us").unwrap(), "eng-us");
         assert_eq!(charsiu_lang("ru").unwrap(), "rus");
         assert_eq!(charsiu_lang("FR-FR").unwrap(), "fra");
+        assert_eq!(charsiu_lang("pt-br").unwrap(), "por-bz");
+        assert_eq!(charsiu_lang("pt-pt").unwrap(), "por-po");
         assert!(charsiu_lang("xx-XX").is_err());
     }
 

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -1,86 +1,247 @@
-//! Grapheme-to-phoneme via `espeakng-sys`, linked dynamically against system libespeak-ng.
+//! Grapheme-to-phoneme via CharsiuG2P ByT5-tiny ONNX (#123 — replaces
+//! espeak-ng). Three ORT sessions (encoder, decoder, decoder-with-past)
+//! plus greedy decoding with explicit KV-cache management.
 //!
-//! `espeak_TextToPhonemes` returns one sentence at a time — we loop advancing the pointer
-//! until it returns null. `espeak` keeps process-global state, so init + each call are
-//! serialized behind a `Mutex`.
+//! The ByT5 tokenizer is byte-level with a `+3` offset (PAD=0, EOS=1,
+//! UNK=2 reserved; actual byte tokens start at 3). Prompts look like
+//! `"<{lang}>: {word}"` where `{lang}` is a CharsiuG2P code (e.g. `eng-us`).
+//!
+//! Session lifetime: loaded once per `text_to_ipa` call, reused across
+//! all words in the input. This matches the Kokoro/Piper/VAD pattern —
+//! per-call load amortized over all words in one synthesis.
 
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_void};
-use std::ptr;
-use std::sync::{Mutex, OnceLock};
+use std::collections::HashMap;
+use std::path::Path;
 
-/// phonememode bits 0-3 select the phoneme character set; `0x02` = IPA (Unicode).
-/// Bits 4-7 (output destination) are left at 0 so the result is returned from the call.
-const PHONEME_MODE_IPA: i32 = 0x02;
+use anyhow::{Context, Result};
+use ndarray::{Array2, Array3, Array4};
+use ort::session::Session;
+use ort::value::Value;
 
-static ESPEAK_INIT: OnceLock<Mutex<bool>> = OnceLock::new();
+use crate::models;
 
-/// Convert text to IPA phonemes for the given espeak language code (e.g. `en-us`).
-///
-/// Returns a phoneme string concatenated across all sentences, space-separated.
-/// Empty input returns an empty string. Unsupported language returns an error.
-pub fn text_to_ipa(text: &str, lang: &str) -> anyhow::Result<String> {
-    if text.is_empty() {
+const PAD: i64 = 0;
+const EOS: i64 = 1;
+const BYTE_OFFSET: i64 = 3;
+const VOCAB_SIZE: usize = 384;
+const MAX_DECODE_STEPS: usize = 128;
+const NUM_DECODER_LAYERS: usize = 4;
+
+struct G2pSessions {
+    encoder: Session,
+    decoder: Session,
+    decoder_with_past: Session,
+}
+
+impl G2pSessions {
+    fn load() -> Result<Self> {
+        let cache = models::cache_dir();
+        let dir = cache.join("models").join("g2p").join("byt5-tiny");
+        anyhow::ensure!(
+            dir.exists(),
+            "G2P model not installed. Run: kesha install --tts"
+        );
+        let encoder = build_session(&dir.join("encoder_model.onnx")).context("load g2p encoder")?;
+        let decoder = build_session(&dir.join("decoder_model.onnx")).context("load g2p decoder")?;
+        let decoder_with_past = build_session(&dir.join("decoder_with_past_model.onnx"))
+            .context("load g2p decoder_with_past")?;
+        Ok(Self {
+            encoder,
+            decoder,
+            decoder_with_past,
+        })
+    }
+}
+
+fn build_session(path: &Path) -> Result<Session> {
+    // `ort::Error<SessionBuilder>` isn't Send in 2.0.0-rc.12 so it can't
+    // convert through `?` into `anyhow::Error`. Inline `map_err` at each
+    // boundary — see the spike doc's "ort API gotchas" section.
+    Session::builder()
+        .map_err(|e| anyhow::anyhow!("ort session builder: {e}"))?
+        .commit_from_file(path)
+        .with_context(|| format!("open {}", path.display()))
+}
+
+/// Map espeak-style language codes to CharsiuG2P prompt codes. The training
+/// prompts use three-letter ISO codes with optional region suffix.
+pub fn charsiu_lang(espeak: &str) -> Result<&'static str> {
+    Ok(match espeak.to_ascii_lowercase().as_str() {
+        "en-us" => "eng-us",
+        "en" | "en-gb" | "en-uk" => "eng-uk",
+        "ru" | "ru-ru" => "rus",
+        "fr" | "fr-fr" => "fra",
+        "de" | "de-de" => "ger",
+        "es" | "es-es" => "spa",
+        "it" | "it-it" => "ita",
+        "pt" | "pt-br" | "pt-pt" => "por-bz",
+        "ja" | "ja-jp" | "jp" => "jpn",
+        "zh" | "zh-cn" | "cmn" => "cmn",
+        "hi" | "hi-in" => "hin",
+        _ => anyhow::bail!("unsupported G2P lang '{}'", espeak),
+    })
+}
+
+/// Byte-level tokenization: UTF-8 bytes + 3 (ByT5 reserves 0/1/2), with
+/// trailing EOS. The prompt format (`<lang>: word`) is what the CharsiuG2P
+/// checkpoint was trained on; matches the Python reference exactly.
+fn tokenize(charsiu_code: &str, word: &str) -> Vec<i64> {
+    let prompt = format!("<{charsiu_code}>: {word}");
+    let mut ids: Vec<i64> = prompt.bytes().map(|b| b as i64 + BYTE_OFFSET).collect();
+    ids.push(EOS);
+    ids
+}
+
+/// Decode a run of token IDs back to UTF-8. IDs below `BYTE_OFFSET` are
+/// special tokens (PAD/EOS/UNK) and are dropped silently.
+fn detokenize(ids: &[i64]) -> String {
+    let bytes: Vec<u8> = ids
+        .iter()
+        .filter_map(|&id| {
+            if id >= BYTE_OFFSET && id - BYTE_OFFSET < 256 {
+                Some((id - BYTE_OFFSET) as u8)
+            } else {
+                None
+            }
+        })
+        .collect();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn argmax(logits: &[f32]) -> usize {
+    let mut best = 0usize;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > best_v {
+            best_v = v;
+            best = i;
+        }
+    }
+    best
+}
+
+/// Convert one word to IPA. Sessions are passed in so the caller can amortize
+/// the ~100 ms session-load across all words in the input.
+fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<String> {
+    let input_ids = tokenize(charsiu_code, word);
+    let n_in = input_ids.len();
+
+    // --- Encoder ---
+    let enc_ids = Array2::<i64>::from_shape_vec((1, n_in), input_ids.clone())?;
+    let enc_mask = Array2::<i64>::from_shape_vec((1, n_in), vec![1_i64; n_in])?;
+    let enc_out = sess.encoder.run(ort::inputs![
+        "input_ids" => Value::from_array(enc_ids)?,
+        "attention_mask" => Value::from_array(enc_mask.clone())?,
+    ])?;
+    let (h_shape, h_data) = enc_out["last_hidden_state"].try_extract_tensor::<f32>()?;
+    let h_shape_v: Vec<usize> = h_shape.iter().map(|&x| x as usize).collect();
+    let encoder_hidden =
+        Array3::<f32>::from_shape_vec((h_shape_v[0], h_shape_v[1], h_shape_v[2]), h_data.to_vec())?;
+
+    // --- Decoder step 0 (seeded with PAD) ---
+    let seed = Array2::<i64>::from_shape_vec((1, 1), vec![PAD])?;
+    let step0 = sess.decoder.run(ort::inputs![
+        "input_ids" => Value::from_array(seed)?,
+        "encoder_attention_mask" => Value::from_array(enc_mask.clone())?,
+        "encoder_hidden_states" => Value::from_array(encoder_hidden)?,
+    ])?;
+
+    let (_, logits0) = step0["logits"].try_extract_tensor::<f32>()?;
+    let next = argmax(&logits0[..VOCAB_SIZE]) as i64;
+
+    // Harvest all 16 "present" KV entries (4 layers × {decoder, encoder} × {key, value}).
+    let mut present_kv: HashMap<String, Array4<f32>> = HashMap::with_capacity(16);
+    for layer in 0..NUM_DECODER_LAYERS {
+        for place in ["decoder", "encoder"] {
+            for kv in ["key", "value"] {
+                let name = format!("present.{layer}.{place}.{kv}");
+                let (shape, data) = step0[name.as_str()].try_extract_tensor::<f32>()?;
+                let sv: Vec<usize> = shape.iter().map(|&x| x as usize).collect();
+                let arr =
+                    Array4::<f32>::from_shape_vec((sv[0], sv[1], sv[2], sv[3]), data.to_vec())?;
+                present_kv.insert(name, arr);
+            }
+        }
+    }
+
+    if next == EOS {
         return Ok(String::new());
     }
+    let mut output_ids: Vec<i64> = vec![next];
 
-    // Lock across the whole call: espeak's voice state is global, and
-    // a concurrent call in another thread could swap the voice mid-synth.
-    let lock = ESPEAK_INIT.get_or_init(|| Mutex::new(false));
-    let mut initialized = lock.lock().expect("espeak mutex poisoned");
+    // --- Decoder_with_past loop (steps 1..N) ---
+    for _ in 1..MAX_DECODE_STEPS {
+        let last = *output_ids.last().unwrap();
+        let step_ids = Array2::<i64>::from_shape_vec((1, 1), vec![last])?;
 
-    if !*initialized {
-        unsafe {
-            let sample_rate = espeakng_sys::espeak_Initialize(
-                espeakng_sys::espeak_AUDIO_OUTPUT_AUDIO_OUTPUT_SYNCHRONOUS,
-                0,
-                ptr::null(),
-                0,
-            );
-            anyhow::ensure!(
-                sample_rate > 0,
-                "espeak_Initialize failed (rc={sample_rate})"
-            );
-        }
-        *initialized = true;
-    }
-
-    unsafe {
-        let c_lang = CString::new(lang)?;
-        let rc = espeakng_sys::espeak_SetVoiceByName(c_lang.as_ptr());
-        anyhow::ensure!(
-            rc == espeakng_sys::espeak_ERROR_EE_OK,
-            "unsupported lang '{lang}' (espeak rc={rc})"
-        );
-
-        let c_text = CString::new(text)?;
-        let mut text_ptr: *const c_void = c_text.as_ptr() as *const c_void;
-        let text_ptr_ptr: *mut *const c_void = &mut text_ptr;
-
-        let mut out = String::new();
-        loop {
-            let ipa_c = espeakng_sys::espeak_TextToPhonemes(
-                text_ptr_ptr,
-                espeakng_sys::espeakCHARS_UTF8 as i32,
-                PHONEME_MODE_IPA,
-            );
-            if ipa_c.is_null() {
-                break;
-            }
-            let fragment = CStr::from_ptr(ipa_c as *const c_char).to_string_lossy();
-            if !fragment.is_empty() {
-                if !out.is_empty() {
-                    out.push(' ');
+        let mut inputs = ort::inputs![
+            "input_ids" => Value::from_array(step_ids)?,
+            "encoder_attention_mask" => Value::from_array(enc_mask.clone())?,
+        ];
+        for layer in 0..NUM_DECODER_LAYERS {
+            for place in ["decoder", "encoder"] {
+                for kv in ["key", "value"] {
+                    let present_name = format!("present.{layer}.{place}.{kv}");
+                    let past_name = format!("past_key_values.{layer}.{place}.{kv}");
+                    let arr = present_kv
+                        .get(&present_name)
+                        .expect("present KV missing — step 0 must have populated all 16 entries")
+                        .clone();
+                    inputs.push((past_name.into(), Value::from_array(arr)?.into()));
                 }
-                out.push_str(&fragment);
-            }
-            if text_ptr.is_null() {
-                break;
             }
         }
 
-        Ok(out.trim().to_string())
+        let out = sess.decoder_with_past.run(inputs)?;
+
+        let (_, logits) = out["logits"].try_extract_tensor::<f32>()?;
+        let next = argmax(&logits[..VOCAB_SIZE]) as i64;
+        if next == EOS {
+            break;
+        }
+        output_ids.push(next);
+
+        // decoder_with_past only emits *decoder*-side presents; encoder KV
+        // stays constant across steps, so we leave those entries untouched.
+        for layer in 0..NUM_DECODER_LAYERS {
+            for kv in ["key", "value"] {
+                let present_name = format!("present.{layer}.decoder.{kv}");
+                let (shape, data) = out[present_name.as_str()].try_extract_tensor::<f32>()?;
+                let sv: Vec<usize> = shape.iter().map(|&x| x as usize).collect();
+                let arr =
+                    Array4::<f32>::from_shape_vec((sv[0], sv[1], sv[2], sv[3]), data.to_vec())?;
+                present_kv.insert(present_name, arr);
+            }
+        }
     }
+
+    Ok(detokenize(&output_ids))
+}
+
+/// Convert text to IPA phonemes for the given espeak-style language code.
+/// Words are split on whitespace; punctuation is stripped per-word. Empty
+/// input returns an empty string.
+pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
+    if text.trim().is_empty() {
+        return Ok(String::new());
+    }
+    let charsiu = charsiu_lang(lang)?;
+    let mut sess = G2pSessions::load()?;
+    let mut out: Vec<String> = Vec::new();
+    for raw_word in text.split_whitespace() {
+        let word: String = raw_word
+            .chars()
+            .filter(|c| c.is_alphanumeric() || c == &'\'' || c == &'-')
+            .collect();
+        if word.is_empty() {
+            continue;
+        }
+        let ipa = g2p_word(&mut sess, charsiu, &word)?;
+        if !ipa.is_empty() {
+            out.push(ipa);
+        }
+    }
+    Ok(out.join(" "))
 }
 
 #[cfg(test)]
@@ -88,27 +249,83 @@ mod tests {
     use super::*;
 
     #[test]
-    fn hello_world_produces_ipa() {
-        let ipa = text_to_ipa("Hello, world", "en-us").unwrap();
-        assert!(!ipa.is_empty(), "ipa empty");
-        // Multiple sentences should both be represented — "hello" + "world" => "h" and "w" at minimum.
-        assert!(ipa.contains('h'), "ipa missing 'h' for hello: {ipa}");
-        assert!(ipa.contains('w'), "ipa missing 'w' for world: {ipa}");
+    fn tokenize_adds_byte_offset_and_eos() {
+        let ids = tokenize("eng-us", "hi");
+        // '<' 'e' 'n' 'g' '-' 'u' 's' '>' ':' ' ' 'h' 'i' + EOS
+        assert_eq!(ids.len(), 13);
+        assert_eq!(*ids.last().unwrap(), EOS);
+        assert_eq!(ids[0], b'<' as i64 + BYTE_OFFSET);
     }
 
     #[test]
-    fn empty_text_ok() {
-        let ipa = text_to_ipa("", "en-us").unwrap();
-        assert!(ipa.is_empty());
+    fn detokenize_drops_specials() {
+        // EOS + PAD + byte('h') + byte('i') → "hi"
+        let ids = vec![
+            EOS,
+            PAD,
+            b'h' as i64 + BYTE_OFFSET,
+            b'i' as i64 + BYTE_OFFSET,
+        ];
+        assert_eq!(detokenize(&ids), "hi");
+    }
+
+    #[test]
+    fn detokenize_round_trips_utf8_ipa() {
+        let ipa = "hɛloʊ";
+        let ids: Vec<i64> = ipa.bytes().map(|b| b as i64 + BYTE_OFFSET).collect();
+        assert_eq!(detokenize(&ids), ipa);
+    }
+
+    #[test]
+    fn charsiu_lang_accepts_common_codes() {
+        assert_eq!(charsiu_lang("en-us").unwrap(), "eng-us");
+        assert_eq!(charsiu_lang("ru").unwrap(), "rus");
+        assert_eq!(charsiu_lang("FR-FR").unwrap(), "fra");
+        assert!(charsiu_lang("xx-XX").is_err());
+    }
+
+    #[test]
+    fn empty_text_returns_empty() {
+        assert_eq!(text_to_ipa("", "en-us").unwrap(), "");
+        assert_eq!(text_to_ipa("   ", "en-us").unwrap(), "");
     }
 
     #[test]
     fn unsupported_lang_errors() {
         let err = text_to_ipa("hi", "xx-XX").unwrap_err();
-        let msg = err.to_string().to_lowercase();
-        assert!(
-            msg.contains("lang") || msg.contains("xx-xx"),
-            "expected lang error, got: {err}"
-        );
+        assert!(err.to_string().to_lowercase().contains("xx-xx"));
+    }
+
+    /// Gated on the presence of the G2P model cache. Run `kesha install --tts`
+    /// first. Verifies byte-identical IPA against the spike's reference fixtures
+    /// (see docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md section 5).
+    #[test]
+    fn hello_world_matches_reference_when_model_available() {
+        let dir = models::cache_dir()
+            .join("models")
+            .join("g2p")
+            .join("byt5-tiny");
+        if !dir.exists() {
+            eprintln!("g2p model not cached at {} — skipping", dir.display());
+            return;
+        }
+        let ipa = text_to_ipa("hello", "en-us").unwrap();
+        assert_eq!(ipa, "ˈhɛɫoʊ", "expected spike-reference IPA for 'hello'");
+        let ipa = text_to_ipa("world", "en-us").unwrap();
+        assert_eq!(ipa, "ˈwɝɫd");
+    }
+
+    #[test]
+    fn multiword_input_produces_space_joined_ipa() {
+        let dir = models::cache_dir()
+            .join("models")
+            .join("g2p")
+            .join("byt5-tiny");
+        if !dir.exists() {
+            return;
+        }
+        let ipa = text_to_ipa("hello world", "en-us").unwrap();
+        assert!(ipa.contains(' '), "expected space between words: {ipa}");
+        assert!(ipa.starts_with("ˈh"), "starts with hello: {ipa}");
     }
 }

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -63,8 +63,15 @@ fn build_session(path: &Path) -> Result<Session> {
         .with_context(|| format!("open {}", path.display()))
 }
 
-/// Map espeak-style language codes to CharsiuG2P prompt codes. The training
-/// prompts use three-letter ISO codes with optional region suffix.
+/// Map espeak-style language codes to CharsiuG2P prompt codes.
+///
+/// The upstream checkpoint uses non-standard ISO-ish suffixes — Portuguese
+/// is `por-bz` (Brazilian) / `por-po` (European) rather than `-br`/`-pt`,
+/// per the training dictionary names in
+/// <https://github.com/lingjzhu/CharsiuG2P/tree/main/dicts>. Every code in
+/// this table is verified against that directory listing; "ISO-looking"
+/// substitutions (e.g. `por-br`) would silently produce garbage because
+/// the model has never seen that prompt.
 pub fn charsiu_lang(espeak: &str) -> Result<&'static str> {
     Ok(match espeak.to_ascii_lowercase().as_str() {
         "en-us" => "eng-us",
@@ -74,7 +81,8 @@ pub fn charsiu_lang(espeak: &str) -> Result<&'static str> {
         "de" | "de-de" => "ger",
         "es" | "es-es" => "spa",
         "it" | "it-it" => "ita",
-        "pt" | "pt-br" | "pt-pt" => "por-bz",
+        "pt" | "pt-br" => "por-bz",
+        "pt-pt" => "por-po",
         "ja" | "ja-jp" | "jp" => "jpn",
         "zh" | "zh-cn" | "cmn" => "cmn",
         "hi" | "hi-in" => "hin",
@@ -128,10 +136,13 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
 
     // --- Encoder ---
     let enc_ids = Array2::<i64>::from_shape_vec((1, n_in), input_ids.clone())?;
-    let enc_mask = Array2::<i64>::from_shape_vec((1, n_in), vec![1_i64; n_in])?;
+    // `Value::from_array` consumes its input, so the attention mask is a
+    // fresh all-ones Array2 at each boundary (encoder, step 0, and every
+    // decode step below). `Array2::ones` is an inline allocation rather
+    // than a clone of an outer binding — same memory, clearer intent.
     let enc_out = sess.encoder.run(ort::inputs![
         "input_ids" => Value::from_array(enc_ids)?,
-        "attention_mask" => Value::from_array(enc_mask.clone())?,
+        "attention_mask" => Value::from_array(Array2::<i64>::ones((1, n_in)))?,
     ])?;
     let (h_shape, h_data) = enc_out["last_hidden_state"].try_extract_tensor::<f32>()?;
     let h_shape_v: Vec<usize> = h_shape.iter().map(|&x| x as usize).collect();
@@ -142,11 +153,16 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
     let seed = Array2::<i64>::from_shape_vec((1, 1), vec![PAD])?;
     let step0 = sess.decoder.run(ort::inputs![
         "input_ids" => Value::from_array(seed)?,
-        "encoder_attention_mask" => Value::from_array(enc_mask.clone())?,
+        "encoder_attention_mask" => Value::from_array(Array2::<i64>::ones((1, n_in)))?,
         "encoder_hidden_states" => Value::from_array(encoder_hidden)?,
     ])?;
 
     let (_, logits0) = step0["logits"].try_extract_tensor::<f32>()?;
+    anyhow::ensure!(
+        logits0.len() >= VOCAB_SIZE,
+        "g2p decoder logits too small: got {}, need {VOCAB_SIZE}",
+        logits0.len()
+    );
     let next = argmax(&logits0[..VOCAB_SIZE]) as i64;
 
     // Harvest all 16 "present" KV entries (4 layers × {decoder, encoder} × {key, value}).
@@ -176,7 +192,7 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
 
         let mut inputs = ort::inputs![
             "input_ids" => Value::from_array(step_ids)?,
-            "encoder_attention_mask" => Value::from_array(enc_mask.clone())?,
+            "encoder_attention_mask" => Value::from_array(Array2::<i64>::ones((1, n_in)))?,
         ];
         for layer in 0..NUM_DECODER_LAYERS {
             for place in ["decoder", "encoder"] {
@@ -195,6 +211,11 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
         let out = sess.decoder_with_past.run(inputs)?;
 
         let (_, logits) = out["logits"].try_extract_tensor::<f32>()?;
+        anyhow::ensure!(
+            logits.len() >= VOCAB_SIZE,
+            "g2p decoder logits too small: got {}, need {VOCAB_SIZE}",
+            logits.len()
+        );
         let next = argmax(&logits[..VOCAB_SIZE]) as i64;
         if next == EOS {
             break;

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -1,0 +1,15 @@
+//! Tiny shared helpers used across modules.
+
+/// Index of the largest f32 in a slice. Ties pick the lowest index.
+/// Shared by `tts::g2p` (ByT5 decoder) and `backend::onnx` (Parakeet TDT).
+pub fn argmax(xs: &[f32]) -> usize {
+    let mut best = 0;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, &v) in xs.iter().enumerate() {
+        if v > best_v {
+            best_v = v;
+            best = i;
+        }
+    }
+    best
+}

--- a/rust/tests/tts_e2e.rs
+++ b/rust/tests/tts_e2e.rs
@@ -1,4 +1,4 @@
-//! End-to-end TTS: real model, real voice, real espeak-ng → produces real WAV bytes.
+//! End-to-end TTS: real model, real voice, ONNX G2P → produces real WAV bytes.
 //! Gated on engine-specific env vars so default CI without models stays fast.
 
 #![cfg(feature = "tts")]

--- a/rust/tests/tts_smoke.rs
+++ b/rust/tests/tts_smoke.rs
@@ -182,7 +182,26 @@ fn resolves_from_cache_when_installed() {
             return;
         }
     };
-    // Build a temp cache dir that mirrors the real layout via symlinks.
+    // G2P became a runtime requirement in #123 (Phase 2a). Source dir
+    // comes from the parent `KESHA_CACHE_DIR` (set by the CI runner) —
+    // we copy the 3 ONNX files into the tempdir alongside Kokoro so the
+    // sub-process finds them under the test's own KESHA_CACHE_DIR.
+    let g2p_src = match std::env::var("KESHA_CACHE_DIR") {
+        Ok(c) => {
+            let p = std::path::PathBuf::from(c).join("models/g2p/byt5-tiny");
+            if p.join("encoder_model.onnx").exists() {
+                p
+            } else {
+                eprintln!("skipping: G2P not at $KESHA_CACHE_DIR/models/g2p/byt5-tiny");
+                return;
+            }
+        }
+        Err(_) => {
+            eprintln!("skipping: set KESHA_CACHE_DIR to a cache containing G2P models");
+            return;
+        }
+    };
+
     let tmp = tempfile::tempdir().unwrap();
     let voices_dir = tmp.path().join("models/kokoro-82m/voices");
     std::fs::create_dir_all(&voices_dir).unwrap();
@@ -190,6 +209,16 @@ fn resolves_from_cache_when_installed() {
     // creation requires elevated privileges and the os::unix API is not available).
     std::fs::copy(&model, tmp.path().join("models/kokoro-82m/model.onnx")).unwrap();
     std::fs::copy(&voice, voices_dir.join("af_heart.bin")).unwrap();
+
+    let g2p_dst = tmp.path().join("models/g2p/byt5-tiny");
+    std::fs::create_dir_all(&g2p_dst).unwrap();
+    for f in [
+        "encoder_model.onnx",
+        "decoder_model.onnx",
+        "decoder_with_past_model.onnx",
+    ] {
+        std::fs::copy(g2p_src.join(f), g2p_dst.join(f)).unwrap();
+    }
 
     let bin = env!("CARGO_BIN_EXE_kesha-engine");
     let out = Command::new(bin)

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -65,7 +65,7 @@ try {
 const typoProc = Bun.spawnSync(["kesha", "instal"], { stdout: "pipe", stderr: "pipe" });
 check("typo suggestion works", typoProc.exitCode === 1 && typoProc.stderr.toString().includes("Did you mean"));
 
-// 6. TTS smoke (opt-in via --tts flag; requires `kesha install --tts` + espeak-ng)
+// 6. TTS smoke (opt-in via --tts flag; requires `kesha install --tts`)
 if (process.argv.includes("--tts")) {
   for (const [label, text] of [
     ["en (Kokoro)", "Hello, world"],

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -92,7 +92,7 @@ export const installCommand = defineCommand({
     },
     tts: {
       type: "boolean",
-      description: "Also install TTS models (Kokoro EN + Piper RU, ~390MB, requires espeak-ng on PATH)",
+      description: "Also install TTS models (Kokoro EN + Piper RU + ONNX G2P, ~490MB)",
       default: false,
     },
     vad: {

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -51,7 +51,7 @@ export const sayCommand = defineCommand({
   args: {
     text: { type: "positional", required: false, description: "Text to speak (stdin if omitted)" },
     voice: { type: "string", description: "Voice id, e.g. en-af_heart" },
-    lang: { type: "string", description: "espeak language code (default en-us)" },
+    lang: { type: "string", description: "BCP 47 language code (default en-us)" },
     out: { type: "string", description: "Write WAV to file instead of stdout" },
     rate: { type: "string", description: "Speaking rate 0.5–2.0", default: "1.0" },
     "list-voices": { type: "boolean", description: "List installed voices and exit" },

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -95,7 +95,7 @@ async function downloadAVSpeechSidecar(binPath: string, engineVersion: string): 
 }
 
 export interface InstallOptions {
-  /** Also install Kokoro TTS models. Requires espeak-ng on PATH. */
+  /** Also install Kokoro + Piper + ONNX G2P TTS models. */
   tts?: boolean;
   /** Also install Silero VAD model for long-audio preprocessing. */
   vad?: boolean;

--- a/src/say.ts
+++ b/src/say.ts
@@ -10,7 +10,7 @@ export interface SayOptions {
   text?: string;
   /** Voice id, e.g. `en-af_heart`. Defaults to engine default. */
   voice?: string;
-  /** Override the voice's default espeak language code. */
+  /** Override the voice's default BCP 47 language code (e.g. `en-us`, `ru`). */
   lang?: string;
   /** Write audio to this path instead of returning bytes. */
   out?: string;

--- a/tests/integration/say-e2e.test.ts
+++ b/tests/integration/say-e2e.test.ts
@@ -11,10 +11,18 @@ const CLI_PATH = new URL("../../bin/kesha.js", import.meta.url).pathname;
  */
 const SPIKE_MODEL = process.env.KOKORO_MODEL ?? "/tmp/kokoro-spike/model.onnx";
 const SPIKE_VOICE = process.env.KOKORO_VOICE ?? "/tmp/kokoro-spike/af_heart.bin";
-const SPIKE_AVAILABLE = existsSync(SPIKE_MODEL) && existsSync(SPIKE_VOICE);
+// G2P source dir lives under the inherited KESHA_CACHE_DIR (CI runner
+// layout). Required since #123 Phase 2a — Kokoro pipes through ONNX G2P.
+const G2P_SRC_DIR = process.env.KESHA_CACHE_DIR
+  ? `${process.env.KESHA_CACHE_DIR}/models/g2p/byt5-tiny`
+  : "";
+const G2P_AVAILABLE =
+  G2P_SRC_DIR !== "" && existsSync(`${G2P_SRC_DIR}/encoder_model.onnx`);
+const SPIKE_AVAILABLE = existsSync(SPIKE_MODEL) && existsSync(SPIKE_VOICE) && G2P_AVAILABLE;
 
 const CACHE_DIR = `/tmp/kesha-e2e-${Date.now()}`;
 const MODEL_DIR = `${CACHE_DIR}/models/kokoro-82m`;
+const G2P_DIR = `${CACHE_DIR}/models/g2p/byt5-tiny`;
 const BUILT_ENGINE = `${new URL("../..", import.meta.url).pathname}rust/target/release/kesha-engine`;
 
 beforeAll(() => {
@@ -22,6 +30,10 @@ beforeAll(() => {
   mkdirSync(`${MODEL_DIR}/voices`, { recursive: true });
   symlinkSync(SPIKE_MODEL, `${MODEL_DIR}/model.onnx`);
   symlinkSync(SPIKE_VOICE, `${MODEL_DIR}/voices/af_heart.bin`);
+  mkdirSync(G2P_DIR, { recursive: true });
+  for (const f of ["encoder_model.onnx", "decoder_model.onnx", "decoder_with_past_model.onnx"]) {
+    symlinkSync(`${G2P_SRC_DIR}/${f}`, `${G2P_DIR}/${f}`);
+  }
 });
 
 function spawnCli(args: string[], extraEnv: Record<string, string> = {}) {


### PR DESCRIPTION
## Summary

Phase 2a of replacing espeak-ng with ONNX G2P (plan: #185, Phase 1: #189). This PR does the **hard swap** — CharsiuG2P ByT5-tiny ONNX takes over G2P duty, `espeakng-sys` is dropped, and every CI toolchain step that existed to build/link espeak-ng is deleted.

SSML `<phoneme>` override (M2.5 in the plan) ships in Phase 2b as a separate PR — it's additive and easier to review in isolation.

## Core change

`rust/src/tts/g2p.rs` rewritten end-to-end. Drives three ORT sessions (encoder, decoder, decoder_with_past) with byte-level tokenization (`<lang>: {word}` prompt + byte+3 offset) and greedy decoding with explicit 16-entry KV-cache management. Sessions load once per `text_to_ipa` call and are amortized across all words in the input — matching the Kokoro/Piper/VAD per-call pattern.

**Byte-identical output vs the Python spike reference** (PR #185 section 5):
- `hello → ˈhɛɫoʊ`
- `world → ˈwɝɫd`

The `hello_world_matches_reference_when_model_available` test pins those two outputs. Five new unit tests cover tokenization, detokenization, language-code mapping, empty-input handling, and unsupported-lang error path.

## CI cleanup (this is where the operational tax was)

Every workflow that used to install / link / generate a `.lib` for espeak-ng loses that code:

- `rust-test.yml`: -72 lines (removes `brew install`, `apt install`, `choco install`, and the 42-line `Generate libespeak-ng import lib from DLL` dumpbin+lib recipe). Retains `msvc-dev-cmd` + pin-MSVC-linker — still useful for other C deps.
- `build-engine.yml`: -83 lines (same removals across every matrix row).
- `ci.yml`: -6 lines (two macOS `brew install espeak-ng` steps — integration + tts-e2e).
- `rust/ci/run-cargo-test.sh`: drops `LIBCLANG_PATH`, `RUSTFLAGS=-L /opt/homebrew/lib`, `DYLD_FALLBACK_LIBRARY_PATH` — all espeak-specific.

## Docs / UX (small, high-signal)

- `README.md`: drops the three-line platform install block. Clarifies G2P runs entirely through ONNX. Bundle size updated 390 MB → 490 MB.
- `SKILL.md`, `CLAUDE.md`, `Makefile`, `scripts/smoke-test.ts`: drop espeak prereq bullets.
- `src/cli/install.ts`, `src/engine-install.ts`: tts flag description refresh.
- `src/say.ts`, `src/cli/say.ts`, `rust/src/main.rs`: `--lang` help text: "espeak language code" → "BCP 47 language code" (same accepted values).

## Design calls worth a look

1. **`pub mod models` added to `rust/src/lib.rs`** — the tts module now calls `crate::models::cache_dir()` to find the G2P cache dir. Lib-test path needs models exposed. Mirrors the existing `pub mod tts` pattern.
2. **Per-call session load.** Three sessions (~100 MB total) load each `text_to_ipa` call. For a long utterance the load cost is amortized across many words; for a single-word input it's dominant (~100 ms). Explicitly followed Kokoro/Piper/VAD pattern instead of process-global caching to keep the codebase consistent — see spike doc risks section.
3. **Kept espeak-style language codes internally.** `charsiu_lang(espeak_code)` maps `en-us` → `eng-us`, `ru` → `rus`, etc. The `espeak_lang` field on voice metadata stays by name (still accurate — users still type BCP 47 codes), avoiding churn on a large struct rename.

## Test plan

- [x] 5 new Rust unit tests (tokenization, detokenization, language-code mapping, empty input, unsupported-lang error)
- [x] Real-model test `hello_world_matches_reference_when_model_available` pins IPA against Python reference
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib --bin kesha-engine` → 85 pass (was 80)
- [x] `cargo fmt --check` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` → 137 pass
- [x] Local E2E: `kesha install --tts` fetches all 7 files incl. G2P; new G2P dispatch runs under `kesha say`
- [ ] CI matrix across all 3 platforms (rust-test.yml + build-engine.yml + ci.yml) — this PR is the first real test that no espeak toolchain is left leaking into any job

Refs #123 (plan #185, Phase 1 #189). Phase 2b (#122 SSML `<phoneme>`) and Phase 3 (parity harness) queued as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)