### PR TITLE
chore(release): v1.4.1 — SSML <phoneme> + G2P parity harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -663,7 +663,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
## Summary

Rolls PR #193 (Phases 2b + 3 of #123) into a published engine release. v1.4.0 was tagged before #193 merged, so its binary is missing the SSML `<phoneme>` override and the G2P parity harness.

## What's new since v1.4.0

- **#123 Phase 2b** — SSML `<phoneme alphabet="ipa" ph="…">` override now bypasses G2P and feeds IPA straight to Kokoro/Piper.
- **#123 Phase 3** — `rust/tests/g2p_parity.rs`: 40-word × 11-lang frozen reference harness guarding against silent drift in ByT5-tiny tokenization/decode plumbing (SHA-256 on model weights doesn't catch tokenizer offset or argmax tie-break drift).
- **BENCHMARK.md** — added G2P backend section.

No user-facing breaking changes from v1.4.0.

## Release procedure (from CLAUDE.md)

After merge:

1. Tag: `git tag v1.4.1 && git push origin v1.4.1` — triggers `build-engine.yml`.
2. `gh release edit v1.4.1 --notes "..."` (write before publishing — `--notes` silently no-ops on already-published releases).
3. `make smoke-test` locally.
4. Publish draft release + `npm publish --access public`.
5. Follow-up PR removes `brew install espeak-ng` bridge from `integration-tests` in ci.yml (v1.4.0 still needs it; v1.4.1 won't).

## Test plan

- [x] File-level bumps verified (package.json, rust/Cargo.toml, rust/Cargo.lock — lockstep)
- [ ] CI matrix passes (integration-tests auto-skipped via \`release/*\` guard; tts-e2e on fresh cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)