### PR TITLE
ci: drop brew install espeak-ng bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
               - 'tests/integration/**'
               - 'fixtures/**'
               - 'rust/**'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/**'
 
   unit-tests:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,14 +94,6 @@ jobs:
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
-      # BRIDGE: integration-tests downloads the released `kesha-engine`
-      # binary, which still dynamic-links libespeak-ng because Phase 2a
-      # (ONNX G2P hard swap, #123) hasn't cut a new release yet. Once a
-      # fresh engine release ships, remove this step — the new binary
-      # has no espeak dep.
-      - name: Install espeak-ng (bridge for released engine binary)
-        run: brew install espeak-ng
-
       - name: 🔊 Setup integration backend
         uses: ./.github/actions/install-parakeet-backend
         with:


### PR DESCRIPTION
## Summary

Removes the \`brew install espeak-ng\` step from the \`integration-tests\` job in \`ci.yml\`. v1.4.0 and v1.4.1 engine binaries both ship without espeak-ng (CharsiuG2P ByT5-tiny ONNX replaced it in #190), so the bridge is no longer needed.

This closes the follow-up item called out in the v1.4.0 release notes and PR #191.

Refs #123.

## Test plan

- [ ] \`integration-tests\` still passes on macOS runner (downloads v1.4.1 binary via \`install-parakeet-backend\` action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)