### PR TITLE
feat(status): show per-component disk usage + cache cleanup hint

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -93,12 +93,13 @@ function showDiskUsage(binPath: string): void {
   const cache = kesheCacheDir();
   // Engine binary lives under `<cache>/engine/bin/` (managed by the TS CLI's
   // engine-install) while all models live under `<cache>/models/` (managed by
-  // the Rust engine). Derive the engine dir from `getEngineBinPath()` so we
-  // stay in sync if the TS layout ever moves.
-  const engineDir = join(binPath, "..");
+  // the Rust engine). Point at `engine/` (two levels up from the binary) so
+  // any future sibling files under that root (metadata, hooks, etc.) are
+  // counted too.
+  const engineDir = join(binPath, "..", "..");
 
   const components: Array<{ label: string; path: string }> = [
-    { label: "Engine binary", path: engineDir },
+    { label: "Engine", path: engineDir },
     { label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") },
     { label: "Language ID", path: join(cache, "models/lang-id-ecapa") },
     { label: "VAD (Silero)", path: join(cache, "models/silero-vad") },
@@ -108,16 +109,24 @@ function showDiskUsage(binPath: string): void {
   ];
 
   const rows: Array<{ label: string; size: number }> = [];
-  let total = 0;
   for (const c of components) {
     const size = dirSizeBytes(c.path);
-    if (size > 0) {
-      rows.push({ label: c.label, size });
-      total += size;
-    }
+    if (size > 0) rows.push({ label: c.label, size });
   }
 
   if (rows.length === 0) return;
+
+  // Total counts everything under both the model cache root AND the engine
+  // dir (which may live outside the cache when `KESHA_ENGINE_BIN` overrides
+  // the default layout). That way the number matches what the `rm -rf` hint
+  // below would actually free, including any temp downloads or future
+  // components not in the per-row list.
+  const componentTotal = rows.reduce((n, r) => n + r.size, 0);
+  const cacheTotal = dirSizeBytes(cache);
+  const engineOutsideCache = engineDir.startsWith(cache)
+    ? 0
+    : dirSizeBytes(engineDir);
+  const total = cacheTotal + engineOutsideCache;
 
   log.info(`Disk usage (${cache}):`);
   const labelWidth = Math.max(...rows.map((r) => r.label.length), "Total".length);
@@ -127,6 +136,10 @@ function showDiskUsage(binPath: string): void {
   }
   const totalPad = " ".repeat(labelWidth - "Total".length + 2);
   log.info(`  ${pc.bold("Total")}:${totalPad}${pc.bold(humanBytes(total))}`);
+  if (total > componentTotal) {
+    const other = total - componentTotal;
+    log.info(pc.dim(`  (includes ${humanBytes(other)} of other cache files)`));
+  }
   log.info("");
   log.info(pc.dim(`  To reset cache: rm -rf ${cache} — next \`kesha install\` re-downloads.`));
   log.info("");

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,9 +1,36 @@
-import { readdirSync } from "fs";
+import { readdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { isEngineInstalled, getEngineBinPath, getEngineCapabilities } from "./engine";
 import { log } from "./log";
 import pc from "picocolors";
+
+function humanBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB"];
+  let n = bytes / 1024;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
+}
+
+function dirSizeBytes(path: string): number {
+  let total = 0;
+  try {
+    const st = statSync(path);
+    if (st.isFile()) return st.size;
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const p = join(path, entry.name);
+      total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size;
+    }
+  } catch {
+    /* missing path — component not installed */
+  }
+  return total;
+}
 
 export function formatStatusLine(
   label: string,
@@ -53,11 +80,56 @@ export async function showStatus(): Promise<void> {
       }
       log.info("");
     }
+
+    showDiskUsage(binPath);
   }
 
   if (!installed) {
     log.warn('Run "kesha install" to download the engine and models.');
   }
+}
+
+function showDiskUsage(binPath: string): void {
+  const cache = kesheCacheDir();
+  // Engine binary lives under `<cache>/engine/bin/` (managed by the TS CLI's
+  // engine-install) while all models live under `<cache>/models/` (managed by
+  // the Rust engine). Derive the engine dir from `getEngineBinPath()` so we
+  // stay in sync if the TS layout ever moves.
+  const engineDir = join(binPath, "..");
+
+  const components: Array<{ label: string; path: string }> = [
+    { label: "Engine binary", path: engineDir },
+    { label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") },
+    { label: "Language ID", path: join(cache, "models/lang-id-ecapa") },
+    { label: "VAD (Silero)", path: join(cache, "models/silero-vad") },
+    { label: "TTS (Kokoro)", path: join(cache, "models/kokoro-82m") },
+    { label: "TTS (Piper)", path: join(cache, "models/piper-ru") },
+    { label: "TTS (G2P)", path: join(cache, "models/g2p") },
+  ];
+
+  const rows: Array<{ label: string; size: number }> = [];
+  let total = 0;
+  for (const c of components) {
+    const size = dirSizeBytes(c.path);
+    if (size > 0) {
+      rows.push({ label: c.label, size });
+      total += size;
+    }
+  }
+
+  if (rows.length === 0) return;
+
+  log.info(`Disk usage (${cache}):`);
+  const labelWidth = Math.max(...rows.map((r) => r.label.length), "Total".length);
+  for (const r of rows) {
+    const pad = " ".repeat(labelWidth - r.label.length + 2);
+    log.info(`  ${r.label}:${pad}${humanBytes(r.size)}`);
+  }
+  const totalPad = " ".repeat(labelWidth - "Total".length + 2);
+  log.info(`  ${pc.bold("Total")}:${totalPad}${pc.bold(humanBytes(total))}`);
+  log.info("");
+  log.info(pc.dim(`  To reset cache: rm -rf ${cache} — next \`kesha install\` re-downloads.`));
+  log.info("");
 }
 
 function kesheCacheDir(): string {


### PR DESCRIPTION
## Summary

\`kesha status\` now surfaces how much disk each cache component occupies, plus a one-liner on how to reset the cache. Useful for users debugging \"why is my \`~/.cache\` this big\" without reaching for \`du -sh\`.

Missing components are skipped — partial installs stay clean in the output.

## Sample output

\`\`\`
Disk usage (~/.cache/kesha):
  Engine binary:   21.9 MB
  ASR (Parakeet):  2.4 GB
  Language ID:     82.1 MB
  VAD (Silero):    2.2 MB
  TTS (Kokoro):    311 MB
  TTS (Piper):     60.3 MB
  TTS (G2P):       101 MB
  Total:           2.9 GB

  To reset cache: rm -rf ~/.cache/kesha — next \`kesha install\` re-downloads.
\`\`\`

## Design notes

- \`dirSizeBytes(path)\` — recursive sync walk using \`fs.statSync\`; swallows missing-path errors so uninstalled components contribute zero.
- \`humanBytes(n)\` — light precision rule (≥100 → integer, otherwise 1 decimal) up to GB.
- Engine-binary dir is derived from \`getEngineBinPath()\` so the size stays accurate if the TS CLI's install layout ever shifts.
- Cache cleanup stays out of the CLI surface for now — a \`kesha clean\` subcommand is a follow-up if user feedback justifies it.

## Test plan

- [x] \`bunx tsc --noEmit\` passes
- [x] \`bun test tests/unit/\` — 109/109 pass (no test regressions; new code is display-only)
- [x] Manually ran \`bun src/cli.ts status\` on a fully-provisioned cache (output above matches)
- [ ] Manually verify on a fresh cache (no \`Disk usage\` block should render when engine isn't installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)