### PR TITLE
chore: align package.json description with repo About

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
   "version": "1.4.1",
-  "description": "Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.",
+  "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
     "kesha": "bin/kesha.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
   "version": "1.4.1",
-  "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), language detection (107 langs). Rust engine, OpenClaw skill.",
+  "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Piper + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
     "kesha": "bin/kesha.js",


### PR DESCRIPTION
## Summary

Updates \`package.json#description\` to match the GitHub repo About blurb (just updated to the same copy) so npm search results and the repo card tell the same story. Surfaces the three facts that actually differentiate this toolkit:

- Whisper-beating STT perf (\`~19× faster on Apple Silicon, ONNX fallback on CPU\`)
- Broader language-detection coverage (\`107 langs\` vs. STT's \`25\`)
- Rust engine + OpenClaw skill integration

Before:
> Open-source voice toolkit for Apple Silicon. Speech-to-text, language detection. 25 languages.

After:
> Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), language detection (107 langs). Rust engine, OpenClaw skill.

## Test plan

- [x] \`bunx tsc --noEmit\` — unchanged
- [x] Diff is one line in \`package.json\` — no runtime surface touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)