### PR TITLE
chore(release): v1.4.2 (CLI-only) — status disk usage + description sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Piper + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

CLI-only patch. Engine stays pinned at v1.4.1 — no Rust rebuild, no new engine binaries.

## What's new since v1.4.1

- **#197** — \`kesha status\` now prints per-component disk usage (engine, ASR, lang-id, VAD, Kokoro, Piper, G2P) with a total + \`rm -rf\` cleanup hint.
- **#198** — \`package.json#description\` aligned with the GitHub About blurb; now surfaces TTS (Kokoro + Piper + ~180 macOS voices) and VAD alongside STT + language detection.

## Release procedure (per CLAUDE.md CLI-only flow)

After this PR merges:

1. \`npm publish --access public\`
2. Cut marker release:
   \`\`\`bash
   gh release create v1.4.2-cli \\
     --title \"v1.4.2 (CLI-only)\" \\
     --notes \"Engine: v1.4.1 (unchanged). See commits in #197, #198.\"
   \`\`\`
   The \`-cli\` suffix is excluded from \`build-engine.yml\`'s tag filter → no Rust rebuild fires.

## Test plan

- [x] Only \`package.json#version\` changed (\`keshaEngine.version\` + \`rust/Cargo.toml\` untouched — verified via diff)
- [ ] CI green on this PR (integration-tests auto-skipped via \`release/*\` filter — correct for CLI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)