### PR TITLE
ci: add tsgo (TS 7 preview) as advisory second type-checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: bunx tsc --noEmit
 
+      - name: 🔬 Type check (tsgo / TS 7 preview, advisory)
+        if: matrix.os == 'ubuntu-latest'
+        continue-on-error: true
+        run: bunx tsgo --noEmit
+
       - name: 🧪 Unit tests
         run: mkdir -p test-results && bun run test:unit --reporter=junit --reporter-outfile=test-results/unit-${{ matrix.os }}.xml
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test unit integration lint smoke-test release publish help
+.PHONY: install test unit integration lint lint-tsgo smoke-test release publish help
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -16,6 +16,9 @@ integration: ## Run integration tests
 
 lint: ## Type-check with tsc
 	bunx tsc --noEmit
+
+lint-tsgo: ## Type-check with tsgo (TypeScript 7 native preview, advisory)
+	bunx tsgo --noEmit
 
 smoke-test: ## Run smoke tests against fixtures
 	bun link @drakulavich/kesha-voice-kit

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@typescript/native-preview": "^7.0.0-dev.20260423.1",
         "fast-xml-parser": "^5.5.10",
         "typescript": "^6.0.2",
       },
@@ -24,6 +25,22 @@
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260423.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260423.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "arm" }, "sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "test": "bun test",
     "test:unit": "bun test tests/unit/",
     "test:integration": "bun test tests/integration/",
+    "lint": "tsc --noEmit",
+    "lint:tsgo": "tsgo --noEmit",
     "postinstall": "node scripts/postinstall.cjs"
   },
   "keywords": [
@@ -65,6 +67,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@typescript/native-preview": "^7.0.0-dev.20260423.1",
     "fast-xml-parser": "^5.5.10",
     "typescript": "^6.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "bun test",
     "test:unit": "bun test tests/unit/",
     "test:integration": "bun test tests/integration/",
-    "lint": "tsc --noEmit",
-    "lint:tsgo": "tsgo --noEmit",
+    "lint": "bunx tsc --noEmit",
+    "lint:tsgo": "bunx tsgo --noEmit",
     "postinstall": "node scripts/postinstall.cjs"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- Adds `@typescript/native-preview` (the Go-rewritten `tsgo`, shipping toward TS 7) as a dev dep.
- CI runs `bunx tsgo --noEmit` alongside the existing `bunx tsc --noEmit` step on the ubuntu unit-tests job, with `continue-on-error: true`.
- `tsc` 6.x remains the required gate. `tsgo` is advisory until the TS 7 native compiler exits preview — this lets us surface future incompatibilities without blocking merges.
- Adds `bun run lint`, `bun run lint:tsgo`, and `make lint-tsgo` for local parity.

Both checkers currently pass clean on the tree (`bunx tsc --noEmit` and `bunx tsgo --noEmit` exit 0).

## Test plan

- [ ] CI: confirm the new "🔬 Type check (tsgo ...)" step appears and succeeds on the ubuntu runner
- [ ] `bun run lint && bun run lint:tsgo` locally
- [ ] When tsgo exits preview, flip `continue-on-error` off and promote to a required check

🤖 Generated with [Claude Code](https://claude.com/claude-code)