### PR TITLE
docs: trim README to essentials; move deep-dives under docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center"><b>Open-source voice toolkit.</b> Optimized for Apple Silicon (CoreML), works on any platform (ONNX fallback).<br>A collection of small, fast, open-source audio models — packaged as CLI tools and an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill for LLM agents.</p>
 
 - **Speech-to-text** — 25 languages, ~15x faster than Whisper on Apple Silicon, ~2.5x on CPU
-- **Language detection** — 107 languages from audio, text language via NLLanguageRecognizer
+- **Text-to-speech** — Kokoro (EN) + Piper (RU) + macOS system voices, SSML preview
 - **Rust engine** — single 20MB binary, no ffmpeg, no Python, no native Node addons
 - **OpenClaw-ready** — plug into your LLM agent as a voice processing skill
 
@@ -30,61 +30,17 @@ kesha install       # downloads engine + models
 kesha audio.ogg     # transcript to stdout
 ```
 
-### Air-gapped / corporate mirrors
+Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-mirror.md).
 
-Set `KESHA_MODEL_MIRROR` to redirect all HuggingFace model downloads to an internal mirror ([#121](https://github.com/drakulavich/kesha-voice-kit/issues/121)). The HF path hierarchy is preserved, so any HTTP-readable mirror populated with `wget --mirror` or `rsync` works:
-
-```bash
-export KESHA_MODEL_MIRROR=https://models.corp.internal/kesha
-kesha install        # ASR + lang-id + TTS models fetch from your mirror
-kesha status         # confirms the active Mirror URL
-```
-
-Unset / empty falls back to `huggingface.co` with no regression. The engine binary itself still comes from GitHub Releases — this env var only redirects model downloads.
-
-## OpenClaw Integration
-
-Kesha Voice Kit ships as a plugin for [OpenClaw](https://github.com/openclaw/openclaw) — give your LLM agent ears. No API keys, everything runs locally on your machine.
+## Speech-to-text
 
 ```bash
-bun add -g @drakulavich/kesha-voice-kit && kesha install
-openclaw plugins install @drakulavich/kesha-voice-kit
-openclaw config set tools.media.audio.models \
-  '[{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}]'
-```
-
-> If audio transcription is not already enabled: `openclaw config set tools.media.audio.enabled true`
-
-Your agent receives a voice message in Telegram/WhatsApp/Slack, Kesha transcribes it locally, and the agent sees enriched context:
-
-```
-Таити, Таити! Не были мы ни в какой Таити! Нас и тут неплохо кормят.
-[lang: ru, confidence: 1.00]
-```
-
-Manage the plugin with `openclaw plugins list`, `openclaw plugins disable kesha-voice-kit`, or `openclaw plugins uninstall kesha-voice-kit`.
-
-## Raycast Extension (macOS)
-
-Transcribe audio and speak clipboard text from Raycast's launcher without opening a terminal. Two commands:
-
-- **Transcribe Selected Audio** — pick an audio file in Finder, hit the command, transcript lands on your clipboard.
-- **Speak Clipboard** — synthesize whatever's on your clipboard and play it through the default output.
-
-Source + install instructions: [`raycast/`](raycast/). Tracked in [#145](https://github.com/drakulavich/kesha-voice-kit/issues/145); not yet on the Raycast Store — install via `ray develop` from the subdirectory.
-
-## CLI Tools
-
-```bash
-kesha install                              # download engine and models
 kesha audio.ogg                            # transcribe (plain text)
 kesha --format transcript audio.ogg        # text + language/confidence
 kesha --format json audio.ogg              # full JSON with lang fields
-kesha --json audio.ogg                     # alias for --format json
-kesha --toon audio.ogg                     # compact LLM-friendly TOON (same data as --json)
+kesha --toon audio.ogg                     # compact LLM-friendly TOON
 kesha --verbose audio.ogg                  # show language detection details
 kesha --lang en audio.ogg                  # warn if detected language differs
-kesha --vad lecture.m4a                    # segment with Silero VAD first (long/silence-heavy audio)
 kesha status                               # show installed backend info
 ```
 
@@ -101,85 +57,19 @@ $ kesha freedom.ogg tahiti.ogg
 
 Stdout: transcript. Stderr: errors. Pipe-friendly. Also available as `parakeet` command (backward-compatible alias).
 
-### Long / silence-heavy audio: `--vad`
+For long / silence-heavy audio, use `--vad` (auto-on past 120 s). Details: [docs/vad.md](docs/vad.md).
 
-For meetings, lectures, and podcasts, enable Silero VAD so Parakeet only sees the speech bits. Segment boundaries land at natural speech starts/ends instead of arbitrary cuts, and long silences are skipped entirely.
+## Text-to-speech
 
-```bash
-kesha install --vad                   # one-time, ~2.3MB
-kesha lecture.m4a                     # auto-on when audio ≥ 120s and VAD installed
-kesha --vad short-clip.ogg            # force VAD on any input
-kesha --no-vad meeting.m4a            # force VAD off even on long audio
-```
-
-Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. If you have long audio without VAD installed, Kesha prints a one-time stderr hint. Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues #128 (base) and #187 (auto-trigger).
-
-## Text-to-Speech
-
-Kesha speaks back via Kokoro-82M (English) and Piper (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Piper. Pass `--voice` to override.
+Kesha speaks back via Kokoro-82M (English) and Piper (Russian) — voice auto-picks from the text's language:
 
 ```bash
-kesha install --tts                 # ~490MB (Kokoro + Piper RU + ONNX G2P, opt-in)
+kesha install --tts                      # ~490MB (Kokoro + Piper RU + ONNX G2P, opt-in)
 kesha say "Hello, world" > hello.wav
-kesha say "Привет, мир" > privet.wav    # auto-routes to ru-denis
-echo "long text" | kesha say > reply.wav
-kesha say --out reply.wav "text"
-kesha say --voice en-af_heart "text"    # explicit voice overrides auto-routing
-kesha say --list-voices
+kesha say "Привет, мир" > privet.wav     # auto-routes to ru-denis
 ```
 
-Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Opus and MP3 are tracked in follow-up issues. Grapheme-to-phoneme runs entirely through ONNX (CharsiuG2P ByT5-tiny, [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123)) — no `espeak-ng` system dep.
-
-**Supported voices:**
-- English: `en-af_heart` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/`
-- Russian: `ru-denis` (default). More speakers (dmitri, irina, ruslan) are ready to drop in once needed.
-- macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
-
-### macOS system voices
-
-`kesha say --voice macos-*` routes through `AVSpeechSynthesizer` on macOS, so you get voice synthesis for free — no 490 MB TTS bundle. The sidecar binary ships alongside `kesha-engine` on darwin-arm64 releases (#141); `kesha install` places both in `~/.cache/kesha/bin/`.
-
-```bash
-kesha say --list-voices | grep ^macos-                                       # discover installed voices
-kesha say --voice macos-com.apple.voice.compact.en-US.Samantha "Hello" > out.wav
-kesha say --voice macos-ru-RU "Привет, мир" > hello-ru.wav                   # language-code fallback
-```
-
-Voice id format: `macos-<id>` where `<id>` is either a full Apple identifier (`com.apple.voice.compact.en-US.Samantha`) or a language code (`en-US`, `ru-RU`) — the Swift helper tries the identifier first and falls back to the language. Output is mono float32 @ 22050 Hz, structurally identical to Piper.
-
-Quality tradeoff is honest: macOS system voices are notification-grade. Use them when you want zero-install TTS on macOS; keep Kokoro/Piper for anything that needs to sound good.
-
-### SSML (preview)
-
-`kesha say --ssml` accepts [SSML](https://www.w3.org/TR/speech-synthesis11/) for pauses and text-structuring. v1 is deliberately small:
-
-```bash
-kesha say --ssml '<speak>Hello <break time="500ms"/> world.</speak>'
-kesha say --ssml --voice ru-denis '<speak>Привет <break time="1s"/> мир.</speak>'
-```
-
-| Tag | Status |
-|---|---|
-| `<speak>` | ✅ required root |
-| `<break time="Nms"\|"Ns"\|default>` | ✅ inserts silence of the given duration |
-| plain text inside `<speak>` | ✅ synthesized via the selected engine |
-| `<emphasis>`, `<prosody>`, `<phoneme>`, `<say-as>` | ⚠️ stripped with a stderr warning (contained text still synthesized); tracked in [#122](https://github.com/drakulavich/kesha-voice-kit/issues/122) |
-| `<!DOCTYPE>` | ❌ rejected (hardening against XXE) |
-
-SSML is opt-in via the explicit `--ssml` flag — inputs that happen to contain `<angle brackets>` aren't misinterpreted as SSML.
-
-## What's Inside
-
-Kesha Voice Kit bundles open-source models optimized for on-device inference:
-
-| Model | Task | Size | Source |
-|---|---|---|---|
-| NVIDIA Parakeet TDT 0.6B v3 | Speech-to-text | ~2.5GB | [HuggingFace](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) |
-| SpeechBrain ECAPA-TDNN | Audio language detection | ~86MB | [HuggingFace](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa) |
-| Apple NLLanguageRecognizer | Text language detection | built-in | macOS system framework |
-| Silero VAD v5 (opt-in) | Voice activity detection | ~2.3MB | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) |
-
-All models run through `kesha-engine` — a Rust binary using [FluidAudio](https://github.com/FluidInference/FluidAudio) (CoreML) on Apple Silicon and [ort](https://github.com/pykeio/ort) (ONNX Runtime) on other platforms.
+macOS system voices, SSML, voice listing, and the full voice catalogue: [docs/tts.md](docs/tts.md).
 
 ## Performance
 
@@ -189,48 +79,39 @@ Compared against Whisper `large-v3-turbo` — all engines auto-detect language.
 
 ![Benchmark: openai-whisper vs faster-whisper vs Kesha Voice Kit](assets/benchmark.svg)
 
-<details>
-<summary>Full results with per-file breakdown</summary>
+See [BENCHMARK.md](BENCHMARK.md) for the full per-file breakdown (Russian + English).
 
-See [BENCHMARK.md](BENCHMARK.md) — includes Russian (real voice messages) and English transcription results with all four engines.
+## What's Inside
 
-</details>
+| Model | Task | Size | Source |
+|---|---|---|---|
+| NVIDIA Parakeet TDT 0.6B v3 | Speech-to-text | ~2.5GB | [HuggingFace](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) |
+| SpeechBrain ECAPA-TDNN | Audio language detection | ~86MB | [HuggingFace](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa) |
+| Apple NLLanguageRecognizer | Text language detection | built-in | macOS system framework |
+| Silero VAD v5 (opt-in) | Voice activity detection | ~2.3MB | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) |
+| Kokoro-82M / Piper (opt-in) | Text-to-speech | ~490MB | [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M) · [Piper](https://github.com/rhasspy/piper) |
 
-## Supported Audio Formats
+All models run through `kesha-engine` — a Rust binary using [FluidAudio](https://github.com/FluidInference/FluidAudio) (CoreML) on Apple Silicon and [ort](https://github.com/pykeio/ort) (ONNX Runtime) on other platforms.
 
-Built-in audio decoding via [symphonia](https://github.com/pdeljanov/Symphonia) — no ffmpeg required:
+Audio decoding via [symphonia](https://github.com/pdeljanov/Symphonia) — WAV, MP3, OGG/Opus, FLAC, AAC, M4A. No ffmpeg.
 
-| Format | Extension |
-|---|---|
-| WAV | `.wav` |
-| MP3 | `.mp3` |
-| OGG Vorbis/Opus | `.ogg`, `.opus` |
-| FLAC | `.flac` |
-| AAC / M4A | `.aac`, `.m4a` |
+## Languages
 
-## Supported Languages
+- **Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
+- **Audio language detection (107):** [full list](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa).
 
-**Speech-to-text (25):** :bulgaria: Bulgarian, :croatia: Croatian, :czech_republic: Czech, :denmark: Danish, :netherlands: Dutch, :gb: English, :estonia: Estonian, :finland: Finnish, :fr: French, :de: German, :greece: Greek, :hungary: Hungarian, :it: Italian, :latvia: Latvian, :lithuania: Lithuanian, :malta: Maltese, :poland: Polish, :portugal: Portuguese, :romania: Romanian, :ru: Russian, :slovakia: Slovak, :slovenia: Slovenian, :es: Spanish, :sweden: Swedish, :ukraine: Ukrainian
+## Integrations
 
-**Audio language detection (107):** Full list at [speechbrain/lang-id-voxlingua107-ecapa](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa)
-
-## Architecture
-
-```
-kesha audio.ogg
-  → kesha-engine (Rust binary)
-    ├── Apple Silicon? → FluidAudio (CoreML / Neural Engine)
-    └── Other?        → ort (ONNX Runtime / CPU)
-  → transcript to stdout
-```
+- **OpenClaw** — give your LLM agent ears. Install & config: [docs/openclaw.md](docs/openclaw.md).
+- **Raycast** (macOS) — transcribe selected audio & speak clipboard from the launcher. Source + install: [`raycast/`](raycast/).
 
 ## Programmatic API
 
 ```typescript
 import { transcribe, downloadModel } from "@drakulavich/kesha-voice-kit/core";
 
-await downloadModel();                    // install engine + models
-const text = await transcribe("audio.ogg"); // transcribe
+await downloadModel();                       // install engine + models
+const text = await transcribe("audio.ogg");  // transcribe
 ```
 
 ## Requirements

--- a/docs/model-mirror.md
+++ b/docs/model-mirror.md
@@ -1,0 +1,11 @@
+# Air-gapped / corporate mirrors
+
+Set `KESHA_MODEL_MIRROR` to redirect all HuggingFace model downloads to an internal mirror ([#121](https://github.com/drakulavich/kesha-voice-kit/issues/121)). The HF path hierarchy is preserved, so any HTTP-readable mirror populated with `wget --mirror` or `rsync` works:
+
+```bash
+export KESHA_MODEL_MIRROR=https://models.corp.internal/kesha
+kesha install        # ASR + lang-id + TTS models fetch from your mirror
+kesha status         # confirms the active Mirror URL
+```
+
+Unset / empty falls back to `huggingface.co` with no regression. The engine binary itself still comes from GitHub Releases — this env var only redirects model downloads.

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -1,0 +1,21 @@
+# OpenClaw Integration
+
+Kesha Voice Kit ships as a plugin for [OpenClaw](https://github.com/openclaw/openclaw) — give your LLM agent ears. No API keys, everything runs locally on your machine.
+
+```bash
+bun add -g @drakulavich/kesha-voice-kit && kesha install
+openclaw plugins install @drakulavich/kesha-voice-kit
+openclaw config set tools.media.audio.models \
+  '[{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}]'
+```
+
+> If audio transcription is not already enabled: `openclaw config set tools.media.audio.enabled true`
+
+Your agent receives a voice message in Telegram/WhatsApp/Slack, Kesha transcribes it locally, and the agent sees enriched context:
+
+```
+Таити, Таити! Не были мы ни в какой Таити! Нас и тут неплохо кормят.
+[lang: ru, confidence: 1.00]
+```
+
+Manage the plugin with `openclaw plugins list`, `openclaw plugins disable kesha-voice-kit`, or `openclaw plugins uninstall kesha-voice-kit`.

--- a/docs/superpowers/plans/2026-04-24-readme-trim.md
+++ b/docs/superpowers/plans/2026-04-24-readme-trim.md
@@ -1,0 +1,440 @@
+# README Trim Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shrink `README.md` from ~247 to ~100 lines by extracting advanced/operational sections to dedicated pages under `docs/`.
+
+**Architecture:** Docs-only change. No code or tests. Move content verbatim in per-section commits so each step is independently reviewable and revertible. README keeps one-line pointers to every moved section so nothing becomes invisible.
+
+**Tech Stack:** Markdown. Git.
+
+**Spec:** [`docs/superpowers/specs/2026-04-24-readme-trim-design.md`](../specs/2026-04-24-readme-trim-design.md)
+
+---
+
+## Working assumptions
+
+- Branch `docs/readme-trim` already exists (created during spec commit `849cf3f`).
+- All work happens from the repo root: `/Users/anton/Personal/repos/parakeet-cli`.
+- "Verbatim" means the moved markdown is copied without editing prose, examples, or issue links. The only permitted edit to moved content is demoting the section's `##` heading to `#` when it becomes a standalone file's H1.
+- README keeps image paths (`assets/logo.png`, `assets/benchmark.svg`) at repo-root-relative paths. New docs pages that reference the benchmark link to the existing root-level `BENCHMARK.md` rather than re-embedding images.
+
+---
+
+### Task 1: Create `docs/vad.md`
+
+**Files:**
+- Create: `docs/vad.md`
+
+- [ ] **Step 1: Create the file with moved content**
+
+Copy the current README block starting at `### Long / silence-heavy audio: \`--vad\`` (line ~104) through its last line (the one ending `#128 (base) and #187 (auto-trigger)`). Promote the heading to `# Voice Activity Detection (VAD)` and add a one-line intro.
+
+```markdown
+# Voice Activity Detection (VAD)
+
+For meetings, lectures, and podcasts, enable Silero VAD so Parakeet only sees the speech bits. Segment boundaries land at natural speech starts/ends instead of arbitrary cuts, and long silences are skipped entirely.
+
+```bash
+kesha install --vad                   # one-time, ~2.3MB
+kesha lecture.m4a                     # auto-on when audio ≥ 120s and VAD installed
+kesha --vad short-clip.ogg            # force VAD on any input
+kesha --no-vad meeting.m4a            # force VAD off even on long audio
+```
+
+Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. If you have long audio without VAD installed, Kesha prints a one-time stderr hint. Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues [#128](https://github.com/drakulavich/kesha-voice-kit/issues/128) (base) and [#187](https://github.com/drakulavich/kesha-voice-kit/issues/187) (auto-trigger).
+```
+
+- [ ] **Step 2: Verify the file exists and renders**
+
+Run: `wc -l docs/vad.md && head -1 docs/vad.md`
+Expected: ~12 lines; first line is `# Voice Activity Detection (VAD)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/vad.md
+git commit -m "docs: extract VAD section to docs/vad.md"
+```
+
+---
+
+### Task 2: Create `docs/tts.md`
+
+**Files:**
+- Create: `docs/tts.md`
+
+- [ ] **Step 1: Create the file with moved content**
+
+Concatenate three current README sections into one page, preserving their subsections as `## ...`:
+
+1. The `## Text-to-Speech` intro + `kesha say` examples + voices bullet list (README lines ~118–136).
+2. The `### macOS system voices` block (~138–150).
+3. The `### SSML (preview)` block including the tag table and opt-in note (~153–169).
+
+Promote the top `## Text-to-Speech` heading to `# Text-to-Speech`. Keep both nested `###` headings as `##`.
+
+The file starts like this (full content copied verbatim from current README, headings adjusted):
+
+```markdown
+# Text-to-Speech
+
+Kesha speaks back via Kokoro-82M (English) and Piper (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Piper. Pass `--voice` to override.
+
+[... rest of the TTS examples ...]
+
+## macOS system voices
+
+[... existing macOS voices content verbatim ...]
+
+## SSML (preview)
+
+[... existing SSML content verbatim, including the tag table ...]
+```
+
+- [ ] **Step 2: Verify content parity**
+
+Run: `grep -c "kesha say" docs/tts.md`
+Expected: ≥ 6 (matches the current README count for `kesha say` in these sections).
+
+Run: `grep -E "macos-|--ssml|<break" docs/tts.md | wc -l`
+Expected: ≥ 4 (ensures macOS, SSML, and break-tag examples all landed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/tts.md
+git commit -m "docs: extract TTS, macOS voices, and SSML sections to docs/tts.md"
+```
+
+---
+
+### Task 3: Create `docs/openclaw.md`
+
+**Files:**
+- Create: `docs/openclaw.md`
+
+- [ ] **Step 1: Create the file with moved content**
+
+Copy the current README's `## OpenClaw Integration` block (~45–65) into a new file. Promote `##` to `# OpenClaw Integration`.
+
+Content to copy (verbatim from current README):
+
+```markdown
+# OpenClaw Integration
+
+Kesha Voice Kit ships as a plugin for [OpenClaw](https://github.com/openclaw/openclaw) — give your LLM agent ears. No API keys, everything runs locally on your machine.
+
+```bash
+bun add -g @drakulavich/kesha-voice-kit && kesha install
+openclaw plugins install @drakulavich/kesha-voice-kit
+openclaw config set tools.media.audio.models \
+  '[{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}]'
+```
+
+> If audio transcription is not already enabled: `openclaw config set tools.media.audio.enabled true`
+
+Your agent receives a voice message in Telegram/WhatsApp/Slack, Kesha transcribes it locally, and the agent sees enriched context:
+
+```
+Таити, Таити! Не были мы ни в какой Таити! Нас и тут неплохо кормят.
+[lang: ru, confidence: 1.00]
+```
+
+Manage the plugin with `openclaw plugins list`, `openclaw plugins disable kesha-voice-kit`, or `openclaw plugins uninstall kesha-voice-kit`.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -c "openclaw" docs/openclaw.md`
+Expected: ≥ 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/openclaw.md
+git commit -m "docs: extract OpenClaw integration to docs/openclaw.md"
+```
+
+---
+
+### Task 4: Create `docs/model-mirror.md`
+
+**Files:**
+- Create: `docs/model-mirror.md`
+
+- [ ] **Step 1: Create the file with moved content**
+
+Copy the current README's `### Air-gapped / corporate mirrors` block (~33–43). Promote `###` to `# Air-gapped / corporate mirrors` and prepend a one-line intro that fits a standalone page.
+
+```markdown
+# Air-gapped / corporate mirrors
+
+Set `KESHA_MODEL_MIRROR` to redirect all HuggingFace model downloads to an internal mirror ([#121](https://github.com/drakulavich/kesha-voice-kit/issues/121)). The HF path hierarchy is preserved, so any HTTP-readable mirror populated with `wget --mirror` or `rsync` works:
+
+```bash
+export KESHA_MODEL_MIRROR=https://models.corp.internal/kesha
+kesha install        # ASR + lang-id + TTS models fetch from your mirror
+kesha status         # confirms the active Mirror URL
+```
+
+Unset / empty falls back to `huggingface.co` with no regression. The engine binary itself still comes from GitHub Releases — this env var only redirects model downloads.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -c "KESHA_MODEL_MIRROR" docs/model-mirror.md`
+Expected: ≥ 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/model-mirror.md
+git commit -m "docs: extract model-mirror section to docs/model-mirror.md"
+```
+
+---
+
+### Task 5: Rewrite `README.md`
+
+**Files:**
+- Modify: `README.md` (full replacement)
+
+This is the largest task — it replaces the README with the slim version. All moved content already lives under `docs/` (Tasks 1–4), so this task only deletes from README and adds pointers.
+
+- [ ] **Step 1: Replace the file**
+
+Overwrite `README.md` with exactly this content (preserves the hero block, badges, quick-start, core CLI, TTS teaser, perf chart, models table, compact languages, integrations pointers, programmatic API, requirements, contributing, license):
+
+````markdown
+<p align="center">
+  <img src="assets/logo.png" alt="Kesha Voice Kit" width="200">
+</p>
+
+<h1 align="center">Kesha Voice Kit</h1>
+
+<p align="center">
+  <a href="https://github.com/drakulavich/kesha-voice-kit/actions/workflows/ci.yml"><img src="https://github.com/drakulavich/kesha-voice-kit/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://www.npmjs.com/package/@drakulavich/kesha-voice-kit"><img src="https://img.shields.io/npm/v/@drakulavich/kesha-voice-kit" alt="npm version"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="https://bun.sh"><img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun" alt="Bun"></a>
+</p>
+
+<p align="center"><b>Open-source voice toolkit.</b> Optimized for Apple Silicon (CoreML), works on any platform (ONNX fallback).<br>A collection of small, fast, open-source audio models — packaged as CLI tools and an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill for LLM agents.</p>
+
+- **Speech-to-text** — 25 languages, ~15x faster than Whisper on Apple Silicon, ~2.5x on CPU
+- **Text-to-speech** — Kokoro (EN) + Piper (RU) + macOS system voices, SSML preview
+- **Rust engine** — single 20MB binary, no ffmpeg, no Python, no native Node addons
+- **OpenClaw-ready** — plug into your LLM agent as a voice processing skill
+
+## Quick Start
+
+Runtime: **[Bun](https://bun.sh)** >= 1.3.0.
+
+```bash
+curl -fsSL https://bun.sh/install | bash   # skip if Bun is already installed
+
+bun install -g @drakulavich/kesha-voice-kit
+kesha install       # downloads engine + models
+kesha audio.ogg     # transcript to stdout
+```
+
+Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-mirror.md).
+
+## Speech-to-text
+
+```bash
+kesha audio.ogg                            # transcribe (plain text)
+kesha --format transcript audio.ogg        # text + language/confidence
+kesha --format json audio.ogg              # full JSON with lang fields
+kesha --toon audio.ogg                     # compact LLM-friendly TOON
+kesha --verbose audio.ogg                  # show language detection details
+kesha --lang en audio.ogg                  # warn if detected language differs
+kesha status                               # show installed backend info
+```
+
+Multiple files — headers per file, like `head`:
+
+```bash
+$ kesha freedom.ogg tahiti.ogg
+=== freedom.ogg ===
+Свободу попугаям! Свободу!
+
+=== tahiti.ogg ===
+Таити, Таити! Не были мы ни в какой Таити! Нас и тут неплохо кормят.
+```
+
+Stdout: transcript. Stderr: errors. Pipe-friendly. Also available as `parakeet` command (backward-compatible alias).
+
+For long / silence-heavy audio, use `--vad` (auto-on past 120 s). Details: [docs/vad.md](docs/vad.md).
+
+## Text-to-speech
+
+Kesha speaks back via Kokoro-82M (English) and Piper (Russian) — voice auto-picks from the text's language:
+
+```bash
+kesha install --tts                      # ~490MB (Kokoro + Piper RU + ONNX G2P, opt-in)
+kesha say "Hello, world" > hello.wav
+kesha say "Привет, мир" > privet.wav     # auto-routes to ru-denis
+```
+
+macOS system voices, SSML, voice listing, and the full voice catalogue: [docs/tts.md](docs/tts.md).
+
+## Performance
+
+> **~15x faster than Whisper** on Apple Silicon (M3 Pro), **~2.5x faster** on CPU
+
+Compared against Whisper `large-v3-turbo` — all engines auto-detect language.
+
+![Benchmark: openai-whisper vs faster-whisper vs Kesha Voice Kit](assets/benchmark.svg)
+
+See [BENCHMARK.md](BENCHMARK.md) for the full per-file breakdown (Russian + English).
+
+## What's Inside
+
+| Model | Task | Size | Source |
+|---|---|---|---|
+| NVIDIA Parakeet TDT 0.6B v3 | Speech-to-text | ~2.5GB | [HuggingFace](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) |
+| SpeechBrain ECAPA-TDNN | Audio language detection | ~86MB | [HuggingFace](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa) |
+| Apple NLLanguageRecognizer | Text language detection | built-in | macOS system framework |
+| Silero VAD v5 (opt-in) | Voice activity detection | ~2.3MB | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) |
+| Kokoro-82M / Piper (opt-in) | Text-to-speech | ~490MB | [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M) · [Piper](https://github.com/rhasspy/piper) |
+
+All models run through `kesha-engine` — a Rust binary using [FluidAudio](https://github.com/FluidInference/FluidAudio) (CoreML) on Apple Silicon and [ort](https://github.com/pykeio/ort) (ONNX Runtime) on other platforms.
+
+Audio decoding via [symphonia](https://github.com/pdeljanov/Symphonia) — WAV, MP3, OGG/Opus, FLAC, AAC, M4A. No ffmpeg.
+
+## Languages
+
+- **Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
+- **Audio language detection (107):** [full list](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa).
+
+## Integrations
+
+- **OpenClaw** — give your LLM agent ears. Install & config: [docs/openclaw.md](docs/openclaw.md).
+- **Raycast** (macOS) — transcribe selected audio & speak clipboard from the launcher. Source + install: [`raycast/`](raycast/).
+
+## Programmatic API
+
+```typescript
+import { transcribe, downloadModel } from "@drakulavich/kesha-voice-kit/core";
+
+await downloadModel();                       // install engine + models
+const text = await transcribe("audio.ogg");  // transcribe
+```
+
+## Requirements
+
+- [Bun](https://bun.sh) >= 1.3
+- macOS arm64, Linux x64, or Windows x64
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+Made with 💛🩵 and 🥤 energy under MIT License
+````
+
+- [ ] **Step 2: Verify line count and key keywords**
+
+Run: `wc -l README.md`
+Expected: 100 ± 20 (the content above is ~115 lines).
+
+Run: `grep -E "docs/vad\.md|docs/tts\.md|docs/openclaw\.md|docs/model-mirror\.md|raycast/" README.md`
+Expected: 5 pointer lines, one per moved destination.
+
+Run: `grep -E "KESHA_MODEL_MIRROR|<speak>|AVSpeechSynthesizer|openclaw plugins install" README.md`
+Expected: no matches (those details now live under `docs/` only, confirming the move was complete, not duplicated).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: trim README to essentials; link to docs/ for deep-dives"
+```
+
+---
+
+### Task 6: Link check
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Enumerate relative links in README and docs**
+
+Run:
+```bash
+grep -oE '\]\(\.?\.?/?[A-Za-z0-9_./-]+\)' README.md docs/vad.md docs/tts.md docs/openclaw.md docs/model-mirror.md | sort -u
+```
+
+- [ ] **Step 2: Verify each target resolves**
+
+For every link target that is a repo-relative path (not `http...`), confirm the file exists:
+
+```bash
+for f in assets/logo.png assets/benchmark.svg BENCHMARK.md CONTRIBUTING.md docs/vad.md docs/tts.md docs/openclaw.md docs/model-mirror.md raycast/README.md; do
+  test -e "$f" && echo "OK  $f" || echo "MISS $f"
+done
+```
+
+Expected: every line says `OK`.
+
+- [ ] **Step 3: Content-parity grep**
+
+Ensure nothing critical vanished — each keyword must still appear somewhere in the tree:
+
+```bash
+for kw in KESHA_MODEL_MIRROR '--vad' '--ssml' 'macos-' 'openclaw plugins install' 'parakeet' 'Kokoro' 'Piper'; do
+  matches=$(grep -rl --include='*.md' "$kw" README.md docs/ 2>/dev/null | wc -l | tr -d ' ')
+  echo "$kw → $matches file(s)"
+done
+```
+
+Expected: every keyword matches ≥ 1 file.
+
+- [ ] **Step 4: If all checks pass, no commit needed**
+
+If a check fails, fix the link/content inline and commit with message `docs: fix broken link/content parity after README trim`.
+
+---
+
+### Task 7: Push branch and open PR (optional — ask user first)
+
+**Files:** none.
+
+- [ ] **Step 1: Ask the user** whether to push `docs/readme-trim` and open a PR, or leave it local for further review.
+
+- [ ] **Step 2: If user approves, push:**
+
+```bash
+git push -u origin docs/readme-trim
+```
+
+- [ ] **Step 3: If user approves, open PR:**
+
+```bash
+gh pr create --title "docs: trim README to essentials; move deep-dives under docs/" --body "$(cat <<'EOF'
+## Summary
+- README shrinks from ~247 → ~115 lines
+- VAD, TTS (incl. macOS voices + SSML), OpenClaw, and model-mirror sections move to dedicated pages under \`docs/\`
+- All moved content is verbatim — no prose rewrites
+
+## Test plan
+- [ ] Preview README and new \`docs/*.md\` on GitHub; tables, code fences, and images render
+- [ ] All relative links resolve
+- [ ] Every feature keyword (\`KESHA_MODEL_MIRROR\`, \`--vad\`, \`--ssml\`, \`macos-\`, \`openclaw plugins install\`) still appears somewhere in the tree
+
+Spec: \`docs/superpowers/specs/2026-04-24-readme-trim-design.md\`
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** Tasks 1–4 create each of the four docs pages called out in the spec. Task 5 implements the target README structure (hero, quick start, STT, TTS teaser, perf, models table, compact languages, integrations, programmatic API, requirements, contributing, license). Task 6 validates content parity. All spec items covered.
+- **Placeholders:** none. Each task has exact file paths, full content for docs pages, and full replacement content for README.
+- **Type consistency:** N/A (docs-only).
+- **Reversibility:** per-section commits mean any single extraction can be reverted without touching the others.

--- a/docs/superpowers/plans/2026-04-24-readme-trim.md
+++ b/docs/superpowers/plans/2026-04-24-readme-trim.md
@@ -15,7 +15,7 @@
 ## Working assumptions
 
 - Branch `docs/readme-trim` already exists (created during spec commit `849cf3f`).
-- All work happens from the repo root: `/Users/anton/Personal/repos/parakeet-cli`.
+- All work happens from the repo root.
 - "Verbatim" means the moved markdown is copied without editing prose, examples, or issue links. The only permitted edit to moved content is demoting the section's `##` heading to `#` when it becomes a standalone file's H1.
 - README keeps image paths (`assets/logo.png`, `assets/benchmark.svg`) at repo-root-relative paths. New docs pages that reference the benchmark link to the existing root-level `BENCHMARK.md` rather than re-embedding images.
 

--- a/docs/superpowers/specs/2026-04-24-readme-trim-design.md
+++ b/docs/superpowers/specs/2026-04-24-readme-trim-design.md
@@ -1,0 +1,65 @@
+# README Trim — Design
+
+**Date:** 2026-04-24
+**Topic:** Shrink `README.md` to essentials; push advanced/operational detail to `docs/`.
+
+## Goal
+
+Cut `README.md` from ~247 lines to ~100 lines while preserving the information a new visitor needs in the first 30 seconds: what Kesha is, how fast it is, how to install and transcribe, and a teaser for TTS. Everything else moves under `docs/` or into the already-existing subdirectory READMEs (`raycast/`).
+
+## Non-goals
+
+- Rewriting the product positioning or tagline.
+- Changing published CLI behavior, flags, or examples.
+- Refactoring `raycast/README.md` or `BENCHMARK.md`.
+- Moving `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`, `NOTICES.md`, `LICENSE` (they stay at repo root).
+
+## Target README structure (~100 lines)
+
+1. **Hero** — logo, title, badges, tagline, 4 bullets. *Unchanged.*
+2. **Quick Start** — Bun install one-liner + `kesha install` + `kesha audio.ogg`. *Kept verbatim.*
+3. **CLI (Speech-to-text)** — core flags only (`--format`, `--json`, `--toon`, `--verbose`, `--lang`, `status`), multi-file `head`-style example, stdout/stderr note. One-line `--vad` mention linking to `docs/vad.md`.
+4. **Text-to-speech** — 3-4 line teaser + one `kesha say` example (EN + RU auto-routing). Link to `docs/tts.md` for macOS voices, SSML, full voice list.
+5. **Performance** — kept: headline, benchmark SVG, BENCHMARK.md link.
+6. **What's Inside** — kept: model table.
+7. **Supported languages** — compact: "25 STT languages ([list](…BENCHMARK.md#languages) or models table), 107 audio lang-id languages ([full list](huggingface…))". Drop the flag-emoji wall.
+8. **Integrations** — two one-liners: OpenClaw (→ `docs/openclaw.md`), Raycast (→ `raycast/`).
+9. **Programmatic API** — kept: the 4-line TypeScript snippet.
+10. **Requirements / Contributing / License** — kept.
+
+## New files under `docs/`
+
+| File | Source material | Purpose |
+|---|---|---|
+| `docs/vad.md` | "Long / silence-heavy audio: `--vad`" section (~15 lines) | VAD install, auto-trigger threshold, tuning defaults, references to #128/#187. |
+| `docs/tts.md` | "Text-to-Speech" + "macOS system voices" + "SSML (preview)" (~60 lines) | Voice routing, supported voices, macOS `AVSpeechSynthesizer` sidecar, SSML tag table, output formats. |
+| `docs/openclaw.md` | "OpenClaw Integration" section (~20 lines) | Plugin install, config snippet, agent example, plugin management commands. |
+| `docs/model-mirror.md` | "Air-gapped / corporate mirrors" section (~10 lines) | `KESHA_MODEL_MIRROR` usage, mirror layout, fallback behavior. |
+
+Each new doc is a self-contained markdown page. The moved content is **copied verbatim** from the current README — no rewriting during this pass — so the trim is reversible and review-friendly.
+
+## Sections dropped entirely
+
+- **Architecture** ascii box (duplicates "What's Inside" and the hero bullet about the Rust engine).
+- **Supported Audio Formats** table → collapsed to one line in "What's Inside" area: "Audio decoding via [symphonia](…) — WAV, MP3, OGG/Opus, FLAC, AAC, M4A. No ffmpeg."
+
+## Link hygiene
+
+- Every moved section leaves a one-line pointer in the README so nothing becomes invisible.
+- Cross-links use relative paths (`docs/tts.md`, `raycast/`) so they work on GitHub and on any mirror.
+- No docs page links back to the README's deep-linked anchors (those anchors go away); instead each doc is self-contained.
+
+## Validation
+
+Before declaring the task done:
+
+1. **Markdown rendering** — preview the new `README.md` and each new `docs/*.md` on GitHub (or locally with a markdown viewer) to confirm tables, code fences, and image paths render.
+2. **Link check** — every relative link (`docs/vad.md`, `raycast/`, `assets/benchmark.svg`, issue links) resolves.
+3. **Content parity** — grep the old README for each feature keyword (`KESHA_MODEL_MIRROR`, `--vad`, `ssml`, `macos-`, `openclaw plugins`) and confirm each still appears *somewhere* in the new tree.
+4. **Line count** — `wc -l README.md` ≈ 100 (± 20).
+
+## Out of scope / deferred
+
+- A `docs/README.md` index page — nice-to-have; can be added later if `docs/` grows beyond 4 pages.
+- Reworking the tagline or the 4 hero bullets.
+- Any changes to content that isn't currently in the top-level `README.md`.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,0 +1,53 @@
+# Text-to-Speech
+
+Kesha speaks back via Kokoro-82M (English) and Piper (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Piper. Pass `--voice` to override.
+
+```bash
+kesha install --tts                 # ~490MB (Kokoro + Piper RU + ONNX G2P, opt-in)
+kesha say "Hello, world" > hello.wav
+kesha say "Привет, мир" > privet.wav    # auto-routes to ru-denis
+echo "long text" | kesha say > reply.wav
+kesha say --out reply.wav "text"
+kesha say --voice en-af_heart "text"    # explicit voice overrides auto-routing
+kesha say --list-voices
+```
+
+Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Opus and MP3 are tracked in follow-up issues. Grapheme-to-phoneme runs entirely through ONNX (CharsiuG2P ByT5-tiny, [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123)) — no `espeak-ng` system dep.
+
+**Supported voices:**
+- English: `en-af_heart` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/`
+- Russian: `ru-denis` (default). More speakers (dmitri, irina, ruslan) are ready to drop in once needed.
+- macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
+
+## macOS system voices
+
+`kesha say --voice macos-*` routes through `AVSpeechSynthesizer` on macOS, so you get voice synthesis for free — no 490 MB TTS bundle. The sidecar binary ships alongside `kesha-engine` on darwin-arm64 releases (#141); `kesha install` places both in `~/.cache/kesha/bin/`.
+
+```bash
+kesha say --list-voices | grep ^macos-                                       # discover installed voices
+kesha say --voice macos-com.apple.voice.compact.en-US.Samantha "Hello" > out.wav
+kesha say --voice macos-ru-RU "Привет, мир" > hello-ru.wav                   # language-code fallback
+```
+
+Voice id format: `macos-<id>` where `<id>` is either a full Apple identifier (`com.apple.voice.compact.en-US.Samantha`) or a language code (`en-US`, `ru-RU`) — the Swift helper tries the identifier first and falls back to the language. Output is mono float32 @ 22050 Hz, structurally identical to Piper.
+
+Quality tradeoff is honest: macOS system voices are notification-grade. Use them when you want zero-install TTS on macOS; keep Kokoro/Piper for anything that needs to sound good.
+
+## SSML (preview)
+
+`kesha say --ssml` accepts [SSML](https://www.w3.org/TR/speech-synthesis11/) for pauses and text-structuring. v1 is deliberately small:
+
+```bash
+kesha say --ssml '<speak>Hello <break time="500ms"/> world.</speak>'
+kesha say --ssml --voice ru-denis '<speak>Привет <break time="1s"/> мир.</speak>'
+```
+
+| Tag | Status |
+|---|---|
+| `<speak>` | ✅ required root |
+| `<break time="Nms"\|"Ns"\|default>` | ✅ inserts silence of the given duration |
+| plain text inside `<speak>` | ✅ synthesized via the selected engine |
+| `<emphasis>`, `<prosody>`, `<phoneme>`, `<say-as>` | ⚠️ stripped with a stderr warning (contained text still synthesized); tracked in [#122](https://github.com/drakulavich/kesha-voice-kit/issues/122) |
+| `<!DOCTYPE>` | ❌ rejected (hardening against XXE) |
+
+SSML is opt-in via the explicit `--ssml` flag — inputs that happen to contain `<angle brackets>` aren't misinterpreted as SSML.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -21,7 +21,7 @@ Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Op
 
 ## macOS system voices
 
-`kesha say --voice macos-*` routes through `AVSpeechSynthesizer` on macOS, so you get voice synthesis for free — no 490 MB TTS bundle. The sidecar binary ships alongside `kesha-engine` on darwin-arm64 releases (#141); `kesha install` places both in `~/.cache/kesha/bin/`.
+`kesha say --voice macos-*` routes through `AVSpeechSynthesizer` on macOS, so you get voice synthesis for free — no 490 MB TTS bundle. The sidecar binary ships alongside `kesha-engine` on darwin-arm64 releases ([#141](https://github.com/drakulavich/kesha-voice-kit/issues/141)); `kesha install` places both in `~/.cache/kesha/bin/`.
 
 ```bash
 kesha say --list-voices | grep ^macos-                                       # discover installed voices

--- a/docs/vad.md
+++ b/docs/vad.md
@@ -1,0 +1,12 @@
+# Voice Activity Detection (VAD)
+
+For meetings, lectures, and podcasts, enable Silero VAD so Parakeet only sees the speech bits. Segment boundaries land at natural speech starts/ends instead of arbitrary cuts, and long silences are skipped entirely.
+
+```bash
+kesha install --vad                   # one-time, ~2.3MB
+kesha lecture.m4a                     # auto-on when audio ≥ 120s and VAD installed
+kesha --vad short-clip.ogg            # force VAD on any input
+kesha --no-vad meeting.m4a            # force VAD off even on long audio
+```
+
+Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. If you have long audio without VAD installed, Kesha prints a one-time stderr hint. Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues #128 (base) and #187 (auto-trigger).

--- a/docs/vad.md
+++ b/docs/vad.md
@@ -9,4 +9,4 @@ kesha --vad short-clip.ogg            # force VAD on any input
 kesha --no-vad meeting.m4a            # force VAD off even on long audio
 ```
 
-Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. If you have long audio without VAD installed, Kesha prints a one-time stderr hint. Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues #128 (base) and #187 (auto-trigger).
+Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. If you have long audio without VAD installed, Kesha prints a one-time stderr hint. Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues [#128](https://github.com/drakulavich/kesha-voice-kit/issues/128) (base) and [#187](https://github.com/drakulavich/kesha-voice-kit/issues/187) (auto-trigger).


### PR DESCRIPTION
## Summary
- README shrinks from 247 → 128 lines
- VAD, TTS (incl. macOS voices + SSML), OpenClaw, and model-mirror sections move to dedicated pages under \`docs/\`
- All moved content is verbatim — no prose rewrites; each extraction is a separate commit for easy review/revert

## New pages
- \`docs/vad.md\` — Voice Activity Detection
- \`docs/tts.md\` — TTS + macOS system voices + SSML preview
- \`docs/openclaw.md\` — OpenClaw plugin install & config
- \`docs/model-mirror.md\` — \`KESHA_MODEL_MIRROR\` / air-gapped setup

## Test plan
- [ ] Preview README and new \`docs/*.md\` on GitHub; tables, code fences, and images render
- [ ] All relative links resolve (verified locally)
- [ ] Every feature keyword (\`KESHA_MODEL_MIRROR\`, \`--vad\`, \`--ssml\`, \`macos-\`, \`openclaw plugins install\`) still appears somewhere in the tree (verified locally)

Spec: \`docs/superpowers/specs/2026-04-24-readme-trim-design.md\`
Plan: \`docs/superpowers/plans/2026-04-24-readme-trim.md\`