### PR TITLE
chore(release): v1.4.3 (CLI-only) — README trim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ CLI and engine versions are **decoupled** — see `CLAUDE.md` for details. Tags
 with a `-cli` suffix are CLI-only patches that reuse the previous engine
 binary.
 
+## [1.4.3] — 2026-04-24
+
+### Changed
+- README trimmed from 247 → 128 lines. Advanced sections (VAD, TTS, OpenClaw
+  integration, air-gapped model mirror) moved into dedicated pages under
+  `docs/` with one-line pointers from the README. (#203)
+
+CLI-only release; engine v1.4.1 unchanged.
+
 ## [1.4.2] — 2026-04-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Piper + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps \`package.json#version\` to 1.4.3 (CLI-only patch — engine v1.4.1 unchanged)
- CHANGELOG entry for #203 (README trim to essentials; deep-dives moved under \`docs/\`)

After merge:
1. \`npm publish --access public\` from main
2. \`gh release create v1.4.3-cli --title "v1.4.3 (CLI-only)" --notes "Engine: v1.4.1 (unchanged). README trim (#203)."\`

## Test plan
- [ ] CI green (docs/release-metadata-only; no code change)