### PR TITLE
chore(raycast): track CHANGELOG.md in repo

### DIFF
--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Kesha Voice Kit Changelog
+
+## [Initial Version] - {PR_MERGED_AT}
+
+- Add **Transcribe Selected Audio** command — transcribes the audio file selected in Finder using the local `kesha` CLI, shows transcript + detected language, pre-copies to clipboard.
+- Add **Speak Clipboard** command — synthesizes the current clipboard text via `kesha say` and plays it through the default output; voice auto-routed by detected language (Kokoro for English, Piper for Russian, AVSpeech for macOS system voices).
+- Preferences for overriding the `kesha` binary path and default voice.


### PR DESCRIPTION
## Summary

- Track \`raycast/CHANGELOG.md\` in this repo so it stays in sync with the version submitted in [raycast/extensions#27375](https://github.com/raycast/extensions/pull/27375).
- The file uses Raycast's standard \`{PR_MERGED_AT}\` placeholder and lists the M1 + M2 commands shipped in the initial extension version.

## Test plan

- [x] No code change; tracking-only. Existing CI runs unchanged.

Refs #145

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)