### PR TITLE
fix(tts): route ru → AVSpeech Milena on darwin until Piper-ru is fixed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,21 @@ Two interfaces: the CLI and a programmatic API exported from `@drakulavich/kesha
 - TypeScript executed directly by Bun — no build step
 - The engine is a Rust binary invoked as a subprocess — not linked in-process
 
+### PYTHON DEPENDENCIES GO IN A VENV — NEVER SYSTEM-WIDE
+
+When investigating, spiking, or comparing against an upstream Python reference (piper-tts, misaki, phonemizer, num2words, etc.), **always create a venv first**. Never run `pip install --break-system-packages`, never `pip3 install <pkg>` against the system interpreter, never use `pipx` for libraries (only for global CLIs the user explicitly wants). The `--break-system-packages` flag exists because modern Python distros refuse system-wide installs for safety; bypassing it pollutes every project on the machine and shadows versions other tools expect.
+
+Throwaway recipe:
+
+```bash
+python3 -m venv /tmp/<spike-name>-venv
+/tmp/<spike-name>-venv/bin/pip install --quiet <pkg>
+/tmp/<spike-name>-venv/bin/python3 -c "..."
+rm -rf /tmp/<spike-name>-venv      # when done
+```
+
+If the spike persists into project work, ask which env tool the user wants (uv, poetry, requirements.txt) rather than installing system-wide as a stopgap. Past offence: 2026-04-26 spike installed `piper-tts`, `misaki`, `num2words`, `spacy`, `phonemizer-fork`, `en-core-web-sm` directly into pyenv 3.13 system site-packages — user had to flag it for cleanup.
+
 ### RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY
 
 `package.json#version` (CLI) and `package.json#keshaEngine.version` (engine, mirrored in `rust/Cargo.toml`) are **decoupled**. `src/engine-install.ts` downloads from `v${keshaEngine.version}`, falling back to `package.json#version`.

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -3,12 +3,10 @@ import { detectTextLanguageEngine, getEngineBinPath } from "../engine";
 import { log } from "../log";
 import { say, SayError } from "../say";
 
-/**
- * Map a detected language code to a default voice id. Unknown / low-confidence → undefined.
- *
- * Russian on darwin routes to AVSpeech / Milena because Piper `ru-denis` is currently
- * unintelligible — see #207. Non-darwin keeps `ru-denis` (no AVSpeech available).
- */
+/** Workaround for #207 (Piper `ru-denis` unintelligible) — remove when Piper-ru is fixed. */
+const RU_DARWIN_FALLBACK_VOICE = "macos-com.apple.voice.compact.ru-RU.Milena";
+
+/** Map a detected language code to a default voice id. Unknown / low-confidence → undefined. */
 export function pickVoiceForLang(
   code: string | undefined,
   confidence: number,
@@ -19,9 +17,7 @@ export function pickVoiceForLang(
     case "en":
       return "en-af_heart";
     case "ru":
-      return platform === "darwin"
-        ? "macos-com.apple.voice.compact.ru-RU.Milena"
-        : "ru-denis";
+      return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-denis";
     default:
       return undefined;
   }

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -3,17 +3,25 @@ import { detectTextLanguageEngine, getEngineBinPath } from "../engine";
 import { log } from "../log";
 import { say, SayError } from "../say";
 
-/** Map a detected language code to a default voice id. Unknown / low-confidence → undefined. */
+/**
+ * Map a detected language code to a default voice id. Unknown / low-confidence → undefined.
+ *
+ * Russian on darwin routes to AVSpeech / Milena because Piper `ru-denis` is currently
+ * unintelligible — see #207. Non-darwin keeps `ru-denis` (no AVSpeech available).
+ */
 export function pickVoiceForLang(
   code: string | undefined,
   confidence: number,
+  platform: NodeJS.Platform = process.platform,
 ): string | undefined {
   if (!code || confidence < 0.5) return undefined;
   switch (code) {
     case "en":
       return "en-af_heart";
     case "ru":
-      return "ru-denis";
+      return platform === "darwin"
+        ? "macos-com.apple.voice.compact.ru-RU.Milena"
+        : "ru-denis";
     default:
       return undefined;
   }

--- a/tests/unit/say.test.ts
+++ b/tests/unit/say.test.ts
@@ -63,8 +63,15 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("en", 0.95)).toBe("en-af_heart");
   });
 
-  it("returns ru-denis for Russian with high confidence", () => {
-    expect(pickVoiceForLang("ru", 0.95)).toBe("ru-denis");
+  it("returns Milena for Russian on darwin (Piper ru-denis is unintelligible — #207)", () => {
+    expect(pickVoiceForLang("ru", 0.95, "darwin")).toBe(
+      "macos-com.apple.voice.compact.ru-RU.Milena",
+    );
+  });
+
+  it("falls back to ru-denis for Russian on non-darwin (no AVSpeech available)", () => {
+    expect(pickVoiceForLang("ru", 0.95, "linux")).toBe("ru-denis");
+    expect(pickVoiceForLang("ru", 0.95, "win32")).toBe("ru-denis");
   });
 
   it("returns undefined below 0.5 confidence (too ambiguous)", () => {


### PR DESCRIPTION
## Summary

- On darwin, `pickVoiceForLang('ru', ...)` now returns `macos-com.apple.voice.compact.ru-RU.Milena` instead of `ru-denis`. Linux/Windows still get `ru-denis` (no AVSpeech available there).
- Adds a `CLAUDE.md` rule forbidding system-wide `pip install` for spike work — surfaced during the underlying investigation. See \"PYTHON DEPENDENCIES GO IN A VENV\" near the BUN runtime section.

## Why

Piper `ru-denis` produces unintelligible audio today. Detailed bisection in #207 — four independent defects in our Kokoro/Piper stack (wrong model SHA, padding, off-by-one in style selection, CharsiuG2P G2P unfit). Fixing all four is a larger PR (and is gated on misaki integration tracked in #208). This PR is the immediate workaround so Russian users on macOS get usable audio out of the box. Linux/Windows users continue to hear the broken Piper output and that limitation is documented in the larger #207 PR.

Refs #207

## Test plan

- [x] `bun test tests/unit/say.test.ts` — 17/17 pass (covers darwin → Milena and linux/win32 → ru-denis branches).
- [x] `bunx tsc --noEmit` — clean.
- [ ] Manual: on darwin, `kesha say "Привет, как дела?" --out /tmp/x.wav && afplay /tmp/x.wav` → Milena voice (no `--voice` flag). On Linux/Windows: still routes to ru-denis (broken) — known, tracked in #207.