### PR TITLE
fix(tts): English G2P → misaki-rs + 4 Kokoro pipeline bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-v2-${{ runner.os }}
+          key: kokoro-spike-v3-${{ runner.os }}
 
       - name: 📥 Download Kokoro models (if cache miss)
         run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-v2-${{ runner.os }}
+          key: kokoro-spike-v3-${{ runner.os }}
 
       - name: Download Kokoro model (if cache miss)
         shell: bash

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -144,6 +144,8 @@ Both engines preserve enough signal for downstream agents to act on the content 
 
 Grapheme-to-phoneme conversion for Kokoro (English) and Piper (Russian) ran on `espeak-ng` through v1.3.0; v1.4.0 replaced it with [klebster/g2p_multilingual_byT5_tiny_onnx](https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx) (CharsiuG2P ByT5-tiny ONNX, FP32). See issue [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123).
 
+> **Updated post-#207:** English moved off CharsiuG2P to embedded `misaki-rs` (the G2P Kokoro was actually trained against). The latency/quality numbers below still describe CharsiuG2P, which now serves only the non-English path (Russian via Piper today; tracked for further per-language replacement in [#210](https://github.com/drakulavich/kesha-voice-kit/issues/210) and [#212](https://github.com/drakulavich/kesha-voice-kit/issues/212)).
+
 | | espeak-ng (≤ v1.3.0) | CharsiuG2P ByT5-tiny (v1.4.0+) |
 |---|---|---|
 | Binary (release, stripped) | 23 MB + **system dep** | **23 MB**, no system dep |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ const text = await transcribe("audio.ogg");
 - **CoreML engine**: macOS 14+, Apple Silicon (arm64)
 - **ONNX engine**: macOS, Linux, Windows
 - `ffmpeg` is **not required** — the Rust engine uses symphonia + rubato
-- **TTS**: no system deps. G2P runs as ONNX (CharsiuG2P ByT5-tiny, #123) alongside Kokoro/Piper.
+- **TTS**: no system deps. G2P for English uses [`misaki-rs`](https://github.com/MicheleYin/misaki-rs) (embedded lexicon + POS, #207); other languages use ONNX CharsiuG2P ByT5-tiny (#123).
 
 ## TTS
 
@@ -370,10 +370,10 @@ Opt-in via `kesha install --tts` (downloads Kokoro + Piper + ONNX G2P, ~490 MB).
 
 - TTS models are **never auto-downloaded** — `kesha say` fails loudly with a `kesha install --tts` hint when models are missing.
 - `kesha say` writes WAV mono f32 to stdout unless `--out` is given. Stderr is progress/errors only.
-- G2P uses CharsiuG2P ByT5-tiny ONNX (`rust/src/tts/g2p.rs`, FP32, ~100 MB), shared across Kokoro and Piper pipelines. See [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123) and `docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md`.
+- G2P split (post-#207): English (`en`/`en-us`/`en-gb`) routes to embedded `misaki-rs` (Kokoro-trained inventory, no system deps, OOV words letter-spell). Other languages still use CharsiuG2P ByT5-tiny ONNX (`rust/src/tts/g2p.rs`, FP32, ~100 MB) until per-language replacements land (#210 for Russian, #212 for fr/it/es/pt). See [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123) for original CharsiuG2P spike.
 - **Auto-routing:** when `--voice` is omitted, the TS CLI calls `NLLanguageRecognizer` on the input text and picks `en-af_heart` or `ru-denis`. Confidence < 0.5 or unmapped language falls through to the engine default. `pickVoiceForLang` in `src/cli.ts` is the routing table — add a language by adding a match arm.
 - **SSML** (opt-in via `--ssml`): uses the `ssml-parser` crate; supports `<speak>` root and `<break time="...">` for silence. Unknown tags (`<emphasis>`, `<prosody>`, `<phoneme>`, `<say-as>`) warn to stderr once per name and are stripped, but contained text is still synthesized. Hardening: required `<speak>` root, `<!DOCTYPE>` rejected anywhere in input. `tts::ssml::parse` returns `Vec<Segment>`; `tts::say()` loads the engine once and concatenates f32 samples for text vs silence for breaks before a single `wav::encode_wav`. See issue #122 for the full scope matrix and future tag support.
-- Kokoro ONNX: `input_ids` (int64 `[1,N]`), `style` (f32 `[1,256]` — rank-2), `speed` (f32 `[1]`). Output name `"waveform"`. Voice file 510 rows × 256 cols.
+- Kokoro ONNX (post-#207, official `kokoro-onnx` v1.0 release): `tokens` (int64 `[1,N]`), `style` (f32 `[1,256]` — rank-2), `speed` (f32 `[1]`). Output name `"audio"`. Voice file 510 rows × 256 cols. The earlier HF onnx-community variant used `input_ids`/`waveform` and produced broken audio with `af_heart`.
 - Piper ONNX: `input` (int64 `[1,N]` — BOS + pad-interleaved phoneme IDs + EOS), `input_lengths` (int64 `[1]`), `scales` (f32 `[3]` = `[noise_scale, length_scale, noise_w]`). Output name `"output"`, rank-4 `[1,1,1,T]`. `--rate` is mapped to Piper via `length_scale = voice_default / speed`.
 - **AVSpeech** (#141, `system_tts` feature, default-on for darwin-arm64 release builds): `kesha-engine` spawns the `say-avspeech` Swift helper. Runtime path resolution tries sibling-of-exe first (release layout: `~/.cache/kesha/bin/say-avspeech` next to `kesha-engine`) and falls back to the build-time `$OUT_DIR/say-avspeech` baked in by `build.rs` for `cargo run` / `cargo test`. UTF-8 text on stdin, voice id as argv[1]; `--list-voices` prints `identifier|language|name` rows that the Rust side prefixes with `macos-` and merges into `say --list-voices`. Output: complete mono f32 IEEE_FLOAT WAV @ 22050 Hz. Gotcha: AVSpeechSynthesizer callbacks dispatch on the main queue, so the helper MUST pump `CFRunLoopRun()` — `DispatchSemaphore` hangs. `--rate` not wired yet (AVSpeechUtterance has its own `.rate`, mapping TBD). SSML + AVSpeech explicitly rejected in v1.
 - `KESHA_ENGINE_BIN` — override the engine-binary path (useful when iterating on `rust/target/release/kesha-engine`).

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -12,7 +12,9 @@ kesha say --voice en-af_heart "text"    # explicit voice overrides auto-routing
 kesha say --list-voices
 ```
 
-Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Opus and MP3 are tracked in follow-up issues. Grapheme-to-phoneme runs entirely through ONNX (CharsiuG2P ByT5-tiny, [#123](https://github.com/drakulavich/kesha-voice-kit/issues/123)) — no `espeak-ng` system dep.
+Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Piper). OGG/Opus and MP3 are tracked in follow-up issues.
+
+Grapheme-to-phoneme: English uses [misaki-rs](https://github.com/MicheleYin/misaki-rs) — a self-contained Rust port of [hexgrad/misaki](https://github.com/hexgrad/misaki) (the G2P Kokoro was trained against). Lexicon and POS-tagger weights are embedded at compile time, no system deps. Out-of-vocabulary words (proper nouns, technical jargon) currently spell letter-by-letter — `espeak-ng` fallback for OOV is tracked as a follow-up. Other languages (Russian via Piper) currently use the older CharsiuG2P ByT5-tiny ONNX path ([#123](https://github.com/drakulavich/kesha-voice-kit/issues/123)) — replacement tracked per-language ([#210](https://github.com/drakulavich/kesha-voice-kit/issues/210) for `ru`).
 
 **Supported voices:**
 - English: `en-af_heart` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/`

--- a/raycast/README.md
+++ b/raycast/README.md
@@ -22,7 +22,7 @@ kesha install          # downloads engine + ASR + lang-id models (~350 MB)
 kesha install --tts    # Kokoro + Piper + ONNX G2P (~490 MB, required by Speak Clipboard)
 ```
 
-No system dependencies. Grapheme-to-phoneme runs entirely through bundled ONNX (CharsiuG2P ByT5-tiny) — there's no longer any `espeak-ng` / `brew` / `apt` step.
+No system dependencies. Grapheme-to-phoneme: English uses `misaki-rs` (embedded lexicon, OOV words spell letter-by-letter); other languages use bundled ONNX (CharsiuG2P ByT5-tiny). No `espeak-ng` / `brew` / `apt` step.
 
 `macos-*` system voices need no install — they use voices already on your Mac.
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -135,6 +135,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +473,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +697,7 @@ dependencies = [
  "dirs",
  "fluidaudio-rs",
  "hound",
+ "misaki-rs",
  "ndarray",
  "ort",
  "rayon",
@@ -684,6 +711,22 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "ureq",
+]
+
+[[package]]
+name = "language-tokenizer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9d23ae923f144698673d87d508ee7cd8627ddae99c23549a43525c4f7a4a23"
+dependencies = [
+ "num_enum",
+ "strsim 0.11.1",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "waken_snowball",
 ]
 
 [[package]]
@@ -764,6 +807,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "misaki-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e93650257ef50ccc74057b6248912e844b8874d9c7dfdd145d91f65deef095e"
+dependencies = [
+ "fancy-regex",
+ "language-tokenizer",
+ "log",
+ "num2words",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +879,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num2words"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f9771c0512b6a954a62b5106cc000bb5d77b1f60a792b5f70f531b84baefff"
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -976,6 +1063,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
 dependencies = [
  "num-integer",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1179,6 +1275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1434,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -1584,6 +1707,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1791,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -1703,6 +1886,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "waken_snowball"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a3e068c98d5736c4b5d2dfc0ab9f3b1dcb8f9dbc5a22bde166550c5d3788c0"
 
 [[package]]
 name = "wasi"
@@ -1898,6 +2087,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,6 +59,7 @@ sha2 = "0.10"
 ssml-parser = { version = "0.1", optional = true }
 
 tempfile = { version = "3", optional = true }
+misaki-rs = { version = "0.3.0", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,7 +59,9 @@ sha2 = "0.10"
 ssml-parser = { version = "0.1", optional = true }
 
 tempfile = { version = "3", optional = true }
-misaki-rs = { version = "0.3.0", default-features = false }
+# Pinned exactly so transitive minor bumps can't silently mutate the IPA
+# our `g2p_parity` test freezes — see #207.
+misaki-rs = { version = "=0.3.0", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/ci/download-kokoro.sh
+++ b/rust/ci/download-kokoro.sh
@@ -13,9 +13,11 @@ DEST="${1:?usage: download-kokoro.sh <dest_dir>}"
 mkdir -p "$DEST"
 
 if [[ ! -f "$DEST/model.onnx" ]]; then
-  echo "Downloading Kokoro model.onnx..."
+  echo "Downloading Kokoro model.onnx (kokoro-onnx official release)..."
+  # Mirrors rust/src/models.rs::kokoro_manifest URL — see #207 for why we
+  # switched off the HF onnx-community variant.
   curl -fL -o "$DEST/model.onnx" \
-    https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/onnx/model.onnx
+    https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx
 fi
 
 if [[ ! -f "$DEST/af_heart.bin" ]]; then

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -85,9 +85,14 @@ const LANG_ID_FILES: &[ModelFile] = &[
 pub fn kokoro_manifest() -> Vec<ModelFile> {
     vec![
         ModelFile {
+            // The HF onnx-community variant produces unintelligible audio with
+            // `af_heart` — confirmed by audio bisection, see #207. Use the
+            // official kokoro-onnx project release, which uses different IO
+            // tensor names (`tokens`/`audio` vs `input_ids`/`waveform`) but
+            // same dtypes/shapes — handled in `kokoro::Kokoro::infer`.
             rel_path: "models/kokoro-82m/model.onnx",
-            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/onnx/model.onnx",
-            sha256: "8fbea51ea711f2af382e88c833d9e288c6dc82ce5e98421ea61c058ce21a34cb",
+            url: "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx",
+            sha256: "7d5df8ecf7d4b1878015a32686053fd0eebe2bc377234608764cc0ef3636a6c5",
         },
         ModelFile {
             rel_path: "models/kokoro-82m/voices/af_heart.bin",

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -229,7 +229,7 @@ pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
         return Ok(String::new());
     }
     if let Some(misaki_lang) = misaki_lang_for(lang) {
-        return Ok(misaki_to_ipa(text, misaki_lang));
+        return misaki_to_ipa(text, misaki_lang);
     }
     text_to_ipa_charsiu(text, lang)
 }
@@ -243,18 +243,21 @@ fn misaki_lang_for(lang: &str) -> Option<misaki_rs::Language> {
 }
 
 /// Run misaki-rs and strip the U+200D zero-width joiners it inserts for
-/// diphthong cohesion — Kokoro/Piper vocabs don't include them.
-fn misaki_to_ipa(text: &str, lang: misaki_rs::Language) -> String {
+/// diphthong cohesion — Kokoro/Piper vocabs don't include them. Errors from
+/// the embedded G2P (e.g. corrupted lexicon, internal panic surfaced via
+/// poisoned mutex) propagate so callers don't synthesize silent audio
+/// indistinguishable from an empty utterance.
+fn misaki_to_ipa(text: &str, lang: misaki_rs::Language) -> Result<String> {
     let g2p = misaki_rs::G2P::new(lang);
-    match g2p.g2p(text) {
-        Ok((ipa, _)) => ipa
-            .chars()
-            .filter(|c| *c != '\u{200d}')
-            .collect::<String>()
-            .trim()
-            .to_string(),
-        Err(_) => String::new(),
-    }
+    let (ipa, _) = g2p
+        .g2p(text)
+        .map_err(|e| anyhow::anyhow!("misaki-rs g2p failed: {e:?}"))?;
+    Ok(ipa
+        .chars()
+        .filter(|c| *c != '\u{200d}')
+        .collect::<String>()
+        .trim()
+        .to_string())
 }
 
 /// CharsiuG2P fallback for languages misaki-rs doesn't support. Per-word
@@ -353,5 +356,24 @@ mod tests {
         assert!(misaki_lang_for("en-gb").is_some());
         assert!(misaki_lang_for("en-uk").is_some());
         assert!(misaki_lang_for("ru").is_none());
+    }
+
+    /// Locks the letter-spell fallback behavior we ship in v1.4.x — without
+    /// the misaki-rs `espeak` feature, OOV proper nouns expand to per-letter
+    /// English names. Documented in `docs/tts.md` so users hitting this
+    /// "kesha spells my name" symptom can find the cause. Tracked as the
+    /// follow-up under #207 to re-enable the espeak fallback.
+    #[test]
+    fn english_oov_letter_spells_without_espeak_fallback() {
+        let ipa = text_to_ipa("Kubernetes", "en-us").unwrap();
+        // A single phonemized word is short; letter-spelling expands to one
+        // emphasized chunk per letter (K-U-B-E-R-N-E-T-E-S = 10 chunks).
+        let chunks = ipa.split_whitespace().count();
+        assert!(
+            chunks >= 5,
+            "expected letter-spell (≥5 stress-marked chunks) for OOV, got {chunks}: {ipa:?}"
+        );
+        // ZWJ stripping is a pipeline-owned property, not a misaki one.
+        assert!(!ipa.contains('\u{200d}'), "ZWJ leaked: {ipa:?}");
     }
 }

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -221,12 +221,46 @@ fn g2p_word(sess: &mut G2pSessions, charsiu_code: &str, word: &str) -> Result<St
 }
 
 /// Convert text to IPA phonemes for the given espeak-style language code.
-/// Words are split on whitespace; punctuation is stripped per-word. Empty
-/// input returns an empty string.
+/// English (`en`, `en-us`, `en-gb`) uses misaki-rs (POS-aware, Kokoro-trained
+/// inventory + espeak fallback for OOV). Other languages fall through to the
+/// CharsiuG2P ONNX path. Empty input returns an empty string.
 pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
     if text.trim().is_empty() {
         return Ok(String::new());
     }
+    if let Some(misaki_lang) = misaki_lang_for(lang) {
+        return Ok(misaki_to_ipa(text, misaki_lang));
+    }
+    text_to_ipa_charsiu(text, lang)
+}
+
+fn misaki_lang_for(lang: &str) -> Option<misaki_rs::Language> {
+    match lang.to_ascii_lowercase().as_str() {
+        "en" | "en-us" => Some(misaki_rs::Language::EnglishUS),
+        "en-gb" | "en-uk" => Some(misaki_rs::Language::EnglishGB),
+        _ => None,
+    }
+}
+
+/// Run misaki-rs and strip the U+200D zero-width joiners it inserts for
+/// diphthong cohesion — Kokoro/Piper vocabs don't include them.
+fn misaki_to_ipa(text: &str, lang: misaki_rs::Language) -> String {
+    let g2p = misaki_rs::G2P::new(lang);
+    match g2p.g2p(text) {
+        Ok((ipa, _)) => ipa
+            .chars()
+            .filter(|c| *c != '\u{200d}')
+            .collect::<String>()
+            .trim()
+            .to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+/// CharsiuG2P fallback for languages misaki-rs doesn't support. Per-word
+/// tokenization strips punctuation — see #210 for the Russian-Piper followup
+/// that needs punctuation passthrough via espeak-ng.
+fn text_to_ipa_charsiu(text: &str, lang: &str) -> Result<String> {
     let charsiu = charsiu_lang(lang)?;
     let mut sess = G2pSessions::load()?;
     let mut out: Vec<String> = Vec::new();
@@ -299,36 +333,25 @@ mod tests {
         assert!(err.to_string().to_lowercase().contains("xx-xx"));
     }
 
-    /// Gated on the presence of the G2P model cache. Run `kesha install --tts`
-    /// first. Verifies byte-identical IPA against the spike's reference fixtures
-    /// (see docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md section 5).
+    /// English path uses misaki-rs (self-contained, no cache needed). Verifies
+    /// the IPA contains the expected stressed vowels for `hello world`.
     #[test]
-    fn hello_world_matches_reference_when_model_available() {
-        let dir = models::cache_dir()
-            .join("models")
-            .join("g2p")
-            .join("byt5-tiny");
-        if !dir.exists() {
-            eprintln!("g2p model not cached at {} — skipping", dir.display());
-            return;
-        }
-        let ipa = text_to_ipa("hello", "en-us").unwrap();
-        assert_eq!(ipa, "ˈhɛɫoʊ", "expected spike-reference IPA for 'hello'");
-        let ipa = text_to_ipa("world", "en-us").unwrap();
-        assert_eq!(ipa, "ˈwɝɫd");
+    fn english_misaki_produces_expected_phonemes() {
+        let ipa = text_to_ipa("hello world", "en-us").unwrap();
+        assert!(ipa.contains('h'), "missing /h/ in: {ipa}");
+        assert!(ipa.contains('w'), "missing /w/ in: {ipa}");
+        assert!(ipa.contains('ˈ'), "missing primary stress in: {ipa}");
+        // No zero-width joiner — we strip it before returning.
+        assert!(!ipa.contains('\u{200d}'), "ZWJ leaked into IPA: {ipa:?}");
     }
 
     #[test]
-    fn multiword_input_produces_space_joined_ipa() {
-        let dir = models::cache_dir()
-            .join("models")
-            .join("g2p")
-            .join("byt5-tiny");
-        if !dir.exists() {
-            return;
-        }
-        let ipa = text_to_ipa("hello world", "en-us").unwrap();
-        assert!(ipa.contains(' '), "expected space between words: {ipa}");
-        assert!(ipa.starts_with("ˈh"), "starts with hello: {ipa}");
+    fn english_dispatches_to_misaki_for_en_aliases() {
+        assert!(misaki_lang_for("en").is_some());
+        assert!(misaki_lang_for("en-us").is_some());
+        assert!(misaki_lang_for("EN-US").is_some());
+        assert!(misaki_lang_for("en-gb").is_some());
+        assert!(misaki_lang_for("en-uk").is_some());
+        assert!(misaki_lang_for("ru").is_none());
     }
 }

--- a/rust/src/tts/kokoro.rs
+++ b/rust/src/tts/kokoro.rs
@@ -1,7 +1,11 @@
 //! Kokoro-82M ONNX inference session.
 //!
-//! Inputs:  `input_ids` (int64 [1,N]), `style` (f32 [1,256]), `speed` (f32 [1])
-//! Output:  `waveform` (f32 [1,T]) at 24 kHz
+//! Inputs:  `tokens` (int64 [1,N]), `style` (f32 [1,256]), `speed` (f32 [1])
+//! Output:  `audio` (f32 [T]) at 24 kHz
+//!
+//! Tensor names follow the kokoro-onnx official release. The earlier HF
+//! onnx-community variant used `(input_ids, waveform)` and produced
+//! unintelligible audio with `af_heart` — see #207.
 
 use std::path::Path;
 
@@ -43,12 +47,12 @@ impl Kokoro {
         let sp = Value::from_array(Array1::<f32>::from_vec(vec![speed]))?;
 
         let outputs = self.session.run(ort::inputs![
-            "input_ids" => ids,
-            "style"     => st,
-            "speed"     => sp,
+            "tokens" => ids,
+            "style"  => st,
+            "speed"  => sp,
         ])?;
 
-        let (_shape, data) = outputs["waveform"].try_extract_tensor::<f32>()?;
+        let (_shape, data) = outputs["audio"].try_extract_tensor::<f32>()?;
         Ok(data.to_vec())
     }
 }

--- a/rust/src/tts/tokenizer.rs
+++ b/rust/src/tts/tokenizer.rs
@@ -5,9 +5,8 @@ use std::collections::HashMap;
 
 const VOCAB_JSON: &str = include_str!("../../fixtures/tts/kokoro_vocab.json");
 
-/// Kokoro's max context length. Input tensor is padded to this size.
-pub const KOKORO_MAX_TOKENS: usize = 512;
-/// Max *active* tokens — we reserve room for a leading+trailing 0 pad.
+/// Max *active* tokens — Kokoro's published context length is 512; we wrap
+/// with a leading+trailing 0, leaving 510 for actual phoneme IDs.
 pub const KOKORO_MAX_ACTIVE: usize = 510;
 
 pub struct Tokenizer {
@@ -31,19 +30,18 @@ impl Tokenizer {
             .collect()
     }
 
-    /// Pad to Kokoro's 512-token context with leading+trailing 0 tokens.
-    /// Truncates anything beyond [`KOKORO_MAX_ACTIVE`] silently.
+    /// Wrap with a single leading+trailing 0 — matches `kokoro-onnx` upstream
+    /// (`tokens = [[0, *tokens, 0]]`). Truncates beyond [`KOKORO_MAX_ACTIVE`]
+    /// silently. Earlier versions padded to 512 with trailing zeros, which the
+    /// model interpreted as additional silence/noise tokens — see #207.
     pub fn pad_to_context(mut ids: Vec<i64>) -> Vec<i64> {
         if ids.len() > KOKORO_MAX_ACTIVE {
             ids.truncate(KOKORO_MAX_ACTIVE);
         }
-        let mut out = Vec::with_capacity(KOKORO_MAX_TOKENS);
+        let mut out = Vec::with_capacity(ids.len() + 2);
         out.push(0);
         out.extend(ids);
         out.push(0);
-        while out.len() < KOKORO_MAX_TOKENS {
-            out.push(0);
-        }
         out
     }
 }
@@ -81,20 +79,17 @@ mod tests {
     }
 
     #[test]
-    fn pads_short_to_context() {
+    fn wraps_with_leading_and_trailing_zero() {
         let padded = Tokenizer::pad_to_context(vec![1, 2, 3]);
-        assert_eq!(padded.len(), KOKORO_MAX_TOKENS);
-        assert_eq!(&padded[..5], &[0, 1, 2, 3, 0]);
+        assert_eq!(padded, vec![0, 1, 2, 3, 0]);
     }
 
     #[test]
-    fn truncates_long_to_context() {
+    fn truncates_beyond_max_active() {
         let ids: Vec<i64> = (1..=600).collect();
         let padded = Tokenizer::pad_to_context(ids);
-        assert_eq!(padded.len(), KOKORO_MAX_TOKENS);
-        // Still has leading 0
+        assert_eq!(padded.len(), KOKORO_MAX_ACTIVE + 2);
         assert_eq!(padded[0], 0);
-        // Trailing pad 0 is at index 511 (last char of vocab is truncated to fit)
-        assert_eq!(padded[KOKORO_MAX_TOKENS - 1], 0);
+        assert_eq!(padded[padded.len() - 1], 0);
     }
 }

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -30,9 +30,11 @@ pub fn load_voice(path: &Path) -> anyhow::Result<Vec<f32>> {
 }
 
 /// Select the style embedding row for a given active-token count.
-/// Indexes by `min(token_count - 1, VOICE_ROWS - 1)` (clamp both ends to valid range).
+/// Indexes `voice[token_count]` (clamped to `VOICE_ROWS - 1`) to match
+/// `kokoro-onnx` upstream — earlier code used `token_count - 1` (off-by-one),
+/// see #207.
 pub fn select_style(voice: &[f32], token_count: usize) -> &[f32] {
-    let row = token_count.saturating_sub(1).min(VOICE_ROWS - 1);
+    let row = token_count.min(VOICE_ROWS - 1);
     &voice[row * VOICE_COLS..(row + 1) * VOICE_COLS]
 }
 
@@ -188,10 +190,10 @@ mod tests {
                 voice.push(row as f32);
             }
         }
-        // token_count = 8 should pick row 7
+        // token_count = 8 picks row 8 (kokoro-onnx uses voice[len(tokens)]).
         let s = select_style(&voice, 8);
-        assert_eq!(s[0], 7.0);
-        assert_eq!(s[VOICE_COLS - 1], 7.0);
+        assert_eq!(s[0], 8.0);
+        assert_eq!(s[VOICE_COLS - 1], 8.0);
     }
 
     fn populate_cache(cache: &Path) {

--- a/rust/tests/g2p_parity.rs
+++ b/rust/tests/g2p_parity.rs
@@ -22,22 +22,24 @@ use kesha_engine::models;
 use kesha_engine::tts::g2p::text_to_ipa;
 
 /// Frozen reference. `(espeak-style lang code, input word, expected IPA)`.
+/// English entries pass through misaki-rs (#207 / #208); non-English still use
+/// CharsiuG2P ONNX, which is being tracked for replacement language-by-language.
 const REFERENCE: &[(&str, &str, &str)] = &[
-    // English (American) — in-dict and common engineering vocabulary
-    ("en-us", "hello", "ˈhɛɫoʊ"),
-    ("en-us", "world", "ˈwɝɫd"),
-    ("en-us", "cat", "ˈkætu"),
-    ("en-us", "dog", "ˈdɑɡz"),
-    ("en-us", "phone", "ˈfoʊniˈoʊ"),
-    ("en-us", "music", "ˈmuzɪk"),
-    ("en-us", "code", "ˈkoʊdeɪ"),
-    ("en-us", "review", "ɹɪvˈju"),
-    ("en-us", "deploy", "dɪˈpɫɔɪ"),
-    ("en-us", "test", "ˈtɛstoʊ"),
-    // English (British) — RP-ish
+    // English (American) — misaki-rs lexicon + espeak fallback for OOV.
+    ("en-us", "hello", "həlˈoʊ"),
+    ("en-us", "world", "wˈɜːld"),
+    ("en-us", "cat", "kˈæt"),
+    ("en-us", "dog", "dˈɑːɡ"),
+    ("en-us", "phone", "fˈoʊn"),
+    ("en-us", "music", "mjˈuːzɪk"),
+    ("en-us", "code", "kˈoʊd"),
+    ("en-us", "review", "ɹᵻvjˈuː"),
+    ("en-us", "deploy", "dᵻplˈɔɪ"),
+    ("en-us", "test", "tˈɛst"),
+    // English (British) — misaki-rs en-gb dialect.
     ("en-gb", "colour", "kˈʌlə"),
-    ("en-gb", "theatre", "tˈiːtɹeɪ"),
-    ("en-gb", "metre", "mˈɛtɹeɪ"),
+    ("en-gb", "theatre", "θˈiətə"),
+    ("en-gb", "metre", "mˈiːtə"),
     ("en-gb", "harbour", "hˈɑːbə"),
     // French
     ("fr", "bonjour", "bɔ̃ʒuʁ"),


### PR DESCRIPTION
## Summary

Fixes Kokoro English producing unintelligible audio. Audio bisection on 2026-04-26 isolated **four independent defects** in our stack — each had to be fixed for the result to be intelligible. This PR ships all four together.

## What changed

1. **Model file** — switched URL to `thewh1teagle/kokoro-onnx` v1.0 official release; updated SHA-256 pin. The HF onnx-community variant we were downloading produces broken audio with `af_heart`. New variant uses different IO tensor names (`tokens`/`audio` vs `input_ids`/`waveform`) — handled in `kokoro.rs`.
2. **Padding** — `tokenizer::pad_to_context` no longer pads to 512. Wraps with single zero each side, matching `kokoro-onnx` upstream. The 510 trailing zeros were interpreted as silence/noise tokens by the model.
3. **Style embedding off-by-one** — `voices::select_style` now indexes `voice[len(tokens)]`, not `voice[len-1]`.
4. **G2P** — English (`en`, `en-us`, `en-gb`) now routes to [`misaki-rs`](https://github.com/MicheleYin/misaki-rs), a self-contained Rust port of `hexgrad/misaki` (the G2P Kokoro was trained against). CharsiuG2P (#123) hallucinated phantom diphthongs on common words; misaki-rs is correct by construction. Other languages keep CharsiuG2P for now (Russian replacement tracked in #210).

## Trade-offs

- `misaki-rs` ships **without** espeak fallback to preserve the zero-system-deps brand promise. OOV words (proper nouns, technical jargon) spell letter-by-letter. Common English works fine. Re-enabling espeak fallback for OOV is a follow-up that requires `brew install espeak-ng` / `apt install espeak-ng` across CI matrices and bundling considerations (essentially the #124 conversation again).
- Existing `kesha install --tts` caches will silently re-download the model on next run because the SHA pin changed. Users with the broken cached model just need to run `kesha install --tts --force` (or wait for next install).

## Refs

- Closes #208 (misaki-rs adoption fulfills the misaki-port track)
- Refs #207 (English path of the four-bug bisection)
- Refs #210 (Russian Piper still needs espeak-ng + punctuation passthrough; out of scope here)

## Test plan

- [x] `cargo test --release --features onnx,tts --no-default-features` — 179 tests pass
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` — clean
- [x] `bun test && bunx tsc --noEmit` — 138 pass, 4 skip, 0 fail
- [x] Manual: `kesha say --voice en-af_heart "Hello world. This is a test of the Kokoro voice."` produces clearly intelligible audio (verified via Telegram, msg 365)
- [x] Manual: OOV word ("Kokoro") audibly spells K-O-K-O-R-O letter-by-letter, confirming espeak feature is OFF (msg 366)
- [ ] CI green