### PR TITLE
chore(release): v1.4.4 (CLI-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ CLI and engine versions are **decoupled** — see `CLAUDE.md` for details. Tags
 with a `-cli` suffix are CLI-only patches that reuse the previous engine
 binary.
 
+## [1.4.4] — 2026-04-29
+
+### Changed
+- Default voice for English auto-routing flipped from `en-af_heart` (female) to
+  `en-am_michael` (male) to match Kesha's brand voice. Pass `--voice` to
+  override. (#211)
+- `kesha status` reports the `vosk-ru` cache directory and lists Vosk-TTS
+  speaker ids (`ru-vosk-{f01,f02,f03,m01,m02}`) instead of the Piper layout.
+  Aligns the CLI with the engine work queued for the next engine release.
+  (#214)
+- Russian auto-routing on darwin now picks AVSpeech `Milena` (zero install);
+  Linux/Windows fall through to `ru-vosk-m02`. (#209, #214)
+
+### Internal
+- `protoc` install pulled into a reusable composite action and shared across
+  `ci.yml`, `rust-test.yml`, and `build-engine.yml`.
+- `actions/setup-node` bumped 4 → 6. (#215)
+- Raycast extension `CHANGELOG.md` tracked in repo. (#206)
+
+CLI-only release; engine v1.4.1 unchanged. Engine source in `main` carries the
+Vosk-TTS / misaki-rs / AVSpeech-routing changes (#209, #211, #214) which will
+ship with the next engine bump — Linux/Windows users hitting `ru-vosk-m02`
+auto-routing today will get an "unknown voice" error until that release.
+
 ## [1.4.3] — 2026-04-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Reconciles \`main\` with the already-published state: npm \`@drakulavich/kesha-voice-kit@1.4.4\` (2026-04-29) and GitHub release [v1.4.4-cli](https://github.com/drakulavich/kesha-voice-kit/releases/tag/v1.4.4-cli).
- Bumps \`package.json#version\` 1.4.3 → 1.4.4. Engine \`keshaEngine.version\` stays at 1.4.1 — CLI-only patch.
- Adds the missing \`CHANGELOG.md\` entry covering the user-visible CLI changes since v1.4.3:
  - English auto-routing default flipped to \`en-am_michael\` (male) per the brand-voice rule.
  - \`kesha status\` now reports the Vosk-TTS layout (\`vosk-ru\`) and lists \`ru-vosk-{f01..m02}\`.
  - Russian auto-routing on darwin → AVSpeech \`Milena\`; Linux/Windows → \`ru-vosk-m02\`.
  - Internal: shared \`protoc\` composite action, \`actions/setup-node\` 4 → 6, raycast CHANGELOG tracked.

## Caveat
Engine source in \`main\` includes #209 / #211 / #214 (Vosk-TTS replacement, misaki-rs G2P, ru→AVSpeech routing) but the engine binary shipped with npm 1.4.4 is still v1.4.1. The \`ru-vosk-m02\` Linux/Windows auto-route therefore returns "unknown voice" until the next engine release lands. Called out explicitly in the CHANGELOG entry.

## Test plan
- [x] \`bun test\` passes locally
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI green
- [ ] After merge: rewrite \`v1.4.4-cli\` release body via API PATCH (the published one-liner doesn't reflect the actual scope; \`gh release edit --notes\` no-ops on published releases per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)