### PR TITLE
docs(agents): user-facing install uses bun, never npm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ make release         # lint + test + smoke-test
 
 - **NEVER** auto-download engine or models — `kesha install` only
 - **NEVER** use Node.js APIs — Bun-only (`Bun.spawn`, `Bun.write`, `Bun.file`)
+- **NEVER** tell users to `npm install/update/uninstall` the package — user-facing install/upgrade/remove guidance (release notes, READMEs, error hints, support replies) is bun: `bun add -g @drakulavich/kesha-voice-kit[@latest|@x.y.z]`, `bun remove -g …`. The maintainer publish path (`npm publish --access public`) is the only npm command that stays.
 - **NEVER** push directly to `main` — PRs only
 - **NEVER** forward CLI flags blindly to `kesha-engine` — validate against `--capabilities-json`
 - **BEFORE npm publish**: `make smoke-test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ When adding a new default, list available `m_*` voices first (`kesha say --list-
 - Bun-native APIs only (`Bun.spawn`, `Bun.write`, `Bun.file`, `Bun.which`)
 - TypeScript executed directly by Bun — no build step
 - The engine is a Rust binary invoked as a subprocess — not linked in-process
+- **User-facing install/upgrade/remove instructions use bun, never npm.** Release notes, READMEs, error-message hints, support replies — always `bun add -g @drakulavich/kesha-voice-kit[@latest|@x.y.z]`, `bun add -g @drakulavich/kesha-voice-kit@latest` for upgrade, `bun remove -g @drakulavich/kesha-voice-kit` for uninstall. Don't even mention `npm i -g` as an alternative. The maintainer publish path (`npm publish --access public`) is exempt — that's a publish step, not user guidance.
 
 ### PYTHON DEPENDENCIES GO IN A VENV — NEVER SYSTEM-WIDE
 

--- a/raycast/README.md
+++ b/raycast/README.md
@@ -17,7 +17,7 @@ Synthesize speech from the current clipboard text and play it through the defaul
 Install the `kesha` CLI and fetch the engine + models:
 
 ```bash
-npm install -g @drakulavich/kesha-voice-kit   # or bun add --global
+bun add -g @drakulavich/kesha-voice-kit
 kesha install          # downloads engine + ASR + lang-id models (~350 MB)
 kesha install --tts    # Kokoro + Vosk-TTS (~990 MB, required by Speak Clipboard)
 ```


### PR DESCRIPTION
## Summary
- Adds an explicit rule to **CLAUDE.md** and **AGENTS.md** that user-facing install/upgrade/remove guidance uses bun (\`bun add -g …\`, \`bun remove -g …\`) — never \`npm install -g\` etc. Future agent sessions should not draft release notes or READMEs with npm install commands.
- The maintainer publish path (\`npm publish --access public\`) is called out as the only npm command that stays — that's a publish step, not user guidance.
- Fixes the one stale \`npm install -g\` line in \`raycast/README.md\` while we're here.

Context: v1.4.4-cli release notes were originally drafted with \`npm update -g …\`; user pushed back and asked to lock the rule into the agent configs.

## Test plan
- [x] \`grep -nE 'npm install|npm i -g|npm update -g|npm remove' README.md docs/*.md raycast/README.md\` returns nothing
- [x] CLAUDE.md / AGENTS.md describe the rule and the publish-path exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)