### PR TITLE
chore(release): v1.5.0 — Vosk-TTS RU + misaki-rs G2P EN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ CLI and engine versions are **decoupled** — see `CLAUDE.md` for details. Tags
 with a `-cli` suffix are CLI-only patches that reuse the previous engine
 binary.
 
+## [1.5.0] — 2026-04-29
+
+First engine release since v1.4.1. Catches the binary up to the engine source
+that's been sitting in `main` since #209/#211/#214. CLI 1.4.4 features
+(Vosk-aware status, male English default, RU darwin auto-route) become
+functional once this engine binary is installed.
+
+### Added
+- **Vosk-TTS for Russian** (multi-speaker, 5 baked-in voices: `ru-vosk-{f01,f02,f03,m01,m02}`). Uses `vosk-tts-rs` directly — BERT prosody + dictionary G2P, no espeak-ng / no separate G2P model. Default Russian voice on non-darwin platforms is now `ru-vosk-m02` (male, per the brand-voice rule); darwin keeps `Milena` for the zero-install AVSpeech path. (#214, closes #210)
+- **misaki-rs G2P for English** in Kokoro — embedded lexicon + POS tagging, OOV words letter-spell. Replaces the ONNX ByT5-tiny G2P pipeline for English specifically. Russian is now handled inside Vosk-TTS. (#211)
+
+### Changed
+- **`kesha install --tts`** now downloads Kokoro + Vosk-TTS (~990 MB total) instead of Kokoro + Piper-RU + ONNX G2P. Disk savings on top of removing the FP32 G2P weights.
+- **`kesha status`** reports the `vosk-ru` cache directory and the 5 Vosk speakers; Piper / G2P rows removed.
+- Russian auto-routing: darwin → AVSpeech `Milena` (zero install); Linux/Windows → `ru-vosk-m02`. (#209, #214)
+
+### Removed
+- **Piper-RU** as the Russian backend. Old voice ids (`ru-denis`, `ru-irina`, etc.) no longer resolve. Migration: pass `--voice ru-vosk-m02` (default), or any of `ru-vosk-{f01,f02,f03,m01,m02}`. macOS users can also use `--voice macos-com.apple.voice.compact.ru-RU.Milena` (no model download).
+- **CharsiuG2P (ONNX ByT5-tiny)** removed — the model files (`models/g2p/byt5-tiny/*`) are no longer downloaded. Existing caches are dead weight; `rm -rf ~/.cache/kesha/models/{g2p,piper-ru}` to reclaim space.
+
+### Breaking changes
+- Russian voice ids changed (`ru-denis` → `ru-vosk-m02`). The change is in source since #214; v1.5.0 is when the engine binary actually enforces it.
+- `kesha install --tts` cache layout changed: `models/vosk-ru/` replaces `models/piper-ru/` and `models/g2p/`.
+
+### Internal
+- `protoc` install pulled into a reusable composite action (`.github/actions/install-protoc`) shared across `ci.yml`, `rust-test.yml`, and `build-engine.yml`.
+- New CI agents: `audio-quality-check` (post-commit WAV stats sanity check) and `ci-feature-matrix-auditor` (verifies every cargo default feature appears in every build-engine matrix row).
+- `rust/src/tts/kokoro.rs` — 4 pipeline bugs fixed alongside the misaki-rs swap (#211).
+
+### Upgrade
+```bash
+bun add -g @drakulavich/kesha-voice-kit@latest
+kesha install              # engine v1.5.0 (~22 MB)
+kesha install --tts        # Kokoro + Vosk-RU (~990 MB; dedupe with prior cache happens automatically)
+```
+
+If you had `models/piper-ru/` or `models/g2p/` in your cache from a previous install, they're orphaned now — `rm -rf ~/.cache/kesha/models/{g2p,piper-ru}` to reclaim ~700 MB.
+
 ## [1.4.4] — 2026-04-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.4.1"
+    "version": "1.5.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
## Summary
First engine release since v1.4.1. Catches the engine binary up to the source that's been sitting in \`main\` since #209/#211/#214. CLI 1.4.4 features (Vosk-aware \`kesha status\`, male English default, RU darwin auto-route) become **functional** once users install this engine binary.

### Bumps
- \`rust/Cargo.toml\` + \`Cargo.lock\` 1.4.1 → 1.5.0
- \`package.json#version\` 1.4.4 → 1.5.0
- \`package.json#keshaEngine.version\` 1.4.1 → 1.5.0

### Engine work shipping in this release
- **#214** — Russian backend swap: Piper-RU → \`vosk-tts-rs\` (multi-speaker, BERT prosody, no espeak-ng / no separate G2P). 5 baked-in voices: \`ru-vosk-{f01,f02,f03,m01,m02}\`. Default male: \`ru-vosk-m02\`.
- **#211** — English G2P swap: ONNX ByT5-tiny → \`misaki-rs\` (embedded lexicon + POS, OOV letter-spell). Plus 4 Kokoro pipeline bug fixes that landed alongside the swap.
- **#209** — Russian darwin auto-routing → AVSpeech \`Milena\` (zero install).

### Breaking changes (called out in CHANGELOG)
- Old Piper voice ids (\`ru-denis\`, \`ru-irina\`, …) no longer resolve. Migrate to \`ru-vosk-{f01..m02}\` or \`macos-…\`.
- Cache layout: \`models/vosk-ru/\` replaces \`models/piper-ru/\` and \`models/g2p/\` — \`rm -rf ~/.cache/kesha/models/{g2p,piper-ru}\` reclaims ~700 MB.

## Pre-PR verification (local)
- [x] \`cd rust && cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo check --features coreml --no-default-features\` clean
- [x] \`cargo test --release\` 13 passed, 0 failed
- [x] \`bun test\` clean
- [x] \`bunx tsc --noEmit\` clean

## Post-merge plan (per CLAUDE.md "Engine release")
1. \`git tag v1.5.0 && git push origin v1.5.0\` — triggers \`build-engine.yml\` to build 3 platform binaries (macOS coreml+tts, Linux onnx+tts, Windows onnx+tts), each smoke-tested with \`--capabilities-json\`. Creates a draft release.
2. **Author release notes** before publish (\`build-engine.yml\` creates an empty draft body — CLAUDE.md says always write notes before publishing). I'll port the CHANGELOG entry to the release body.
3. \`gh release edit v1.5.0 --draft=false\` to publish, then \`make smoke-test\` against the published binary.
4. \`npm publish --access public\` once smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)