### PR TITLE
docs: drop Piper from user-facing docs, fix SKILL.md YAML

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -27,19 +27,13 @@ Pinned to the `v6.2.1` tag.
 
 Text-to-speech (English). Apache 2.0. ONNX export by [onnx-community/Kokoro-82M-v1.0-ONNX](https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX).
 
-### Piper voices (Russian: `ru-denis`)
+### Vosk-TTS (Russian, multi-speaker)
 
-Text-to-speech (multilingual, Piper VITS). MIT. Voice packs from [rhasspy/piper-voices](https://huggingface.co/rhasspy/piper-voices).
+Text-to-speech (Russian, 5 baked-in speakers). Apache 2.0. Model: [alphacep/vosk-tts](https://huggingface.co/alphacep/vosk-tts) (`vosk-model-tts-ru-0.9-multi`). Integrated via [`vosk-tts-rs`](https://github.com/alphacep/vosk-tts-rs).
 
-### CharsiuG2P ByT5-tiny (ONNX export)
+### misaki-rs (English G2P)
 
-Grapheme-to-phoneme conversion for Kokoro and Piper pipelines (#123).
-
-**License: CC-BY 4.0** (declared on the ONNX-export repo). Attribution required.
-
-- ONNX export: [klebster/g2p_multilingual_byT5_tiny_onnx](https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx) by Kleber Noel — CC-BY 4.0.
-- Base checkpoint: [charsiu/g2p_multilingual_byT5_tiny_16_layers_100](https://huggingface.co/charsiu/g2p_multilingual_byT5_tiny_16_layers_100) — **no explicit license declared on HuggingFace**; usage here follows the CC-BY 4.0 declared by the downstream export and the paper's terms.
-- Paper: Zhu, J., Zhang, C., & Jurgens, D. (2022). "ByT5 model for massively multilingual grapheme-to-phoneme conversion." [arXiv:2204.03067](https://arxiv.org/abs/2204.03067) · Interspeech 2022.
+Embedded grapheme-to-phoneme for English (Kokoro pipeline, #207). MIT. Source: [`misaki-rs`](https://github.com/MicheleYin/misaki-rs).
 
 ## System libraries linked by the engine binary
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: kesha-voice-kit
-description: Local multilingual voice toolkit — speech-to-text (STT), text-to-speech (TTS), and language detection. Runs entirely offline on Apple Silicon, Linux, and Windows. No API keys, no cloud. NVIDIA Parakeet TDT for STT across 25 European languages, Kokoro-82M + Piper VITS for TTS, plus macOS AVSpeechSynthesizer for ~180 system voices with zero install.
+description: Local multilingual voice toolkit — speech-to-text (STT), text-to-speech (TTS), and language detection. Runs entirely offline on Apple Silicon, Linux, and Windows. No API keys, no cloud. NVIDIA Parakeet TDT for STT across 25 European languages, Kokoro-82M + Vosk-TTS for TTS, plus macOS AVSpeechSynthesizer for ~180 system voices with zero install.
 emoji: 🎙️
 
 requires:
   bins: [kesha]
 
 install:
-  - kind: npm
-    packages: [@drakulavich/kesha-voice-kit]
-    flags: [--global]
+  - kind: bash
+    cmd: bun add -g "@drakulavich/kesha-voice-kit"
   - kind: bash
     cmd: kesha install
 ---
@@ -23,7 +22,7 @@ Local voice toolkit: transcribe voice messages to text, synthesize speech, detec
 ## When to use
 
 - **Voice memo arrived** (Telegram, WhatsApp, Slack, Signal .ogg/.opus/.m4a): transcribe with `kesha --json <path>` and branch on the detected language.
-- **Need to reply with audio**: synthesize with `kesha say "<text>" > reply.wav`. Auto-routes by detected language (Kokoro-82M for English, Piper for Russian). For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
+- **Need to reply with audio**: synthesize with `kesha say "<text>" > reply.wav`. Auto-routes by detected language (Kokoro-82M for English, Vosk-TTS for Russian). For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
 - **Need to detect what language a file is in** before choosing a pipeline: `kesha --json audio.ogg` returns both audio-based and text-based language detection with confidence scores.
 
 ## STT: transcribe audio
@@ -57,9 +56,9 @@ Use `lang` (or the more detailed `audioLanguage`/`textLanguage`) to decide how t
 
 ```bash
 kesha say "Hello, world" > hello.wav               # auto-routes en → Kokoro-82M
-kesha say "Привет, мир" > privet.wav              # auto-routes ru → Piper
+kesha say "Привет, мир" > privet.wav              # auto-routes ru → Vosk-TTS
 kesha say --voice macos-de-DE "Guten Tag" > de.wav # any macOS system voice — German, French, Italian, ...
-kesha say --list-voices                            # Kokoro + Piper + ~180 macos-* voices
+kesha say --list-voices                            # Kokoro + Vosk-TTS + ~180 macos-* voices
 ```
 
 Output: WAV mono float32. `--out <path>` writes to a file instead of stdout.
@@ -71,18 +70,18 @@ Output: WAV mono float32. `--out <path>` writes to a file instead of stdout.
 ## Install
 
 ```bash
-bun add --global @drakulavich/kesha-voice-kit    # or: npm i -g @drakulavich/kesha-voice-kit
+bun add -g @drakulavich/kesha-voice-kit          # global CLI install
 kesha install                                    # downloads engine (~350 MB)
-kesha install --tts                              # adds Kokoro + Piper RU + ONNX G2P (~490 MB more, for TTS)
+kesha install --tts                              # adds Kokoro + Vosk-TTS RU (~990 MB more, for TTS)
 ```
 
-No system deps — G2P runs as ONNX alongside Kokoro/Piper. `macos-*` voices need no install either — they use voices already on the Mac.
+No system deps — English G2P is embedded (`misaki-rs`); Russian G2P is bundled inside Vosk-TTS. `macos-*` voices need no install either — they use voices already on the Mac.
 
 ## Supported languages
 
 **Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
 
-**Text-to-speech:** English (Kokoro-82M, ~70 voices), Russian (Piper `ru-denis`), plus any macOS system voice via `--voice macos-*`.
+**Text-to-speech:** English (Kokoro-82M, ~70 voices), Russian (Vosk-TTS, 5 baked-in speakers — default `ru-vosk-m02`), plus any macOS system voice via `--voice macos-*`.
 
 ## Performance
 

--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -3,5 +3,5 @@
 ## [Initial Version] - {PR_MERGED_AT}
 
 - Add **Transcribe Selected Audio** command — transcribes the audio file selected in Finder using the local `kesha` CLI, shows transcript + detected language, pre-copies to clipboard.
-- Add **Speak Clipboard** command — synthesizes the current clipboard text via `kesha say` and plays it through the default output; voice auto-routed by detected language (Kokoro for English, Piper for Russian, AVSpeech for macOS system voices).
+- Add **Speak Clipboard** command — synthesizes the current clipboard text via `kesha say` and plays it through the default output; voice auto-routed by detected language (Kokoro for English, Vosk-TTS for Russian, AVSpeech for macOS system voices).
 - Preferences for overriding the `kesha` binary path and default voice.


### PR DESCRIPTION
## Summary

- Post-#213 user-facing docs still mentioned Piper / CharsiuG2P; v1.5.0 ships Vosk-TTS for Russian and embedded `misaki-rs` for English G2P. Brought SKILL.md, NOTICES.md, and the (still-unreleased) raycast CHANGELOG into sync with the shipped engine.
- Fixed a YAML parse error in SKILL.md frontmatter (line 10): `packages: [@drakulavich/kesha-voice-kit]` is not valid YAML — `@` cannot start an unquoted scalar. Replaced the npm install step with `bun add -g "@drakulavich/kesha-voice-kit"`, which also brings the doc in line with CLAUDE.md's bun-only user guidance rule.

## Changes

- **SKILL.md** — Piper → Vosk-TTS in description, auto-routing notes, `--list-voices` example, install size (~990 MB for `--tts`), and supported-voices section. Updated G2P note: English uses embedded `misaki-rs` (#207); Russian G2P is bundled inside Vosk-TTS (#213). Replaced npm install step with bun.
- **NOTICES.md** — replaced "Piper voices" + "CharsiuG2P ByT5-tiny" sections with "Vosk-TTS" + "misaki-rs" entries (both upstream models were removed in #207/#213).
- **raycast/CHANGELOG.md** — still-unreleased "Speak Clipboard" entry: Piper → Vosk-TTS.

Historical references in `CHANGELOG.md`, `BENCHMARK.md`, `CLAUDE.md`, and the `"replaces Piper-ruslan"` comments in `src/cli/say.ts` + `say.test.ts` are intentionally left alone — they describe pre-v1.5.0 state.

## Test plan

- [x] `awk '/^---$/{c++; next} c==1{print}' SKILL.md | ruby -ryaml -e 'YAML.safe_load(STDIN.read)'` → `YAML OK`
- [x] `grep -i piper SKILL.md NOTICES.md raycast/CHANGELOG.md` → no matches
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)