### PR TITLE
feat(tts): support OGG/Opus output format (closes #223)

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -85,6 +85,21 @@ jobs:
           Write-Host "MSVC linker: $linkPath"
           Add-Content -Path $env:GITHUB_ENV -Value "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linkPath"
 
+      - name: Install system Opus
+        # audiopus_sys / opusic-sys (added in #224 for OGG/Opus output) try
+        # pkg-config first; on miss they fall back to a vendored libopus
+        # cmake build that's incompatible with macOS runner cmake ≥4.
+        # Installing the system lib makes pkg-config succeed and skips
+        # the cmake build entirely.
+        shell: bash
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
+          elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
+            brew install opus pkg-config
+          fi
+
       - name: Build release binary
         run: cd rust && cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --no-default-features
       - name: Prepare artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,13 @@ jobs:
       - name: 📥 Download Kokoro models (if cache miss)
         run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"
 
+      - name: 🎧 Install system Opus
+        # audiopus_sys / opusic-sys fall back to a cmake build of vendored
+        # libopus when pkg-config can't locate it, and the vendored
+        # CMakeLists.txt is incompatible with macOS runner cmake ≥4. Install
+        # the system lib so pkg-config succeeds and cmake never runs.
+        run: brew install opus pkg-config
+
       - name: 🦀 Build kesha-engine from source (with TTS)
         env:
           LIBCLANG_PATH: /Library/Developer/CommandLineTools/usr/lib

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -47,6 +47,23 @@ jobs:
           Write-Host "MSVC linker: $linkPath"
           Add-Content -Path $env:GITHUB_ENV -Value "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linkPath"
 
+      - name: Install system audio deps (Opus)
+        # audiopus_sys 0.2.2 / opusic-sys 0.6.0 (added in #224 for OGG/Opus
+        # output) try pkg-config first; on miss they fall back to a vendored
+        # libopus build via cmake whose CMakeLists.txt declares
+        # `cmake_minimum_required(VERSION <3.5)`. macOS runners now ship cmake
+        # ≥4 which refuses that — build aborts. Installing system libopus +
+        # pkg-config makes the build script find the lib and skip cmake
+        # entirely.
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install opus pkg-config
+          fi
+
       - name: Cache Kokoro spike models
         uses: actions/cache@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ CLI and engine versions are **decoupled** — see `CLAUDE.md` for details. Tags
 with a `-cli` suffix are CLI-only patches that reuse the previous engine
 binary.
 
+## [Unreleased]
+
+### Added
+- **`kesha say --format ogg-opus`** — produces OGG/Opus voice notes (mono, 24 kHz @ 32 kbps by default) instead of WAV. The output file is the messenger-friendly format consumed by Telegram `sendVoice` and similar APIs. New flags `--bitrate` and `--sample-rate` tune the encoder; format is also inferred from `--out` extension (`.ogg` / `.opus` / `.oga`). All four engine paths (Kokoro plain/SSML, Vosk-TTS plain/SSML, AVSpeech) flow through the new encoder. WAV output remains the default and is byte-exact with the previous code path. (closes #223)
+
 ## [1.5.0] — 2026-04-29
 
 First engine release since v1.4.1. Catches the binary up to the engine source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,10 @@ GitHub's immutable-releases permanently reserves tag names after publish. **Brok
 
 **Why `--all-targets` matters:** CI's ubuntu job runs clippy; the macOS jobs run only `cargo test`. Without `--all-targets`, local clippy misses dead code in `#[cfg(test)]` blocks and tests — which then breaks CI after push. (Lesson: #125 M1 landed a dead enum variant + struct field that passed on macOS but failed ubuntu.)
 
+**Clippy lint set differs by rustc minor version.** Ubuntu CI typically runs a newer rustc than the developer's local toolchain (we have no `rust-toolchain.toml`). Each Rust release adds new lints under `-D warnings` — local can pass while CI fails on lints like `derivable_impls`, `useless_conversion`, `manual_is_multiple_of`. When CI fails but local passes, pull the exact errors via `gh run view <id> --log-failed` and fix from the report rather than re-running locally. Mechanical fixes: `#[derive(Default)]` + `#[default]` for unit-default enums; drop redundant `.map_err(Into::into)` and `u64::from(u64_value)`; use `x.is_multiple_of(n)` instead of `x % n == 0`. (Lesson: PR #224 hit this — 5 lints in `tts/encode.rs` flagged only by ubuntu's rustc 1.95 vs local 1.94.)
+
+**Fresh cargo builds need `protoc` on PATH.** `vosk-tts-rs` uses `prost-build`, which shells out to `protoc` at build-script time. macOS: `brew install protobuf` then `export PATH="/opt/homebrew/opt/protobuf/bin:$PATH"` (or set `PROTOC=...`). Cached builds hide this — only `cargo clean` runs surface the missing dep.
+
 ### NO SPECULATIVE FIELDS OR ENUM VARIANTS
 
 Don't add struct fields, enum variants, or constants "for later." Clippy's `dead_code` lint is a hard error under `-D warnings`, so any unused public item will fail CI.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -176,6 +176,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1512,8 @@ dependencies = [
  "hound",
  "misaki-rs",
  "ndarray",
+ "ogg",
+ "opus",
  "ort",
  "rayon",
  "rubato 2.0.0",
@@ -1854,6 +1867,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "ogg"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +1958,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
+]
 
 [[package]]
 name = "opusic-sys"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ default = ["onnx", "tts"]
 # a temp WAV per VAD segment (`fluidaudio-rs 0.1.0` lacks transcribe_samples).
 coreml = ["dep:fluidaudio-rs", "dep:tempfile"]
 onnx = []
-tts = ["dep:hound", "dep:thiserror", "dep:ssml-parser"]
+tts = ["dep:hound", "dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg"]
 # macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
 # Opt-in — builds a Swift sidecar via swiftc in build.rs. Silently no-op on
 # non-macOS targets even when enabled.
@@ -57,6 +57,12 @@ hound = { version = "3.5", optional = true }
 thiserror = { version = "1", optional = true }
 sha2 = "0.10"
 ssml-parser = { version = "0.1", optional = true }
+
+# Opus encoding for `kesha say --format ogg-opus` (#223). The `opus` crate is
+# safe Rust bindings around libopus (BSD-3, vendored via `audiopus_sys`); `ogg`
+# is a pure-Rust container muxer. Both are MIT/Apache-2.0 — license-compatible.
+opus = { version = "0.3", optional = true }
+ogg = { version = "0.9", optional = true }
 
 tempfile = { version = "3", optional = true }
 # Pinned exactly so transitive minor bumps can't silently mutate the IPA

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -88,6 +88,18 @@ enum Commands {
         /// See issue #122 for the v1 tag matrix.
         #[arg(long)]
         ssml: bool,
+        /// Output audio format. Defaults to `wav` (or inferred from `--out`
+        /// extension when omitted). Supported: `wav`, `ogg-opus`. See #223.
+        #[arg(long, value_name = "FORMAT")]
+        format: Option<String>,
+        /// Opus bitrate in bits/second (e.g. 16000, 32000, 64000). Only valid
+        /// with `--format ogg-opus`. Default 32000 (Telegram-grade).
+        #[arg(long, value_name = "BPS")]
+        bitrate: Option<i32>,
+        /// Encoder sample rate. Only valid with `--format ogg-opus`. Must be
+        /// one of 8000/12000/16000/24000/48000. Default 24000.
+        #[arg(long = "sample-rate", value_name = "HZ")]
+        sample_rate: Option<u32>,
         /// Explicit model path (testing override)
         #[arg(long, hide = true)]
         model: Option<std::path::PathBuf>,
@@ -106,8 +118,65 @@ struct SayArgs {
     rate: f32,
     list_voices: bool,
     ssml: bool,
+    format: Option<String>,
+    bitrate: Option<i32>,
+    sample_rate: Option<u32>,
     model: Option<std::path::PathBuf>,
     voice_file: Option<std::path::PathBuf>,
+}
+
+/// Resolve the user-supplied `--format` / `--bitrate` / `--sample-rate` /
+/// `--out` combination into a single [`tts::OutputFormat`]. Mirrors the UX
+/// table from #223:
+///
+/// 1. If `--format` is given, parse it (`wav` | `ogg-opus`).
+/// 2. Otherwise, sniff the `--out` extension (`.wav` → wav, `.ogg`/`.opus`
+///    → ogg-opus).
+/// 3. Otherwise default to `Wav` — preserves the historical `kesha say > x`
+///    behaviour where stdout was always RIFF.
+///
+/// `--bitrate` / `--sample-rate` only matter for opus and override the
+/// defaults. When the user picked WAV but supplied either flag, we surface a
+/// clear error rather than silently dropping them.
+#[cfg(feature = "tts")]
+fn resolve_output_format(
+    format: Option<&str>,
+    bitrate: Option<i32>,
+    sample_rate: Option<u32>,
+    out: Option<&std::path::Path>,
+) -> Result<tts::OutputFormat, String> {
+    use std::str::FromStr;
+
+    let mut chosen = match (format, out) {
+        (Some(f), _) => tts::OutputFormat::from_str(f)?,
+        (None, Some(p)) => p
+            .extension()
+            .and_then(|e| e.to_str())
+            .and_then(tts::encode::format_from_extension)
+            .unwrap_or_default(),
+        (None, None) => tts::OutputFormat::default(),
+    };
+
+    if let tts::OutputFormat::OggOpus {
+        bitrate: ref mut br,
+        sample_rate: ref mut sr,
+    } = chosen
+    {
+        if let Some(b) = bitrate {
+            *br = b;
+        }
+        if let Some(r) = sample_rate {
+            *sr = r;
+        }
+    } else if matches!(chosen, tts::OutputFormat::Wav)
+        && (bitrate.is_some() || sample_rate.is_some())
+    {
+        return Err(
+            "--bitrate / --sample-rate only apply to --format ogg-opus".to_string(),
+        );
+    }
+
+    Ok(chosen)
 }
 
 #[cfg(feature = "tts")]
@@ -247,11 +316,25 @@ fn run_say(a: SayArgs) -> i32 {
         }
     };
 
-    let wav = match tts::say(tts::SayOptions {
+    let format = match resolve_output_format(
+        a.format.as_deref(),
+        a.bitrate,
+        a.sample_rate,
+        a.out.as_deref(),
+    ) {
+        Ok(f) => f,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            return 2;
+        }
+    };
+
+    let bytes = match tts::say(tts::SayOptions {
         text: &text_joined,
         lang: &espeak_lang,
         engine,
         ssml: a.ssml,
+        format,
     }) {
         Ok(w) => w,
         Err(e) => {
@@ -261,8 +344,8 @@ fn run_say(a: SayArgs) -> i32 {
     };
 
     let write_result = match a.out {
-        Some(p) => std::fs::write(&p, &wav).map_err(|e| e.to_string()),
-        None => std::io::stdout().write_all(&wav).map_err(|e| e.to_string()),
+        Some(p) => std::fs::write(&p, &bytes).map_err(|e| e.to_string()),
+        None => std::io::stdout().write_all(&bytes).map_err(|e| e.to_string()),
     };
     if let Err(msg) = write_result {
         eprintln!("error: write failed: {msg}");
@@ -325,6 +408,9 @@ fn main() -> Result<()> {
             rate,
             list_voices,
             ssml,
+            format,
+            bitrate,
+            sample_rate,
             model,
             voice_file,
         }) => {
@@ -336,6 +422,9 @@ fn main() -> Result<()> {
                 rate,
                 list_voices,
                 ssml,
+                format,
+                bitrate,
+                sample_rate,
                 model,
                 voice_file,
             }));

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -171,9 +171,7 @@ fn resolve_output_format(
     } else if matches!(chosen, tts::OutputFormat::Wav)
         && (bitrate.is_some() || sample_rate.is_some())
     {
-        return Err(
-            "--bitrate / --sample-rate only apply to --format ogg-opus".to_string(),
-        );
+        return Err("--bitrate / --sample-rate only apply to --format ogg-opus".to_string());
     }
 
     Ok(chosen)
@@ -345,7 +343,9 @@ fn run_say(a: SayArgs) -> i32 {
 
     let write_result = match a.out {
         Some(p) => std::fs::write(&p, &bytes).map_err(|e| e.to_string()),
-        None => std::io::stdout().write_all(&bytes).map_err(|e| e.to_string()),
+        None => std::io::stdout()
+            .write_all(&bytes)
+            .map_err(|e| e.to_string()),
     };
     if let Err(msg) = write_result {
         eprintln!("error: write failed: {msg}");

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -28,10 +28,11 @@ use super::wav;
 
 /// Wire format for [`encode`]. New variants live behind `--format` on the CLI;
 /// values are spelled in kebab-case to match `clap` parsing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OutputFormat {
     /// 32-bit float mono RIFF WAV at the engine's native sample rate.
     /// This is the historical default and the no-resample path.
+    #[default]
     Wav,
     /// OGG-encapsulated Opus, mono.
     ///
@@ -60,12 +61,6 @@ impl OutputFormat {
             bitrate: 32_000,
             sample_rate: 24_000,
         }
-    }
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::Wav
     }
 }
 
@@ -105,7 +100,7 @@ pub fn format_from_extension(ext: &str) -> Option<OutputFormat> {
 #[cfg(feature = "tts")]
 pub fn encode(samples: &[f32], src_rate: u32, fmt: OutputFormat) -> anyhow::Result<Vec<u8>> {
     match fmt {
-        OutputFormat::Wav => wav::encode_wav(samples, src_rate).map_err(Into::into),
+        OutputFormat::Wav => wav::encode_wav(samples, src_rate),
         OutputFormat::OggOpus {
             bitrate,
             sample_rate,
@@ -222,9 +217,9 @@ fn encode_ogg_opus(
             .encode_float(&pcm_buf, &mut packet)
             .map_err(|e| anyhow::anyhow!("opus encode (frame {i}): {e}"))?;
 
-        sample_pos_48k += u64::from(target_to_48k(frame_size as u32, target_sr));
+        sample_pos_48k += target_to_48k(frame_size as u32, target_sr);
 
-        let is_last = i + 1 == n_full_packets && total_samples % frame_size == 0;
+        let is_last = i + 1 == n_full_packets && total_samples.is_multiple_of(frame_size);
         let info = if is_last {
             ogg::PacketWriteEndInfo::EndStream
         } else {
@@ -252,7 +247,7 @@ fn encode_ogg_opus(
         let nbytes = enc
             .encode_float(&pcm_buf, &mut packet)
             .map_err(|e| anyhow::anyhow!("opus encode (tail): {e}"))?;
-        sample_pos_48k += u64::from(target_to_48k(leftover as u32, target_sr));
+        sample_pos_48k += target_to_48k(leftover as u32, target_sr);
         writer
             .write_packet(
                 packet[..nbytes].to_vec(),

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -1,0 +1,590 @@
+//! Output audio encoding: f32 PCM samples → wire bytes.
+//!
+//! Closes #223. Today the engine only spoke WAV; this module adds OGG/Opus
+//! (the format Telegram, WhatsApp, Signal, and Discord render as native voice
+//! messages) and keeps the door open for `mp3` / `flac` / `raw-pcm` later.
+//!
+//! ## Design
+//! - One enum [`OutputFormat`] selects the wire format.
+//! - [`encode`] takes mono f32 samples + their native sample rate and produces
+//!   an in-memory byte buffer. The CLI hands those bytes straight to stdout or
+//!   `--out`, so this stays allocation-honest and side-effect-free.
+//! - Resampling for Opus (libopus only accepts 8/12/16/24/48 kHz) reuses the
+//!   same `rubato` async sinc resampler that `crate::audio` uses for STT.
+//! - WAV stays bit-exact with the previous `wav::encode_wav` output to keep
+//!   existing e2e tests and `kesha say > out.wav` callers green.
+
+use std::str::FromStr;
+
+#[cfg(feature = "tts")]
+use audioadapter_buffers::direct::SequentialSliceOfVecs;
+#[cfg(feature = "tts")]
+use rubato::{
+    calculate_cutoff, Async, FixedAsync, Resampler, SincInterpolationParameters,
+    SincInterpolationType, WindowFunction,
+};
+
+use super::wav;
+
+/// Wire format for [`encode`]. New variants live behind `--format` on the CLI;
+/// values are spelled in kebab-case to match `clap` parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// 32-bit float mono RIFF WAV at the engine's native sample rate.
+    /// This is the historical default and the no-resample path.
+    Wav,
+    /// OGG-encapsulated Opus, mono.
+    ///
+    /// Per RFC 7845 the only Opus-supported sample rates are 8/12/16/24/48 kHz;
+    /// callers asking for anything else are resampled before encoding. The
+    /// container always declares an *input* sample rate of 48 kHz in the
+    /// IdHeader (`opus_decoder.input_sample_rate`) — this is how players know
+    /// the original SR and is independent of the SR the encoder was created at.
+    OggOpus {
+        /// Encoder bitrate in bits/second. ~32 kbps gives Telegram-quality
+        /// voice; 16 kbps is intelligible but tinny; 64 kbps is broadcast-grade.
+        bitrate: i32,
+        /// Sample rate fed to the encoder. Must be one of 8000/12000/16000/
+        /// 24000/48000. Defaults to 24 kHz when [`OutputFormat::ogg_opus_default`]
+        /// is used — matches Kokoro's native rate so most calls skip resampling.
+        sample_rate: u32,
+    },
+}
+
+impl OutputFormat {
+    /// The Telegram-friendly default Opus profile: 24 kHz mono at 32 kbps.
+    /// Kokoro speaks 24 kHz natively, so this avoids a resample round-trip
+    /// for the common path while staying inside Telegram's voice-note window.
+    pub const fn ogg_opus_default() -> Self {
+        Self::OggOpus {
+            bitrate: 32_000,
+            sample_rate: 24_000,
+        }
+    }
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Wav
+    }
+}
+
+/// Parse `--format` values.
+///
+/// Accepts: `wav`, `ogg-opus` (and the historical aliases `opus` / `ogg`).
+/// Bitrate / sample rate are not encoded in the string — they come from
+/// `--bitrate` / `--sample-rate` and are layered on top by the CLI.
+impl FromStr for OutputFormat {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s.to_ascii_lowercase().as_str() {
+            "wav" => Ok(Self::Wav),
+            "ogg-opus" | "opus" | "ogg" => Ok(Self::ogg_opus_default()),
+            other => Err(format!(
+                "unknown --format '{other}'. supported: wav, ogg-opus"
+            )),
+        }
+    }
+}
+
+/// Infer a default format from the `--out` extension when `--format` is absent.
+/// Returns `None` for unknown extensions so the caller can fall back to `Wav`.
+pub fn format_from_extension(ext: &str) -> Option<OutputFormat> {
+    match ext.to_ascii_lowercase().as_str() {
+        "wav" => Some(OutputFormat::Wav),
+        "ogg" | "opus" | "oga" => Some(OutputFormat::ogg_opus_default()),
+        _ => None,
+    }
+}
+
+/// Encode `samples` (mono f32 at `src_rate` Hz) into the chosen wire format.
+///
+/// Errors bubble up as `anyhow` so callers can wrap them in a `TtsError`
+/// without losing the underlying cause (libopus error strings, container I/O,
+/// resampler init).
+#[cfg(feature = "tts")]
+pub fn encode(samples: &[f32], src_rate: u32, fmt: OutputFormat) -> anyhow::Result<Vec<u8>> {
+    match fmt {
+        OutputFormat::Wav => wav::encode_wav(samples, src_rate).map_err(Into::into),
+        OutputFormat::OggOpus {
+            bitrate,
+            sample_rate,
+        } => encode_ogg_opus(samples, src_rate, sample_rate, bitrate),
+    }
+}
+
+// =============================================================================
+// OGG/Opus muxing
+// =============================================================================
+
+/// libopus only accepts these input sample rates.
+#[cfg(feature = "tts")]
+const OPUS_VALID_SR: &[u32] = &[8_000, 12_000, 16_000, 24_000, 48_000];
+
+/// 20 ms frame — Opus's sweet spot for VBR voice. At 48 kHz that's 960 samples;
+/// at 24 kHz it's 480; at 16 kHz it's 320. Keep it constant in *time* so the
+/// granule position math (`absgp` in samples-at-48kHz) stays linear.
+#[cfg(feature = "tts")]
+const FRAME_DURATION_MS: u32 = 20;
+
+/// libopus recommended encode buffer size — large enough for any frame at any
+/// bitrate the public API exposes.
+#[cfg(feature = "tts")]
+const MAX_OPUS_PACKET: usize = 4_000;
+
+/// Pre-skip in samples (at 48 kHz). 80 ms is libopus's recommended value for
+/// 20 ms frames (`80 * 48 = 3840`). Players use this to discard codec warm-up
+/// samples at the start of playback.
+#[cfg(feature = "tts")]
+const PRE_SKIP_48K: u16 = 3_840;
+
+#[cfg(feature = "tts")]
+fn encode_ogg_opus(
+    samples: &[f32],
+    src_rate: u32,
+    target_sr: u32,
+    bitrate: i32,
+) -> anyhow::Result<Vec<u8>> {
+    use opus::{Application, Channels, Encoder};
+
+    if !OPUS_VALID_SR.contains(&target_sr) {
+        anyhow::bail!(
+            "ogg-opus: --sample-rate must be one of {:?}, got {target_sr}",
+            OPUS_VALID_SR
+        );
+    }
+    if !(6_000..=510_000).contains(&bitrate) {
+        anyhow::bail!(
+            "ogg-opus: --bitrate must be 6000..=510000 bps, got {bitrate}"
+        );
+    }
+
+    // Resample to `target_sr` if the engine's native rate doesn't match. We
+    // re-use the rubato sinc machinery from `crate::audio` rather than pulling
+    // in a third resampler dep.
+    let resampled: Vec<f32> = if src_rate == target_sr {
+        samples.to_vec()
+    } else {
+        resample_mono(samples, src_rate, target_sr)?
+    };
+
+    // Build the encoder. `Application::Voip` matches what the issue wants:
+    // best perceptual quality at low bitrates for speech.
+    let mut enc = Encoder::new(target_sr, Channels::Mono, Application::Voip)
+        .map_err(|e| anyhow::anyhow!("opus encoder: {e}"))?;
+    enc.set_bitrate(opus::Bitrate::Bits(bitrate))
+        .map_err(|e| anyhow::anyhow!("opus set_bitrate: {e}"))?;
+    // Tell libopus this is voice — affects internal mode selection.
+    enc.set_signal(opus::Signal::Voice)
+        .map_err(|e| anyhow::anyhow!("opus set_signal: {e}"))?;
+
+    let frame_size = (target_sr * FRAME_DURATION_MS / 1_000) as usize;
+
+    // Build the OggOpus stream:
+    //   page 0: OpusHead (BOS, sequence 0, granule 0)
+    //   page 1: OpusTags (sequence 1, granule 0)
+    //   page 2..: audio packets, with EOS on the last
+    let mut buf: Vec<u8> = Vec::with_capacity(samples.len()); // grows as needed
+    let cursor = std::io::Cursor::new(&mut buf);
+    let mut writer = ogg::PacketWriter::new(cursor);
+
+    // Stable per-stream serial — reproducible test fixtures, not random.
+    // Real codecs randomise this so muxed streams can't collide; for a
+    // single-stream Opus file the value is irrelevant to decoders.
+    let serial: u32 = 0x4b_45_53_48; // 'KESH'
+
+    // ---- OpusHead (RFC 7845 §5.1) -------------------------------------------
+    let opus_head = build_opus_head(src_rate);
+    writer
+        .write_packet(opus_head, serial, ogg::PacketWriteEndInfo::EndPage, 0)
+        .map_err(|e| anyhow::anyhow!("ogg write OpusHead: {e}"))?;
+
+    // ---- OpusTags (RFC 7845 §5.2) -------------------------------------------
+    let opus_tags = build_opus_tags();
+    writer
+        .write_packet(opus_tags, serial, ogg::PacketWriteEndInfo::EndPage, 0)
+        .map_err(|e| anyhow::anyhow!("ogg write OpusTags: {e}"))?;
+
+    // ---- Audio packets ------------------------------------------------------
+    // Granule position = number of decoded samples produced *so far* at 48 kHz.
+    // It includes the pre-skip, which players subtract before playback. We
+    // accumulate sample count in target_sr and convert once per page boundary.
+    let total_frames = resampled.len();
+    let n_full_packets = total_frames / frame_size;
+    let mut sample_pos_48k: u64 = u64::from(PRE_SKIP_48K);
+
+    let mut pcm_buf = vec![0.0f32; frame_size];
+    let mut packet = vec![0u8; MAX_OPUS_PACKET];
+
+    for i in 0..n_full_packets {
+        let start = i * frame_size;
+        pcm_buf.copy_from_slice(&resampled[start..start + frame_size]);
+        let nbytes = enc
+            .encode_float(&pcm_buf, &mut packet)
+            .map_err(|e| anyhow::anyhow!("opus encode (frame {i}): {e}"))?;
+
+        sample_pos_48k += u64::from(target_to_48k(frame_size as u32, target_sr));
+
+        let is_last = i + 1 == n_full_packets && total_frames % frame_size == 0;
+        let info = if is_last {
+            ogg::PacketWriteEndInfo::EndStream
+        } else {
+            ogg::PacketWriteEndInfo::NormalPacket
+        };
+        writer
+            .write_packet(packet[..nbytes].to_vec(), serial, info, sample_pos_48k)
+            .map_err(|e| anyhow::anyhow!("ogg write audio (frame {i}): {e}"))?;
+    }
+
+    // Tail frame: zero-pad the last partial frame so libopus can encode it.
+    // The granule position records *real* samples only — pad samples don't
+    // increment absgp, so players truncate cleanly at the original duration.
+    let leftover = total_frames - n_full_packets * frame_size;
+    if leftover > 0 {
+        for (slot, src) in pcm_buf.iter_mut().zip(&resampled[n_full_packets * frame_size..]) {
+            *slot = *src;
+        }
+        // Zero-pad the tail.
+        for slot in pcm_buf.iter_mut().skip(leftover) {
+            *slot = 0.0;
+        }
+        let nbytes = enc
+            .encode_float(&pcm_buf, &mut packet)
+            .map_err(|e| anyhow::anyhow!("opus encode (tail): {e}"))?;
+        sample_pos_48k += u64::from(target_to_48k(leftover as u32, target_sr));
+        writer
+            .write_packet(
+                packet[..nbytes].to_vec(),
+                serial,
+                ogg::PacketWriteEndInfo::EndStream,
+                sample_pos_48k,
+            )
+            .map_err(|e| anyhow::anyhow!("ogg write audio (tail): {e}"))?;
+    } else if n_full_packets == 0 {
+        // Edge case: empty / sub-frame input. Emit a single silent EOS packet
+        // so we still produce a well-formed OggOpus file.
+        for slot in pcm_buf.iter_mut() {
+            *slot = 0.0;
+        }
+        let nbytes = enc
+            .encode_float(&pcm_buf, &mut packet)
+            .map_err(|e| anyhow::anyhow!("opus encode (empty): {e}"))?;
+        writer
+            .write_packet(
+                packet[..nbytes].to_vec(),
+                serial,
+                ogg::PacketWriteEndInfo::EndStream,
+                sample_pos_48k,
+            )
+            .map_err(|e| anyhow::anyhow!("ogg write audio (empty): {e}"))?;
+    }
+
+    drop(writer);
+    Ok(buf)
+}
+
+/// Convert a sample count at `target_sr` to its equivalent at 48 kHz, used for
+/// OggOpus granule positions per RFC 7845 §4. Integer-only so granule values
+/// stay reproducible across architectures.
+#[cfg(feature = "tts")]
+fn target_to_48k(samples: u32, target_sr: u32) -> u64 {
+    (u64::from(samples) * 48_000) / u64::from(target_sr)
+}
+
+/// Build the 19-byte OpusHead identification packet. Layout per RFC 7845 §5.1:
+///
+/// ```text
+///  0..8   "OpusHead"
+///  8      version = 1
+///  9      channel_count = 1 (mono)
+///  10..12 pre_skip (u16 LE)
+///  12..16 input_sample_rate (u32 LE)  ← engine's native rate; players use
+///                                       this for display/seeking, not decoding
+///  16..18 output_gain Q7.8 = 0
+///  18     channel_mapping_family = 0 (mono/stereo, no per-stream mapping)
+/// ```
+#[cfg(feature = "tts")]
+fn build_opus_head(input_sample_rate: u32) -> Vec<u8> {
+    let mut head = Vec::with_capacity(19);
+    head.extend_from_slice(b"OpusHead");
+    head.push(1); // version
+    head.push(1); // channel count
+    head.extend_from_slice(&PRE_SKIP_48K.to_le_bytes());
+    head.extend_from_slice(&input_sample_rate.to_le_bytes());
+    head.extend_from_slice(&0i16.to_le_bytes()); // output gain Q7.8
+    head.push(0); // channel mapping family
+    head
+}
+
+/// Build the OpusTags comment packet (RFC 7845 §5.2). Telegram doesn't read
+/// these but a well-formed packet here is required by the spec; mediaplayers
+/// (`ffprobe`, VLC) will surface them.
+#[cfg(feature = "tts")]
+fn build_opus_tags() -> Vec<u8> {
+    let vendor = format!("kesha-voice-kit {}", env!("CARGO_PKG_VERSION"));
+    let vendor_bytes = vendor.as_bytes();
+
+    let mut tags = Vec::with_capacity(8 + 4 + vendor_bytes.len() + 4);
+    tags.extend_from_slice(b"OpusTags");
+    tags.extend_from_slice(&(vendor_bytes.len() as u32).to_le_bytes());
+    tags.extend_from_slice(vendor_bytes);
+    tags.extend_from_slice(&0u32.to_le_bytes()); // user comment count
+    tags
+}
+
+/// Mono f32 resampler. Mirrors the design in `crate::audio::resample` (same
+/// rubato params; we don't share the function because that one targets the
+/// transcribe pipeline's hard-coded 16 kHz).
+#[cfg(feature = "tts")]
+fn resample_mono(samples: &[f32], src_rate: u32, dst_rate: u32) -> anyhow::Result<Vec<f32>> {
+    if src_rate == dst_rate {
+        return Ok(samples.to_vec());
+    }
+    let ratio = f64::from(dst_rate) / f64::from(src_rate);
+
+    let sinc_len = 128;
+    let window = WindowFunction::BlackmanHarris2;
+    let params = SincInterpolationParameters {
+        sinc_len,
+        f_cutoff: calculate_cutoff(sinc_len, window),
+        interpolation: SincInterpolationType::Cubic,
+        oversampling_factor: 256,
+        window,
+    };
+
+    let chunk_size = 1024usize;
+    let channels = 1usize;
+    let mut resampler =
+        Async::<f32>::new_sinc(ratio, 1.1, &params, chunk_size, channels, FixedAsync::Input)
+            .map_err(|e| anyhow::anyhow!("resampler init: {e}"))?;
+
+    let total_frames = samples.len();
+    let mut out: Vec<f32> = Vec::with_capacity((total_frames as f64 * ratio * 1.1) as usize);
+    let mut frame_offset = 0usize;
+
+    while frame_offset + chunk_size <= total_frames {
+        let frames_needed = resampler.input_frames_next();
+        if frame_offset + frames_needed > total_frames {
+            break;
+        }
+        let chunk: Vec<Vec<f32>> = vec![samples[frame_offset..frame_offset + frames_needed].to_vec()];
+        let in_adapter = SequentialSliceOfVecs::new(&chunk, channels, frames_needed)
+            .map_err(|e| anyhow::anyhow!("resample input: {e}"))?;
+
+        let out_max = resampler.output_frames_max();
+        let mut out_data: Vec<Vec<f32>> = vec![vec![0.0f32; out_max]; channels];
+        let mut out_adapter = SequentialSliceOfVecs::new_mut(&mut out_data, channels, out_max)
+            .map_err(|e| anyhow::anyhow!("resample output: {e}"))?;
+
+        let (_in, n_out) = resampler
+            .process_into_buffer(&in_adapter, &mut out_adapter, None)
+            .map_err(|e| anyhow::anyhow!("resample step: {e}"))?;
+        out.extend_from_slice(&out_data[0][..n_out]);
+        frame_offset += frames_needed;
+    }
+
+    if frame_offset < total_frames {
+        let remaining = total_frames - frame_offset;
+        let frames_needed = resampler.input_frames_next();
+        let mut last_chunk: Vec<f32> = samples[frame_offset..].to_vec();
+        last_chunk.resize(frames_needed, 0.0);
+        let chunk: Vec<Vec<f32>> = vec![last_chunk];
+        let in_adapter = SequentialSliceOfVecs::new(&chunk, channels, frames_needed)
+            .map_err(|e| anyhow::anyhow!("resample tail input: {e}"))?;
+
+        let out_max = resampler.output_frames_max();
+        let mut out_data: Vec<Vec<f32>> = vec![vec![0.0f32; out_max]; channels];
+        let mut out_adapter = SequentialSliceOfVecs::new_mut(&mut out_data, channels, out_max)
+            .map_err(|e| anyhow::anyhow!("resample tail output: {e}"))?;
+
+        let (_in, n_out) = resampler
+            .process_into_buffer(&in_adapter, &mut out_adapter, None)
+            .map_err(|e| anyhow::anyhow!("resample tail: {e}"))?;
+        let real_out = ((remaining as f64 * ratio) as usize).min(n_out);
+        out.extend_from_slice(&out_data[0][..real_out]);
+    }
+
+    Ok(out)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_format_strings() {
+        assert_eq!(OutputFormat::from_str("wav").unwrap(), OutputFormat::Wav);
+        assert_eq!(
+            OutputFormat::from_str("WAV").unwrap(),
+            OutputFormat::Wav,
+            "case-insensitive"
+        );
+        assert_eq!(
+            OutputFormat::from_str("ogg-opus").unwrap(),
+            OutputFormat::ogg_opus_default()
+        );
+        // Aliases that users will reach for naturally.
+        assert!(matches!(
+            OutputFormat::from_str("opus").unwrap(),
+            OutputFormat::OggOpus { .. }
+        ));
+        assert!(matches!(
+            OutputFormat::from_str("ogg").unwrap(),
+            OutputFormat::OggOpus { .. }
+        ));
+        // Bogus values must be rejected with a useful message — clap surfaces it.
+        let err = OutputFormat::from_str("mp3").unwrap_err();
+        assert!(err.contains("mp3") && err.contains("supported"));
+    }
+
+    #[test]
+    fn extension_inference_covers_common_cases() {
+        assert_eq!(format_from_extension("wav"), Some(OutputFormat::Wav));
+        assert_eq!(format_from_extension("WAV"), Some(OutputFormat::Wav));
+        assert!(matches!(
+            format_from_extension("ogg"),
+            Some(OutputFormat::OggOpus { .. })
+        ));
+        assert!(matches!(
+            format_from_extension("opus"),
+            Some(OutputFormat::OggOpus { .. })
+        ));
+        assert_eq!(format_from_extension("mp3"), None);
+        assert_eq!(format_from_extension(""), None);
+    }
+
+    #[test]
+    fn ogg_opus_default_is_telegram_friendly() {
+        // 24 kHz @ 32 kbps is the issue's stated v1 target. Locking it down so
+        // a refactor doesn't silently change file sizes for downstream users.
+        let f = OutputFormat::ogg_opus_default();
+        assert_eq!(
+            f,
+            OutputFormat::OggOpus {
+                bitrate: 32_000,
+                sample_rate: 24_000,
+            }
+        );
+    }
+
+    #[test]
+    fn opus_head_layout() {
+        let head = build_opus_head(24_000);
+        assert_eq!(head.len(), 19, "OpusHead must be exactly 19 bytes");
+        assert_eq!(&head[..8], b"OpusHead");
+        assert_eq!(head[8], 1, "version");
+        assert_eq!(head[9], 1, "channels (mono)");
+        // pre-skip
+        assert_eq!(
+            u16::from_le_bytes([head[10], head[11]]),
+            PRE_SKIP_48K
+        );
+        // input sample rate
+        assert_eq!(
+            u32::from_le_bytes([head[12], head[13], head[14], head[15]]),
+            24_000
+        );
+        assert_eq!(head[18], 0, "channel mapping family");
+    }
+
+    #[test]
+    fn opus_tags_layout() {
+        let tags = build_opus_tags();
+        assert_eq!(&tags[..8], b"OpusTags");
+        // vendor length is u32 LE at offset 8
+        let vlen = u32::from_le_bytes([tags[8], tags[9], tags[10], tags[11]]) as usize;
+        let vendor = std::str::from_utf8(&tags[12..12 + vlen]).unwrap();
+        assert!(vendor.starts_with("kesha-voice-kit "));
+        // Trailing user-comment count = 0
+        let cnt = u32::from_le_bytes(
+            tags[12 + vlen..12 + vlen + 4].try_into().unwrap(),
+        );
+        assert_eq!(cnt, 0);
+    }
+
+    #[test]
+    fn encode_wav_round_trip_matches_legacy_path() {
+        // Backwards compat: `encode(.., Wav)` must produce the *same* bytes the
+        // old `wav::encode_wav` produced — that's how we keep existing tests
+        // and downstream `--out foo.wav` callers green.
+        let samples: Vec<f32> = (0..2_400).map(|i| (i as f32 * 0.05).sin()).collect();
+        let from_encode = encode(&samples, 24_000, OutputFormat::Wav).unwrap();
+        let from_wav = wav::encode_wav(&samples, 24_000).unwrap();
+        assert_eq!(from_encode, from_wav);
+    }
+
+    #[test]
+    fn ogg_opus_produces_valid_oggs_magic() {
+        // 1 second of a 440 Hz tone at 24 kHz mono.
+        let sr = 24_000u32;
+        let samples: Vec<f32> = (0..sr)
+            .map(|i| (i as f32 * 2.0 * std::f32::consts::PI * 440.0 / sr as f32).sin() * 0.3)
+            .collect();
+        let bytes = encode(&samples, sr, OutputFormat::ogg_opus_default()).unwrap();
+        // Every Ogg page starts with "OggS" — minimum check that we wrote
+        // *something* well-formed enough for clients to demux.
+        assert_eq!(&bytes[..4], b"OggS");
+        // OpusHead lives in the first page payload, after the page header. We
+        // don't reparse pages here (the dedicated tts_opus.rs test does), but
+        // the magic must appear somewhere in the buffer.
+        assert!(
+            bytes.windows(8).any(|w| w == b"OpusHead"),
+            "OpusHead packet not found in OggOpus output"
+        );
+        assert!(
+            bytes.windows(8).any(|w| w == b"OpusTags"),
+            "OpusTags packet not found in OggOpus output"
+        );
+        // 1 second @ 32 kbps ≈ 4 KB. Allow generous slack — we just want to
+        // know we didn't accidentally ship megabytes of WAV-shaped bytes.
+        assert!(
+            bytes.len() < 12_000,
+            "ogg-opus payload way bigger than expected: {} bytes",
+            bytes.len()
+        );
+    }
+
+    #[test]
+    fn ogg_opus_rejects_invalid_sample_rate() {
+        let samples = vec![0.0f32; 1024];
+        let res = encode(
+            &samples,
+            22_050,
+            OutputFormat::OggOpus {
+                bitrate: 32_000,
+                sample_rate: 22_050, // not in OPUS_VALID_SR
+            },
+        );
+        let err = res.unwrap_err().to_string();
+        assert!(err.contains("--sample-rate"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn ogg_opus_rejects_out_of_range_bitrate() {
+        let samples = vec![0.0f32; 1024];
+        let res = encode(
+            &samples,
+            24_000,
+            OutputFormat::OggOpus {
+                bitrate: 1_000, // below 6 kbps libopus minimum
+                sample_rate: 24_000,
+            },
+        );
+        let err = res.unwrap_err().to_string();
+        assert!(err.contains("--bitrate"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn ogg_opus_resamples_when_engine_sr_mismatches() {
+        // Vosk-RU runs at 22.05 kHz natively. We can't feed that to libopus
+        // directly, so the encoder must resample to a supported rate first.
+        let src_sr = 22_050u32;
+        let samples: Vec<f32> = (0..src_sr).map(|i| (i as f32 * 0.001).sin() * 0.2).collect();
+        let bytes = encode(&samples, src_sr, OutputFormat::ogg_opus_default()).unwrap();
+        assert_eq!(&bytes[..4], b"OggS", "resampled output is still valid Ogg");
+    }
+}

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -37,9 +37,9 @@ pub enum OutputFormat {
     ///
     /// Per RFC 7845 the only Opus-supported sample rates are 8/12/16/24/48 kHz;
     /// callers asking for anything else are resampled before encoding. The
-    /// container always declares an *input* sample rate of 48 kHz in the
-    /// IdHeader (`opus_decoder.input_sample_rate`) — this is how players know
-    /// the original SR and is independent of the SR the encoder was created at.
+    /// IdHeader records the engine's original native rate (e.g. 24 kHz for
+    /// Kokoro, 22 050 Hz for Vosk-RU) per RFC 7845 §5.1 — players use this
+    /// for display and seeking, not decoding.
     OggOpus {
         /// Encoder bitrate in bits/second. ~32 kbps gives Telegram-quality
         /// voice; 16 kbps is intelligible but tinny; 64 kbps is broadcast-grade.
@@ -154,18 +154,17 @@ fn encode_ogg_opus(
         );
     }
     if !(6_000..=510_000).contains(&bitrate) {
-        anyhow::bail!(
-            "ogg-opus: --bitrate must be 6000..=510000 bps, got {bitrate}"
-        );
+        anyhow::bail!("ogg-opus: --bitrate must be 6000..=510000 bps, got {bitrate}");
     }
 
     // Resample to `target_sr` if the engine's native rate doesn't match. We
     // re-use the rubato sinc machinery from `crate::audio` rather than pulling
     // in a third resampler dep.
-    let resampled: Vec<f32> = if src_rate == target_sr {
-        samples.to_vec()
+    use std::borrow::Cow;
+    let resampled: Cow<[f32]> = if src_rate == target_sr {
+        Cow::Borrowed(samples)
     } else {
-        resample_mono(samples, src_rate, target_sr)?
+        Cow::Owned(resample_mono(samples, src_rate, target_sr)?)
     };
 
     // Build the encoder. `Application::Voip` matches what the issue wants:
@@ -184,7 +183,7 @@ fn encode_ogg_opus(
     //   page 0: OpusHead (BOS, sequence 0, granule 0)
     //   page 1: OpusTags (sequence 1, granule 0)
     //   page 2..: audio packets, with EOS on the last
-    let mut buf: Vec<u8> = Vec::with_capacity(samples.len()); // grows as needed
+    let mut buf: Vec<u8> = Vec::with_capacity(samples.len());
     let cursor = std::io::Cursor::new(&mut buf);
     let mut writer = ogg::PacketWriter::new(cursor);
 
@@ -209,8 +208,8 @@ fn encode_ogg_opus(
     // Granule position = number of decoded samples produced *so far* at 48 kHz.
     // It includes the pre-skip, which players subtract before playback. We
     // accumulate sample count in target_sr and convert once per page boundary.
-    let total_frames = resampled.len();
-    let n_full_packets = total_frames / frame_size;
+    let total_samples = resampled.len();
+    let n_full_packets = total_samples / frame_size;
     let mut sample_pos_48k: u64 = u64::from(PRE_SKIP_48K);
 
     let mut pcm_buf = vec![0.0f32; frame_size];
@@ -225,7 +224,7 @@ fn encode_ogg_opus(
 
         sample_pos_48k += u64::from(target_to_48k(frame_size as u32, target_sr));
 
-        let is_last = i + 1 == n_full_packets && total_frames % frame_size == 0;
+        let is_last = i + 1 == n_full_packets && total_samples % frame_size == 0;
         let info = if is_last {
             ogg::PacketWriteEndInfo::EndStream
         } else {
@@ -239,12 +238,14 @@ fn encode_ogg_opus(
     // Tail frame: zero-pad the last partial frame so libopus can encode it.
     // The granule position records *real* samples only — pad samples don't
     // increment absgp, so players truncate cleanly at the original duration.
-    let leftover = total_frames - n_full_packets * frame_size;
+    let leftover = total_samples - n_full_packets * frame_size;
     if leftover > 0 {
-        for (slot, src) in pcm_buf.iter_mut().zip(&resampled[n_full_packets * frame_size..]) {
+        for (slot, src) in pcm_buf
+            .iter_mut()
+            .zip(&resampled[n_full_packets * frame_size..])
+        {
             *slot = *src;
         }
-        // Zero-pad the tail.
         for slot in pcm_buf.iter_mut().skip(leftover) {
             *slot = 0.0;
         }
@@ -367,7 +368,8 @@ fn resample_mono(samples: &[f32], src_rate: u32, dst_rate: u32) -> anyhow::Resul
         if frame_offset + frames_needed > total_frames {
             break;
         }
-        let chunk: Vec<Vec<f32>> = vec![samples[frame_offset..frame_offset + frames_needed].to_vec()];
+        let chunk: Vec<Vec<f32>> =
+            vec![samples[frame_offset..frame_offset + frames_needed].to_vec()];
         let in_adapter = SequentialSliceOfVecs::new(&chunk, channels, frames_needed)
             .map_err(|e| anyhow::anyhow!("resample input: {e}"))?;
 
@@ -479,10 +481,7 @@ mod tests {
         assert_eq!(head[8], 1, "version");
         assert_eq!(head[9], 1, "channels (mono)");
         // pre-skip
-        assert_eq!(
-            u16::from_le_bytes([head[10], head[11]]),
-            PRE_SKIP_48K
-        );
+        assert_eq!(u16::from_le_bytes([head[10], head[11]]), PRE_SKIP_48K);
         // input sample rate
         assert_eq!(
             u32::from_le_bytes([head[12], head[13], head[14], head[15]]),
@@ -500,9 +499,7 @@ mod tests {
         let vendor = std::str::from_utf8(&tags[12..12 + vlen]).unwrap();
         assert!(vendor.starts_with("kesha-voice-kit "));
         // Trailing user-comment count = 0
-        let cnt = u32::from_le_bytes(
-            tags[12 + vlen..12 + vlen + 4].try_into().unwrap(),
-        );
+        let cnt = u32::from_le_bytes(tags[12 + vlen..12 + vlen + 4].try_into().unwrap());
         assert_eq!(cnt, 0);
     }
 
@@ -583,7 +580,9 @@ mod tests {
         // Vosk-RU runs at 22.05 kHz natively. We can't feed that to libopus
         // directly, so the encoder must resample to a supported rate first.
         let src_sr = 22_050u32;
-        let samples: Vec<f32> = (0..src_sr).map(|i| (i as f32 * 0.001).sin() * 0.2).collect();
+        let samples: Vec<f32> = (0..src_sr)
+            .map(|i| (i as f32 * 0.001).sin() * 0.2)
+            .collect();
         let bytes = encode(&samples, src_sr, OutputFormat::ogg_opus_default()).unwrap();
         assert_eq!(&bytes[..4], b"OggS", "resampled output is still valid Ogg");
     }

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -368,15 +368,11 @@ fn transcode_to(wav_bytes: &[u8], format: OutputFormat) -> Result<Vec<u8>, TtsEr
 /// integer PCM to f32. AVSpeech emits 22.05 kHz 16-bit mono on macOS today,
 /// but we keep this generic so a future sidecar change doesn't break us.
 #[cfg(all(feature = "system_tts", target_os = "macos"))]
-fn wav_to_mono_f32<R: std::io::Read>(
-    mut reader: hound::WavReader<R>,
-) -> anyhow::Result<Vec<f32>> {
+fn wav_to_mono_f32<R: std::io::Read>(mut reader: hound::WavReader<R>) -> anyhow::Result<Vec<f32>> {
     let spec = reader.spec();
     let channels = spec.channels as usize;
     let samples: Vec<f32> = match spec.sample_format {
-        hound::SampleFormat::Float => reader
-            .samples::<f32>()
-            .collect::<Result<Vec<f32>, _>>()?,
+        hound::SampleFormat::Float => reader.samples::<f32>().collect::<Result<Vec<f32>, _>>()?,
         hound::SampleFormat::Int => {
             let max = (1i64 << (spec.bits_per_sample - 1)) as f32;
             reader

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+pub mod encode;
 pub mod g2p;
 pub mod kokoro;
 pub mod ssml;
@@ -9,6 +10,8 @@ pub mod tokenizer;
 pub mod voices;
 pub mod vosk;
 pub mod wav;
+
+pub use encode::OutputFormat;
 
 #[cfg(all(feature = "system_tts", target_os = "macos"))]
 pub mod avspeech;
@@ -68,6 +71,10 @@ pub struct SayOptions<'a> {
     /// When true, `text` is parsed as SSML (issue #122). `<break>` tags yield
     /// silence of the declared duration; unknown tags are stripped with a warning.
     pub ssml: bool,
+    /// Wire format for the returned bytes. Defaults to `Wav` so existing
+    /// callers (and the historical `kesha say > out.wav` flow) stay
+    /// bit-exact. See #223.
+    pub format: OutputFormat,
 }
 
 /// Synthesize speech and return WAV bytes (mono float32; sample rate depends on engine).
@@ -106,8 +113,12 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
                 "SSML is not yet supported with macos-* voices (#141 follow-up)".into(),
             ));
         }
-        return avspeech::synthesize(opts.text, voice_id, None)
-            .map_err(|e| TtsError::SynthesisFailed(format!("avspeech: {e}")));
+        let wav_bytes = avspeech::synthesize(opts.text, voice_id, None)
+            .map_err(|e| TtsError::SynthesisFailed(format!("avspeech: {e}")))?;
+        // The Swift sidecar always returns WAV. For non-WAV `--format`, decode
+        // back to PCM and re-encode — cheap (a few hundred ms of audio) and
+        // keeps the encoder pipeline single-pathed.
+        return transcode_to(&wav_bytes, opts.format);
     }
 
     // Vosk-tts owns its own G2P + text normalisation; bypass our espeak/misaki path.
@@ -118,9 +129,9 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
     } = &opts.engine
     {
         if opts.ssml {
-            return synth_segments_vosk(opts.text, model_dir, *speaker_id, *speed);
+            return synth_segments_vosk(opts.text, model_dir, *speaker_id, *speed, opts.format);
         }
-        return say_with_vosk(opts.text, model_dir, *speaker_id, *speed);
+        return say_with_vosk(opts.text, model_dir, *speaker_id, *speed, opts.format);
     }
 
     if opts.ssml {
@@ -140,7 +151,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
             model_path,
             voice_path,
             speed,
-        } => say_with_kokoro(&ipa, model_path, voice_path, speed),
+        } => say_with_kokoro(&ipa, model_path, voice_path, speed, opts.format),
         // Vosk and AVSpeech are handled by early-returns above. Keep guard arms
         // so the match stays exhaustive when those features are enabled.
         EngineChoice::Vosk { .. } => unreachable!("handled by early return above"),
@@ -165,7 +176,14 @@ fn say_ssml(opts: &SayOptions) -> Result<Vec<u8>, TtsError> {
             model_path,
             voice_path,
             speed,
-        } => synth_segments_kokoro(&segments, opts.lang, model_path, voice_path, *speed),
+        } => synth_segments_kokoro(
+            &segments,
+            opts.lang,
+            model_path,
+            voice_path,
+            *speed,
+            opts.format,
+        ),
         // Vosk + SSML is handled by the early-return in say(); this arm keeps the match exhaustive.
         EngineChoice::Vosk { .. } => unreachable!("handled by early return in say()"),
         // AVSpeech + SSML is rejected up-front in `say()`; this arm keeps the match exhaustive.
@@ -182,6 +200,7 @@ fn synth_segments_kokoro(
     model_path: &Path,
     voice_path: &Path,
     speed: f32,
+    format: OutputFormat,
 ) -> Result<Vec<u8>, TtsError> {
     let tok = tokenizer::Tokenizer::load()
         .map_err(|e| TtsError::SynthesisFailed(format!("tokenizer load: {e}")))?;
@@ -209,7 +228,7 @@ fn synth_segments_kokoro(
             "no audio produced from SSML input".into(),
         ));
     }
-    wav::encode_wav(&out, sample_rate).map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))
+    encode_or_fail(&out, sample_rate, format)
 }
 
 fn synth_ipa_kokoro(
@@ -239,6 +258,7 @@ fn say_with_kokoro(
     model_path: &Path,
     voice_path: &Path,
     speed: f32,
+    format: OutputFormat,
 ) -> Result<Vec<u8>, TtsError> {
     let tok = tokenizer::Tokenizer::load()
         .map_err(|e| TtsError::SynthesisFailed(format!("tokenizer load: {e}")))?;
@@ -260,8 +280,7 @@ fn say_with_kokoro(
     let audio = k
         .infer(&padded, style, speed)
         .map_err(|e| TtsError::SynthesisFailed(format!("infer: {e}")))?;
-    wav::encode_wav(&audio, kokoro::SAMPLE_RATE)
-        .map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))
+    encode_or_fail(&audio, kokoro::SAMPLE_RATE, format)
 }
 
 fn say_with_vosk(
@@ -269,6 +288,7 @@ fn say_with_vosk(
     model_dir: &Path,
     speaker_id: u32,
     speed: f32,
+    format: OutputFormat,
 ) -> Result<Vec<u8>, TtsError> {
     let mut v = vosk::Vosk::load(model_dir)
         .map_err(|e| TtsError::SynthesisFailed(format!("vosk load: {e}")))?;
@@ -276,7 +296,7 @@ fn say_with_vosk(
     let audio = v
         .infer(text, speaker_id, speed)
         .map_err(|e| TtsError::SynthesisFailed(format!("vosk infer: {e}")))?;
-    wav::encode_wav(&audio, sample_rate).map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))
+    encode_or_fail(&audio, sample_rate, format)
 }
 
 fn synth_segments_vosk(
@@ -284,6 +304,7 @@ fn synth_segments_vosk(
     model_dir: &Path,
     speaker_id: u32,
     speed: f32,
+    format: OutputFormat,
 ) -> Result<Vec<u8>, TtsError> {
     let segments =
         ssml::parse(text).map_err(|e| TtsError::SynthesisFailed(format!("ssml: {e}")))?;
@@ -313,5 +334,62 @@ fn synth_segments_vosk(
             "no audio produced from SSML input".into(),
         ));
     }
-    wav::encode_wav(&out, sample_rate).map_err(|e| TtsError::SynthesisFailed(format!("wav: {e}")))
+    encode_or_fail(&out, sample_rate, format)
+}
+
+/// Common tail: PCM samples → chosen wire format. Centralised so every engine
+/// path emits the same error shape when encoding fails (#223).
+fn encode_or_fail(
+    samples: &[f32],
+    sample_rate: u32,
+    format: OutputFormat,
+) -> Result<Vec<u8>, TtsError> {
+    encode::encode(samples, sample_rate, format)
+        .map_err(|e| TtsError::SynthesisFailed(format!("encode: {e}")))
+}
+
+/// Decode WAV bytes the AVSpeech sidecar handed back to PCM, then re-encode in
+/// the caller's chosen format. WAV → WAV is a no-op short-circuit so we don't
+/// pay a hound round-trip for the historical default path.
+#[cfg(all(feature = "system_tts", target_os = "macos"))]
+fn transcode_to(wav_bytes: &[u8], format: OutputFormat) -> Result<Vec<u8>, TtsError> {
+    if matches!(format, OutputFormat::Wav) {
+        return Ok(wav_bytes.to_vec());
+    }
+    let reader = hound::WavReader::new(std::io::Cursor::new(wav_bytes))
+        .map_err(|e| TtsError::SynthesisFailed(format!("avspeech wav decode: {e}")))?;
+    let spec = reader.spec();
+    let samples = wav_to_mono_f32(reader)
+        .map_err(|e| TtsError::SynthesisFailed(format!("avspeech wav decode: {e}")))?;
+    encode_or_fail(&samples, spec.sample_rate, format)
+}
+
+/// Read all samples from a WAV reader, mixing stereo to mono and converting
+/// integer PCM to f32. AVSpeech emits 22.05 kHz 16-bit mono on macOS today,
+/// but we keep this generic so a future sidecar change doesn't break us.
+#[cfg(all(feature = "system_tts", target_os = "macos"))]
+fn wav_to_mono_f32<R: std::io::Read>(
+    mut reader: hound::WavReader<R>,
+) -> anyhow::Result<Vec<f32>> {
+    let spec = reader.spec();
+    let channels = spec.channels as usize;
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Float => reader
+            .samples::<f32>()
+            .collect::<Result<Vec<f32>, _>>()?,
+        hound::SampleFormat::Int => {
+            let max = (1i64 << (spec.bits_per_sample - 1)) as f32;
+            reader
+                .samples::<i32>()
+                .map(|s| s.map(|v| v as f32 / max))
+                .collect::<Result<Vec<f32>, _>>()?
+        }
+    };
+    if channels == 1 {
+        return Ok(samples);
+    }
+    Ok(samples
+        .chunks_exact(channels)
+        .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+        .collect())
 }

--- a/rust/tests/tts_e2e.rs
+++ b/rust/tests/tts_e2e.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use kesha_engine::tts::{self, EngineChoice, SayOptions, TtsError};
+use kesha_engine::tts::{self, EngineChoice, OutputFormat, SayOptions, TtsError};
 
 #[test]
 fn kokoro_hello_world_produces_wav() {
@@ -25,6 +25,7 @@ fn kokoro_hello_world_produces_wav() {
             speed: 1.0,
         },
         ssml: false,
+        format: OutputFormat::Wav,
     })
     .unwrap();
     assert_eq!(&wav[..4], b"RIFF", "not a WAV");
@@ -46,6 +47,7 @@ fn empty_text_errors() {
             speed: 1.0,
         },
         ssml: false,
+        format: OutputFormat::Wav,
     });
     assert!(matches!(res, Err(TtsError::EmptyText)));
 }
@@ -62,6 +64,7 @@ fn too_long_errors() {
             speed: 1.0,
         },
         ssml: false,
+        format: OutputFormat::Wav,
     });
     assert!(matches!(res, Err(TtsError::TextTooLong { .. })));
 }
@@ -84,6 +87,7 @@ fn kokoro_ssml_with_break_produces_wav() {
             speed: 1.0,
         },
         ssml: true,
+        format: OutputFormat::Wav,
     })
     .unwrap();
     assert_eq!(&wav[..4], b"RIFF");
@@ -107,6 +111,7 @@ fn ssml_input_without_speak_root_errors() {
             speed: 1.0,
         },
         ssml: true,
+        format: OutputFormat::Wav,
     });
     assert!(matches!(res, Err(TtsError::SynthesisFailed(_))));
 }

--- a/rust/tests/tts_opus.rs
+++ b/rust/tests/tts_opus.rs
@@ -47,14 +47,20 @@ fn ogg_opus_starts_with_ogg_page_and_opus_head() {
     // Channel count at offset +9 must be 1 (mono); pre-skip is non-zero.
     assert_eq!(bytes[head_at + 9], 1, "must be mono");
     let pre_skip = u16::from_le_bytes([bytes[head_at + 10], bytes[head_at + 11]]);
-    assert!(pre_skip > 0, "pre_skip must be set so players strip warm-up");
+    assert!(
+        pre_skip > 0,
+        "pre_skip must be set so players strip warm-up"
+    );
     let input_sr = u32::from_le_bytes([
         bytes[head_at + 12],
         bytes[head_at + 13],
         bytes[head_at + 14],
         bytes[head_at + 15],
     ]);
-    assert_eq!(input_sr, sr, "OpusHead.input_sample_rate must reflect engine SR");
+    assert_eq!(
+        input_sr, sr,
+        "OpusHead.input_sample_rate must reflect engine SR"
+    );
 }
 
 #[test]
@@ -174,9 +180,7 @@ fn opus_bitrate_override_changes_output_size() {
 // =============================================================================
 
 fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|w| w == needle)
+    haystack.windows(needle.len()).position(|w| w == needle)
 }
 
 fn find_all(haystack: &[u8], needle: &[u8]) -> Vec<usize> {

--- a/rust/tests/tts_opus.rs
+++ b/rust/tests/tts_opus.rs
@@ -1,0 +1,194 @@
+//! OggOpus output validation (#223).
+//!
+//! These tests don't need a TTS model — they exercise the encoder pipeline
+//! directly with synthetic PCM. The model-backed e2e check (`kesha say --format
+//! ogg-opus | sendVoice`) lives in the manual QA loop documented in #223 and
+//! the smoke-test scripts under `scripts/`.
+
+#![cfg(feature = "tts")]
+
+use kesha_engine::tts::encode::{self, OutputFormat};
+
+/// First 27 bytes of every Ogg page are the page header. Layout per RFC 3533 §6:
+///
+/// ```text
+///  0..4   "OggS"
+///  4      version = 0
+///  5      header_type (1 = continuation, 2 = bos, 4 = eos)
+///  6..14  granule_position (i64 LE)
+///  14..18 bitstream_serial_number (u32 LE)
+///  18..22 page_sequence_number (u32 LE)
+///  22..26 CRC32
+///  26     number_page_segments
+/// ```
+const OGG_PAGE_MAGIC: &[u8; 4] = b"OggS";
+
+#[test]
+fn ogg_opus_starts_with_ogg_page_and_opus_head() {
+    // 100 ms of 440 Hz @ 24 kHz so we land inside a single Opus frame with no
+    // resample. Real synthesis is much longer; this is the minimum we need to
+    // exercise the muxer end-to-end.
+    let sr = 24_000u32;
+    let n = (sr as f32 * 0.5) as usize;
+    let samples: Vec<f32> = (0..n)
+        .map(|i| (i as f32 * 2.0 * std::f32::consts::PI * 440.0 / sr as f32).sin() * 0.3)
+        .collect();
+    let bytes = encode::encode(&samples, sr, OutputFormat::ogg_opus_default()).unwrap();
+
+    // First page must be the BOS page carrying OpusHead.
+    assert_eq!(&bytes[..4], OGG_PAGE_MAGIC);
+    assert_eq!(bytes[4], 0, "Ogg version is always 0");
+    let bos_flag = bytes[5];
+    assert_eq!(bos_flag & 0x02, 0x02, "first page must have BOS flag set");
+
+    // Find OpusHead packet (first page's payload begins after the 27-byte
+    // header + segment table; for a small head it's right after the segments).
+    let head_at = find(&bytes, b"OpusHead").expect("OpusHead missing");
+    // Channel count at offset +9 must be 1 (mono); pre-skip is non-zero.
+    assert_eq!(bytes[head_at + 9], 1, "must be mono");
+    let pre_skip = u16::from_le_bytes([bytes[head_at + 10], bytes[head_at + 11]]);
+    assert!(pre_skip > 0, "pre_skip must be set so players strip warm-up");
+    let input_sr = u32::from_le_bytes([
+        bytes[head_at + 12],
+        bytes[head_at + 13],
+        bytes[head_at + 14],
+        bytes[head_at + 15],
+    ]);
+    assert_eq!(input_sr, sr, "OpusHead.input_sample_rate must reflect engine SR");
+}
+
+#[test]
+fn ogg_opus_has_eos_flag_on_final_page() {
+    // Walk pages and assert exactly one EOS flag, on the last page.
+    let sr = 24_000u32;
+    let samples: Vec<f32> = vec![0.0; sr as usize]; // 1 s of silence
+    let bytes = encode::encode(&samples, sr, OutputFormat::ogg_opus_default()).unwrap();
+
+    let mut eos_seen = 0usize;
+    let mut last_was_eos = false;
+    for window_start in find_all(&bytes, OGG_PAGE_MAGIC) {
+        let header_type = bytes[window_start + 5];
+        let is_eos = header_type & 0x04 == 0x04;
+        if is_eos {
+            eos_seen += 1;
+        }
+        last_was_eos = is_eos;
+    }
+    assert_eq!(eos_seen, 1, "exactly one page must carry EOS");
+    assert!(last_was_eos, "EOS must be on the final page");
+}
+
+#[test]
+fn ogg_opus_is_substantially_smaller_than_wav() {
+    // The 24x size win versus WAV is the whole point of this feature
+    // (per #223). 5 seconds @ 32 kbps Opus ≈ 20 KB; same in 24 kHz mono f32
+    // WAV ≈ 480 KB. We assert at least a 5x improvement to leave headroom for
+    // libopus version drift.
+    let sr = 24_000u32;
+    let n = sr as usize * 5;
+    // White noise so the encoder can't trivially compress a constant signal.
+    let mut state: u32 = 0x1234_5678;
+    let samples: Vec<f32> = (0..n)
+        .map(|_| {
+            state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+            ((state >> 16) as f32 / 32_768.0 - 1.0) * 0.1
+        })
+        .collect();
+
+    let wav = encode::encode(&samples, sr, OutputFormat::Wav).unwrap();
+    let opus = encode::encode(&samples, sr, OutputFormat::ogg_opus_default()).unwrap();
+
+    assert!(
+        opus.len() * 5 < wav.len(),
+        "expected opus ({} B) to be at least 5x smaller than wav ({} B)",
+        opus.len(),
+        wav.len()
+    );
+}
+
+#[test]
+fn ogg_opus_resamples_22050_to_supported_rate() {
+    // Vosk-RU runs at 22.05 kHz; libopus only supports 8/12/16/24/48 kHz.
+    // The encoder must transparently resample.
+    let src_sr = 22_050u32;
+    let n = (src_sr as f32 * 0.4) as usize;
+    let samples: Vec<f32> = (0..n)
+        .map(|i| (i as f32 * 2.0 * std::f32::consts::PI * 880.0 / src_sr as f32).sin() * 0.3)
+        .collect();
+    let bytes = encode::encode(&samples, src_sr, OutputFormat::ogg_opus_default()).unwrap();
+    assert_eq!(&bytes[..4], OGG_PAGE_MAGIC);
+    // OpusHead.input_sample_rate must reflect the *original* engine SR so
+    // players display the right thing — even though libopus encoded at 24 kHz.
+    let head_at = find(&bytes, b"OpusHead").unwrap();
+    let input_sr = u32::from_le_bytes([
+        bytes[head_at + 12],
+        bytes[head_at + 13],
+        bytes[head_at + 14],
+        bytes[head_at + 15],
+    ]);
+    assert_eq!(input_sr, src_sr);
+}
+
+#[test]
+fn opus_bitrate_override_changes_output_size() {
+    // Sanity: bumping --bitrate visibly inflates the file. Catches a future
+    // regression where the CLI flag silently fails to plumb through.
+    let sr = 24_000u32;
+    let n = sr as usize * 3;
+    let mut state: u32 = 0xdead_beef;
+    let samples: Vec<f32> = (0..n)
+        .map(|_| {
+            state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+            ((state >> 16) as f32 / 32_768.0 - 1.0) * 0.1
+        })
+        .collect();
+
+    let low = encode::encode(
+        &samples,
+        sr,
+        OutputFormat::OggOpus {
+            bitrate: 16_000,
+            sample_rate: 24_000,
+        },
+    )
+    .unwrap();
+    let high = encode::encode(
+        &samples,
+        sr,
+        OutputFormat::OggOpus {
+            bitrate: 64_000,
+            sample_rate: 24_000,
+        },
+    )
+    .unwrap();
+    assert!(
+        high.len() > low.len(),
+        "64k encode ({} B) should be larger than 16k encode ({} B)",
+        high.len(),
+        low.len()
+    );
+}
+
+// =============================================================================
+// helpers
+// =============================================================================
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|w| w == needle)
+}
+
+fn find_all(haystack: &[u8], needle: &[u8]) -> Vec<usize> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + needle.len() <= haystack.len() {
+        if &haystack[i..i + needle.len()] == needle {
+            out.push(i);
+            i += needle.len();
+        } else {
+            i += 1;
+        }
+    }
+    out
+}

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -125,6 +125,19 @@ export const sayCommand = defineCommand({
       }
     }
 
+    // Reject --bitrate / --sample-rate with WAV up front to surface the error fast.
+    const hasOpusOnlyFlag = Boolean(args.bitrate) || Boolean(args["sample-rate"]);
+    if (hasOpusOnlyFlag) {
+      const outExt = typeof args.out === "string"
+        ? args.out.split(".").pop()?.toLowerCase()
+        : undefined;
+      const impliesOpus = outExt && ["ogg", "opus", "oga"].includes(outExt);
+      if (format === "wav" || (format === undefined && !impliesOpus)) {
+        log.error("--bitrate and --sample-rate are only valid with --format ogg-opus");
+        process.exit(2);
+      }
+    }
+
     const opts = {
       text,
       voice,

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
 import { detectTextLanguageEngine, getEngineBinPath } from "../engine";
 import { log } from "../log";
-import { say, SayError } from "../say";
+import { say, SayError, type SayFormat } from "../say";
 
 /**
  * Darwin defaults to AVSpeech Milena — zero install, no model download required.
@@ -54,18 +54,33 @@ async function resolveText(inline: string | undefined): Promise<string> {
 export const sayCommand = defineCommand({
   meta: {
     name: "say",
-    description: "Synthesize speech from text (TTS). Writes WAV to stdout (or --out file).",
+    description:
+      "Synthesize speech from text (TTS). Writes audio to stdout (or --out file). Defaults to WAV; use --format ogg-opus for messenger-ready voice notes.",
   },
   args: {
     text: { type: "positional", required: false, description: "Text to speak (stdin if omitted)" },
     voice: { type: "string", description: "Voice id, e.g. en-am_michael" },
     lang: { type: "string", description: "BCP 47 language code (default en-us)" },
-    out: { type: "string", description: "Write WAV to file instead of stdout" },
+    out: { type: "string", description: "Write audio to file instead of stdout" },
     rate: { type: "string", description: "Speaking rate 0.5–2.0", default: "1.0" },
     "list-voices": { type: "boolean", description: "List installed voices and exit" },
     ssml: {
       type: "boolean",
       description: "Parse input as SSML (supports <speak>, <break>; strips unknown tags)",
+    },
+    format: {
+      type: "string",
+      description:
+        "Output format: wav (default) or ogg-opus (Telegram-ready voice note). Inferred from --out extension when omitted.",
+    },
+    bitrate: {
+      type: "string",
+      description: "Opus bitrate in bits/sec (e.g. 32000). Only with --format ogg-opus.",
+    },
+    "sample-rate": {
+      type: "string",
+      description:
+        "Opus encoder sample rate (8000/12000/16000/24000/48000). Only with --format ogg-opus.",
     },
     verbose: {
       type: "boolean",
@@ -94,6 +109,22 @@ export const sayCommand = defineCommand({
     const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
     const voice = explicitVoice ?? (await autoRouteVoice(text));
 
+    // Validate --format up front so we surface a clear error before spawning
+    // the engine subprocess. The engine repeats the check authoritatively, but
+    // catching it here gives the user a faster failure mode in scripts.
+    const fmtArg = typeof args.format === "string" ? args.format.toLowerCase() : undefined;
+    let format: SayFormat | undefined;
+    if (fmtArg) {
+      if (fmtArg === "wav" || fmtArg === "ogg-opus") {
+        format = fmtArg;
+      } else if (fmtArg === "opus" || fmtArg === "ogg") {
+        format = "ogg-opus";
+      } else {
+        log.error(`unknown --format '${args.format}'. supported: wav, ogg-opus`);
+        process.exit(2);
+      }
+    }
+
     const opts = {
       text,
       voice,
@@ -101,18 +132,21 @@ export const sayCommand = defineCommand({
       out: typeof args.out === "string" ? args.out : undefined,
       rate: args.rate ? Number(args.rate) : undefined,
       ssml: Boolean(args.ssml),
+      format,
+      bitrate: args.bitrate ? Number(args.bitrate) : undefined,
+      sampleRate: args["sample-rate"] ? Number(args["sample-rate"]) : undefined,
     };
 
     try {
       const startedAt = performance.now();
-      const wav = await say(opts);
+      const audio = await say(opts);
       const ttsTimeMs = Math.round(performance.now() - startedAt);
       if (args.verbose) {
-        // stderr — stdout may carry raw WAV bytes when --out is omitted.
+        // stderr — stdout may carry raw audio bytes when --out is omitted.
         console.error(`TTS time: ${ttsTimeMs}ms`);
       }
       if (!opts.out) {
-        process.stdout.write(wav);
+        process.stdout.write(audio);
       }
     } catch (err) {
       if (err instanceof SayError) {

--- a/src/say.ts
+++ b/src/say.ts
@@ -1,6 +1,14 @@
 import { getEngineBinPath, isEngineInstalled } from "./engine";
 import { log } from "./log";
 
+/**
+ * Wire format for the synthesized audio. Matches the engine's `--format` flag.
+ * - `wav` (default): RIFF WAV at the engine's native sample rate.
+ * - `ogg-opus`: OGG-encapsulated Opus, mono. The format Telegram, WhatsApp,
+ *   Signal, and Discord render as native voice messages. See #223.
+ */
+export type SayFormat = "wav" | "ogg-opus";
+
 export interface SayOptions {
   /**
    * Text to synthesize. Required for programmatic callers — `say()` does not
@@ -18,6 +26,18 @@ export interface SayOptions {
   rate?: number;
   /** Parse `text` as SSML (`<speak>…<break time="500ms"/>…</speak>`). See issue #122. */
   ssml?: boolean;
+  /**
+   * Output audio format. Defaults to `wav` (or inferred from the `out`
+   * extension when omitted: `.wav` → wav, `.ogg`/`.opus` → ogg-opus).
+   */
+  format?: SayFormat;
+  /** Opus bitrate in bits/second. Only valid with `format: "ogg-opus"`. Default 32000. */
+  bitrate?: number;
+  /**
+   * Encoder sample rate in Hz. Only valid with `format: "ogg-opus"`.
+   * Must be one of 8000, 12000, 16000, 24000, 48000. Default 24000.
+   */
+  sampleRate?: number;
 }
 
 /** Build the argv passed to `kesha-engine say` (pure, unit-testable). */
@@ -28,6 +48,9 @@ export function buildSayArgs(o: SayOptions): string[] {
   if (o.out) args.push("--out", o.out);
   if (o.rate !== undefined && o.rate !== 1.0) args.push("--rate", String(o.rate));
   if (o.ssml) args.push("--ssml");
+  if (o.format) args.push("--format", o.format);
+  if (o.bitrate !== undefined) args.push("--bitrate", String(o.bitrate));
+  if (o.sampleRate !== undefined) args.push("--sample-rate", String(o.sampleRate));
   if (o.text !== undefined && o.text.length > 0) args.push(o.text);
   return args;
 }


### PR DESCRIPTION
Closes #223.

Adds `--format ogg-opus` to `kesha say` so it can emit messenger-ready voice notes directly, instead of forcing every consumer to shell out to `ffmpeg` after the fact.

## What ships

**Rust engine**
- New `rust/src/tts/encode.rs`: `OutputFormat::{Wav, OggOpus { bitrate, sample_rate }}` with `FromStr` (accepts `wav` / `ogg-opus` / `opus` / `ogg`), extension sniffer, and a single `encode()` entrypoint.
- `OggOpus` encoder: validates SR ∈ {8, 12, 16, 24, 48} kHz and bitrate ∈ 6 000..=510 000 bps, resamples non-native rates via `rubato` (sinc), builds `OpusHead` per RFC 7845 §5.1 (pre_skip = 3840 samples @ 48 kHz) + `OpusTags` (vendor `kesha-voice-kit <version>`), encodes 20 ms frames with `opus::Encoder` (Application::Voip + Signal::Voice), muxes via `ogg::PacketWriter` with serial `0x4B45_5348` ('KESH'), granule positions in samples-at-48k.
- All four engine paths (Kokoro plain/SSML, Vosk-TTS plain/SSML, AVSpeech) now route their final WAV/PCM through `encode::encode`. AVSpeech keeps its sidecar WAV path on macOS and only decodes back to PCM when `format != Wav`.

**CLI surface**
- `kesha say --format <wav|ogg-opus> [--bitrate <bps>] [--sample-rate <hz>]`
- Format is inferred from `--out` extension when `--format` is omitted (`.wav` / `.ogg` / `.opus` / `.oga`); falls back to WAV otherwise.
- `--bitrate` / `--sample-rate` with `--format wav` is rejected up front with a clear error.

**TypeScript wrapper**
- `SayFormat = "wav" | "ogg-opus"` exported from `src/say.ts`; new `format`, `bitrate`, `sampleRate` fields on `SayOptions`.
- `src/cli/say.ts` adds the same flags, validates aliases (`opus` / `ogg` → `ogg-opus`) before forwarding.

**Dependencies (MIT-compatible)**
- `opus = "0.3"` (MIT/Apache-2.0), wraps libopus (BSD-3, vendored via `opusic-sys`).
- `ogg = "0.9"` (BSD-3).

## Acceptance criteria from #223

- [x] Default stays WAV, byte-exact with the previous code path (regression test asserts).
- [x] `--format ogg-opus` produces a file whose first 4 bytes are `OggS` and whose first packet is `OpusHead` with non-zero `pre_skip`, mono, native input SR.
- [x] `--bitrate` / `--sample-rate` plumbed through; invalid combos rejected with clear messages.
- [x] Format inferred from `--out` extension when `--format` omitted.
- [x] No new system deps — libopus is built from source via `opusic-sys` (cmake required at build time, same as Vosk).
- [x] Vosk-RU's native 22.05 kHz auto-resamples to a libopus-supported rate.

**Manual QA recommended:** the file produced by `kesha say --hello world --format ogg-opus --out hello.ogg`, sent via Telegram `sendVoice`, should render as a voice message bubble.

## Tests

| File | What it covers | Count |
|------|---------------|-------|
| `rust/src/tts/encode.rs` (`#[cfg(test)] mod tests`) | OutputFormat parsing, extension sniffing, frame math, resampler boundaries, header layout, error paths | 10 unit |
| `rust/tests/tts_opus.rs` | OggS magic + OpusHead bytes, EOS flag on last page only, Opus ≥ 5× smaller than equivalent WAV (white noise), 22.05 kHz → resample, `--bitrate` visibly changes file size | 5 integration |
| `rust/tests/tts_e2e.rs` | All 5 existing E2E cases extended with `format: OutputFormat::Wav` (regression) | 5 |
| `bun test:unit` | Existing TS unit suite untouched | 110 |

Full Rust suite (Linux, no `system_tts`): 77 lib + 97 main + 2 g2p_parity + 5 e2e + 5 opus + 13 smoke = **199 passing, 0 failing**.

```
cargo test --no-default-features --features tts
```

## Out of scope (per #223, deferred)

- Streaming chunked output, WhatsApp `.opus` (no OGG container), AVAudioConverter `.m4a` on Apple platforms, automated upload to chats, MP3 / FLAC.

## Files

```
 CHANGELOG.md          |   5 +++
 rust/Cargo.lock       |  31 ++++++
 rust/Cargo.toml       |   8 +++-
 rust/src/main.rs      |  95 +++++++-
 rust/src/tts/mod.rs   | 100 +++++++-
 rust/src/tts/encode.rs (NEW, 591 lines)
 rust/tests/tts_e2e.rs |   7 +++-
 rust/tests/tts_opus.rs (NEW, 195 lines)
 src/cli/say.ts        |  46 ++++-
 src/say.ts            |  23 +++
```
