### PR TITLE
perf(tts): drop redundant pcm copy + right-size opus output buffer

### DIFF
--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -178,7 +178,9 @@ fn encode_ogg_opus(
     //   page 0: OpusHead (BOS, sequence 0, granule 0)
     //   page 1: OpusTags (sequence 1, granule 0)
     //   page 2..: audio packets, with EOS on the last
-    let mut buf: Vec<u8> = Vec::with_capacity(samples.len());
+    // Rough upper bound for compressed bytes: bitrate × duration + header pages.
+    let cap = (samples.len() as u64 * bitrate as u64 / (8 * src_rate as u64)) as usize + 4 * 1024;
+    let mut buf: Vec<u8> = Vec::with_capacity(cap);
     let cursor = std::io::Cursor::new(&mut buf);
     let mut writer = ogg::PacketWriter::new(cursor);
 
@@ -212,9 +214,8 @@ fn encode_ogg_opus(
 
     for i in 0..n_full_packets {
         let start = i * frame_size;
-        pcm_buf.copy_from_slice(&resampled[start..start + frame_size]);
         let nbytes = enc
-            .encode_float(&pcm_buf, &mut packet)
+            .encode_float(&resampled[start..start + frame_size], &mut packet)
             .map_err(|e| anyhow::anyhow!("opus encode (frame {i}): {e}"))?;
 
         sample_pos_48k += target_to_48k(frame_size as u32, target_sr);


### PR DESCRIPTION
Two hot-path efficiency wins for `kesha say --format ogg-opus`, surfaced by post-merge review of #224.

## Changes

**`rust/src/tts/encode.rs::encode_ogg_opus`**

1. **Skip the `pcm_buf.copy_from_slice` in the main encode loop.** `opus::Encoder::encode_float` only needs `&[f32]`, so we now pass `&resampled[start..start + frame_size]` directly. Saves one frame-sized memcpy per 20 ms frame — ~1500 redundant copies on a 30 s utterance. `pcm_buf` is still allocated and used for the zero-padded tail and empty-input branches.

2. **Right-size the OGG output `Vec::with_capacity`.** It was sized to `samples.len()` — i.e. f32-sample-count *bytes*, which over-allocates by ~6× for a typical 32 kbps Opus stream. Now estimated from the actual encoder budget: `samples.len() * bitrate / (8 * src_rate) + 4 KiB` (bitrate × duration in bytes, plus a header pad).

## What was *not* changed

The packet writes still call `.to_vec()` on the encoded Opus bytes. The borrowing alternative (`&packet[..nbytes]`) fails to compile — `ogg::PacketWriter<'writer, T>` captures the slice for its `'writer` lifetime parameter, which outlives a single `write_packet` call, so the next `&mut packet` borrow for the following frame is blocked. The `to_vec()` is load-bearing.

## Verification

- `cargo clippy --all-targets --features tts,onnx --no-default-features -- -D warnings` — clean
- `cargo test --features tts,onnx --no-default-features --lib tts::encode` — 10/10 pass (including `ogg_opus_produces_valid_oggs_magic` and `ogg_opus_resamples_when_engine_sr_mismatches`)

Refs #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)