### PR TITLE
chore(release): v1.6.0 — OGG/Opus output, Windows MSVC, perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,19 @@ binary.
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-04-30
+
+Engine release. Adds OGG/Opus voice-note output, restores Windows MSVC builds via a vendored vosk-tts crate, and tightens the Opus hot path. CLI surface is unchanged — npm consumers get the new format flag automatically once the engine binary updates.
+
 ### Added
-- **`kesha say --format ogg-opus`** — produces OGG/Opus voice notes (mono, 24 kHz @ 32 kbps by default) instead of WAV. The output file is the messenger-friendly format consumed by Telegram `sendVoice` and similar APIs. New flags `--bitrate` and `--sample-rate` tune the encoder; format is also inferred from `--out` extension (`.ogg` / `.opus` / `.oga`). All four engine paths (Kokoro plain/SSML, Vosk-TTS plain/SSML, AVSpeech) flow through the new encoder. WAV output remains the default and is byte-exact with the previous code path. (closes #223)
+- **`kesha say --format ogg-opus`** — produces OGG/Opus voice notes (mono, 24 kHz @ 32 kbps by default) instead of WAV. The output file is the messenger-friendly format consumed by Telegram `sendVoice` and similar APIs. New flags `--bitrate` and `--sample-rate` tune the encoder; format is also inferred from `--out` extension (`.ogg` / `.opus` / `.oga`). All four engine paths (Kokoro plain/SSML, Vosk-TTS plain/SSML, AVSpeech) flow through the new encoder. WAV output remains the default and is byte-exact with the previous code path. (#224, closes #223)
+
+### Changed
+- **Vendored `vosk-tts-rs`** into `rust/vendor/vosk-tts` so Windows builds compile under MSVC again — upstream's `tonic`/`prost` chain pulled in MinGW-only deps that broke the Windows engine artifact. Behaviour and the public Rust API are unchanged. (#225, closes #216)
+- npm `homepage` field now points at the project landing page (`https://drakulavich.github.io/kesha-voice-kit/`) instead of the README anchor.
+
+### Performance
+- **OGG/Opus encoder hot path:** dropped a redundant `pcm_buf.copy_from_slice` per 20 ms frame (saves N memcpys for an N-frame utterance), and right-sized the output `Vec::with_capacity` from `samples.len()` (≈6× over) to `bitrate × duration / 8 + 4 KiB`. (#226)
 
 ## [1.5.0] — 2026-04-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.5.0"
+    "version": "1.6.0"
   },
   "scripts": {
     "test": "bun test",
@@ -58,7 +58,7 @@
     "type": "git",
     "url": "git+https://github.com/drakulavich/kesha-voice-kit.git"
   },
-  "homepage": "https://github.com/drakulavich/kesha-voice-kit#readme",
+  "homepage": "https://drakulavich.github.io/kesha-voice-kit/",
   "bugs": {
     "url": "https://github.com/drakulavich/kesha-voice-kit/issues"
   },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
Engine release. Bumps CLI + engine to **v1.6.0** in lockstep.

## Versions

| | before | after |
|---|---|---|
| `package.json#version` | 1.5.0 | **1.6.0** |
| `package.json#keshaEngine.version` | 1.5.0 | **1.6.0** |
| `rust/Cargo.toml` | 1.5.0 | **1.6.0** |
| `rust/Cargo.lock` | — | regenerated |

## What's in v1.6.0

**Engine:**
- **#224** — `kesha say --format ogg-opus` produces Telegram-ready voice notes (24 kHz @ 32 kbps mono by default), with `--bitrate` / `--sample-rate` / `--out` extension inference. WAV output stays bit-exact.
- **#225** — vendored `vosk-tts-rs` into `rust/vendor/vosk-tts`, restoring Windows MSVC builds (closes #216).
- **#226** — Opus encoder hot-path: skip a redundant `pcm_buf.copy_from_slice` per frame; right-size the output `Vec::with_capacity` (was ~6× over).

**CLI metadata:**
- npm `homepage` → `https://drakulavich.github.io/kesha-voice-kit/` (was the README anchor; site is live, returns 200).

## Post-merge checklist (per CLAUDE.md → \"Engine release\")

- [ ] `git tag v1.6.0 && git push origin v1.6.0` — triggers `build-engine.yml`
- [ ] Author release notes via `gh release edit v1.6.0 --notes …` while the draft is still draft
- [ ] `gh release edit v1.6.0 --draft=false` to publish the assets
- [ ] Run the v1.6.0 validation script (download published `kesha-engine-darwin-arm64`, exercise `--capabilities-json` + a real `say` synth) — \"DOWNLOAD AND EXERCISE THE PUBLISHED ASSET DIRECTLY BEFORE \`npm publish\`\"
- [ ] `npm publish --access public`
- [ ] Verify the new homepage shows on https://www.npmjs.com/package/@drakulavich/kesha-voice-kit

## CI

`integration-tests` is filtered to skip on `release/*` branches because it tries to download the (yet-unbuilt) v1.6.0 engine — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)