### PR TITLE
docs(skill,raycast): surface v1.6.0 OGG/Opus voice notes; fix stale voices

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -17,12 +17,13 @@ install:
 
 Local voice toolkit: transcribe voice messages to text, synthesize speech, detect language of audio or text. Fully offline after `kesha install`. No API keys, no per-minute billing.
 
-**Trigger keywords for when to use this skill:** voice message, voice memo, .ogg, .wav, .mp3, audio file, transcribe, transcription, speech-to-text, STT, text-to-speech, TTS, synthesize speech, say, multilingual voice, multilingual ASR, language detection, offline voice, privacy, Apple Silicon, CoreML.
+**Trigger keywords for when to use this skill:** voice message, voice memo, voice note, .ogg, .opus, .wav, .mp3, audio file, transcribe, transcription, speech-to-text, STT, text-to-speech, TTS, synthesize speech, say, telegram voice note, whatsapp voice note, ogg-opus, opus, multilingual voice, multilingual ASR, language detection, offline voice, privacy, Apple Silicon, CoreML.
 
 ## When to use
 
 - **Voice memo arrived** (Telegram, WhatsApp, Slack, Signal .ogg/.opus/.m4a): transcribe with `kesha --json <path>` and branch on the detected language.
-- **Need to reply with audio**: synthesize with `kesha say "<text>" > reply.wav`. Auto-routes by detected language (Kokoro-82M for English, Vosk-TTS for Russian). For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
+- **Need to reply with audio (file playback)**: synthesize with `kesha say "<text>" > reply.wav`. Auto-routes by detected language (Kokoro-82M for English, Vosk-TTS for Russian). For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
+- **Need to send a voice note (Telegram, WhatsApp, Signal, Discord)**: synthesize directly into the messenger-native format with `kesha say "<text>" --format ogg-opus --out reply.ogg`. Default is mono 24 kHz @ 32 kbps — what Telegram `sendVoice` expects. No `ffmpeg` round-trip needed.
 - **Need to detect what language a file is in** before choosing a pipeline: `kesha --json audio.ogg` returns both audio-based and text-based language detection with confidence scores.
 
 ## STT: transcribe audio
@@ -61,7 +62,17 @@ kesha say --voice macos-de-DE "Guten Tag" > de.wav # any macOS system voice — 
 kesha say --list-voices                            # Kokoro + Vosk-TTS + ~180 macos-* voices
 ```
 
-Output: WAV mono float32. `--out <path>` writes to a file instead of stdout.
+Output: WAV mono float32 by default. `--out <path>` writes to a file instead of stdout.
+
+**Voice notes (Telegram / WhatsApp / Signal / Discord):** add `--format ogg-opus` to emit OGG/Opus directly — the format messenger APIs render as a native voice message:
+
+```bash
+kesha say "Hello there" --format ogg-opus --out reply.ogg                  # 24 kHz @ 32 kbps mono — Telegram-grade
+kesha say "Привет" --voice ru-vosk-m02 --format ogg-opus --out reply.ogg   # Russian voice note
+kesha say "Hi" --format ogg-opus --bitrate 16000 --out tiny.ogg            # tinier file, intelligible but lossy
+```
+
+Format is also inferred from `--out` extension (`.ogg` / `.opus` / `.oga` → OGG/Opus). `--bitrate` (6 000–510 000 bps) and `--sample-rate` (8 000 / 12 000 / 16 000 / 24 000 / 48 000 Hz) tune the encoder.
 
 ## Language detection standalone
 

--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -4,4 +4,5 @@
 
 - Add **Transcribe Selected Audio** command — transcribes the audio file selected in Finder using the local `kesha` CLI, shows transcript + detected language, pre-copies to clipboard.
 - Add **Speak Clipboard** command — synthesizes the current clipboard text via `kesha say` and plays it through the default output; voice auto-routed by detected language (Kokoro for English, Vosk-TTS for Russian, AVSpeech for macOS system voices).
-- Preferences for overriding the `kesha` binary path and default voice.
+- Preferences for overriding the `kesha` binary path and default voice. Default-voice placeholder lists the male Kokoro / Vosk picks (`en-am_michael`, `ru-vosk-m02`) per the project's brand-voice rule.
+- Recommended CLI: `@drakulavich/kesha-voice-kit@1.6.0` or newer (engine v1.6.0+) — adds OGG/Opus output (`kesha say --format ogg-opus`) for messenger-grade voice notes; not used by these commands directly but available to users via the `kesha` CLI on the command line.

--- a/raycast/package.json
+++ b/raycast/package.json
@@ -41,7 +41,7 @@
       "type": "textfield",
       "required": false,
       "default": "",
-      "placeholder": "en-af_heart, ru-denis, macos-com.apple.voice.compact.en-US.Samantha, ..."
+      "placeholder": "en-am_michael, ru-vosk-m02, macos-com.apple.voice.compact.en-US.Samantha, ..."
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Post-v1.6.0 follow-up. Two surfaces that exist outside of the engine release flow needed touching:

## OpenClaw skill (`SKILL.md`)

- **Trigger keywords** now include `voice note`, `telegram voice note`, `whatsapp voice note`, `ogg-opus`, `opus`, `.opus` — so an OpenClaw agent picks this skill when the user says "send X as a voice note" instead of falling through to a generic TTS skill.
- **New "When to use" bullet** for the messenger-grade reply path:
  > **Need to send a voice note (Telegram, WhatsApp, Signal, Discord):** synthesize directly into the messenger-native format with `kesha say "<text>" --format ogg-opus --out reply.ogg`.
- **TTS section** documents `--format` / `--bitrate` / `--sample-rate` with three example invocations (default Telegram-grade, Russian voice note, low-bitrate small file).

`SKILL.md` ships in the npm package, so this content takes effect on the next CLI publish (likely v1.6.1-cli).

## Raycast extension

- `raycast/package.json` — `defaultVoice` placeholder no longer suggests `en-af_heart` (female — breaks the project's brand-voice rule from CLAUDE.md) or `ru-denis` (Piper — removed in v1.5.0). Now: `en-am_michael, ru-vosk-m02, macos-com.apple.voice.compact.en-US.Samantha, …`.
- `raycast/CHANGELOG.md` — documents the brand-voice placeholder fix and notes the recommended CLI is now v1.6.0+ (extension commands themselves still write WAV → afplay, no behaviour change).

The Raycast extension publishes via `ray publish`, separate from npm.

## Out of scope

- `openclaw-plugin.cjs` — ASR-only provider; nothing to update for the v1.6.0 TTS feature.
- Speak Clipboard command behaviour — keeps WAV → `afplay`. OGG would need an extra decode step on playback for no benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)