### PR TITLE
chore(release): v1.8.1 — emphasis warn-once polish (closes #237, #238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ binary.
 
 ## [Unreleased]
 
+## [1.8.1] (unreleased)
+
+### Fixed
+
+- **`<emphasis level="none">` no longer triggers the "non-ru-vosk" warning** on Kokoro and the defensive Vosk arm. The user explicitly opted out of stress markers via `level="none"`; emitting "stress markers are honored only on ru-vosk-* voices" was technically accurate but misleading. The `warn_once` call is now gated on `!suppress`. Closes [#238](https://github.com/drakulavich/kesha-voice-kit/issues/238).
+
+### Added
+
+- **End-to-end test for warn-once dedup** across multiple `<emphasis>` calls in the same engine process (`emphasis_warn_once_dedups_across_calls` in `rust/tests/tts_ru_normalize.rs`). The `LoopEngine` test wrapper now captures stderr to a tempfile via a new `into_stderr_log()` consuming method so the contract "one warning per process, not per call" is verified at the integration layer. Closes [#237](https://github.com/drakulavich/kesha-voice-kit/issues/237).
+
 ## [1.8.0] (unreleased)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.8.0"
+    "version": "1.8.1"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -261,15 +261,20 @@ pub fn synth_segments_kokoro_with(
                 out.extend(audio);
             }
             ssml::Segment::Break(dur) => out.extend(silence_samples(*dur, sample_rate)),
-            ssml::Segment::Emphasis { content, .. } => {
+            ssml::Segment::Emphasis { content, suppress } => {
                 // <emphasis> stress markers are honored only on ru-vosk-* voices.
                 // For Kokoro, strip `+` from content (G2P would otherwise choke on
                 // the unfamiliar character) and warn the user once per process.
-                crate::tts::warn::warn_once(
-                    "emphasis-non-ru-vosk",
-                    "<emphasis> stress markers are honored only on ru-vosk-* voices; \
-                     stripping `+` from content for non-Vosk path",
-                );
+                // Skip the warning when suppress=true: the caller used level="none"
+                // to explicitly opt out of stress markers — the warning would be
+                // misleading. Closes #238.
+                if !suppress {
+                    crate::tts::warn::warn_once(
+                        "emphasis-non-ru-vosk",
+                        "<emphasis> stress markers are honored only on ru-vosk-* voices; \
+                         stripping `+` from content for non-Vosk path",
+                    );
+                }
                 let stripped = if content.contains('+') {
                     content.replace('+', "")
                 } else {
@@ -378,13 +383,18 @@ pub fn synth_segments_vosk_with(
                 out.extend(audio);
             }
             ssml::Segment::Break(dur) => out.extend(silence_samples(*dur, sample_rate)),
-            ssml::Segment::Emphasis { content, .. } => {
+            ssml::Segment::Emphasis { content, suppress } => {
                 // Defensive fallback: ru::normalize_segments converts Emphasis→Text upstream.
-                crate::tts::warn::warn_once(
-                    "emphasis-non-ru-vosk",
-                    "<emphasis> reached the Vosk synth without ru::normalize_segments \
-                     preprocessing; stripping `+` markers as a fallback",
-                );
+                // Skip the warning when suppress=true: the caller used level="none"
+                // to explicitly opt out of stress markers — the warning would be
+                // misleading. Closes #238.
+                if !suppress {
+                    crate::tts::warn::warn_once(
+                        "emphasis-non-ru-vosk",
+                        "<emphasis> reached the Vosk synth without ru::normalize_segments \
+                         preprocessing; stripping `+` markers as a fallback",
+                    );
+                }
                 let stripped = if content.contains('+') {
                     content.replace('+', "")
                 } else {

--- a/rust/tests/tts_ru_normalize.rs
+++ b/rust/tests/tts_ru_normalize.rs
@@ -85,6 +85,9 @@ struct LoopEngine {
     /// the test deadlocks at end-of-scope.
     stdin: Option<std::process::ChildStdin>,
     stdout: std::process::ChildStdout,
+    /// Path to a tempfile where the child's stderr is captured.
+    /// Used by `into_stderr_log()` to verify warn-once dedup. (#237)
+    stderr_path: std::path::PathBuf,
 }
 
 impl LoopEngine {
@@ -93,11 +96,21 @@ impl LoopEngine {
     fn spawn() -> Option<Self> {
         vosk_model_dir_or_skip()?;
         let bin = env!("CARGO_BIN_EXE_kesha-engine");
+        // Capture stderr to a tempfile so tests can assert warn-once dedup. (#237)
+        let stderr_path = std::env::temp_dir().join(format!(
+            "kesha-loop-test-{}-{}.stderr.log",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        let stderr_file = std::fs::File::create(&stderr_path).expect("create stderr log");
         let mut child = Command::new(bin)
             .args(["say", "--voice", "ru-vosk-m02", "--stdin-loop"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::from(stderr_file))
             .spawn()
             .expect("spawn kesha-engine --stdin-loop");
         let stdin = child.stdin.take().expect("child stdin");
@@ -106,7 +119,20 @@ impl LoopEngine {
             child,
             stdin: Some(stdin),
             stdout,
+            stderr_path,
         })
+    }
+
+    /// Consume the engine, close stdin (→ engine exits), wait for the child,
+    /// read the captured stderr log, and return its contents.
+    ///
+    /// Call this INSTEAD of letting the engine drop naturally when a test
+    /// wants to inspect stderr — it reads the file before Drop removes it.
+    fn into_stderr_log(mut self) -> String {
+        // Close stdin → engine sees EOF and exits cleanly.
+        drop(self.stdin.take());
+        let _ = self.child.wait();
+        std::fs::read_to_string(&self.stderr_path).unwrap_or_default()
     }
 
     /// Synthesise `text` and return the raw audio bytes (WAV).
@@ -311,5 +337,47 @@ fn emphasis_marker_shifts_stress() {
         suppressed.len(),
         baseline.len(),
         r2,
+    );
+}
+
+/// Issue #237 — verify that `warn_once("emphasis-no-plus", ...)` is
+/// deduplicated across multiple SSML calls within the same engine process.
+/// The stdin-loop daemon shares one Vosk session AND one warn-once HashSet,
+/// so multiple bad inputs must produce ONE stderr line, not N.
+#[test]
+fn emphasis_warn_once_dedups_across_calls() {
+    let mut eng = match LoopEngine::spawn() {
+        Some(e) => e,
+        None => {
+            eprintln!("skipping emphasis_warn_once_dedups_across_calls: vosk-ru models not staged");
+            return;
+        }
+    };
+
+    // Three calls without `+` markers — should fire warn_once exactly once.
+    let _ = eng.synth(r#"<speak><emphasis>обычно</emphasis></speak>"#, true, false);
+    let _ = eng.synth(
+        r#"<speak><emphasis>другое слово</emphasis></speak>"#,
+        true,
+        false,
+    );
+    let _ = eng.synth(
+        r#"<speak><emphasis>третий вход</emphasis></speak>"#,
+        true,
+        false,
+    );
+
+    // Consume the engine: closes stdin → engine exits → stderr file fully
+    // written before we read it.
+    let stderr = eng.into_stderr_log();
+
+    let warn_count = stderr
+        .lines()
+        .filter(|l| l.contains("emphasis-no-plus") || l.contains("no `+` marker"))
+        .count();
+
+    assert_eq!(
+        warn_count, 1,
+        "expected exactly one emphasis-no-plus warning across 3 calls, got {warn_count}.\nstderr:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Patch release combining two follow-ups from #233:

- **#238**: `<emphasis level=\"none\">` on Kokoro/AVSpeech paths no longer spuriously fires the \"stress markers are honored only on ru-vosk-*\" warning. The user explicitly opted out via \`level=\"none\"\`, so the warning was technically correct but misleading.
- **#237**: end-to-end integration test asserts that three consecutive `<emphasis>без-плюса</emphasis>` calls in the same engine process produce exactly one stderr warning, not three. `LoopEngine` test wrapper now captures stderr to a tempfile via a new `into_stderr_log()` consuming method.

## Versions bumped

- `rust/Cargo.toml`: 1.8.0 → **1.8.1**
- `rust/Cargo.lock`: regenerated
- `package.json#keshaEngine.version`: 1.8.0 → **1.8.1**
- `package.json#version`: 1.8.0 → **1.8.1**

## Acceptance

- [x] `<emphasis level=\"none\">word</emphasis>` on en-am_michael produces no warning.
- [x] `<emphasis>word</emphasis>` (default level, no \`+\`) still produces one warning per process.
- [x] New integration test `emphasis_warn_once_dedups_across_calls` confirms warn-once dedup over 3 consecutive calls.
- [x] All Rust lib + integration tests green (118 lib + 4 integration incl. new).
- [x] `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Refs

Closes #237, #238. Built on v1.8.0 (#240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)