### PR TITLE
feat: add timestamped transcript segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-m
 kesha audio.ogg                            # transcribe (plain text)
 kesha --format transcript audio.ogg        # text + language/confidence
 kesha --format json audio.ogg              # full JSON with lang fields
+kesha --json --timestamps audio.ogg        # JSON with timestamped segments
 kesha --toon audio.ogg                     # compact LLM-friendly TOON
 kesha --verbose audio.ogg                  # show language detection details
 kesha --lang en audio.ogg                  # warn if detected language differs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.8.2"
+    "version": "1.9.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.8.2"
+version = "1.9.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 

--- a/rust/src/capabilities.rs
+++ b/rust/src/capabilities.rs
@@ -10,7 +10,7 @@ pub struct Capabilities {
 
 pub fn get_capabilities() -> Capabilities {
     #[allow(unused_mut)]
-    let mut features = vec!["transcribe", "detect-lang", "vad"];
+    let mut features = vec!["transcribe", "transcribe.segments", "detect-lang", "vad"];
 
     #[cfg(target_os = "macos")]
     features.push("detect-text-lang");

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -33,6 +33,9 @@ enum Commands {
     Transcribe {
         /// Path to audio file
         audio_path: String,
+        /// Output structured JSON with text and timestamped segments.
+        #[arg(long)]
+        json: bool,
         /// Force Silero VAD preprocessing. Requires the VAD model to be
         /// installed (`kesha install --vad`). Mutually exclusive with
         /// `--no-vad`. Without either flag, VAD auto-engages on audio
@@ -385,12 +388,18 @@ fn main() -> Result<()> {
     match cli.command {
         Some(Commands::Transcribe {
             audio_path,
+            json,
             vad,
             no_vad,
         }) => {
             let mode = transcribe::VadMode::from_flags(vad, no_vad);
-            let text = transcribe::transcribe(&audio_path, mode)?;
-            println!("{}", text);
+            if json {
+                let output = transcribe::transcribe_output(&audio_path, mode)?;
+                println!("{}", serde_json::to_string(&output)?);
+            } else {
+                let text = transcribe::transcribe(&audio_path, mode)?;
+                println!("{}", text);
+            }
         }
         Some(Commands::DetectLang { audio_path }) => {
             let result = lang_id::detect_audio_language(&audio_path)?;

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use serde::Serialize;
 use std::path::Path;
 use std::time::Instant;
 
@@ -46,6 +47,19 @@ impl VadMode {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct TranscriptionSegment {
+    pub start: f32,
+    pub end: f32,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TranscriptionOutput {
+    pub text: String,
+    pub segments: Vec<TranscriptionSegment>,
+}
+
 /// Pure decision function so the auto-trigger rules can be unit-tested
 /// without ONNX, disk, or symphonia in the loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +83,10 @@ fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDec
 }
 
 pub fn transcribe(audio_path: &str, mode: VadMode) -> Result<String> {
+    Ok(transcribe_output(audio_path, mode)?.text)
+}
+
+pub fn transcribe_output(audio_path: &str, mode: VadMode) -> Result<TranscriptionOutput> {
     let model_dir = ensure_asr_installed()?;
     let vad_dir = models::vad_model_dir();
     let vad_installed = models::is_vad_cached(&vad_dir);
@@ -99,18 +117,21 @@ pub fn transcribe(audio_path: &str, mode: VadMode) -> Result<String> {
     }
 }
 
-fn transcribe_plain(audio_path: &str, model_dir: &str) -> Result<String> {
+fn transcribe_plain(audio_path: &str, model_dir: &str) -> Result<TranscriptionOutput> {
     let t0 = Instant::now();
     let mut be = backend::create_backend(model_dir)?;
     dtrace!("asr::backend_loaded dt={}ms", t0.elapsed().as_millis());
     let t1 = Instant::now();
-    let out = be.transcribe(audio_path)?;
+    let text = be.transcribe(audio_path)?;
     dtrace!(
         "asr::transcribe.end dt={}ms chars={}",
         t1.elapsed().as_millis(),
-        out.chars().count()
+        text.chars().count()
     );
-    Ok(out)
+    Ok(TranscriptionOutput {
+        segments: whole_file_segment(audio_path, &text),
+        text,
+    })
 }
 
 /// VAD-preprocessed transcription: segment the audio with Silero VAD,
@@ -123,7 +144,7 @@ fn transcribe_via_vad(
     model_dir: &str,
     vad_dir: &str,
     cfg: VadConfig,
-) -> Result<String> {
+) -> Result<TranscriptionOutput> {
     if !models::is_vad_cached(vad_dir) {
         anyhow::bail!(
             "Error: VAD model not installed\n\n\
@@ -159,11 +180,15 @@ fn transcribe_via_vad(
                 "warning: VAD produced no speech segments; transcribing full file (consider lowering --vad threshold or skipping --vad)"
             );
         }
-        return be.transcribe_samples(&samples);
+        let text = be.transcribe_samples(&samples)?;
+        return Ok(TranscriptionOutput {
+            segments: sample_span_segment(0.0, samples.len(), &text),
+            text,
+        });
     }
 
     let sr = VAD_SAMPLE_RATE as f32;
-    let mut transcripts: Vec<String> = Vec::with_capacity(segments.len());
+    let mut output_segments: Vec<TranscriptionSegment> = Vec::with_capacity(segments.len());
     for (start_s, end_s) in &segments {
         let start = (*start_s * sr) as usize;
         let end = ((*end_s * sr) as usize).min(samples.len());
@@ -183,7 +208,11 @@ fn transcribe_via_vad(
                 );
                 let trimmed = text.trim();
                 if !trimmed.is_empty() {
-                    transcripts.push(trimmed.to_string());
+                    output_segments.push(TranscriptionSegment {
+                        start: *start_s,
+                        end: *end_s,
+                        text: trimmed.to_string(),
+                    });
                 }
             }
             Err(e) => {
@@ -196,7 +225,43 @@ fn transcribe_via_vad(
         }
     }
 
-    Ok(transcripts.join(" "))
+    let text = output_segments
+        .iter()
+        .map(|s| s.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    Ok(TranscriptionOutput {
+        text,
+        segments: output_segments,
+    })
+}
+
+fn whole_file_segment(audio_path: &str, text: &str) -> Vec<TranscriptionSegment> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return vec![];
+    }
+    let Ok(Some(duration)) = audio::probe_duration_seconds(audio_path) else {
+        return vec![];
+    };
+    vec![TranscriptionSegment {
+        start: 0.0,
+        end: duration,
+        text: trimmed.to_string(),
+    }]
+}
+
+fn sample_span_segment(start_s: f32, sample_count: usize, text: &str) -> Vec<TranscriptionSegment> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return vec![];
+    }
+    vec![TranscriptionSegment {
+        start: start_s,
+        end: start_s + sample_count as f32 / VAD_SAMPLE_RATE as f32,
+        text: trimmed.to_string(),
+    }]
 }
 
 /// Probe audio duration for the `Auto` decision, gated on a cheap

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -83,10 +83,18 @@ fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDec
 }
 
 pub fn transcribe(audio_path: &str, mode: VadMode) -> Result<String> {
-    Ok(transcribe_output(audio_path, mode)?.text)
+    Ok(transcribe_inner(audio_path, mode, false)?.text)
 }
 
 pub fn transcribe_output(audio_path: &str, mode: VadMode) -> Result<TranscriptionOutput> {
+    transcribe_inner(audio_path, mode, true)
+}
+
+fn transcribe_inner(
+    audio_path: &str,
+    mode: VadMode,
+    timestamps_required: bool,
+) -> Result<TranscriptionOutput> {
     let model_dir = ensure_asr_installed()?;
     let vad_dir = models::vad_model_dir();
     let vad_installed = models::is_vad_cached(&vad_dir);
@@ -106,18 +114,22 @@ pub fn transcribe_output(audio_path: &str, mode: VadMode) -> Result<Transcriptio
         VadDecision::Vad => {
             transcribe_via_vad(audio_path, &model_dir, &vad_dir, VadConfig::default())
         }
-        VadDecision::Plain => transcribe_plain(audio_path, &model_dir),
+        VadDecision::Plain => transcribe_plain(audio_path, &model_dir, timestamps_required),
         VadDecision::PlainWithHint => {
             let secs = duration.unwrap_or(0.0);
             eprintln!(
                 "hint: audio is {secs:.0}s; `kesha install --vad` would improve long-audio accuracy"
             );
-            transcribe_plain(audio_path, &model_dir)
+            transcribe_plain(audio_path, &model_dir, timestamps_required)
         }
     }
 }
 
-fn transcribe_plain(audio_path: &str, model_dir: &str) -> Result<TranscriptionOutput> {
+fn transcribe_plain(
+    audio_path: &str,
+    model_dir: &str,
+    timestamps_required: bool,
+) -> Result<TranscriptionOutput> {
     let t0 = Instant::now();
     let mut be = backend::create_backend(model_dir)?;
     dtrace!("asr::backend_loaded dt={}ms", t0.elapsed().as_millis());
@@ -128,10 +140,12 @@ fn transcribe_plain(audio_path: &str, model_dir: &str) -> Result<TranscriptionOu
         t1.elapsed().as_millis(),
         text.chars().count()
     );
-    Ok(TranscriptionOutput {
-        segments: whole_file_segment(audio_path, &text),
-        text,
-    })
+    let segments = if timestamps_required {
+        whole_file_segment(audio_path, &text)?
+    } else {
+        vec![]
+    };
+    Ok(TranscriptionOutput { segments, text })
 }
 
 /// VAD-preprocessed transcription: segment the audio with Silero VAD,
@@ -237,19 +251,23 @@ fn transcribe_via_vad(
     })
 }
 
-fn whole_file_segment(audio_path: &str, text: &str) -> Vec<TranscriptionSegment> {
+fn whole_file_segment(audio_path: &str, text: &str) -> Result<Vec<TranscriptionSegment>> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
-        return vec![];
+        return Ok(vec![]);
     }
-    let Ok(Some(duration)) = audio::probe_duration_seconds(audio_path) else {
-        return vec![];
-    };
-    vec![TranscriptionSegment {
+    let duration = audio::probe_duration_seconds(audio_path)
+        .with_context(|| {
+            format!("failed to probe audio duration for timestamped segments: {audio_path}")
+        })?
+        .with_context(|| {
+            format!("audio duration is unavailable for timestamped segments: {audio_path}")
+        })?;
+    Ok(vec![TranscriptionSegment {
         start: 0.0,
         end: duration,
         text: trimmed.to_string(),
-    }]
+    }])
 }
 
 fn sample_span_segment(start_s: f32, sample_count: usize, text: &str) -> Vec<TranscriptionSegment> {
@@ -381,6 +399,24 @@ mod tests {
         assert_eq!(
             probe_duration_if_plausible("/nonexistent/path/to/audio.wav"),
             None
+        );
+    }
+
+    #[test]
+    fn whole_file_segment_errors_when_duration_is_unavailable() {
+        let tmp = tempfile::Builder::new()
+            .prefix("kesha-no-duration-")
+            .suffix(".raw")
+            .tempfile()
+            .unwrap();
+        std::fs::write(tmp.path(), b"not an audio container").unwrap();
+
+        let err = whole_file_segment(tmp.path().to_str().unwrap(), "hello")
+            .expect_err("timestamped output should require a known duration");
+        assert!(
+            err.to_string()
+                .contains("failed to probe audio duration for timestamped segments"),
+            "{err}"
         );
     }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "citty";
 import { detect } from "tinyld";
-import { transcribe } from "../lib";
+import { transcribeWithSegments } from "../transcribe";
 import { detectAudioLanguageEngine, detectTextLanguageEngine } from "../engine";
 import type { LangDetectResult } from "../engine";
 import { log } from "../log";
@@ -23,6 +23,7 @@ interface MainCommandArgs {
   debug: boolean;
   vad: boolean;
   "no-vad": boolean;
+  timestamps: boolean;
   format?: string;
   lang?: string;
 }
@@ -55,6 +56,11 @@ export const mainCommand = defineCommand({
     toon: {
       type: "boolean",
       description: "Output results as TOON (compact, LLM-friendly encoding of the same data as --json)",
+      default: false,
+    },
+    timestamps: {
+      type: "boolean",
+      description: "Include timestamped transcript segments in JSON/TOON output",
       default: false,
     },
     verbose: {
@@ -99,6 +105,10 @@ export const mainCommand = defineCommand({
       log.error("--vad and --no-vad are mutually exclusive.");
       process.exit(2);
     }
+    if (args.timestamps && !(args.json || args.toon || args.format === "json")) {
+      log.error("--timestamps requires --json, --toon, or --format json.");
+      process.exit(2);
+    }
     const vadMode = args.vad ? "on" : args["no-vad"] ? "off" : "auto";
 
     if (files.length === 0) {
@@ -114,11 +124,12 @@ export const mainCommand = defineCommand({
     for (const file of files) {
       const startedAt = performance.now();
       try {
-        // Run audio lang-id and transcription concurrently
-        const [audioResult, text] = await Promise.all([
+        // Run audio lang-id and transcription concurrently.
+        const [audioResult, transcript] = await Promise.all([
           wantsLangId ? detectAudioLanguageEngine(file) : Promise.resolve(null),
-          transcribe(file, { vad: vadMode }),
+          transcribeWithSegments(file, { vad: vadMode, timestamps: args.timestamps }),
         ]);
+        const { text, segments } = transcript;
 
         let audioLanguage: LangDetectResult | undefined;
         if (audioResult && audioResult.code) {
@@ -145,14 +156,18 @@ export const mainCommand = defineCommand({
         const mismatchWarning = checkLanguageMismatch(args.lang, lang);
         if (mismatchWarning) log.warn(`${file}: ${mismatchWarning}`);
 
-        results.push({
+        const result: TranscribeResult = {
           file,
           text,
           lang,
           audioLanguage,
           textLanguage: textLanguage ?? (tinyldLang ? { code: tinyldLang, confidence: 0 } : undefined),
           sttTimeMs: Math.round(performance.now() - startedAt),
-        });
+        };
+        if (args.timestamps) {
+          result.segments = segments;
+        }
+        results.push(result);
       } catch (err: unknown) {
         hasError = true;
         const message = err instanceof Error ? err.message : String(err);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8,6 +8,17 @@ export interface LangDetectResult {
   confidence: number;
 }
 
+export interface TranscriptionSegment {
+  start: number;
+  end: number;
+  text: string;
+}
+
+export interface TranscriptionOutput {
+  text: string;
+  segments: TranscriptionSegment[];
+}
+
 const DEFAULT_ENGINE_BIN_PATH = join(homedir(), ".cache", "kesha", "engine", "bin", "kesha-engine");
 
 /**
@@ -65,6 +76,57 @@ export async function transcribeEngine(
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
   }
   return stdout;
+}
+
+function parseTranscriptionOutput(stdout: string): TranscriptionOutput {
+  const parsed = JSON.parse(stdout);
+  if (typeof parsed?.text !== "string" || !Array.isArray(parsed?.segments)) {
+    throw new Error("Invalid transcription JSON returned by kesha-engine");
+  }
+
+  const segments = parsed.segments.map((segment: unknown) => {
+    const s = segment as Record<string, unknown>;
+    if (
+      typeof s.start !== "number" ||
+      typeof s.end !== "number" ||
+      typeof s.text !== "string"
+    ) {
+      throw new Error("Invalid transcription segment returned by kesha-engine");
+    }
+    return {
+      start: s.start,
+      end: s.end,
+      text: s.text,
+    };
+  });
+
+  return { text: parsed.text, segments };
+}
+
+export async function transcribeEngineWithSegments(
+  audioPath: string,
+  opts: TranscribeEngineOptions = {},
+): Promise<TranscriptionOutput> {
+  const caps = await getEngineCapabilities();
+  if (!caps?.features.includes("transcribe.segments")) {
+    throw new Error(
+      "Timestamped segments require a newer kesha-engine. Run `kesha install` after upgrading Kesha Voice Kit.",
+    );
+  }
+
+  const args = ["transcribe", audioPath, "--json"];
+  if (opts.vad === "on") args.push("--vad");
+  else if (opts.vad === "off") args.push("--no-vad");
+  const { stdout, stderr, exitCode } = await runEngine(args);
+  if (exitCode !== 0) {
+    throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
+  }
+  try {
+    return parseTranscriptionOutput(stdout);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${message}: ${stdout}`);
+  }
 }
 
 export function parseLangResult(stdout: string): LangDetectResult | null {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -161,12 +161,22 @@ export interface EngineCapabilities {
   features: string[];
 }
 
+let cachedEngineCapabilities:
+  | { binPath: string; capabilities: EngineCapabilities }
+  | null = null;
+
 export async function getEngineCapabilities(): Promise<EngineCapabilities | null> {
-  if (!isEngineInstalled()) return null;
+  const binPath = getEngineBinPath();
+  if (cachedEngineCapabilities?.binPath === binPath) {
+    return cachedEngineCapabilities.capabilities;
+  }
+  if (!existsSync(binPath)) return null;
   const { stdout, exitCode } = await runEngine(["--capabilities-json"]);
   if (exitCode !== 0) return null;
   try {
-    return JSON.parse(stdout) as EngineCapabilities;
+    const capabilities = JSON.parse(stdout) as EngineCapabilities;
+    cachedEngineCapabilities = { binPath, capabilities };
+    return capabilities;
   } catch {
     return null;
   }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,8 +1,13 @@
 import { existsSync } from "fs";
-import { transcribe as internalTranscribe, type TranscribeOptions } from "./transcribe";
+import {
+  transcribe as internalTranscribe,
+  transcribeWithSegments as internalTranscribeWithSegments,
+  type TranscribeOptions,
+} from "./transcribe";
 import { downloadEngine } from "./engine-install";
 
 export type { TranscribeOptions };
+export type { TranscriptionOutput, TranscriptionSegment } from "./engine";
 export { downloadEngine as downloadModel };
 export { say, type SayOptions, SayError } from "./say";
 
@@ -37,4 +42,19 @@ export async function transcribe(
   }
 
   return internalTranscribe(audioPath, { ...options, silent: true });
+}
+
+export async function transcribeWithSegments(
+  audioPath: string,
+  options: TranscribeOptions = {},
+) {
+  if (!existsSync(audioPath)) {
+    throw new Error(`File not found: ${audioPath}`);
+  }
+
+  return internalTranscribeWithSegments(audioPath, {
+    ...options,
+    timestamps: true,
+    silent: true,
+  });
 }

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -1,14 +1,30 @@
-import { isEngineInstalled, transcribeEngine, type VadMode } from "./engine";
+import {
+  isEngineInstalled,
+  transcribeEngine,
+  transcribeEngineWithSegments,
+  type TranscriptionOutput,
+  type VadMode,
+} from "./engine";
 
 export type { VadMode };
+export type { TranscriptionOutput };
 
 export interface TranscribeOptions {
   silent?: boolean;
   /** Silero VAD preprocessing selector. Defaults to `"auto"`. */
   vad?: VadMode;
+  /** Request timestamped transcript segments from the engine. */
+  timestamps?: boolean;
 }
 
 export async function transcribe(audioPath: string, opts: TranscribeOptions = {}): Promise<string> {
+  return (await transcribeWithSegments(audioPath, opts)).text;
+}
+
+export async function transcribeWithSegments(
+  audioPath: string,
+  opts: TranscribeOptions = {},
+): Promise<TranscriptionOutput> {
   if (!isEngineInstalled()) {
     throw new Error(
       "Error: No transcription backend is installed\n\n" +
@@ -20,5 +36,10 @@ export async function transcribe(audioPath: string, opts: TranscribeOptions = {}
     );
   }
 
-  return transcribeEngine(audioPath, { vad: opts.vad });
+  if (opts.timestamps) {
+    return transcribeEngineWithSegments(audioPath, { vad: opts.vad });
+  }
+
+  const text = await transcribeEngine(audioPath, { vad: opts.vad });
+  return { text, segments: [] };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { LangDetectResult } from "./engine";
+import type { LangDetectResult, TranscriptionSegment } from "./engine";
 
 /**
  * One row of `kesha --json` / `kesha --toon` output. Canonical output shape
@@ -11,8 +11,10 @@ export type TranscribeResult = {
   lang: string;
   audioLanguage?: LangDetectResult;
   textLanguage?: LangDetectResult;
+  /** Timestamped transcript segments when requested via `--timestamps`. */
+  segments?: TranscriptionSegment[];
   /** Wall-clock time around the engine subprocess calls for this file, ms. See #139. */
   sttTimeMs?: number;
 };
 
-export type { LangDetectResult };
+export type { LangDetectResult, TranscriptionSegment };

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -37,6 +37,7 @@ describe("e2e-cli", () => {
     expect(stdout).toContain("--json");
     expect(stdout).toContain("--verbose");
     expect(stdout).toContain("--lang");
+    expect(stdout).toContain("--timestamps");
   });
 
   test("install --help shows --no-cache flag", async () => {
@@ -85,5 +86,11 @@ describe("e2e-cli", () => {
     const { stderr, exitCode } = await runCli(["--json", "--toon", "a.wav"]);
     expect(exitCode).toBe(2);
     expect(stderr.toLowerCase()).toContain("mutually exclusive");
+  });
+
+  test("--timestamps without machine-readable output exits 2", async () => {
+    const { stderr, exitCode } = await runCli(["--timestamps", "a.wav"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--timestamps requires");
   });
 });

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -56,6 +56,26 @@ describe.skipIf(!engineInstalled)("e2e-engine", () => {
     expect(stdout.length).toBeGreaterThan(10);
   }, 60_000);
 
+  test("engine transcribe --json returns text and segments", async () => {
+    const capsRun = await runEngine(["--capabilities-json"]);
+    const caps = JSON.parse(capsRun.stdout);
+    if (!caps.features.includes("transcribe.segments")) {
+      console.warn("engine lacks transcribe.segments; skipping timestamp e2e");
+      return;
+    }
+
+    const { stdout, exitCode } = await runEngine(["transcribe", FIXTURE_EN, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.text.length).toBeGreaterThan(10);
+    expect(Array.isArray(parsed.segments)).toBe(true);
+    if (parsed.segments.length > 0) {
+      expect(parsed.segments[0].start).toBeGreaterThanOrEqual(0);
+      expect(parsed.segments[0].end).toBeGreaterThan(parsed.segments[0].start);
+      expect(parsed.segments[0].text.length).toBeGreaterThan(0);
+    }
+  }, 60_000);
+
   test("engine detect-lang identifies Russian", async () => {
     const { stdout, exitCode } = await runEngine(["detect-lang", FIXTURE_RU]);
     expect(exitCode).toBe(0);
@@ -100,6 +120,27 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
     expect(parsed[0].textLanguage).toBeDefined();
     expect(parsed[0].textLanguage.code).toBeDefined();
     expect(parsed[0].textLanguage.confidence).toBeGreaterThan(0);
+  }, 60_000);
+
+  test("kesha --json --timestamps includes transcript segments", async () => {
+    const capsRun = await runEngine(["--capabilities-json"]);
+    const caps = JSON.parse(capsRun.stdout);
+    if (!caps.features.includes("transcribe.segments")) {
+      console.warn("engine lacks transcribe.segments; skipping timestamp e2e");
+      return;
+    }
+
+    const { stdout, exitCode } = await runCli(["--json", "--timestamps", FIXTURE_EN]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].text.length).toBeGreaterThan(0);
+    expect(Array.isArray(parsed[0].segments)).toBe(true);
+    if (parsed[0].segments.length > 0) {
+      expect(parsed[0].segments[0].start).toBeGreaterThanOrEqual(0);
+      expect(parsed[0].segments[0].end).toBeGreaterThan(parsed[0].segments[0].start);
+      expect(parsed[0].segments[0].text.length).toBeGreaterThan(0);
+    }
   }, 60_000);
 
   test("kesha --verbose shows language info", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -28,6 +28,11 @@ describe("CLI help", () => {
     expect(usage).toMatch(/TOON|LLM/i);
   });
 
+  test("main help contains --timestamps flag", async () => {
+    const usage = await renderUsage(mainCommand);
+    expect(usage).toContain("--timestamps");
+  });
+
   test("main help contains --lang flag", async () => {
     const usage = await renderUsage(mainCommand);
     expect(usage).toContain("--lang");
@@ -80,6 +85,19 @@ describe("output formatting", () => {
     const output = formatJsonOutput([]);
     expect(JSON.parse(output)).toEqual([]);
   });
+
+  test("JSON output preserves timestamped segments", () => {
+    const output = formatJsonOutput([
+      {
+        file: "a.ogg",
+        text: "Hello",
+        lang: "en",
+        segments: [{ start: 0, end: 1.25, text: "Hello" }],
+      },
+    ]);
+    const parsed = JSON.parse(output);
+    expect(parsed[0].segments).toEqual([{ start: 0, end: 1.25, text: "Hello" }]);
+  });
 });
 
 describe("TOON output (#138)", () => {
@@ -113,6 +131,17 @@ describe("TOON output (#138)", () => {
       sttTimeMs: 427,
       audioLanguage: { code: "en", confidence: 0.94 },
       textLanguage: { code: "en", confidence: 0.98 },
+    }];
+    const decoded = decodeToon(formatToonOutput(input));
+    expect(decoded).toEqual(input);
+  });
+
+  test("preserves timestamped segments", () => {
+    const input = [{
+      file: "a.ogg",
+      text: "Hello",
+      lang: "en",
+      segments: [{ start: 0, end: 1.25, text: "Hello" }],
     }];
     const decoded = decodeToon(formatToonOutput(input));
     expect(decoded).toEqual(input);


### PR DESCRIPTION
## Summary

Adds timestamped transcript segments for machine-readable transcription output.

- Adds `kesha-engine transcribe --json`, returning `{ text, segments }`
- Adds CLI `--timestamps` for `--json`, `--toon`, and `--format json`
- Preserves default plain-text transcription behavior
- Uses VAD speech spans as segment `start` / `end` when VAD is active
- Adds `transcribe.segments` engine capability and guards new CLI behavior against older engines
- Exposes `transcribeWithSegments()` from the programmatic API
- Bumps CLI and engine versions to `1.9.0`

## Notes

This is an engine release PR because it changes `rust/**`.

The branch is `release/1.9.0` so integration tests that depend on not-yet-published release assets follow the existing release-branch guard.

## Verification

- `bunx tsc --noEmit`
- `bun test tests/unit/cli.test.ts tests/integration/e2e-cli.test.ts`
- `cargo fmt --check`
- `cargo check`
- `cargo check --no-default-features --features onnx`
- `cargo check --features coreml --no-default-features`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `KESHA_ENGINE_BIN=rust/target/debug/kesha-engine bun test tests/integration/e2e-engine.test.ts --test-name-pattern 'timestamps|transcribe --json returns text and segments'`

Manual verification:

- Verified `--json --timestamps --vad` on a 45-minute lesson audio converted to 16 kHz mono WAV for ONNX testing.
- Result: 817 timestamped segments, no `end <= start` segments, no ordering violations.