### PR TITLE
chore(release): v1.10.1 (CLI-only) — docs from #249

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
CLI-only patch release. Bumps `package.json#version` to 1.10.1; engine + Cargo crates unchanged at 1.10.0.

Ships the doc update merged in #249 (timestamped transcript segments — SKILL.md). No code change beyond the npm version bump.

Per CLAUDE.md "RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY":
- Tag will be `v1.10.1-cli` (the `-cli` suffix excludes it from `build-engine.yml`'s tag filter — no Rust rebuild).
- npm publishes `@drakulavich/kesha-voice-kit@1.10.1` which downloads engine `v1.10.0` (existing binary).