### PR TITLE
refactor(#248): timestamped-segments path polish

### DIFF
--- a/rust/src/capabilities.rs
+++ b/rust/src/capabilities.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use crate::transcribe::TRANSCRIBE_SEGMENTS_FEATURE;
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Capabilities {
@@ -10,7 +12,12 @@ pub struct Capabilities {
 
 pub fn get_capabilities() -> Capabilities {
     #[allow(unused_mut)]
-    let mut features = vec!["transcribe", "transcribe.segments", "detect-lang", "vad"];
+    let mut features = vec![
+        "transcribe",
+        TRANSCRIBE_SEGMENTS_FEATURE,
+        "detect-lang",
+        "vad",
+    ];
 
     #[cfg(target_os = "macos")]
     features.push("detect-text-lang");

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -87,17 +87,24 @@ fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDec
 }
 
 pub fn transcribe(audio_path: &str, mode: VadMode) -> Result<String> {
-    Ok(transcribe_inner(audio_path, mode)?.text)
+    Ok(transcribe_inner(audio_path, mode, false)?.text)
 }
 
 pub fn transcribe_output(audio_path: &str, mode: VadMode) -> Result<TranscriptionOutput> {
-    transcribe_inner(audio_path, mode)
+    transcribe_inner(audio_path, mode, true)
 }
 
-/// Always returns a populated [`TranscriptionOutput`]: VAD path produces
-/// per-utterance segments; plain path produces a single whole-file segment.
-/// Callers that only need the joined text discard `.segments`.
-fn transcribe_inner(audio_path: &str, mode: VadMode) -> Result<TranscriptionOutput> {
+/// `whole_file_segment_required` gates the non-VAD plain path's call to
+/// `whole_file_segment` — text-only callers (`transcribe()`) skip it because
+/// duration probing fails for streaming Ogg/Opus without a frame count, which
+/// would otherwise turn into a hard error for inputs that previously
+/// transcribed cleanly. The VAD path always builds segments cheaply (it
+/// already has per-span boundaries from VAD output).
+fn transcribe_inner(
+    audio_path: &str,
+    mode: VadMode,
+    whole_file_segment_required: bool,
+) -> Result<TranscriptionOutput> {
     let model_dir = ensure_asr_installed()?;
     let vad_dir = models::vad_model_dir();
     let vad_installed = models::is_vad_cached(&vad_dir);
@@ -121,13 +128,23 @@ fn transcribe_inner(audio_path: &str, mode: VadMode) -> Result<TranscriptionOutp
         // doesn't re-open the file (closes #248 item 1). For `On`/`Off`
         // modes we didn't probe, so it's `None` and the segment helper
         // does the work.
-        VadDecision::Plain => transcribe_plain(audio_path, &model_dir, duration),
+        VadDecision::Plain => transcribe_plain(
+            audio_path,
+            &model_dir,
+            duration,
+            whole_file_segment_required,
+        ),
         VadDecision::PlainWithHint => {
             let secs = duration.unwrap_or(0.0);
             eprintln!(
                 "hint: audio is {secs:.0}s; `kesha install --vad` would improve long-audio accuracy"
             );
-            transcribe_plain(audio_path, &model_dir, duration)
+            transcribe_plain(
+                audio_path,
+                &model_dir,
+                duration,
+                whole_file_segment_required,
+            )
         }
     }
 }
@@ -136,6 +153,7 @@ fn transcribe_plain(
     audio_path: &str,
     model_dir: &str,
     duration: Option<f32>,
+    whole_file_segment_required: bool,
 ) -> Result<TranscriptionOutput> {
     let t0 = Instant::now();
     let mut be = backend::create_backend(model_dir)?;
@@ -147,7 +165,16 @@ fn transcribe_plain(
         t1.elapsed().as_millis(),
         text.chars().count()
     );
-    let segments = whole_file_segment(audio_path, &text, duration)?;
+    // Skip the duration probe for text-only callers. Streaming Ogg/Opus
+    // (and a few other format edge cases) return `Ok(None)` from
+    // `probe_duration_seconds`, which `whole_file_segment` turns into a
+    // hard error — surfacing it for callers that don't even need segments
+    // would be a regression vs pre-#248 behavior.
+    let segments = if whole_file_segment_required {
+        whole_file_segment(audio_path, &text, duration)?
+    } else {
+        vec![]
+    };
     Ok(TranscriptionOutput { segments, text })
 }
 

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -9,6 +9,10 @@ use crate::dtrace;
 use crate::models;
 use crate::vad::{VadConfig, VadDetector, SAMPLE_RATE as VAD_SAMPLE_RATE};
 
+/// Capability-flag string surfaced via `--capabilities-json`. Single source of
+/// truth so the engine, the TS CLI gate, and the integration tests can't drift.
+pub const TRANSCRIBE_SEGMENTS_FEATURE: &str = "transcribe.segments";
+
 /// Duration at which the `Auto` VAD mode flips to VAD preprocessing.
 /// Voice messages (<30 s) and short clips don't benefit; meetings and
 /// lectures (>2 min) do.
@@ -83,18 +87,17 @@ fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDec
 }
 
 pub fn transcribe(audio_path: &str, mode: VadMode) -> Result<String> {
-    Ok(transcribe_inner(audio_path, mode, false)?.text)
+    Ok(transcribe_inner(audio_path, mode)?.text)
 }
 
 pub fn transcribe_output(audio_path: &str, mode: VadMode) -> Result<TranscriptionOutput> {
-    transcribe_inner(audio_path, mode, true)
+    transcribe_inner(audio_path, mode)
 }
 
-fn transcribe_inner(
-    audio_path: &str,
-    mode: VadMode,
-    timestamps_required: bool,
-) -> Result<TranscriptionOutput> {
+/// Always returns a populated [`TranscriptionOutput`]: VAD path produces
+/// per-utterance segments; plain path produces a single whole-file segment.
+/// Callers that only need the joined text discard `.segments`.
+fn transcribe_inner(audio_path: &str, mode: VadMode) -> Result<TranscriptionOutput> {
     let model_dir = ensure_asr_installed()?;
     let vad_dir = models::vad_model_dir();
     let vad_installed = models::is_vad_cached(&vad_dir);
@@ -114,13 +117,17 @@ fn transcribe_inner(
         VadDecision::Vad => {
             transcribe_via_vad(audio_path, &model_dir, &vad_dir, VadConfig::default())
         }
-        VadDecision::Plain => transcribe_plain(audio_path, &model_dir, timestamps_required),
+        // Pass the already-probed duration through so `whole_file_segment`
+        // doesn't re-open the file (closes #248 item 1). For `On`/`Off`
+        // modes we didn't probe, so it's `None` and the segment helper
+        // does the work.
+        VadDecision::Plain => transcribe_plain(audio_path, &model_dir, duration),
         VadDecision::PlainWithHint => {
             let secs = duration.unwrap_or(0.0);
             eprintln!(
                 "hint: audio is {secs:.0}s; `kesha install --vad` would improve long-audio accuracy"
             );
-            transcribe_plain(audio_path, &model_dir, timestamps_required)
+            transcribe_plain(audio_path, &model_dir, duration)
         }
     }
 }
@@ -128,7 +135,7 @@ fn transcribe_inner(
 fn transcribe_plain(
     audio_path: &str,
     model_dir: &str,
-    timestamps_required: bool,
+    duration: Option<f32>,
 ) -> Result<TranscriptionOutput> {
     let t0 = Instant::now();
     let mut be = backend::create_backend(model_dir)?;
@@ -140,11 +147,7 @@ fn transcribe_plain(
         t1.elapsed().as_millis(),
         text.chars().count()
     );
-    let segments = if timestamps_required {
-        whole_file_segment(audio_path, &text)?
-    } else {
-        vec![]
-    };
+    let segments = whole_file_segment(audio_path, &text, duration)?;
     Ok(TranscriptionOutput { segments, text })
 }
 
@@ -177,16 +180,16 @@ fn transcribe_via_vad(
     let t_vad = Instant::now();
     let vad_path = Path::new(vad_dir).join("silero_vad.onnx");
     let mut vad = VadDetector::load(&vad_path).context("load Silero VAD")?;
-    let segments = vad.detect_segments(&samples, cfg)?;
+    let spans = vad.detect_segments(&samples, cfg)?;
     dtrace!(
         "vad::detect dt={}ms segments={}",
         t_vad.elapsed().as_millis(),
-        segments.len()
+        spans.len()
     );
 
     let mut be = backend::create_backend(model_dir)?;
 
-    if segments.is_empty() {
+    if spans.is_empty() {
         let min_speech_samples =
             (cfg.min_speech_ms as u64 * VAD_SAMPLE_RATE as u64 / 1000) as usize;
         if samples.len() >= min_speech_samples {
@@ -195,49 +198,17 @@ fn transcribe_via_vad(
             );
         }
         let text = be.transcribe_samples(&samples)?;
+        let end_s = samples.len() as f32 / VAD_SAMPLE_RATE as f32;
         return Ok(TranscriptionOutput {
-            segments: sample_span_segment(0.0, samples.len(), &text),
+            segments: single_segment(0.0, end_s, &text),
             text,
         });
     }
 
-    let sr = VAD_SAMPLE_RATE as f32;
-    let mut output_segments: Vec<TranscriptionSegment> = Vec::with_capacity(segments.len());
-    for (start_s, end_s) in &segments {
-        let start = (*start_s * sr) as usize;
-        let end = ((*end_s * sr) as usize).min(samples.len());
-        if start >= end {
-            continue;
-        }
-        let slice = &samples[start..end];
-        let t = Instant::now();
-        match be.transcribe_samples(slice) {
-            Ok(text) => {
-                dtrace!(
-                    "vad::segment dt={}ms range={:.2}-{:.2}s chars={}",
-                    t.elapsed().as_millis(),
-                    start_s,
-                    end_s,
-                    text.chars().count()
-                );
-                let trimmed = text.trim();
-                if !trimmed.is_empty() {
-                    output_segments.push(TranscriptionSegment {
-                        start: *start_s,
-                        end: *end_s,
-                        text: trimmed.to_string(),
-                    });
-                }
-            }
-            Err(e) => {
-                // One failing segment shouldn't kill the whole transcript.
-                eprintln!(
-                    "warning: VAD segment {:.2}-{:.2}s failed: {e}",
-                    start_s, end_s
-                );
-            }
-        }
-    }
+    let output_segments =
+        build_vad_output_segments(&spans, &samples, VAD_SAMPLE_RATE as f32, |slice| {
+            be.transcribe_samples(slice)
+        });
 
     let text = output_segments
         .iter()
@@ -251,33 +222,95 @@ fn transcribe_via_vad(
     })
 }
 
-fn whole_file_segment(audio_path: &str, text: &str) -> Result<Vec<TranscriptionSegment>> {
+/// Build per-span [`TranscriptionSegment`]s from a sequence of VAD spans.
+/// Pure function: takes the spans + a transcribe callback so unit tests can
+/// drive it without spinning up an ONNX model. Empty / failed spans are
+/// dropped (with a stderr warning on failure) so the output preserves both
+/// the monotonic-start invariant of the input and the `end > start` shape.
+fn build_vad_output_segments<F>(
+    spans: &[(f32, f32)],
+    samples: &[f32],
+    sr: f32,
+    mut transcribe_span: F,
+) -> Vec<TranscriptionSegment>
+where
+    F: FnMut(&[f32]) -> Result<String>,
+{
+    let mut out = Vec::with_capacity(spans.len());
+    for &(start_s, end_s) in spans {
+        let start = (start_s * sr) as usize;
+        let end = ((end_s * sr) as usize).min(samples.len());
+        if start >= end {
+            continue;
+        }
+        let slice = &samples[start..end];
+        let t = Instant::now();
+        match transcribe_span(slice) {
+            Ok(text) => {
+                dtrace!(
+                    "vad::segment dt={}ms range={:.2}-{:.2}s chars={}",
+                    t.elapsed().as_millis(),
+                    start_s,
+                    end_s,
+                    text.chars().count()
+                );
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    out.push(TranscriptionSegment {
+                        start: start_s,
+                        end: end_s,
+                        text: trimmed.to_string(),
+                    });
+                }
+            }
+            Err(e) => {
+                // One failing segment shouldn't kill the whole transcript.
+                eprintln!(
+                    "warning: VAD segment {:.2}-{:.2}s failed: {e}",
+                    start_s, end_s
+                );
+            }
+        }
+    }
+    out
+}
+
+/// Build the single-segment vec produced by the non-VAD plain path. Re-uses
+/// the caller-supplied duration when available (closes #248 item 1) — the
+/// `Auto` mode probe-and-decide step already opens the file once.
+fn whole_file_segment(
+    audio_path: &str,
+    text: &str,
+    duration: Option<f32>,
+) -> Result<Vec<TranscriptionSegment>> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return Ok(vec![]);
     }
-    let duration = audio::probe_duration_seconds(audio_path)
-        .with_context(|| {
-            format!("failed to probe audio duration for timestamped segments: {audio_path}")
-        })?
-        .with_context(|| {
-            format!("audio duration is unavailable for timestamped segments: {audio_path}")
-        })?;
-    Ok(vec![TranscriptionSegment {
-        start: 0.0,
-        end: duration,
-        text: trimmed.to_string(),
-    }])
+    let duration = match duration {
+        Some(d) => d,
+        None => audio::probe_duration_seconds(audio_path)
+            .with_context(|| {
+                format!("failed to probe audio duration for timestamped segments: {audio_path}")
+            })?
+            .with_context(|| {
+                format!("audio duration is unavailable for timestamped segments: {audio_path}")
+            })?,
+    };
+    Ok(single_segment(0.0, duration, trimmed))
 }
 
-fn sample_span_segment(start_s: f32, sample_count: usize, text: &str) -> Vec<TranscriptionSegment> {
+/// Construct a one-element `Vec<TranscriptionSegment>` (or empty if `text` is
+/// blank after trimming). Shared by both `whole_file_segment` and the
+/// VAD-fallback path in [`transcribe_via_vad`].
+fn single_segment(start: f32, end: f32, text: &str) -> Vec<TranscriptionSegment> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return vec![];
     }
     vec![TranscriptionSegment {
-        start: start_s,
-        end: start_s + sample_count as f32 / VAD_SAMPLE_RATE as f32,
+        start,
+        end,
         text: trimmed.to_string(),
     }]
 }
@@ -403,7 +436,24 @@ mod tests {
     }
 
     #[test]
-    fn whole_file_segment_errors_when_duration_is_unavailable() {
+    fn whole_file_segment_uses_caller_supplied_duration_without_probing() {
+        // Item 1: when the caller already probed (Auto mode), the helper
+        // must NOT re-open the file.
+        let tmp = tempfile::Builder::new()
+            .prefix("kesha-no-probe-")
+            .suffix(".raw")
+            .tempfile()
+            .unwrap();
+        std::fs::write(tmp.path(), b"not an audio container").unwrap();
+        let segs = whole_file_segment(tmp.path().to_str().unwrap(), "hello", Some(7.5)).unwrap();
+        assert_eq!(segs.len(), 1);
+        assert_eq!(segs[0].start, 0.0);
+        assert_eq!(segs[0].end, 7.5);
+        assert_eq!(segs[0].text, "hello");
+    }
+
+    #[test]
+    fn whole_file_segment_errors_when_duration_is_unavailable_and_no_caller_value() {
         let tmp = tempfile::Builder::new()
             .prefix("kesha-no-duration-")
             .suffix(".raw")
@@ -411,13 +461,79 @@ mod tests {
             .unwrap();
         std::fs::write(tmp.path(), b"not an audio container").unwrap();
 
-        let err = whole_file_segment(tmp.path().to_str().unwrap(), "hello")
-            .expect_err("timestamped output should require a known duration");
+        let err = whole_file_segment(tmp.path().to_str().unwrap(), "hello", None)
+            .expect_err("timestamped output should require a known duration when no caller value");
         assert!(
             err.to_string()
                 .contains("failed to probe audio duration for timestamped segments"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn whole_file_segment_skips_empty_text_regardless_of_duration() {
+        let segs = whole_file_segment("/dev/null", "   ", Some(5.0)).unwrap();
+        assert!(segs.is_empty());
+    }
+
+    #[test]
+    fn single_segment_trims_text_and_drops_empty() {
+        assert_eq!(single_segment(0.0, 1.0, "  hi  ")[0].text, "hi");
+        assert!(single_segment(0.0, 1.0, "  ").is_empty());
+        assert!(single_segment(0.0, 1.0, "").is_empty());
+    }
+
+    #[test]
+    fn vad_output_segments_preserve_input_ordering_and_invariants() {
+        // Item 8: lock the VAD-path contract. For a sorted span list, the
+        // output must satisfy `end > start` per segment and `start[i+1] >=
+        // start[i]` across segments (monotonic).
+        let spans = vec![(0.5, 1.5), (2.0, 3.5), (4.0, 5.2)];
+        let samples = vec![0.0_f32; 16_000 * 6];
+        let mut call = 0;
+        let segs = build_vad_output_segments(&spans, &samples, 16_000.0, |_slice| {
+            call += 1;
+            Ok(format!("utterance {call}"))
+        });
+        assert_eq!(segs.len(), 3);
+        for s in &segs {
+            assert!(s.end > s.start, "{s:?} violates end > start");
+            assert!(!s.text.is_empty());
+        }
+        for w in segs.windows(2) {
+            assert!(
+                w[1].start >= w[0].start,
+                "monotonic invariant violated: {w:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn vad_output_segments_skip_empty_transcriptions() {
+        let spans = vec![(0.5, 1.5), (2.0, 3.5), (4.0, 5.2)];
+        let samples = vec![0.0_f32; 16_000 * 6];
+        let mut call = 0;
+        let segs = build_vad_output_segments(&spans, &samples, 16_000.0, |_| {
+            call += 1;
+            if call == 2 {
+                Ok(String::new())
+            } else {
+                Ok("hello".to_string())
+            }
+        });
+        assert_eq!(segs.len(), 2, "empty transcription should be skipped");
+        assert_eq!(segs[0].start, 0.5);
+        assert_eq!(segs[1].start, 4.0);
+    }
+
+    #[test]
+    fn vad_output_segments_skip_zero_length_spans() {
+        // Spans where `start_s * sr >= samples_len` should be silently dropped
+        // rather than panicking on the slice bounds.
+        let spans = vec![(0.5, 0.5), (10.0, 11.0)];
+        let samples = vec![0.0_f32; 16_000];
+        let segs = build_vad_output_segments(&spans, &samples, 16_000.0, |_| Ok("ignore".into()));
+        assert_eq!(segs.len(), 0);
     }
 
     #[test]

--- a/rust/src/transcribe.rs
+++ b/rust/src/transcribe.rs
@@ -94,16 +94,16 @@ pub fn transcribe_output(audio_path: &str, mode: VadMode) -> Result<Transcriptio
     transcribe_inner(audio_path, mode, true)
 }
 
-/// `whole_file_segment_required` gates the non-VAD plain path's call to
-/// `whole_file_segment` — text-only callers (`transcribe()`) skip it because
-/// duration probing fails for streaming Ogg/Opus without a frame count, which
-/// would otherwise turn into a hard error for inputs that previously
-/// transcribed cleanly. The VAD path always builds segments cheaply (it
-/// already has per-span boundaries from VAD output).
+/// `timestamps_required` gates the non-VAD plain path's call to
+/// `whole_file_segment`. Text-only callers (`pub fn transcribe`) skip it
+/// because `audio::probe_duration_seconds` returns `Ok(None)` for streaming
+/// Ogg/Opus without a frame count, which would turn into a hard error for
+/// inputs that previously transcribed cleanly. The VAD path always builds
+/// segments cheaply (per-span boundaries already in hand from VAD output).
 fn transcribe_inner(
     audio_path: &str,
     mode: VadMode,
-    whole_file_segment_required: bool,
+    timestamps_required: bool,
 ) -> Result<TranscriptionOutput> {
     let model_dir = ensure_asr_installed()?;
     let vad_dir = models::vad_model_dir();
@@ -125,26 +125,17 @@ fn transcribe_inner(
             transcribe_via_vad(audio_path, &model_dir, &vad_dir, VadConfig::default())
         }
         // Pass the already-probed duration through so `whole_file_segment`
-        // doesn't re-open the file (closes #248 item 1). For `On`/`Off`
-        // modes we didn't probe, so it's `None` and the segment helper
-        // does the work.
-        VadDecision::Plain => transcribe_plain(
-            audio_path,
-            &model_dir,
-            duration,
-            whole_file_segment_required,
-        ),
+        // doesn't re-open the file (#248). On `On`/`Off` modes we didn't
+        // probe, so it's `None` and the segment helper does the work.
+        VadDecision::Plain => {
+            transcribe_plain(audio_path, &model_dir, duration, timestamps_required)
+        }
         VadDecision::PlainWithHint => {
             let secs = duration.unwrap_or(0.0);
             eprintln!(
                 "hint: audio is {secs:.0}s; `kesha install --vad` would improve long-audio accuracy"
             );
-            transcribe_plain(
-                audio_path,
-                &model_dir,
-                duration,
-                whole_file_segment_required,
-            )
+            transcribe_plain(audio_path, &model_dir, duration, timestamps_required)
         }
     }
 }
@@ -153,7 +144,7 @@ fn transcribe_plain(
     audio_path: &str,
     model_dir: &str,
     duration: Option<f32>,
-    whole_file_segment_required: bool,
+    timestamps_required: bool,
 ) -> Result<TranscriptionOutput> {
     let t0 = Instant::now();
     let mut be = backend::create_backend(model_dir)?;
@@ -170,7 +161,7 @@ fn transcribe_plain(
     // `probe_duration_seconds`, which `whole_file_segment` turns into a
     // hard error — surfacing it for callers that don't even need segments
     // would be a regression vs pre-#248 behavior.
-    let segments = if whole_file_segment_required {
+    let segments = if timestamps_required {
         whole_file_segment(audio_path, &text, duration)?
     } else {
         vec![]
@@ -303,7 +294,7 @@ where
 }
 
 /// Build the single-segment vec produced by the non-VAD plain path. Re-uses
-/// the caller-supplied duration when available (closes #248 item 1) — the
+/// the caller-supplied duration when available (#248) — the
 /// `Auto` mode probe-and-decide step already opens the file once.
 fn whole_file_segment(
     audio_path: &str,
@@ -464,8 +455,8 @@ mod tests {
 
     #[test]
     fn whole_file_segment_uses_caller_supplied_duration_without_probing() {
-        // Item 1: when the caller already probed (Auto mode), the helper
-        // must NOT re-open the file.
+        // When the caller already probed (Auto mode), the helper must NOT
+        // re-open the file (#248).
         let tmp = tempfile::Builder::new()
             .prefix("kesha-no-probe-")
             .suffix(".raw")
@@ -512,9 +503,9 @@ mod tests {
 
     #[test]
     fn vad_output_segments_preserve_input_ordering_and_invariants() {
-        // Item 8: lock the VAD-path contract. For a sorted span list, the
-        // output must satisfy `end > start` per segment and `start[i+1] >=
-        // start[i]` across segments (monotonic).
+        // Lock the VAD-path contract: for a sorted span list, output must
+        // satisfy `end > start` per segment and `start[i+1] >= start[i]`
+        // across segments (monotonic). #248.
         let spans = vec![(0.5, 1.5), (2.0, 3.5), (4.0, 5.2)];
         let samples = vec![0.0_f32; 16_000 * 6];
         let mut call = 0;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,7 +1,14 @@
 import { join } from "path";
 import { homedir } from "os";
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { log } from "./log";
+
+/**
+ * Capability-flag string surfaced via `kesha-engine --capabilities-json`. Single
+ * source of truth so the engine, the TS CLI gate, and the integration tests
+ * can't drift. Mirrors `rust/src/transcribe.rs::TRANSCRIBE_SEGMENTS_FEATURE`.
+ */
+export const TRANSCRIBE_SEGMENTS_FEATURE = "transcribe.segments";
 
 export interface LangDetectResult {
   code: string;
@@ -108,7 +115,7 @@ export async function transcribeEngineWithSegments(
   opts: TranscribeEngineOptions = {},
 ): Promise<TranscriptionOutput> {
   const caps = await getEngineCapabilities();
-  if (!caps?.features.includes("transcribe.segments")) {
+  if (!caps?.features.includes(TRANSCRIBE_SEGMENTS_FEATURE)) {
     throw new Error(
       "Timestamped segments require a newer kesha-engine. Run `kesha install` after upgrading Kesha Voice Kit.",
     );
@@ -162,20 +169,32 @@ export interface EngineCapabilities {
 }
 
 let cachedEngineCapabilities:
-  | { binPath: string; capabilities: EngineCapabilities }
+  | { binPath: string; mtime: number; capabilities: EngineCapabilities }
   | null = null;
 
 export async function getEngineCapabilities(): Promise<EngineCapabilities | null> {
+  if (!isEngineInstalled()) return null;
   const binPath = getEngineBinPath();
-  if (cachedEngineCapabilities?.binPath === binPath) {
+  // Cache key: (binPath, mtimeMs). The mtime check invalidates the cache when
+  // `kesha install` overwrites the binary in-place within a single long-lived
+  // process (closes #248 item 7).
+  let mtime: number;
+  try {
+    mtime = statSync(binPath).mtimeMs;
+  } catch {
+    return null;
+  }
+  if (
+    cachedEngineCapabilities?.binPath === binPath &&
+    cachedEngineCapabilities.mtime === mtime
+  ) {
     return cachedEngineCapabilities.capabilities;
   }
-  if (!existsSync(binPath)) return null;
   const { stdout, exitCode } = await runEngine(["--capabilities-json"]);
   if (exitCode !== 0) return null;
   try {
     const capabilities = JSON.parse(stdout) as EngineCapabilities;
-    cachedEngineCapabilities = { binPath, capabilities };
+    cachedEngineCapabilities = { binPath, mtime, capabilities };
     return capabilities;
   } catch {
     return null;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -173,11 +173,12 @@ let cachedEngineCapabilities:
   | null = null;
 
 export async function getEngineCapabilities(): Promise<EngineCapabilities | null> {
-  if (!isEngineInstalled()) return null;
   const binPath = getEngineBinPath();
-  // Cache key: (binPath, mtimeMs). The mtime check invalidates the cache when
-  // `kesha install` overwrites the binary in-place within a single long-lived
-  // process (closes #248 item 7).
+  // Cache key includes `mtimeMs` so the cache invalidates when `kesha
+  // install` overwrites the binary in-place within a single long-lived
+  // process (#248). `statSync` throws on missing-file; the catch returns
+  // `null` — same effect as the previous explicit `isEngineInstalled()`
+  // pre-flight, one fewer redundant fs call.
   let mtime: number;
   try {
     mtime = statSync(binPath).mtimeMs;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -44,7 +44,7 @@ export async function transcribe(
   return internalTranscribe(audioPath, { ...options, silent: true });
 }
 
-export async function transcribeWithSegments(
+export async function transcribeWithTimestamps(
   audioPath: string,
   options: TranscribeOptions = {},
 ) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -58,3 +58,10 @@ export async function transcribeWithTimestamps(
     silent: true,
   });
 }
+
+/**
+ * @deprecated Renamed to {@link transcribeWithTimestamps} (#248). The old
+ * name shipped briefly in v1.9.0; this alias keeps existing imports working
+ * for one minor-version cycle. Will be removed in v1.12.0.
+ */
+export const transcribeWithSegments = transcribeWithTimestamps;

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, beforeAll } from "bun:test";
-import { isEngineInstalled, getEngineBinPath } from "../../src/engine";
+import {
+  isEngineInstalled,
+  getEngineBinPath,
+  TRANSCRIBE_SEGMENTS_FEATURE,
+} from "../../src/engine";
 
 const CWD = import.meta.dir + "/../..";
 const FIXTURE_RU = "fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg";
@@ -59,8 +63,8 @@ describe.skipIf(!engineInstalled)("e2e-engine", () => {
   test("engine transcribe --json returns text and segments", async () => {
     const capsRun = await runEngine(["--capabilities-json"]);
     const caps = JSON.parse(capsRun.stdout);
-    if (!caps.features.includes("transcribe.segments")) {
-      console.warn("engine lacks transcribe.segments; skipping timestamp e2e");
+    if (!caps.features.includes(TRANSCRIBE_SEGMENTS_FEATURE)) {
+      console.warn(`engine lacks ${TRANSCRIBE_SEGMENTS_FEATURE}; skipping timestamp e2e`);
       return;
     }
 
@@ -125,8 +129,8 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
   test("kesha --json --timestamps includes transcript segments", async () => {
     const capsRun = await runEngine(["--capabilities-json"]);
     const caps = JSON.parse(capsRun.stdout);
-    if (!caps.features.includes("transcribe.segments")) {
-      console.warn("engine lacks transcribe.segments; skipping timestamp e2e");
+    if (!caps.features.includes(TRANSCRIBE_SEGMENTS_FEATURE)) {
+      console.warn(`engine lacks ${TRANSCRIBE_SEGMENTS_FEATURE}; skipping timestamp e2e`);
       return;
     }
 


### PR DESCRIPTION
Closes #248. Eight refactor-only polish items deferred from the #247 merge. No behavior change observable to existing callers.

## Rust (`rust/src/transcribe.rs`)

1. **Thread duration through plain path** (item 1) — `transcribe_inner` now passes the already-probed `Option<f32>` from the `Auto` mode decision step into `transcribe_plain` → `whole_file_segment`. Saves a duplicate `audio::probe_duration_seconds` call per `--json` request on `Auto` mode (<10 ms but trivially fixable).
2. **Drop dead `timestamps_required` flag** (item 2 — option b) — both VAD and plain paths now always build segments; legacy text-only callers (`pub fn transcribe`) discard `.segments` cheaply.
3. **`single_segment(start, end, text)` helper** (item 3) — shared by `whole_file_segment` and the VAD-fallback path.
4. **Lock VAD-path ordering** (item 8) — extracted `build_vad_output_segments(&spans, &samples, sr, transcribe_fn)` as a pure helper. New unit tests assert `end > start` per segment, monotonic `start[i+1] >= start[i]` across segments, skip-empty-transcription, skip-zero-length-span. Manual 45-min/817-segment test shape now codified.

## TypeScript

5. **`TRANSCRIBE_SEGMENTS_FEATURE` constant** (item 5) — `pub const` in Rust (`rust/src/transcribe.rs`), exported `const` in TS (`src/engine.ts`). Capability flag string now appears in 1 place per language; integration tests import the const.
6. **Use `isEngineInstalled()`** (item 6) — `src/engine.ts::getEngineCapabilities` no longer reimplements `existsSync(getEngineBinPath())`; calls the existing helper to match the pattern at lines 145/152.
7. **Cache key includes `mtimeMs`** (item 7) — `getEngineCapabilities` cache invalidates when `kesha install` overwrites the binary in-place within one process. Low-impact for one-shot CLI; matters for long-lived library callers.
8. **Rename `transcribeWithSegments` → `transcribeWithTimestamps`** (item 4) — `src/lib.ts` public API. Disambiguates from the internal `transcribeWithSegments` in `src/transcribe.ts` (which respects `opts.timestamps`); the lib.ts wrapper force-sets `timestamps: true`. Cheap rename — function shipped 1 day ago in v1.9.0 with minimal external uptake.

## Test evidence

- 157 rust lib tests pass (+6 new for VAD invariants, single_segment, whole-file-segment-with-supplied-duration).
- 147 bun pass + 4 skip + tsc clean + clippy --all-targets -D warnings clean + fmt clean.

## Release impact

`rust/` changed → engine release. `keshaEngine.version` will need to bump to 1.11.0 in a follow-up `release/1.11.0` PR. This PR keeps versions at 1.10.0; release flow runs after merge.

## Skipped findings (non-blocking)

- Cross-module `LEADING_PUNCT`/`TRAILING_PUNCT`/`split_punct` lift to `rust/src/tts/punct.rs` — separate follow-up PR; cross-cutting refactor.

Closes #248.