### PR TITLE
fix(#259): pad sub-second VAD segments + silence FluidAudio stdout

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "dirs",
  "fluidaudio-rs",
  "hound",
+ "libc",
  "misaki-rs",
  "ndarray",
  "ogg",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,10 @@ default = ["onnx", "tts"]
 # ASR backend selection. Language detection always uses ONNX regardless.
 # `tempfile` is pulled in by `coreml` because the FluidAudio backend writes
 # a temp WAV per VAD segment (`fluidaudio-rs 0.1.0` lacks transcribe_samples).
-coreml = ["dep:fluidaudio-rs", "dep:tempfile"]
+# `libc` is used by the coreml backend to silence FluidAudio's stdout during
+# transcribe_file calls — without it, the Swift-side `print("Transcribe error:
+# invalidAudioData")` (see #259) interleaves with kesha-engine's JSON output.
+coreml = ["dep:fluidaudio-rs", "dep:tempfile", "dep:libc"]
 onnx = []
 tts = ["dep:hound", "dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg"]
 # macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
@@ -68,6 +71,7 @@ opus = { version = "0.3", optional = true }
 ogg = { version = "0.9", optional = true }
 
 tempfile = { version = "3", optional = true }
+libc = { version = "0.2", optional = true }
 # Pinned exactly so transitive minor bumps can't silently mutate the IPA
 # our `g2p_parity` test freezes — see #207.
 misaki-rs = { version = "=0.3.0", default-features = false }

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -1,4 +1,5 @@
 use std::io::{BufWriter, Write};
+use std::os::fd::OwnedFd;
 
 use anyhow::{Context, Result};
 use fluidaudio_rs::FluidAudio;
@@ -16,6 +17,13 @@ const MIN_SAMPLES: usize = 16_000 + 16_000 / 2; // 1.5 s @ 16 kHz
 
 pub struct FluidAudioBackend {
     audio: FluidAudio,
+    /// Pre-opened /dev/null reused across `transcribe_samples` calls so
+    /// the per-segment hot path skips the open syscall (~10K saved on a
+    /// 1 h meeting). `None` when the open at construction time failed,
+    /// in which case `with_silenced_stdout` falls back to running the
+    /// closure with stdout untouched — never worse than the pre-#259
+    /// behaviour, just with the residual print risk back on the table.
+    devnull: Option<OwnedFd>,
 }
 
 impl FluidAudioBackend {
@@ -24,7 +32,12 @@ impl FluidAudioBackend {
         audio
             .init_asr()
             .context("failed to initialize FluidAudio ASR (first run compiles models for ANE)")?;
-        Ok(Self { audio })
+        let devnull = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/null")
+            .ok()
+            .map(OwnedFd::from);
+        Ok(Self { audio, devnull })
     }
 }
 
@@ -59,8 +72,10 @@ impl TranscribeBackend for FluidAudioBackend {
             .context("creating temp WAV for VAD segment")?;
         write_float_wav(tmp.path(), &padded, 16_000).context("writing temp WAV for VAD segment")?;
         let path_str = tmp.path().to_str().context("temp WAV path was non-UTF-8")?;
-        let result = with_silenced_stdout(|| self.audio.transcribe_file(path_str))
-            .context("FluidAudio sample transcription failed")?;
+        let result = with_silenced_stdout(self.devnull.as_ref(), || {
+            self.audio.transcribe_file(path_str)
+        })
+        .context("FluidAudio sample transcription failed")?;
         Ok(result.text)
     }
 }
@@ -78,15 +93,19 @@ fn pad_to_min(samples: &[f32], min_len: usize) -> std::borrow::Cow<'_, [f32]> {
     }
 }
 
-/// Run `f` with the process's stdout temporarily redirected to /dev/null.
+/// Run `f` with the process's stdout temporarily redirected to `devnull`.
 /// FluidAudio's CoreML pipeline writes diagnostic strings (`Transcribe
 /// error: invalidAudioData`) to stdout via Swift's `print(...)` — when
 /// `kesha-engine transcribe --json` is the caller, that noise interleaves
 /// with our JSON serialization and breaks downstream `jq` parsers (#259).
 /// Restoring stdout in a `Drop` impl keeps the redirect short-lived even
 /// if `f` panics.
-fn with_silenced_stdout<R>(f: impl FnOnce() -> R) -> R {
-    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+///
+/// `devnull` is the long-lived fd cached on `FluidAudioBackend`; passing
+/// `None` runs `f` with stdout untouched (best-effort fallback for the
+/// pathological case where opening /dev/null at backend init failed).
+fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce() -> R) -> R {
+    use std::os::fd::{AsRawFd, FromRawFd};
 
     struct StdoutGuard {
         saved: Option<OwnedFd>,
@@ -94,9 +113,10 @@ fn with_silenced_stdout<R>(f: impl FnOnce() -> R) -> R {
     impl Drop for StdoutGuard {
         fn drop(&mut self) {
             if let Some(saved) = self.saved.take() {
-                // SAFETY: saved is a duplicated stdout fd we own; restore
-                // it onto fd 1 and let the OwnedFd close itself afterward
-                // via the move into dup2's first arg.
+                // SAFETY: saved is a dup'd stdout fd we own. as_raw_fd
+                // borrows it for the dup2 call (atomic in the kernel);
+                // `saved` is then dropped at end of this block, closing
+                // the duplicate. dup2 retains its own reference on fd 1.
                 let rc = unsafe { libc::dup2(saved.as_raw_fd(), libc::STDOUT_FILENO) };
                 if rc < 0 {
                     // Restore failed — fd 1 stays pointed at /dev/null and
@@ -116,9 +136,9 @@ fn with_silenced_stdout<R>(f: impl FnOnce() -> R) -> R {
     }
 
     // SAFETY: dup(STDOUT) returns a fresh fd we own; OwnedFd takes
-    // responsibility for closing it on drop. /dev/null open is best-effort —
-    // if either syscall fails we just run f without redirect, never worse
-    // than the pre-#259 behaviour.
+    // responsibility for closing it on drop. dup failure is best-effort —
+    // we just run f without a guard, never worse than the pre-#259
+    // behaviour.
     let saved: Option<OwnedFd> = unsafe {
         let raw = libc::dup(libc::STDOUT_FILENO);
         if raw < 0 {
@@ -129,12 +149,10 @@ fn with_silenced_stdout<R>(f: impl FnOnce() -> R) -> R {
     };
     let _guard = StdoutGuard { saved };
 
-    let devnull = std::fs::OpenOptions::new()
-        .write(true)
-        .open("/dev/null")
-        .ok();
     if let Some(devnull) = devnull {
-        // SAFETY: devnull is an open fd; dup2 atomically replaces fd 1.
+        // SAFETY: devnull is the long-lived fd cached on FluidAudioBackend;
+        // dup2 atomically replaces fd 1 with a duplicate of devnull, and
+        // the cached fd remains valid for subsequent calls.
         unsafe {
             libc::dup2(devnull.as_raw_fd(), libc::STDOUT_FILENO);
         }

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -97,8 +97,19 @@ fn with_silenced_stdout<R>(f: impl FnOnce() -> R) -> R {
                 // SAFETY: saved is a duplicated stdout fd we own; restore
                 // it onto fd 1 and let the OwnedFd close itself afterward
                 // via the move into dup2's first arg.
-                unsafe {
-                    libc::dup2(saved.as_raw_fd(), libc::STDOUT_FILENO);
+                let rc = unsafe { libc::dup2(saved.as_raw_fd(), libc::STDOUT_FILENO) };
+                if rc < 0 {
+                    // Restore failed — fd 1 stays pointed at /dev/null and
+                    // every subsequent `println!` (including our final JSON)
+                    // silently vanishes. Surface the OS error on stderr so the
+                    // caller has any chance of noticing the broken pipe.
+                    // Rare path (fd exhaustion mid-run); we can't do better
+                    // than warn from a Drop impl.
+                    let errno = std::io::Error::last_os_error();
+                    let _ = writeln!(
+                        std::io::stderr(),
+                        "warning: failed to restore stdout after FluidAudio call: {errno}"
+                    );
                 }
             }
         }

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -147,14 +147,25 @@ fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce() -> R) -> 
             Some(OwnedFd::from_raw_fd(raw))
         }
     };
+    let have_save = saved.is_some();
     let _guard = StdoutGuard { saved };
 
-    if let Some(devnull) = devnull {
-        // SAFETY: devnull is the long-lived fd cached on FluidAudioBackend;
-        // dup2 atomically replaces fd 1 with a duplicate of devnull, and
-        // the cached fd remains valid for subsequent calls.
-        unsafe {
-            libc::dup2(devnull.as_raw_fd(), libc::STDOUT_FILENO);
+    // Only redirect if we successfully saved stdout — otherwise dup2
+    // would point fd 1 at /dev/null with no way to restore, silently
+    // swallowing the engine's final JSON for the rest of the process.
+    if have_save {
+        if let Some(devnull) = devnull {
+            // SAFETY: devnull is the long-lived fd cached on FluidAudioBackend;
+            // dup2 atomically replaces fd 1 with a duplicate of devnull, and
+            // the cached fd remains valid for subsequent calls.
+            let rc = unsafe { libc::dup2(devnull.as_raw_fd(), libc::STDOUT_FILENO) };
+            if rc < 0 {
+                let errno = std::io::Error::last_os_error();
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "warning: failed to silence stdout before FluidAudio call: {errno}"
+                );
+            }
         }
     }
     f()

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -5,6 +5,15 @@ use fluidaudio_rs::FluidAudio;
 
 use super::TranscribeBackend;
 
+/// FluidAudio's CoreML ASR rejects clips shorter than ~1s (returns
+/// `invalidAudioData` and prints the error to stdout — see #259).
+/// VAD spans frequently produce sub-second segments at speech onsets /
+/// offsets, so we pad them with trailing silence before handing to
+/// `transcribe_file`. 1.5 s @ 16 kHz = 24 000 samples; well above the
+/// observed failure threshold and small enough that the extra silence
+/// doesn't cost meaningful ASR latency.
+const MIN_SAMPLES: usize = 16_000 + 16_000 / 2; // 1.5 s @ 16 kHz
+
 pub struct FluidAudioBackend {
     audio: FluidAudio,
 }
@@ -34,20 +43,92 @@ impl TranscribeBackend for FluidAudioBackend {
     /// slice is negligible vs the ~50-200 ms ASR cost. Drop this shim and
     /// delegate to `transcribe_samples` directly once upstream cuts a
     /// release that exposes it.
+    ///
+    /// Sub-second VAD segments are padded to MIN_SAMPLES with trailing
+    /// silence (#259); FluidAudio's transcribe_file otherwise emits
+    /// `Transcribe error: invalidAudioData` to stdout and returns an Err.
+    /// stdout is silenced for the duration of the call as belt-and-braces
+    /// — even with padding, residual upstream prints would corrupt the
+    /// engine's `--json` output by interleaving with our JSON write.
     fn transcribe_samples(&mut self, samples: &[f32]) -> Result<String> {
+        let padded = pad_to_min(samples, MIN_SAMPLES);
         let tmp = tempfile::Builder::new()
             .prefix("kesha-vad-segment-")
             .suffix(".wav")
             .tempfile()
             .context("creating temp WAV for VAD segment")?;
-        write_float_wav(tmp.path(), samples, 16_000).context("writing temp WAV for VAD segment")?;
+        write_float_wav(tmp.path(), &padded, 16_000).context("writing temp WAV for VAD segment")?;
         let path_str = tmp.path().to_str().context("temp WAV path was non-UTF-8")?;
-        let result = self
-            .audio
-            .transcribe_file(path_str)
+        let result = with_silenced_stdout(|| self.audio.transcribe_file(path_str))
             .context("FluidAudio sample transcription failed")?;
         Ok(result.text)
     }
+}
+
+/// Pad `samples` to at least `min_len` with trailing zeros (silence).
+/// Returns a borrowed `Cow` so already-long-enough inputs don't allocate.
+fn pad_to_min(samples: &[f32], min_len: usize) -> std::borrow::Cow<'_, [f32]> {
+    if samples.len() >= min_len {
+        std::borrow::Cow::Borrowed(samples)
+    } else {
+        let mut padded = Vec::with_capacity(min_len);
+        padded.extend_from_slice(samples);
+        padded.resize(min_len, 0.0);
+        std::borrow::Cow::Owned(padded)
+    }
+}
+
+/// Run `f` with the process's stdout temporarily redirected to /dev/null.
+/// FluidAudio's CoreML pipeline writes diagnostic strings (`Transcribe
+/// error: invalidAudioData`) to stdout via Swift's `print(...)` — when
+/// `kesha-engine transcribe --json` is the caller, that noise interleaves
+/// with our JSON serialization and breaks downstream `jq` parsers (#259).
+/// Restoring stdout in a `Drop` impl keeps the redirect short-lived even
+/// if `f` panics.
+fn with_silenced_stdout<R>(f: impl FnOnce() -> R) -> R {
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    struct StdoutGuard {
+        saved: Option<OwnedFd>,
+    }
+    impl Drop for StdoutGuard {
+        fn drop(&mut self) {
+            if let Some(saved) = self.saved.take() {
+                // SAFETY: saved is a duplicated stdout fd we own; restore
+                // it onto fd 1 and let the OwnedFd close itself afterward
+                // via the move into dup2's first arg.
+                unsafe {
+                    libc::dup2(saved.as_raw_fd(), libc::STDOUT_FILENO);
+                }
+            }
+        }
+    }
+
+    // SAFETY: dup(STDOUT) returns a fresh fd we own; OwnedFd takes
+    // responsibility for closing it on drop. /dev/null open is best-effort —
+    // if either syscall fails we just run f without redirect, never worse
+    // than the pre-#259 behaviour.
+    let saved: Option<OwnedFd> = unsafe {
+        let raw = libc::dup(libc::STDOUT_FILENO);
+        if raw < 0 {
+            None
+        } else {
+            Some(OwnedFd::from_raw_fd(raw))
+        }
+    };
+    let _guard = StdoutGuard { saved };
+
+    let devnull = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/null")
+        .ok();
+    if let Some(devnull) = devnull {
+        // SAFETY: devnull is an open fd; dup2 atomically replaces fd 1.
+        unsafe {
+            libc::dup2(devnull.as_raw_fd(), libc::STDOUT_FILENO);
+        }
+    }
+    f()
 }
 
 /// Write a 16 kHz mono IEEE float32 WAV. FluidAudio loads it via Apple's
@@ -85,4 +166,34 @@ fn write_float_wav(path: &std::path::Path, samples: &[f32], sample_rate: u32) ->
     }
     w.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pad_to_min_borrows_when_already_long_enough() {
+        let s = vec![0.5_f32; MIN_SAMPLES];
+        let out = pad_to_min(&s, MIN_SAMPLES);
+        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(out.len(), MIN_SAMPLES);
+    }
+
+    #[test]
+    fn pad_to_min_pads_short_clip_with_trailing_silence() {
+        let original = vec![0.5_f32; 6_400]; // 0.4 s @ 16 kHz — the failing case from #259
+        let out = pad_to_min(&original, MIN_SAMPLES);
+        assert_eq!(out.len(), MIN_SAMPLES);
+        // Original samples preserved at the head, silence at the tail.
+        assert_eq!(&out[..6_400], original.as_slice());
+        assert!(out[6_400..].iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn pad_to_min_handles_empty_input() {
+        let out = pad_to_min(&[], MIN_SAMPLES);
+        assert_eq!(out.len(), MIN_SAMPLES);
+        assert!(out.iter().all(|&v| v == 0.0));
+    }
 }


### PR DESCRIPTION
Closes #259.

## Problem

On v1.12.0, `kesha --vad --speakers <long-audio>` on darwin-arm64 produces two failures observed during release validation:

1. **stderr noise** — `warning: VAD segment 0.4-0.5s failed: FluidAudio sample transcription failed`. Scales with audio length: 15 / 3 min, 149 / 11 min, 260 / 71 min.
2. **stdout pollution** — FluidAudio's Swift code prints `Transcribe error: invalidAudioData` to stdout. On long audio (148 lines / 11 min), the final JSON gets concatenated mid-line with the trailing error message, breaking `kesha --json file | jq` parsers.

## Fix

Two changes in `rust/src/backend/fluidaudio.rs::transcribe_samples`:

1. **Pad short clips to 1.5 s with trailing silence** before writing the temp WAV. New `pad_to_min` helper returns `Cow::Borrowed` when the clip is already long enough — zero-cost for the common path.
2. **Silence stdout for the duration of the FluidAudio call** via `dup(STDOUT) → dup2(/dev/null)`. New `with_silenced_stdout` helper. Defense-in-depth: any future Swift-side `print(...)` in upstream FluidAudio would otherwise corrupt the `--json` output. Stdout is redirected only during `transcribe_file`; restored via a `Drop` guard so a panic inside FluidAudio still leaves the engine able to emit its final JSON.

## Tests

`pad_to_min` has 3 unit tests:
- length-preserving when input is already ≥ MIN_SAMPLES
- trailing-zero padding when input is short (e.g. 0.4 s @ 16 kHz, the failing case from #259)
- empty-input edge case

The `with_silenced_stdout` path is exercised end-to-end by the existing `rust/tests/diarize_e2e.rs` integration test. CI's macos-14 row builds with `coreml,tts,system_tts,system_diarize` and exercises the path on a fresh release artifact via `make smoke-test`.

## Cargo

- New optional `libc` dep (only pulled when `coreml` feature is on).
- Added `dep:libc` to the `coreml` feature group.

## Test plan

- [x] `cargo check --no-default-features --features onnx,tts` — clean (default-build untouched)
- [x] `cargo clippy --all-targets --no-default-features --features onnx,tts -- -D warnings` — clean
- [ ] CI macos-14 row builds + smoke-tests with full feature set
- [ ] Manual re-run of 71-min meeting validation: zero `FluidAudio sample transcription failed` warnings, clean JSON on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)