### PR TITLE
ci: add supplementary nix-build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,10 +234,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ❄️  Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
 
       - name: 💾 Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: 🔍 Validate flake metadata
         run: nix flake metadata --no-update-lock-file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       integration: ${{ steps.filter.outputs.integration }}
       raycast: ${{ steps.filter.outputs.raycast }}
+      nix: ${{ steps.filter.outputs.nix }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -43,6 +44,12 @@ jobs:
               - '.github/actions/**'
             raycast:
               - 'raycast/**'
+              - '.github/workflows/ci.yml'
+            nix:
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'rust/**'
+              - 'package.json'
               - '.github/workflows/ci.yml'
 
   unit-tests:
@@ -206,6 +213,40 @@ jobs:
 
       - name: 🔍 Lint (ray lint includes tsc --noEmit)
         run: npm run lint
+
+  # Supplementary check: verify the Nix flake still evaluates and the
+  # engine derivation builds. Catches regressions in `flake.nix` /
+  # naersk / ort-sys env-var wiring before they reach main. Does NOT
+  # replace `build-engine.yml` — distributable release artifacts
+  # continue to go through Github-runner cargo + Swift toolchain pins.
+  #
+  # Currently builds only `.#kesha-engine`. The Bun wrapper package
+  # `.#kesha` uses a fixed-output derivation whose `outputHash` requires
+  # a nix-equipped developer to populate (see flake.nix `keshaNodeModules`
+  # block + #264 plan T5); CI without that hash can't build it.
+  nix-build:
+    needs: changes
+    if: needs.changes.outputs.nix == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: ❄️  Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: 💾 Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: 🔍 Validate flake metadata
+        run: nix flake metadata --no-update-lock-file
+
+      - name: 🦀 Build kesha-engine
+        run: nix build .#kesha-engine --no-update-lock-file -L
+
+      - name: 🚬 Smoke
+        run: ./result/bin/kesha-engine --version
 
   pr-comment:
     if: always() && github.event_name == 'pull_request' && (needs.unit-tests.result == 'success' || needs.integration-tests.result == 'success' || needs.tts-e2e.result == 'success')


### PR DESCRIPTION
Supplementary CI safety net for the Nix flake. Runs on every PR that touches \`flake.nix\`, the Rust engine source, \`package.json\`, or this workflow file.

## What it does

- Installs Nix via DeterminateSystems action
- Caches via \`magic-nix-cache-action\` (free for OSS)
- \`nix flake metadata\` — validates the flake parses
- \`nix build .#kesha-engine\` — builds the naersk-built engine derivation
- Smoke-checks \`./result/bin/kesha-engine --version\`

## What it does NOT do

- Build \`.#kesha\` (the Bun wrapper). That package's bun-deps FOD has \`outputHash = lib.fakeHash\` until a nix-equipped developer populates it. Switch to \`nix flake check\` once the hash lands.
- Replace \`build-engine.yml\`. Distributable artifacts (windows-x64.exe, Swift sidecars with the Xcode 16.2 pin) continue to come from Github runners — Nix can't produce those.
- Run on macOS. \`runs-on: ubuntu-latest\` only; we can extend to \`macos-14\` later if we want CoreML coverage via the flake (~10× CI minute cost).

## Cost

- Cold cargo-build of the engine via naersk: ~10-15 min on a fresh Linux runner.
- Warm (magic-nix-cache hit): seconds.

## Test plan

- [ ] CI runs green on this PR.
- [ ] Subsequent PRs that touch \`flake.nix\` re-trigger the job.
- [ ] Subsequent PRs that DON'T touch flake/rust/package.json skip the job (path filter works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)