### PR TITLE
refactor(#267 F2): collapse models.rs accessors into ModelKind enum

### DIFF
--- a/rust/src/lang_id.rs
+++ b/rust/src/lang_id.rs
@@ -2,7 +2,6 @@ use crate::audio;
 use crate::models;
 use anyhow::{Context, Result};
 use serde::Serialize;
-use std::path::Path;
 
 #[derive(Serialize)]
 pub struct LangDetectResult {
@@ -13,12 +12,11 @@ pub struct LangDetectResult {
 const MAX_SECONDS: f32 = 10.0;
 
 pub fn detect_audio_language(audio_path: &str) -> Result<LangDetectResult> {
-    let model_dir = models::lang_id_model_dir();
-    if !models::is_lang_id_cached(&model_dir) {
+    if !models::is_cached(models::ModelKind::LangId) {
         anyhow::bail!("Lang-ID model not installed. Run: kesha install");
     }
 
-    let dir = Path::new(&model_dir);
+    let dir = models::model_dir(models::ModelKind::LangId);
 
     // Load ONNX session
     let mut session = ort::session::Session::builder()

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -226,7 +226,8 @@ fn list_vosk_ru_voices(cache: &std::path::Path) -> Vec<String> {
     // Vosk-TTS Russian is a single multi-speaker model — once installed, all
     // five baked-in speakers are available. Same gate as resolve_vosk_ru, so
     // partial installs don't advertise voices that fail at synthesis time.
-    if !models::is_vosk_ru_cached(&cache.join("models/vosk-ru")) {
+    let dir = models::model_dir_at(models::ModelKind::VoskRu, cache);
+    if !models::is_cached_in(models::ModelKind::VoskRu, &dir) {
         return Vec::new();
     }
     vec![

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -238,56 +238,91 @@ fn log_mirror_once() {
     });
 }
 
-pub fn asr_model_dir() -> String {
-    cache_dir()
-        .join("models")
-        .join("parakeet-tdt-v3")
-        .to_string_lossy()
-        .to_string()
+/// Kinds of model bundle the engine can install, locate, and check. Adding
+/// a new backend means adding a variant plus a `subdir` arm and (if the
+/// layout isn't flat enough for `has_all_files`) a custom layout helper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelKind {
+    /// Parakeet TDT ONNX ASR weights.
+    Asr,
+    /// SpeechBrain ECAPA-TDNN VoxLingua107 audio lang-id ONNX.
+    LangId,
+    /// Silero VAD v5 ONNX.
+    Vad,
+    /// Vosk-TTS multi-speaker Russian model (model + dictionary + BERT).
+    #[cfg(feature = "tts")]
+    VoskRu,
+    /// FluidAudio Sortformer streaming diarizer (`.mlpackage`).
+    #[cfg(feature = "system_diarize")]
+    Diarize,
 }
 
-pub fn lang_id_model_dir() -> String {
-    cache_dir()
-        .join("models")
-        .join("lang-id-ecapa")
-        .to_string_lossy()
-        .to_string()
+impl ModelKind {
+    /// Cache-relative subdirectory.
+    pub fn subdir(self) -> &'static str {
+        match self {
+            ModelKind::Asr => "models/parakeet-tdt-v3",
+            ModelKind::LangId => "models/lang-id-ecapa",
+            ModelKind::Vad => "models/silero-vad",
+            #[cfg(feature = "tts")]
+            ModelKind::VoskRu => "models/vosk-ru",
+            #[cfg(feature = "system_diarize")]
+            ModelKind::Diarize => "models/diarize/SortformerNvidiaLow_v2.mlpackage",
+        }
+    }
 }
 
-pub fn vad_model_dir() -> String {
-    cache_dir()
-        .join("models")
-        .join("silero-vad")
-        .to_string_lossy()
-        .to_string()
+/// Absolute path to a kind's directory under the active cache (honours
+/// `KESHA_CACHE_DIR`).
+pub fn model_dir(kind: ModelKind) -> PathBuf {
+    model_dir_at(kind, &cache_dir())
 }
 
-/// Path to the cached Sortformer `.mlpackage` directory. The Swift sidecar
-/// (`kesha-diarize`) takes this directory as `argv[1]` and feeds it to
-/// `MLModel.compileModel(at:)`. (#199)
+/// Same as [`model_dir`] but with a caller-supplied cache root — for the
+/// list-voices / resolver paths that already have the root and want to
+/// avoid re-reading the env var.
+pub fn model_dir_at(kind: ModelKind, cache_root: &Path) -> PathBuf {
+    cache_root.join(kind.subdir())
+}
+
+/// True iff `kind`'s required files are present under the active cache.
+pub fn is_cached(kind: ModelKind) -> bool {
+    is_cached_in(kind, &model_dir(kind))
+}
+
+/// True iff `kind`'s required files are present in `dir` — callers that
+/// resolved the directory themselves (e.g. from a function-supplied cache
+/// root) use this instead of [`is_cached`] so the cache root parameter
+/// stays single-source.
+pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool {
+    match kind {
+        ModelKind::Asr => has_all_files(dir, ASR_FILES),
+        ModelKind::LangId => has_all_files(dir, LANG_ID_FILES),
+        ModelKind::Vad => has_all_files(dir, VAD_FILES),
+        #[cfg(feature = "tts")]
+        ModelKind::VoskRu => has_vosk_ru_layout(dir),
+        #[cfg(feature = "system_diarize")]
+        ModelKind::Diarize => has_diarize_layout(dir),
+    }
+}
+
+/// `vosk_tts::Model::new` opens these three files — keep this layout check
+/// aligned with the loader. `has_all_files` flattens the manifest to basenames,
+/// which would treat the top-level `model.onnx` and `bert/model.onnx` as
+/// duplicates; this custom walk handles the nested path instead.
+#[cfg(feature = "tts")]
+fn has_vosk_ru_layout(dir: &Path) -> bool {
+    dir.join("model.onnx").exists()
+        && dir.join("dictionary").exists()
+        && dir.join("bert/model.onnx").exists()
+}
+
+/// `.mlpackage` is a directory tree — the runtime-required files live at
+/// nested paths under `Data/com.apple.CoreML/`. Same basename-flattening
+/// problem as the Vosk layout above (two `*-weight.bin` siblings under
+/// different `weights/` subdirs), so we walk each path explicitly. (#199)
 #[cfg(feature = "system_diarize")]
-pub fn diarize_model_dir() -> PathBuf {
-    cache_dir().join("models/diarize/SortformerNvidiaLow_v2.mlpackage")
-}
-
-pub fn is_asr_cached(dir: &str) -> bool {
-    has_all_files(dir, ASR_FILES)
-}
-
-pub fn is_lang_id_cached(dir: &str) -> bool {
-    has_all_files(dir, LANG_ID_FILES)
-}
-
-pub fn is_vad_cached(dir: &str) -> bool {
-    has_all_files(dir, VAD_FILES)
-}
-
-/// True iff the Sortformer `.mlpackage` has every runtime-required file.
-/// `has_all_files` flattens to basenames; `.mlpackage` is a directory tree
-/// with two `*-weight.bin` siblings under nested paths, so we check
-/// each canonical relative path explicitly. (#199)
-#[cfg(feature = "system_diarize")]
-pub fn is_diarize_cached(dir: &Path) -> bool {
+fn has_diarize_layout(dir: &Path) -> bool {
     dir.join("Manifest.json").exists()
         && dir.join("Data/com.apple.CoreML/model.mlmodel").exists()
         && dir
@@ -298,30 +333,12 @@ pub fn is_diarize_cached(dir: &Path) -> bool {
             .exists()
 }
 
-/// Default Vosk-ru model directory under the active cache. Test-only —
-/// production callers (resolver, list-voices) build the path from the
-/// caller-supplied `cache_dir` so they honour `tempfile::tempdir()` test
-/// fixtures and explicit `KESHA_CACHE_DIR` overrides.
-#[cfg(all(feature = "tts", test))]
-pub fn vosk_ru_model_dir() -> PathBuf {
-    cache_dir().join("models/vosk-ru")
-}
-
-/// True iff the Vosk-ru install has the runtime-required files. Mirror what
-/// `vosk_tts::Model::new` actually opens — keep these gates aligned.
-#[cfg(feature = "tts")]
-pub fn is_vosk_ru_cached(dir: &Path) -> bool {
-    dir.join("model.onnx").exists()
-        && dir.join("dictionary").exists()
-        && dir.join("bert/model.onnx").exists()
-}
-
-/// Caller passes the per-model dir (e.g. `asr_model_dir()`); we pull the
-/// basename out of each manifest entry's cache-relative `rel_path` and
-/// check it's present. Keeps the public `dir`-based API while letting the
-/// manifest own the full URL + hash for the download path.
-fn has_all_files(dir: &str, files: &[ModelFile]) -> bool {
-    let dir = Path::new(dir);
+/// Caller passes the per-model dir (typically [`model_dir`] /
+/// [`model_dir_at`]); we pull the basename out of each manifest entry's
+/// cache-relative `rel_path` and check it's present. Keeps the per-kind
+/// layout check simple while letting the manifest own the full URL + hash
+/// for the download path.
+fn has_all_files(dir: &Path, files: &[ModelFile]) -> bool {
     files.iter().all(|f| {
         Path::new(f.rel_path)
             .file_name()

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -138,8 +138,10 @@ fn transcribe_inner(
     speakers_required: bool,
 ) -> Result<TranscriptionOutput> {
     let model_dir = ensure_asr_installed()?;
-    let vad_dir = models::vad_model_dir();
-    let vad_installed = models::is_vad_cached(&vad_dir);
+    let vad_dir = models::model_dir(models::ModelKind::Vad)
+        .to_string_lossy()
+        .into_owned();
+    let vad_installed = models::is_cached(models::ModelKind::Vad);
 
     // `Auto` needs a duration probe first. `On`/`Off` are deterministic.
     let duration = match mode {
@@ -240,7 +242,7 @@ fn transcribe_via_vad(
     vad_dir: &str,
     cfg: VadConfig,
 ) -> Result<TranscriptionOutput> {
-    if !models::is_vad_cached(vad_dir) {
+    if !models::is_cached_in(models::ModelKind::Vad, std::path::Path::new(vad_dir)) {
         anyhow::bail!(
             "Error: VAD model not installed\n\n\
              Please run: kesha install --vad"
@@ -431,8 +433,8 @@ fn resolve_diarize_model_path() -> Result<std::path::PathBuf> {
         );
     }
 
-    let default = crate::models::diarize_model_dir();
-    if crate::models::is_diarize_cached(&default) {
+    let default = crate::models::model_dir(crate::models::ModelKind::Diarize);
+    if crate::models::is_cached(crate::models::ModelKind::Diarize) {
         return Ok(default);
     }
 
@@ -445,14 +447,15 @@ fn resolve_diarize_model_path() -> Result<std::path::PathBuf> {
 
 /// Returns the cached ASR model dir or bails with the install hint.
 fn ensure_asr_installed() -> Result<String> {
-    let model_dir = models::asr_model_dir();
-    if !models::is_asr_cached(&model_dir) {
+    if !models::is_cached(models::ModelKind::Asr) {
         anyhow::bail!(
             "Error: No transcription models installed\n\n\
              Please run: kesha install"
         );
     }
-    Ok(model_dir)
+    Ok(models::model_dir(models::ModelKind::Asr)
+        .to_string_lossy()
+        .into_owned())
 }
 
 #[cfg(test)]

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -145,8 +145,8 @@ fn resolve_vosk_ru(
              ru-vosk-f03, ru-vosk-m01, ru-vosk-m02"
         ),
     };
-    let model_dir = cache_dir.join("models/vosk-ru");
-    if !crate::models::is_vosk_ru_cached(&model_dir) {
+    let model_dir = crate::models::model_dir_at(crate::models::ModelKind::VoskRu, cache_dir);
+    if !crate::models::is_cached_in(crate::models::ModelKind::VoskRu, &model_dir) {
         anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
     }
     Ok(ResolvedVoice::Vosk {

--- a/rust/src/tts/vosk.rs
+++ b/rust/src/tts/vosk.rs
@@ -76,8 +76,8 @@ mod tests {
 
     #[test]
     fn rejects_out_of_range_speaker() {
-        let dir = crate::models::vosk_ru_model_dir();
-        if !crate::models::is_vosk_ru_cached(&dir) {
+        let dir = crate::models::model_dir(crate::models::ModelKind::VoskRu);
+        if !crate::models::is_cached(crate::models::ModelKind::VoskRu) {
             eprintln!(
                 "vosk model not cached at {} — skipping speaker_id range test",
                 dir.display()
@@ -93,8 +93,8 @@ mod tests {
     /// produces non-trivial PCM and uses the model-reported sample rate.
     #[test]
     fn synth_short_phrase_produces_audio() {
-        let dir = crate::models::vosk_ru_model_dir();
-        if !crate::models::is_vosk_ru_cached(&dir) {
+        let dir = crate::models::model_dir(crate::models::ModelKind::VoskRu);
+        if !crate::models::is_cached(crate::models::ModelKind::VoskRu) {
             eprintln!(
                 "vosk model not cached at {} — skipping synth e2e test",
                 dir.display()


### PR DESCRIPTION
## Summary

\`rust/src/models.rs\` had a paired \`is_<X>_cached\` + \`<X>_model_dir\` for every backend (ASR, lang-id, VAD, Vosk-ru, diarize). Adding a new backend meant two new public functions with near-identical signatures, and the signatures weren't even uniform (some \`&str\`, some \`&Path\`; some \`String\`, some \`PathBuf\`).

Replaced with:

\`\`\`rust
pub enum ModelKind { Asr, LangId, Vad, VoskRu, Diarize }
pub fn model_dir(kind: ModelKind) -> PathBuf
pub fn model_dir_at(kind: ModelKind, cache_root: &Path) -> PathBuf
pub fn is_cached(kind: ModelKind) -> bool
pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool
\`\`\`

One contract; new backend = new enum variant + one \`subdir\` arm (plus a custom layout helper if the on-disk shape isn't flat enough for the basename-based \`has_all_files\`). Vosk-ru and Diarize keep their bespoke layout checks as private \`has_*_layout\` helpers, still gated on the same \`tts\` / \`system_diarize\` features.

Migrated 8 call sites across \`lang_id.rs\`, \`main.rs\`, \`tts/voices.rs\`, \`tts/vosk.rs\`, and \`transcribe/mod.rs\`.

Refs #267 (P0.F2)

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean (default features)
- [x] \`cargo test --lib models\` 13/13 passing
- [ ] CI: \`rust-test.yml\` (ubuntu / windows / macos-14, default features + coreml on macos-14)
- [ ] CI: \`build-engine.yml\` not triggered (no tag)