### PR TITLE
ci: fail-fast — run cheap checks before expensive ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,16 @@ jobs:
           retention-days: 7
 
   tts-e2e:
-    needs: changes
-    if: needs.changes.outputs.integration == 'true'
+    # Job-level fail-fast: tts-e2e burns ~15-20 min on `cargo build
+    # --release` + the e2e tests. Gate it on `unit-tests` so a typo
+    # caught by `tsc --noEmit` (10 s into unit-tests) cancels the slow
+    # job instead of running it to completion. `unit-tests` is skipped
+    # for rust-only PRs (code filter false); the explicit
+    # `result == 'skipped'` allowance keeps tts-e2e running in that case.
+    needs: [changes, unit-tests]
+    if: |
+      needs.changes.outputs.integration == 'true' &&
+      (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped')
     runs-on: macos-latest
     timeout-minutes: 20
     env:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -66,19 +66,10 @@ jobs:
         shell: pwsh
         run: Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_POLICY_VERSION_MINIMUM=3.5"
 
-      - name: Cache Kokoro spike models
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-v5-${{ runner.os }}
-
-      - name: Download Kokoro model (if cache miss)
-        shell: bash
-        run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"
-
-      - name: Run tests (with real Kokoro)
-        shell: bash
-        run: bash rust/ci/run-cargo-test.sh "$KOKORO_CACHE" "${{ runner.os }}"
+      # Fail-fast ladder: cheap-to-fail checks first so a typo in fmt
+      # doesn't burn 30 minutes of cargo test before surfacing. fmt
+      # (~5s) → clippy (~30s on warm cache) → coreml check (~5min) →
+      # Kokoro model download + cargo test (~10-30min).
 
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'
@@ -93,3 +84,17 @@ jobs:
       - name: Check coreml feature
         if: matrix.os == 'macos-14'
         run: cd rust && cargo check --features coreml --no-default-features
+
+      - name: Cache Kokoro spike models
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.KOKORO_CACHE }}
+          key: kokoro-spike-v5-${{ runner.os }}
+
+      - name: Download Kokoro model (if cache miss)
+        shell: bash
+        run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"
+
+      - name: Run tests (with real Kokoro)
+        shell: bash
+        run: bash rust/ci/run-cargo-test.sh "$KOKORO_CACHE" "${{ runner.os }}"


### PR DESCRIPTION
## Summary

Two CI reorders, no behavioural changes.

**1. \`rust-test.yml\`: lift fmt + clippy + coreml-check ABOVE Kokoro download + cargo test.**

Today's job ran \`cargo test\` (~10-30 min on cold cache) first, then \`fmt\` (~5 s) and \`clippy\` (~30 s) at the end — a misformatted file or a clippy warning only surfaces after the 30-minute build burns.

Fail-fast ladder is now:

\`\`\`
fmt (5s) → clippy (30s) → coreml check (5min) → Kokoro download → cargo test
\`\`\`

No new dependencies — opus / pkg-config / Xcode 16 / rust-cache already sit at the top of the job, and clippy needs the same crate compile that \`cargo test\` does (warm cache shared).

**2. \`ci.yml\`: \`tts-e2e\` gated on \`unit-tests\`.**

\`tts-e2e\` (~15-20 min: \`cargo build --release\` + Kokoro download + bun test) used to start as soon as \`changes\` resolved. A \`tsc --noEmit\` failure (10 s into \`unit-tests\`) would run in parallel and waste the full e2e lane. Now \`tts-e2e\` depends on \`unit-tests\` finishing green (or being skipped, for rust-only PRs).

\`build-engine.yml\` left alone — tag-only workflow, already flows setup → build → smoke (natural fail-fast).

## Test plan

- [x] YAML validity verified (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [ ] CI: this PR itself runs through both reordered workflows
- [ ] Verify rust-test.yml ubuntu row: fmt + clippy run BEFORE Kokoro download in the live log
- [ ] Verify tts-e2e: starts only after unit-tests completes (visible as serialised in the PR timeline)