### PR TITLE
fix(#275 D3): warn loudly when capability gate drops --no-expand-abbrev

### DIFF
--- a/src/synth.ts
+++ b/src/synth.ts
@@ -65,8 +65,12 @@ export function buildSayArgs(o: SayOptions, capabilities?: EngineCapabilities | 
     if (supportsExpand) {
       args.push("--no-expand-abbrev");
     } else {
-      log.debug(
-        "kesha-engine does not advertise tts.ru_acronym_expansion or tts.en_acronym_expansion; dropping --no-expand-abbrev",
+      // CLAUDE.md "NEVER SWALLOW ERRORS": the user explicitly passed the flag.
+      // Silent drop with only `log.debug` made the flag look effective on old
+      // engines (#275 D3). Surface it as a warning so a CI script or human
+      // user sees the mismatch on every invocation, not only with --debug.
+      log.warn(
+        "--no-expand-abbrev requires kesha-engine ≥ 1.10.0 (advertises no tts.ru_acronym_expansion / tts.en_acronym_expansion capability); flag ignored",
       );
     }
   }

--- a/tests/unit/synth.test.ts
+++ b/tests/unit/synth.test.ts
@@ -80,7 +80,11 @@ describe("--no-expand-abbrev (#232)", () => {
     expect(args).toContain("--no-expand-abbrev");
   });
 
-  it("dropped silently when engine lacks the capability", () => {
+  it("dropped from argv with a warning when engine lacks the capability (#275 D3)", () => {
+    // The drop is no longer silent — `buildSayArgs` emits a `log.warn` so
+    // the user notices their flag had no effect. We can't intercept the
+    // colored stderr from bun:test cleanly, so we only assert the argv
+    // shape here; the warn-call is exercised by the e2e tests on stderr.
     const args = buildSayArgs({
       ...baseOpts,
       noExpandAbbrev: true,


### PR DESCRIPTION
## Summary

\`buildSayArgs\` silently dropped \`--no-expand-abbrev\` on engines that didn't advertise the \`tts.ru_acronym_expansion\` / \`tts.en_acronym_expansion\` capability — the drop was traced via \`log.debug\`, invisible without \`--debug\` or \`KESHA_DEBUG=1\`. Direct violation of CLAUDE.md "NEVER SWALLOW ERRORS".

Swap the \`log.debug\` for \`log.warn\` so the mismatch is visible on every invocation.

Test name updated from "dropped silently" to "dropped from argv with a warning when engine lacks the capability (#275 D3)" — the argv assertion still holds, only the visibility of the drop changed.

Refs #275 (P0.D3)

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test tests/unit\` 122/122 passing; the new warn line is visible in bun:test's stderr capture
- [ ] CI: unit-tests on 3 OSes