### PR TITLE
fix(#275 D9): align KESHA_DEBUG parse grammar across TS and Rust

### DIFF
--- a/rust/src/debug.rs
+++ b/rust/src/debug.rs
@@ -15,12 +15,28 @@
 
 use std::sync::OnceLock;
 
+/// Values that turn `KESHA_DEBUG` OFF — empty, `"0"`, `"false"`, `"no"`,
+/// `"off"`, all matched **case-insensitively** after trimming. Any other
+/// non-empty value turns debug ON. Mirrored verbatim in `src/log.ts`
+/// (post-#275 D9) so `KESHA_DEBUG=False` flips both sides the same
+/// direction.
+const KESHA_DEBUG_OFF_VALUES: &[&str] = &["", "0", "false", "no", "off"];
+
+/// Parse a raw env-var value into the boolean debug state. Pure helper so
+/// production `enabled()` and the test below stay aligned by construction.
+fn debug_on_for(value: Option<&str>) -> bool {
+    match value {
+        None => false,
+        Some(s) => {
+            let normalized = s.trim().to_ascii_lowercase();
+            !KESHA_DEBUG_OFF_VALUES.contains(&normalized.as_str())
+        }
+    }
+}
+
 fn enabled() -> bool {
     static CACHE: OnceLock<bool> = OnceLock::new();
-    *CACHE.get_or_init(|| match std::env::var("KESHA_DEBUG").as_deref() {
-        Ok("0" | "false" | "") | Err(_) => false,
-        Ok(_) => true,
-    })
+    *CACHE.get_or_init(|| debug_on_for(std::env::var("KESHA_DEBUG").ok().as_deref()))
 }
 
 /// Emit a stderr trace line when `KESHA_DEBUG` is on. Accepts `format_args!`
@@ -42,32 +58,53 @@ macro_rules! dtrace {
 
 #[cfg(test)]
 mod tests {
-    // `enabled()` caches via OnceLock so it can only be tested once per
-    // process. Instead of fighting that, assert parsing behavior by calling
-    // the core logic directly at test time.
-    fn parse(v: Option<&str>) -> bool {
-        match v {
-            Some("0" | "false" | "") | None => false,
-            Some(_) => true,
-        }
-    }
+    // `enabled()` caches via OnceLock, so it can only be probed once per
+    // process. Call the pure helper directly instead — it covers the same
+    // parsing rule that production uses.
+    use super::debug_on_for;
 
     #[test]
     fn off_when_unset() {
-        assert!(!parse(None));
+        assert!(!debug_on_for(None));
     }
 
     #[test]
-    fn off_for_zero_and_false() {
-        assert!(!parse(Some("0")));
-        assert!(!parse(Some("false")));
-        assert!(!parse(Some("")));
+    fn off_for_zero_false_empty() {
+        assert!(!debug_on_for(Some("0")));
+        assert!(!debug_on_for(Some("false")));
+        assert!(!debug_on_for(Some("")));
     }
 
     #[test]
-    fn on_for_one_and_true() {
-        assert!(parse(Some("1")));
-        assert!(parse(Some("true")));
-        assert!(parse(Some("anything")));
+    fn off_for_no_and_off() {
+        // Expanded grammar (#275 D9): `no` and `off` join the off-set.
+        assert!(!debug_on_for(Some("no")));
+        assert!(!debug_on_for(Some("off")));
+    }
+
+    #[test]
+    fn off_case_insensitive() {
+        // The pre-D9 Rust pattern was exact-case `"false"`, which let
+        // `"False"` slip through and flipped only the engine ON. Lock
+        // the case-insensitive contract in.
+        assert!(!debug_on_for(Some("False")));
+        assert!(!debug_on_for(Some("FALSE")));
+        assert!(!debug_on_for(Some("No")));
+        assert!(!debug_on_for(Some("OFF")));
+    }
+
+    #[test]
+    fn off_with_surrounding_whitespace() {
+        // `KESHA_DEBUG=" false "` is functionally the same intent as
+        // `=false`; trim before comparing.
+        assert!(!debug_on_for(Some("  false  ")));
+        assert!(!debug_on_for(Some("\t0\n")));
+    }
+
+    #[test]
+    fn on_for_one_true_anything() {
+        assert!(debug_on_for(Some("1")));
+        assert!(debug_on_for(Some("true")));
+        assert!(debug_on_for(Some("anything")));
     }
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -4,10 +4,19 @@ import pc from "picocolors";
  * Debug mode (#148): when `KESHA_DEBUG` is truthy OR the caller has flipped
  * `log.debugEnabled = true` (via `--debug`), `log.debug()` writes structured
  * trace lines to stderr. Otherwise it's a no-op. Stdout is never touched.
+ *
+ * Grammar (#275 D9): values that turn debug OFF — empty, `"0"`, `"false"`,
+ * `"no"`, `"off"`, all matched **case-insensitively** after trimming. Any
+ * other non-empty value turns debug ON. The Rust engine mirrors this list
+ * verbatim in `rust/src/debug.rs` so `KESHA_DEBUG=False` flips both sides
+ * the same direction.
  */
+const KESHA_DEBUG_OFF_VALUES = new Set(["", "0", "false", "no", "off"]);
+
 function envDebug(): boolean {
   const v = process.env.KESHA_DEBUG;
-  return !!v && v !== "0" && v.toLowerCase() !== "false";
+  if (v === undefined) return false;
+  return !KESHA_DEBUG_OFF_VALUES.has(v.trim().toLowerCase());
 }
 
 export const log = {


### PR DESCRIPTION
## Summary

Two parse rules for one env var:

\`\`\`
TS  (src/log.ts):  !!v && v !== "0" && v.toLowerCase() !== "false"
Rust (debug.rs):   match s { "0" | "false" | "" => OFF, _ => ON }
\`\`\`

\`KESHA_DEBUG=False\` flipped TS OFF (lower-cases to \`"false"\`) and engine ON (exact-case fails) — silent one-character casing inconsistency.

Unify both sides on a single case-insensitive grammar. Values that turn debug OFF: \`""\`, \`"0"\`, \`"false"\`, \`"no"\`, \`"off"\`. Any other non-empty value turns debug ON.

- TS hoists the rule to a \`KESHA_DEBUG_OFF_VALUES\` Set; \`envDebug\` trim+lowercase before lookup.
- Rust mirrors the same constant + a new pure helper \`debug_on_for(Option<&str>) -> bool\`. Production \`enabled()\` and the test both call it — drops the per-test \`parse()\` re-implementation that previously had to mirror the rule by hand.

Test surface gains 3 new cases: \`no\` / \`off\`, case-insensitive, surrounding whitespace.

Refs #275 (P2.D9)

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib debug\` 6/6 passing
- [ ] CI: 3-OS unit/rust matrix