### PR TITLE
fix(#275 D6+D7+D10): add boundary dtrace! coverage at G2P / VAD / format

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -173,14 +173,24 @@ pub(crate) fn resolve_output_format(
 ) -> Result<tts::OutputFormat, String> {
     use std::str::FromStr;
 
-    let mut chosen = match (format, out) {
-        (Some(f), _) => tts::OutputFormat::from_str(f)?,
-        (None, Some(p)) => p
-            .extension()
-            .and_then(|e| e.to_str())
-            .and_then(tts::encode::format_from_extension)
-            .unwrap_or_default(),
-        (None, None) => tts::OutputFormat::default(),
+    // #275 D10: track which arm of the resolver fired so the dtrace at
+    // the bottom can surface `chosen=… source=…`. Three possible sources:
+    //   "--format"  — explicit flag wins.
+    //   "out-ext"   — sniffed from the `--out` extension.
+    //   "default"   — fallthrough (no flag, no `--out`, or unknown ext).
+    let (mut chosen, source): (tts::OutputFormat, &'static str) = match (format, out) {
+        (Some(f), _) => (tts::OutputFormat::from_str(f)?, "--format"),
+        (None, Some(p)) => {
+            let ext_fmt = p
+                .extension()
+                .and_then(|e| e.to_str())
+                .and_then(tts::encode::format_from_extension);
+            match ext_fmt {
+                Some(fmt) => (fmt, "out-ext"),
+                None => (tts::OutputFormat::default(), "default"),
+            }
+        }
+        (None, None) => (tts::OutputFormat::default(), "default"),
     };
 
     if let tts::OutputFormat::OggOpus {
@@ -200,6 +210,7 @@ pub(crate) fn resolve_output_format(
         return Err("--bitrate / --sample-rate only apply to --format ogg-opus".to_string());
     }
 
+    crate::dtrace!("format::resolved chosen={chosen:?} source={source}");
     Ok(chosen)
 }
 

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -289,9 +289,10 @@ fn transcribe_via_vad(
             );
         }
         let text = be.transcribe_samples(&samples)?;
-        let end_s = samples.len() as f32 / VAD_SAMPLE_RATE as f32;
+        // Reuse the duration we already computed for the dtrace above
+        // (Greptile follow-up on #282 — was a redundant float divide).
         return Ok(TranscriptionOutput {
-            segments: single_segment(0.0, end_s, &text),
+            segments: single_segment(0.0, total_secs, &text),
             text,
         });
     }

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -272,6 +272,17 @@ fn transcribe_via_vad(
     if spans.is_empty() {
         let min_speech_samples =
             (cfg.min_speech_ms as u64 * VAD_SAMPLE_RATE as u64 / 1000) as usize;
+        // #275 D7: surface the input duration + threshold the segmenter
+        // saw when it concluded "no speech". With the prior `vad::detect
+        // segments=0` line, this gives the user enough to tell "the audio
+        // is actually silent" from "the threshold is too aggressive".
+        let total_secs = samples.len() as f32 / VAD_SAMPLE_RATE as f32;
+        dtrace!(
+            "vad::all_silence total_secs={:.1} min_speech_ms={} threshold={:.2}",
+            total_secs,
+            cfg.min_speech_ms,
+            cfg.threshold
+        );
         if samples.len() >= min_speech_samples {
             eprintln!(
                 "warning: VAD produced no speech segments; transcribing full file (consider lowering --vad threshold or skipping --vad)"

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -12,7 +12,9 @@ use anyhow::Result;
 /// Only English is supported; everything else errors with a pointer to the
 /// engine-specific G2P (Russian → use a `ru-vosk-*` voice; others → not yet).
 pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
+    let text_chars = text.chars().count();
     if text.trim().is_empty() {
+        crate::dtrace!("g2p::route lang={lang} backend=empty text_chars={text_chars}");
         return Ok(String::new());
     }
     let lower = lang.to_ascii_lowercase();
@@ -25,7 +27,13 @@ pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
              Other languages: tracked in #212."
         ),
     };
-    misaki_to_ipa(text, misaki_lang)
+    // #275 D6: log the dispatch branch + char counts so a downstream
+    // `"empty after G2P"` bail has the routing context attached. One
+    // boundary trace, never per-token.
+    crate::dtrace!("g2p::route lang={lang} backend=misaki text_chars={text_chars}");
+    let ipa = misaki_to_ipa(text, misaki_lang)?;
+    crate::dtrace!("g2p::result ipa_chars={}", ipa.chars().count());
+    Ok(ipa)
 }
 
 /// Run misaki-rs and strip the U+200D zero-width joiners it inserts for


### PR DESCRIPTION
## Summary

Three small \`dtrace!\` additions at the failure-prone boundaries the audit flagged. All gated on \`KESHA_DEBUG=1\` (zero cost when off); each emits a single line at the module boundary, never inside a loop.

**D6 — \`tts/g2p.rs\`:** \`text_to_ipa\` could bail without telling the user which backend was picked.

\`\`\`
g2p::route lang=en-us backend=misaki text_chars=20
g2p::result ipa_chars=42
\`\`\`

When the synth-side \`"empty after G2P"\` bail fires, the user has the routing context attached.

**D7 — \`transcribe/mod.rs\`:** Pair the existing \`vad::detect dt=…ms segments=0\` line with one more on the all-silence path:

\`\`\`
vad::all_silence total_secs=125.4 min_speech_ms=250 threshold=0.50
\`\`\`

Distinguishes "audio is actually silent" from "threshold too aggressive" without re-running.

**D10 — \`main.rs::resolve_output_format\`:** The dispatcher had three silent arms. Track and emit which one fires:

\`\`\`
format::resolved chosen=OggOpus { ... } source=out-ext
\`\`\`

Surfaces when a user gets WAV after asking for opus (extension mismatch, etc.).

Refs #275 (P1.D6, P1.D7, P2.D10)

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 178/178 passing
- [ ] CI: rust-test.yml + integration