### PR TITLE
fix(#275 D1): kokoro infer boundary trace for empty-audio diagnostics

### DIFF
--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -10,6 +10,7 @@
 
 use std::borrow::Cow;
 use std::path::Path;
+use std::time::Instant;
 
 use super::encode::OutputFormat;
 use super::{
@@ -317,10 +318,28 @@ fn say_with_kokoro(
 ) -> Result<Vec<u8>, TtsError> {
     let mut sess = sessions::KokoroSession::load(model_path)
         .map_err(|e| TtsError::SynthesisFailed(e.to_string()))?;
+    // #275 D1: boundary trace so a "no recognizable phonemes in input"
+    // bail carries inputs (IPA length + voice file) and outputs (sample
+    // count + wall time) instead of pointing at nothing.
+    let ipa_len = ipa.chars().count();
+    crate::dtrace!(
+        "kokoro::infer.start ipa_len={ipa_len} voice={}",
+        voice_path.display()
+    );
+    let t = Instant::now();
     let audio = sess
         .infer_ipa(ipa, voice_path, speed)
         .map_err(|e| TtsError::SynthesisFailed(format!("infer: {e}")))?;
+    crate::dtrace!(
+        "kokoro::infer.end samples={} dt={}ms",
+        audio.len(),
+        t.elapsed().as_millis()
+    );
     if audio.is_empty() {
+        crate::dtrace!(
+            "kokoro::infer.empty ipa_first_20={:?}",
+            ipa.chars().take(20).collect::<String>()
+        );
         return Err(TtsError::SynthesisFailed(
             "no recognizable phonemes in input".into(),
         ));


### PR DESCRIPTION
## Summary

\`say_with_kokoro\` bailed with \`"no recognizable phonemes in input"\` without telling the user what was passed to the synth (IPA length, voice path) or what came back (sample count, wall time). Diagnosing "silent \`kesha say\`" required re-running with \`KESHA_DEBUG=1\` AND reading the source to know what to look for.

Bracket the \`sess.infer_ipa\` call with three boundary traces:

\`\`\`
kokoro::infer.start ipa_len=42 voice=/.../am_michael.bin
kokoro::infer.end samples=24000 dt=180ms
kokoro::infer.empty ipa_first_20="ˈhɛloʊ wɝld"          # only on the empty branch
\`\`\`

All three gated on \`KESHA_DEBUG=1\` via the existing \`dtrace!\` macro — zero cost on the hot path when off; one line per call when on. The \`empty\` line includes the first 20 IPA chars so the user can tell whether the upstream G2P produced something the synth couldn't render (tokens outside the Kokoro vocab) vs producing nothing at all.

Refs #275 (P0.D1)

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib tts\` 162/162 passing
- [ ] CI: \`rust-test.yml\` matrix + new path-filter dispatch from #280