### PR TITLE
fix(#275 D2): route ssml warnings through process-wide warn_once

### DIFF
--- a/rust/src/tts/ssml/mod.rs
+++ b/rust/src/tts/ssml/mod.rs
@@ -20,13 +20,12 @@ mod segment;
 mod walker;
 mod warnings;
 
-use std::collections::HashSet;
-
 use ssml_parser::elements::{EmphasisLevel, ParsedElement, PhonemeAlphabet};
 use ssml_parser::parse_ssml;
 
 pub use segment::Segment;
 
+use super::warn::warn_once;
 use rate::{find_relative_rate, has_structural_source_siblings, parse_rate_value};
 use segment::DEFAULT_BREAK;
 use walker::{parse_inner_spans, push_text_slice, span_priority};
@@ -90,7 +89,6 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
     });
 
     let mut segments: Vec<Segment> = Vec::new();
-    let mut warned: HashSet<String> = HashSet::new();
     let mut cursor: usize = 0;
 
     for span in &spans {
@@ -140,11 +138,12 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
                         Some(PhonemeAlphabet::Other(s)) => s.clone(),
                         other => format!("{other:?}"),
                     };
-                    if warned.insert(format!("phoneme[alphabet={alpha}]")) {
-                        eprintln!(
-                            "warning: SSML <phoneme alphabet=\"{alpha}\"> not supported — only \"ipa\" is recognised; falling back to G2P on contained text"
-                        );
-                    }
+                    warn_once(
+                        &format!("phoneme[alphabet={alpha}]"),
+                        &format!(
+                            "SSML <phoneme alphabet=\"{alpha}\"> not supported — only \"ipa\" is recognised; falling back to G2P on contained text"
+                        ),
+                    );
                 }
             }
             ParsedElement::SayAs(attrs) => {
@@ -161,13 +160,13 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
                     // Other interpret-as values (cardinal, ordinal, date, telephone, …)
                     // are out of scope for #232. Keep the established warn+strip
                     // behavior; the inner text falls through as a Text segment.
-                    let key = format!("say-as[interpret-as={}]", attrs.interpret_as);
-                    if warned.insert(key) {
-                        eprintln!(
-                            "warning: SSML <say-as interpret-as=\"{}\"> is not supported — only \"characters\" is recognised; falling back to plain text",
+                    warn_once(
+                        &format!("say-as[interpret-as={}]", attrs.interpret_as),
+                        &format!(
+                            "SSML <say-as interpret-as=\"{}\"> is not supported — only \"characters\" is recognised; falling back to plain text",
                             attrs.interpret_as
-                        );
-                    }
+                        ),
+                    );
                 }
             }
             ParsedElement::Emphasis(attrs) => {
@@ -218,8 +217,7 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
                         // Recurse: collect the sub-spans that fall within this prosody's
                         // range and parse them as a nested segment list.
                         push_text_slice(&mut segments, &text, cursor, span.start);
-                        let inner_segs =
-                            parse_inner_spans(&spans, &text, span.start, span.end, &mut warned);
+                        let inner_segs = parse_inner_spans(&spans, &text, span.start, span.end);
                         segments.push(Segment::ProsodyRate {
                             rate,
                             content: inner_segs,
@@ -227,30 +225,29 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
                         cursor = span.end;
                     } else {
                         // Whole-utterance but unparseable rate attribute — warn+strip.
-                        if warned.insert(WARN_PROSODY_NO_SUPPORTED_ATTR.to_string()) {
-                            eprintln!(
-                                "warning: SSML <prosody> without a parseable rate= attribute \
-                                 is not supported (pitch/volume scoped to a follow-up); stripping"
-                            );
-                        }
+                        warn_once(
+                            WARN_PROSODY_NO_SUPPORTED_ATTR,
+                            "SSML <prosody> without a parseable rate= attribute \
+                             is not supported (pitch/volume scoped to a follow-up); stripping",
+                        );
                         // Leave cursor unchanged; inner text flows through as Text.
                     }
                 } else {
                     // Mid-utterance prosody — warn+strip.
-                    if warned.insert(WARN_PROSODY_MID_UTTERANCE.to_string()) {
-                        eprintln!(
-                            "warning: SSML <prosody> mid-utterance is not yet supported \
-                             (whole-utterance only); stripping rate, pitch, and volume"
-                        );
-                    }
+                    warn_once(
+                        WARN_PROSODY_MID_UTTERANCE,
+                        "SSML <prosody> mid-utterance is not yet supported \
+                         (whole-utterance only); stripping rate, pitch, and volume",
+                    );
                     // Leave cursor unchanged; inner text falls through as Text.
                 }
             }
             other => {
                 let name = tag_name(other);
-                if warned.insert(name.clone()) {
-                    eprintln!("warning: SSML tag <{name}> is not supported — stripping");
-                }
+                warn_once(
+                    &format!("unknown-tag-{name}"),
+                    &format!("SSML tag <{name}> is not supported — stripping"),
+                );
                 // Preserve the text content; don't touch cursor.
             }
         }

--- a/rust/src/tts/ssml/walker.rs
+++ b/rust/src/tts/ssml/walker.rs
@@ -2,9 +2,9 @@
 //! module so the top-level `parse()` and the recursive whole-utterance
 //! `<prosody>` body share the same emit/skip logic without duplication.
 
-use std::collections::HashSet;
-
 use ssml_parser::elements::{EmphasisLevel, ParsedElement, PhonemeAlphabet};
+
+use crate::tts::warn::warn_once;
 
 use super::segment::{Segment, DEFAULT_BREAK};
 use super::warnings::WARN_PROSODY_NESTED;
@@ -45,15 +45,14 @@ pub(super) fn push_text_slice(out: &mut Vec<Segment>, text: &[char], start: usiz
 /// Parse the inner content of a whole-utterance `<prosody>` span into segments.
 /// Iterates the sub-spans whose character range falls strictly within
 /// `[prosody_start, prosody_end)`, applying the same rules as the top-level
-/// walker (Break, Phoneme, SayAs, Emphasis). Unknown tags warn+strip. The
-/// outer `warned` set is shared so each warning fires at most once per
-/// document regardless of nesting.
+/// walker (Break, Phoneme, SayAs, Emphasis). Unknown tags warn+strip via the
+/// process-wide `warn_once` (#275 D2 — was a per-call `HashSet` before, which
+/// re-fired warnings on every `--stdin-loop` request).
 pub(super) fn parse_inner_spans(
     all_spans: &[&ssml_parser::parser::Span],
     text: &[char],
     prosody_start: usize,
     prosody_end: usize,
-    warned: &mut HashSet<String>,
 ) -> Vec<Segment> {
     let mut segments: Vec<Segment> = Vec::new();
     let mut cursor = prosody_start;
@@ -85,12 +84,11 @@ pub(super) fn parse_inner_spans(
                 // Nested <prosody> inside another <prosody>: not supported in v1.
                 // Inner attributes are dropped; inner content flows at the outer
                 // rate via the trailing push_text_slice plus any leaf spans below.
-                if warned.insert(WARN_PROSODY_NESTED.to_string()) {
-                    eprintln!(
-                        "warning: SSML <prosody> nested inside another <prosody> is not \
-                         supported; inner rate/pitch/volume attributes ignored"
-                    );
-                }
+                warn_once(
+                    WARN_PROSODY_NESTED,
+                    "SSML <prosody> nested inside another <prosody> is not \
+                     supported; inner rate/pitch/volume attributes ignored",
+                );
             }
             ParsedElement::Break(attrs) => {
                 push_text_slice(&mut segments, text, cursor, span.start);
@@ -115,12 +113,13 @@ pub(super) fn parse_inner_spans(
                         Some(PhonemeAlphabet::Other(s)) => s.clone(),
                         other => format!("{other:?}"),
                     };
-                    if warned.insert(format!("phoneme[alphabet={alpha}]")) {
-                        eprintln!(
-                            "warning: SSML <phoneme alphabet=\"{alpha}\"> not supported — \
+                    warn_once(
+                        &format!("phoneme[alphabet={alpha}]"),
+                        &format!(
+                            "SSML <phoneme alphabet=\"{alpha}\"> not supported — \
                              only \"ipa\" is recognised; falling back to G2P on contained text"
-                        );
-                    }
+                        ),
+                    );
                 }
             }
             ParsedElement::SayAs(attrs) => {
@@ -131,14 +130,14 @@ pub(super) fn parse_inner_spans(
                     }
                     cursor = span.end;
                 } else {
-                    let key = format!("say-as[interpret-as={}]", attrs.interpret_as);
-                    if warned.insert(key) {
-                        eprintln!(
-                            "warning: SSML <say-as interpret-as=\"{}\"> is not supported — \
+                    warn_once(
+                        &format!("say-as[interpret-as={}]", attrs.interpret_as),
+                        &format!(
+                            "SSML <say-as interpret-as=\"{}\"> is not supported — \
                              only \"characters\" is recognised; falling back to plain text",
                             attrs.interpret_as
-                        );
-                    }
+                        ),
+                    );
                 }
             }
             ParsedElement::Emphasis(attrs) => {
@@ -151,9 +150,10 @@ pub(super) fn parse_inner_spans(
             }
             other => {
                 let name = tag_name(other);
-                if warned.insert(name.clone()) {
-                    eprintln!("warning: SSML tag <{name}> is not supported — stripping");
-                }
+                warn_once(
+                    &format!("unknown-tag-{name}"),
+                    &format!("SSML tag <{name}> is not supported — stripping"),
+                );
             }
         }
     }

--- a/rust/src/tts/warn.rs
+++ b/rust/src/tts/warn.rs
@@ -1,28 +1,34 @@
-//! Per-process warn-once helper for SSML feature gates.
+//! Per-process warn-once helper.
 //!
-//! Engine-agnostic: called from both the Russian-Vosk path and the Kokoro /
-//! Vosk defensive arms in `tts::mod`. Emits a single stderr line when a
-//! non-fatal SSML feature is misused (e.g. `<emphasis>` content without a
-//! `+vowel` marker on a `ru-vosk-*` voice, or `<emphasis>` on a non-Vosk
-//! voice where `+` markers are stripped). Dedup is keyed by a `&'static str`
-//! identifier so all instances of the same warning across `kesha say`
-//! invocations within the same process print only once.
+//! Engine-agnostic: called from the SSML parser (`tts::ssml`), the Russian-
+//! Vosk normalization, and the Kokoro / Vosk defensive arms in `tts::say`.
+//! Emits a single stderr line per `key` per process. Two key shapes are
+//! supported via the relaxed `&str` signature:
+//!
+//! - **Constant keys** (e.g. `WARN_PROSODY_MID_UTTERANCE`) — preferred. The
+//!   set of distinct warnings is bounded; one allocation per process.
+//! - **Dynamic keys** (e.g. `phoneme[alphabet=x-sampa]`, `say-as[interpret-as=cardinal]`,
+//!   `unknown-tag-paragraph`) — used by SSML's open-ended attribute spaces.
+//!   One allocation per *unique* combination across the process lifetime.
+//!
+//! Lock poisoning is treated as fatal — at that point another thread panicked
+//! while holding the lock and the process is in an unrecoverable state.
 
 use std::collections::HashSet;
 use std::sync::{Mutex, OnceLock};
 
-fn warned() -> &'static Mutex<HashSet<&'static str>> {
-    static W: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
+fn warned() -> &'static Mutex<HashSet<String>> {
+    static W: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
     W.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
 /// Emit `msg` to stderr if `key` has not been warned in this process.
-/// Subsequent calls with the same `key` are silent. Lock poisoning is
-/// treated as fatal — at that point another thread panicked while
-/// holding the lock and the process is in an unrecoverable state.
-pub fn warn_once(key: &'static str, msg: &str) {
+/// Subsequent calls with the same `key` are silent. See module docs for
+/// the constant-vs-dynamic key contract.
+pub fn warn_once(key: &str, msg: &str) {
     let mut set = warned().lock().expect("warn_once: mutex poisoned");
-    if set.insert(key) {
+    if !set.contains(key) {
+        set.insert(key.to_string());
         eprintln!("warning: {msg}");
     }
 }
@@ -51,7 +57,7 @@ mod tests {
         let still_present = warned().lock().unwrap().contains(key);
         assert!(still_present, "key remains in the set across calls");
         // Manual probe: try inserting the key fresh — should report already-there.
-        let probe = warned().lock().unwrap().insert(key);
+        let probe = warned().lock().unwrap().insert(key.to_string());
         assert!(!probe, "key already present after warn_once recorded it");
     }
 

--- a/rust/src/tts/warn.rs
+++ b/rust/src/tts/warn.rs
@@ -13,6 +13,19 @@
 //!
 //! Lock poisoning is treated as fatal — at that point another thread panicked
 //! while holding the lock and the process is in an unrecoverable state.
+//!
+//! **Test-isolation caveat** (Greptile P2 on #284): the backing `HashSet` is a
+//! `static OnceLock`, so any key inserted by one `#[test]` persists for the
+//! whole process. Today's tests in this module use synthetic keys
+//! (`test-warn-once-key-*`) that don't collide with production keys, but the
+//! `tts::ssml::tests` block runs in the same `cargo test --lib` process and
+//! WILL insert real SSML warn keys (`prosody-mid-utterance`, `say-as[...]`,
+//! `phoneme[alphabet=...]`, etc.) into the shared set. A future test that
+//! asserts a key is *absent* before calling `parse()`, or that counts how
+//! many times a particular warning fires within a single test, would be
+//! order-dependent. If that comes up, add a `#[cfg(test)] pub(crate) fn
+//! reset_for_test()` here and call it in the test's `setUp` — don't try
+//! to work around it from the test side.
 
 use std::collections::HashSet;
 use std::sync::{Mutex, OnceLock};


### PR DESCRIPTION
## Summary

\`ssml::parse\` and \`parse_inner_spans\` deduped per call via a local \`HashSet<String>\` rebuilt every invocation. In \`--stdin-loop\` (#213, long-lived process) a 50-message session containing the same \`<prosody>\` quirk floods stderr with 50 identical warnings. The process-wide \`tts::warn::warn_once\` already existed for the emphasis/non-vosk path — these two systems silently disagreed about scope.

Switch SSML's eight warn sites (\`mod.rs\` × 4, \`walker.rs\` × 4) to \`warn_once\`. One source of truth for "what has been warned in this process". Drops:

- \`let mut warned: HashSet<String>\` in \`parse()\`.
- The \`warned: &mut HashSet<String>\` parameter on \`parse_inner_spans\`.
- \`use std::collections::HashSet\` from both files.

\`warn_once\` is relaxed from \`&'static str\` keys to \`&str\` keys (set backing changes from \`HashSet<&'static str>\` to \`HashSet<String>\`) so SSML's dynamic cases — \`phoneme[alphabet={x}]\`, \`say-as[interpret-as={x}]\`, \`unknown-tag-{name}\` — can compose their keys at call site. Cost: one allocation per *unique* warn key per process. Constant-key callers (\`WARN_PROSODY_*\`) keep working via the \`&str\` signature.

Refs #275 (P0.D2)

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib tts::ssml\` 45/45 passing
- [ ] CI: rust-test.yml on 3 OSes