### PR TITLE
fix(#275 D4): surface engine stderr on the success path

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -66,6 +66,15 @@ async function runEngine(args: string[]): Promise<{ stdout: string; stderr: stri
   ]);
 
   log.debug(`exit=${exitCode} dt=${Math.round(performance.now() - startedAt)}ms args=${JSON.stringify(args)}`);
+
+  // #275 D4: surface engine stderr on the success path so warnings like
+  // `hint: audio is 180s`, `Model mirror active:`, and the dtrace lines
+  // emitted under KESHA_DEBUG=1 reach the user. On non-zero exit we leave
+  // the buffer for callers to fold into a thrown Error — otherwise the
+  // user would see the warning AND a duplicate inside the error message.
+  if (exitCode === 0 && stderr.length > 0) {
+    process.stderr.write(stderr.endsWith("\n") ? stderr : stderr + "\n");
+  }
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -128,6 +128,14 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
   ]);
 
   log.debug(`exit=${exitCode} dt=${Math.round(performance.now() - startedAt)}ms bytes=${stdoutBuf.byteLength}`);
+
+  // #275 D4: surface engine stderr on the success path so warnings like
+  // `Model mirror active:` and the dtrace lines emitted under
+  // KESHA_DEBUG=1 reach the user. Errors keep their existing path
+  // through `SayError.stderr` so we don't double-print.
+  if (exitCode === 0 && stderrText.length > 0) {
+    process.stderr.write(stderrText.endsWith("\n") ? stderrText : stderrText + "\n");
+  }
   if (exitCode !== 0) {
     throw new SayError(
       stderrText.trim() || `kesha-engine say exited ${exitCode}`,


### PR DESCRIPTION
## Summary

The TS subprocess wrappers (\`engine.ts::runEngine\` and the inline spawn in \`synth.ts::say\`) both piped engine stderr into a buffer and only surfaced it inside a thrown \`Error\` / \`SayError\` on non-zero exit. On green runs the engine's warnings silently vanished:

- \`hint: audio is 180s; kesha install --vad would improve …\`
- \`Model mirror active: …\`
- all \`dtrace!\` output under \`KESHA_DEBUG=1\`
- the new \`g2p::route\` / \`vad::all_silence\` / \`format::resolved\` / \`kokoro::infer.*\` traces from #275 D1 / D6 / D7 / D10

Add a one-liner in both spawn paths: when \`exitCode === 0\` and the captured \`stderr\` is non-empty, relay it to \`process.stderr\`. Errors keep the existing path through \`Error\` / \`SayError\` — no double-print: on failure the buffer goes into the thrown message; on success it goes to stderr live.

Closes the last P1 from the debug-signals audit (#275).

Refs #275 (P1.D4)

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test tests/unit\` 123/123 passing
- [ ] CI: unit-tests on 3 OSes + integration-tests (this PR is in the new \`integration\` filter via \`src/**\`)