### PR TITLE
chore(release): v1.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.13.0"
+    "version": "1.14.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
Version bump for v1.14.0 — observability + code-health bundle. No user-facing features, no breaking changes.

## What's in v1.14.0

**Observability (#275, all 11 findings landed)**: every spawn boundary in the TS CLI ↔ Rust engine path now surfaces enough diagnostic information to debug failures from a single \`KESHA_DEBUG=1\` run.

- **D4**: engine stderr relays live on success — warnings (\`hint: audio is 180s\`, \`Model mirror active:\`, all \`dtrace!\` lines) no longer swallowed on green runs.
- **D1**: Kokoro empty-audio bail logs IPA length, voice path, and sample count.
- **D2**: SSML warnings dedup process-wide (was per-call) — fixes \`--stdin-loop\` stderr flood.
- **D3**: \`--no-expand-abbrev\` capability drop now \`log.warn\` (was silent \`log.debug\`).
- **D5/D11**: install hash-mismatch + download errors carry the actual digest + resolved URL.
- **D6/D7/D9/D10**: G2P / VAD / format / \`KESHA_DEBUG\` parse-grammar traces and TS↔Rust alignment.

**Code-health refactors (#267)**: F1 (ssml.rs split), F2 (ModelKind enum), F3 (synth.ts rename + voice-routing), F4 (tts/say.rs extract), F7 (mirror-logging consolidation), F8 partial (test colocation), F10 + F13 (resolved as side effects).

**CI (#274, #280)**: fail-fast reorder + path-filter redesign — catches the latent skip-propagation bug that had silently disabled \`tts-e2e\` on rust-only PRs since the #274 merge.

## Bumps
- \`package.json#version\`: 1.13.0 → 1.14.0
- \`package.json#keshaEngine.version\`: 1.13.0 → 1.14.0
- \`rust/Cargo.toml\` + \`rust/Cargo.lock\`: 1.13.0 → 1.14.0

## Release flow checklist (per CLAUDE.md)

- [ ] Merge to main
- [ ] \`git tag v1.14.0 && git push origin v1.14.0\` (triggers build-engine.yml)
- [ ] Wait for draft release → author notes via \`gh release edit --notes\`
- [ ] Publish draft (\`gh release edit --draft=false\`)
- [ ] \`make smoke-test\` locally
- [ ] **Independent v1.14.0 validation** of the published binary (tempdir, \`--version\` / \`--capabilities-json\` / synth a real en WAV ≥ 50 KB)
- [ ] \`npm publish --access public\`