### PR TITLE
refactor(#267 F9): compose_rate clamp emits stderr warn-once

### DIFF
--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -43,8 +43,23 @@ fn silence_samples(dur: std::time::Duration, sample_rate: u32) -> Vec<f32> {
 /// within ~7% of theoretical at these endpoints; past them quality
 /// degrades. Single source of truth for the clamp range — change here
 /// and the two engine arms in `synth_one_*` pick it up.
+///
+/// Emits a `warn_once` to stderr the first time a clamp diverges from
+/// the raw product — without that line, an SSML `rate="300%"` capped to
+/// `2.0` looks indistinguishable from a clean 2× rate (#267 F9).
 fn compose_rate(cli_rate: f32, ssml_rate: f32) -> f32 {
-    (cli_rate * ssml_rate).clamp(0.5, 2.0)
+    let raw = cli_rate * ssml_rate;
+    let clamped = raw.clamp(0.5, 2.0);
+    if (raw - clamped).abs() > f32::EPSILON {
+        crate::tts::warn::warn_once(
+            "compose-rate-clamped",
+            &format!(
+                "rate {raw:.2} (cli={cli_rate:.2} × ssml={ssml_rate:.2}) \
+                 clamped to {clamped:.2} (engine-safe range 0.5..=2.0)"
+            ),
+        );
+    }
+    clamped
 }
 
 /// Synthesize speech and return WAV bytes (mono float32; sample rate depends on engine).
@@ -553,5 +568,20 @@ mod tests {
                 "cli={cli}, ssml={ssml}: got {effective}, expected {expected}"
             );
         }
+    }
+
+    #[test]
+    fn compose_rate_warns_once_on_clamp() {
+        // F9: clamping must surface a stderr warn so a user passing
+        // SSML rate="300%" learns it was capped. Subsequent clamps reuse
+        // the same key — process-wide warn_once dedupes.
+        let _ = super::compose_rate(2.0, 2.0); // 4.0 → 2.0 (clamp high)
+        assert!(
+            crate::tts::warn::was_warned("compose-rate-clamped"),
+            "compose_rate must record the warn key when clamping"
+        );
+        // Idempotent: a second clamp doesn't change set membership.
+        let _ = super::compose_rate(0.1, 0.1); // 0.01 → 0.5 (clamp low)
+        assert!(crate::tts::warn::was_warned("compose-rate-clamped"));
     }
 }

--- a/rust/src/tts/warn.rs
+++ b/rust/src/tts/warn.rs
@@ -46,6 +46,18 @@ pub fn warn_once(key: &str, msg: &str) {
     }
 }
 
+/// Probe whether `warn_once` has already recorded `key` in this process.
+/// Test-only — the production warn_once path itself doesn't need this.
+/// Honors the test-isolation caveat in the module doc-comment: order
+/// matters across `#[test]` blocks in the same `cargo test --lib` process.
+#[cfg(test)]
+pub(crate) fn was_warned(key: &str) -> bool {
+    warned()
+        .lock()
+        .expect("was_warned: mutex poisoned")
+        .contains(key)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

\`tts::compose_rate(cli, ssml)\` silently clamped the rate product to the engine-safe range \`0.5..=2.0\` with no diagnostic. An SSML \`rate=\"300%\"\` rendered as 2× and looked identical to a clean 2× request — exactly the \"no magic in failures\" case #267 F9 calls out.

Now: the first time a clamp diverges from the raw product, \`warn_once(\"compose-rate-clamped\", …)\` writes one stderr line with raw, factors, and clamped value. Subsequent clamps share the key and stay silent (process-wide dedup, the same idiom as #275 D2).

## Tests

- New \`compose_rate_warns_once_on_clamp\`: asserts the warn key gets recorded after a high-clamp (\`2.0 × 2.0 → 2.0\`) AND remains recorded after a second low-clamp (\`0.1 × 0.1 → 0.5\`) — locks in the dedup contract.
- Existing \`prosody_rate_multiplies_and_clamps\` still green (clamp return values unchanged).
- Full \`cargo test --all-targets\` + \`bun test\` + \`bunx tsc --noEmit\` clean on macos-14 / arm64.

## Implementation note

\`tts/warn.rs\` got a \`#[cfg(test)] pub(crate) fn was_warned(key)\` probe so the warn-set state can be asserted from outside the warn module. Matches the \`reset_for_test()\` recipe sketched in that module's doc-comment (Greptile P2 on #284).

## Refs

Refs #267 (F9 item ticked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)