### PR TITLE
docs(#267 F9): fix incorrect NaN comment in compose_rate

### DIFF
--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -53,8 +53,11 @@ fn compose_rate(cli_rate: f32, ssml_rate: f32) -> f32 {
     // Exact bound check, not `(raw - clamped).abs() > EPSILON`: at raw≈0.5
     // the f32 ULP (~6e-8) is below `EPSILON` (~1.2e-7), so a value one ULP
     // outside the bound would clamp silently (Greptile P2 on #287). NaN
-    // is unordered against any bound → `contains` returns false → no warning,
-    // matching the clamp's own NaN-passthrough behavior.
+    // is unordered against any bound → `contains` returns false → the
+    // warning DOES fire ("rate NaN ... clamped to NaN"). That's
+    // intentional: NaN here means an upstream bug parsed `cli_rate` or
+    // `ssml_rate` as not-a-number, and surfacing it on stderr beats
+    // silently propagating NaN sample-rate params downstream.
     if !(0.5..=2.0).contains(&raw) {
         crate::tts::warn::warn_once(
             "compose-rate-clamped",


### PR DESCRIPTION
## Summary

Documentation-only fix on top of #288. Greptile P2 on #288 caught a factually wrong inline comment in \`compose_rate\`:

> The comment block on lines 53–57 describes NaN behaviour incorrectly and should be corrected before or after merge.

— [#288 review](https://github.com/drakulavich/kesha-voice-kit/pull/288).

#288's clamp logic itself is correct; only the comment lied.

## What I had wrong

> NaN is unordered against any bound → \`contains\` returns false → no warning

The first clause is true but the conclusion inverted: \`!contains(&NaN)\` = \`!false\` = **true** → the warning **does** fire for NaN, with the format string rendering \"rate NaN ... clamped to NaN\".

## What's right (now in the comment)

That behavior is intentional. NaN at this layer means \`cli_rate\` or \`ssml_rate\` was parsed broken upstream, and a stderr line surfacing the brokenness beats silently propagating NaN sample-rate params into Kokoro/Vosk inference.

## Tests

Comment-only change; no test impact. Local \`cargo test --lib tts::say\` 3/3 green, \`cargo clippy --all-targets -- -D warnings\` clean.

## No auto-merge

To break the cascade of \"Greptile finds something one beat too late\" follow-ups from #287 → #288, this one will NOT auto-merge — I'll wait for Greptile's pass and merge manually.

## Refs

Refs #267 (F9 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)