### PR TITLE
chore(ci): auto npm publish on release with provenance attestation

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,13 +27,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # Both `inputs.tag` (workflow_dispatch) and `github.event.release.tag_name`
+      # (release event) flow through `env:` rather than direct
+      # `${{ … }}` interpolation in the `run:` script. The job holds
+      # `id-token: write`; an attacker-controlled tag containing `$(cmd)` or
+      # `;` would otherwise execute arbitrary code AND get the OIDC token
+      # for npm provenance. GHA security hardening guide:
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
       - name: Resolve tag
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout at tag

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,91 @@
+name: "📦 npm Publish"
+
+# Fires once a GitHub release leaves draft (the manual gate per CLAUDE.md
+# release flow). Both real engine releases (`vX.Y.Z`) and CLI-only marker
+# releases (`vX.Y.Z-cli`) un-draft into the same `published` event — both
+# need `npm publish`. Also exposes `workflow_dispatch` so the maintainer
+# can re-publish a tag manually (e.g. after fixing a publishConfig bug)
+# without re-creating the release.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (must already exist and have a published GitHub release)"
+        required: true
+
+# `id-token: write` is what unlocks npm provenance attestation. The OIDC
+# token issued by GitHub is signed by GHA's identity provider, which npm
+# verifies against the public sigstore log. Without this permission the
+# `--provenance` flag would fail.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout at tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      # npm provenance requires npm CLI ≥ 9.5. Node 22 (LTS) ships with
+      # npm 10.x. `registry-url` configures the auth token line that
+      # `NODE_AUTH_TOKEN` consumes via `npm publish`.
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Guard: refuse to publish if `package.json#version` doesn't match
+      # the release tag. Catches an accidental release of a tag that
+      # points at a commit whose package.json wasn't bumped — that
+      # combination is silently bad (npm publishes whatever's in the
+      # checkout, regardless of the GitHub release name).
+      - name: Verify package.json version matches tag
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          # Strip leading "v" and optional "-cli" suffix used for CLI-only
+          # marker releases (see CLAUDE.md → RELEASE PROCESS).
+          expected="${tag#v}"
+          expected="${expected%-cli}"
+          actual=$(jq -r .version package.json)
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Tag $tag implies version $expected but package.json says $actual" >&2
+            exit 1
+          fi
+          echo "package.json version $actual matches tag $tag — OK"
+
+      # Idempotent guard: if this exact version is already on npm, skip
+      # the publish step rather than failing. Lets `workflow_dispatch`
+      # re-runs no-op cleanly after a successful publish.
+      - name: Check npm registry for prior publish
+        id: registry
+        run: |
+          name=$(jq -r .name package.json)
+          version=$(jq -r .version package.json)
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "$name@$version is already on npm — publish step will be skipped."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm with provenance
+        if: steps.registry.outputs.already_published == 'false'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,22 +238,24 @@ Recommended user config:
 
 `integration-tests` in `.github/workflows/ci.yml` downloads the RELEASED `kesha-engine` binary at the version pinned in `package.json#keshaEngine.version`. On a version-bump PR (branch `release/X.Y.Z`) that tag doesn't exist yet — HTTP 404, CI red. The job is filtered via `if: needs.changes.outputs.integration == 'true' && !startsWith(github.head_ref, 'release/')`. Don't remove that filter. If you add a new job that downloads release artifacts, use the same branch guard.
 
-### DRAFT RELEASE ASSET URLS ARE NOT PUBLIC
+### DRAFT RELEASE ASSET URLS ARE 404 TO ANONYMOUS CLIENTS — USE `gh release download`
 
-`build-engine.yml` creates a DRAFT release with the 3 platform binaries. The download URLs (`/releases/download/vX.Y.Z/kesha-engine-*`) return HTTP 404 to unauthenticated clients while the release is a draft — `make smoke-test` / `kesha install` will fail. Run smoke-test AFTER `gh release edit vX.Y.Z --draft=false`, not before. CLAUDE.md's numbered flow above reflects this (publish → smoke → npm publish), easy to flip the order absent-mindedly.
+`build-engine.yml` creates a DRAFT release with the 3 platform binaries. The download URLs (`/releases/download/vX.Y.Z/kesha-engine-*`) return HTTP 404 to **unauthenticated** clients while the release is a draft, so `curl` and `kesha install` (anonymous) will fail. **Authenticated** `gh release download vX.Y.Z -p "..." -D <dir>` works on drafts and is the right tool for the pre-undraft validation step (see next section).
 
-### `make smoke-test` ALONE DOES NOT VALIDATE A NEW ENGINE — DOWNLOAD AND EXERCISE THE PUBLISHED ASSET DIRECTLY BEFORE `npm publish`
+`make smoke-test` is anonymous (`kesha install` curls the URL), so it cannot run against a draft. Treat it as a sanity check AFTER un-drafting — but post-#291 (auto npm publish on un-draft), un-drafting is the irreversible commit point, so the actual release gate is the `gh release download`-based validation BELOW.
+
+### `make smoke-test` ALONE DOES NOT VALIDATE A NEW ENGINE — `gh release download` THE DRAFT BINARY AND EXERCISE IT BEFORE `gh release edit --draft=false`
 
 `make smoke-test` does `bun link @drakulavich/kesha-voice-kit` then `kesha install` then `bun scripts/smoke-test.ts`. **`bun link` does not always replace a globally-installed `kesha`** — if `bun add -g @drakulavich/kesha-voice-kit@<old>` previously ran on this machine, the global shim wins, `kesha --version` keeps reporting the old CLI, `kesha install` re-fetches the OLD `keshaEngine.version`, and the smoke test happily passes against the previous engine release. The "6/6 passed" turns into a false-green publish gate.
 
 Lesson learned the hard way: v1.5.0 darwin engine ran `--capabilities-json` clean (CI's pre-upload smoke) but actually crashed on Kokoro synth (`Invalid input name: tokens`). `make smoke-test` reported pass because it was still routing through the locally-installed v1.4.4 CLI + v1.4.1 engine.
 
-**Always run this independent v\<NEW\>.\<NEW\>.\<NEW\> validation between `gh release edit --draft=false` and `npm publish`:**
+**Always run this independent v\<NEW\>.\<NEW\>.\<NEW\> validation BEFORE `gh release edit --draft=false`.** Once un-drafted, the `📦 npm Publish` workflow fires within ~60 s and the publish is permanent (npm allows unpublish only within 72 h, and provenance attestations make a re-publish noisy). Greptile reviewed #291 and flagged this ordering. **Use `gh release download` (authenticated, works on drafts), NOT `curl` (which 404s on drafts):**
 
 ```bash
 SMOKE=/tmp/kesha-vX.Y.Z-smoke && rm -rf "$SMOKE" && mkdir "$SMOKE" && cd "$SMOKE"
-curl -sLfo kesha-engine \
-  "https://github.com/drakulavich/kesha-voice-kit/releases/download/vX.Y.Z/kesha-engine-darwin-arm64"
+gh release download vX.Y.Z -R drakulavich/kesha-voice-kit \
+  -p "kesha-engine-darwin-arm64" -D "$SMOKE"
 chmod +x kesha-engine && xattr -d com.apple.quarantine kesha-engine 2>/dev/null
 
 # 1. Version string MUST equal the new tag — sanity check
@@ -275,9 +277,9 @@ file "$SMOKE/en.wav"              # must report a valid WAV
   || { echo "ERROR: en.wav is suspiciously small — header-only stub?"; exit 1; }
 ```
 
-Repeat for `kesha-engine-linux-x64` (run via Docker if not on Linux). If ANY of those three steps fail, **DO NOT `npm publish`**. Either yank the GitHub release (`gh release delete vX.Y.Z --yes`, delete the tag, bump patch, retry) or push a fix and rebuild via `gh workflow run "🔨 Build Engine"`.
+Repeat for `kesha-engine-linux-x64` (run via Docker if not on Linux). If ANY of those three steps fail, **DO NOT un-draft** — un-drafting fires `📦 npm Publish` automatically. Either yank the GitHub release (`gh release delete vX.Y.Z --yes`, delete the tag, bump patch, retry) or push a fix and rebuild via `gh workflow run "🔨 Build Engine"`. Since the draft never went public, no recall is needed.
 
-The CI smoke step (`--capabilities-json` only) is a sanity check on the toolchain, not a behavior test. Behavior testing is the human-in-the-loop pre-publish gate; it lives in this checklist, not in the workflow file.
+The CI smoke step (`--capabilities-json` only) is a sanity check on the toolchain, not a behavior test. Behavior testing is the human-in-the-loop pre-undraft gate; it lives in this checklist, not in the workflow file.
 
 ### TESTS THAT STAGE A TEMPDIR CACHE MUST STAGE G2P TOO
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,8 @@ If the spike persists into project work, ask which env tool the user wants (uv, 
 
 1. Bump only `package.json#version`. Leave `keshaEngine.version` and `rust/Cargo.toml` alone.
 2. PR CI uses the existing engine binary — integration tests pass.
-3. Merge, `npm publish --access public`.
-4. Cut a marker release: `gh release create vX.Y.Z-cli --title "vX.Y.Z (CLI-only)" --notes "Engine: v<keshaEngine.version> (unchanged)."` The `-cli` suffix is excluded from `build-engine.yml`'s tag filter — no Rust rebuild.
+3. Merge to main.
+4. Cut a marker release: `gh release create vX.Y.Z-cli --title "vX.Y.Z (CLI-only)" --notes "Engine: v<keshaEngine.version> (unchanged)."` The `-cli` suffix is excluded from `build-engine.yml`'s tag filter — no Rust rebuild. `gh release create` creates a published (non-draft) release, which fires the `📦 npm Publish` workflow → `npm publish --provenance --access public` runs automatically. Verify within ~60 s: `npm view @drakulavich/kesha-voice-kit version` should report `X.Y.Z`.
 
 **Engine release** (anything under `rust/`, or bumping `keshaEngine.version`):
 
@@ -86,9 +86,9 @@ If the spike persists into project work, ask which env tool the user wants (uv, 
    gh api -X PATCH "repos/OWNER/REPO/releases/$RELEASE_ID" --input body.json
    ```
    v1.1.3 shipped with empty notes and was recovered this way.
-5. Publish the draft: `gh release edit vX.Y.Z --draft=false`.
-6. `make smoke-test` locally. Do NOT publish if smoke tests fail.
-7. `npm publish --access public`.
+5. Validate the draft assets BEFORE un-drafting (see the "make smoke-test ALONE DOES NOT VALIDATE" section below). Authenticated `gh release download vX.Y.Z -p "kesha-engine-darwin-arm64" -D <smoke-dir>` works on drafts; anonymous `curl` does not (see "DRAFT RELEASE ASSET URLS ARE NOT PUBLIC").
+6. `make smoke-test` locally is still useful but only sees the OLD globally-installed engine — treat it as a sanity check, not a release gate. The gate is step 5.
+7. Publish the draft: `gh release edit vX.Y.Z --draft=false`. This fires the `📦 npm Publish` workflow (`release: published` event) which runs `npm publish --provenance --access public` with provenance attestation. Verify within ~60 s: `npm view @drakulavich/kesha-voice-kit version` should report `X.Y.Z`. Manual fallback if the workflow is broken: `npm publish --access public` from the maintainer's laptop.
 
 ### TAG NAMES ARE ONE-USE
 


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/npm-publish.yml\` that fires on \`release: published\` and runs \`npm publish --provenance --access public\` automatically. Replaces the manual step 7 from CLAUDE.md → RELEASE PROCESS.

User chose **A.ii + B.ii**: manual un-draft remains the human approval gate, and release notes stay manual via \`gh release edit --notes\`.

## Workflow contract

- **Triggers** on \`release: published\` (both engine \`vX.Y.Z\` and CLI-only \`vX.Y.Z-cli\` marker releases). Also exposes \`workflow_dispatch\` for re-runs.
- **Validates** \`package.json#version\` matches the tag (strips leading \`v\` and trailing \`-cli\`) before publishing — catches an accidental release of a tag pointing at a commit whose package.json wasn't bumped.
- **Idempotent**: if the version is already on npm, the publish step is skipped (not failed). Lets \`workflow_dispatch\` re-runs no-op cleanly.
- **Provenance attestation**: \`permissions.id-token: write\` unlocks GitHub's OIDC token; npm verifies the signed attestation against the public sigstore log. Shows as a verified attestation on the package page.

## CLAUDE.md updates

- CLI-only flow: dropped manual \`npm publish\` step. \`gh release create\` in step 4 fires the workflow directly.
- Engine release flow: validation reordered to run BEFORE un-drafting (step 5, via authenticated \`gh release download\` which works on drafts; anonymous \`curl\` does not). Un-drafting in step 7 fires the npm publish workflow. Manual fallback path preserved.

## ⚠️ Pre-merge requirement

The maintainer must add the **\`NPM_TOKEN\`** secret to the repo BEFORE this is useful:

\`\`\`bash
# 1. Generate granular access token at:
#    https://www.npmjs.com/settings/drakulavich/tokens/granular-access-tokens/new
#    Scope: publish-only on @drakulavich/kesha-voice-kit. 1-year expiry recommended.

# 2. Add as repo secret:
gh secret set NPM_TOKEN -R drakulavich/kesha-voice-kit
# (pastes the token interactively)
\`\`\`

Without the secret, the workflow runs but the \`npm publish\` step will fail with auth error — and the GitHub release stays published, so manual fallback (\`npm publish --access public\` from laptop) still works.

## Testing this

After merge + secret setup, the first real validation is the **next release**:
1. Tag → build-engine.yml → draft (existing)
2. Author notes (existing)
3. Validate via \`gh release download\` against draft assets
4. \`gh release edit --draft=false\` → watch \`📦 npm Publish\` fire in the Actions tab
5. \`npm view @drakulavich/kesha-voice-kit version\` should report the new version within ~60 s
6. Inspect the published version on npmjs — the package page should show a green "verified" provenance badge

No "test publish to npm staging" path exists; the workflow is gated by tag/release, so we exercise it the first time v1.15.0 ships.

## Refs

User ask: "сделай Auto-релиз через GitHub Actions с npm provenance attestation". Hardens the publish path against the maintainer's-laptop dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)