### PR TITLE
docs: move Nix install to docs/, add brew + Windows install for Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Runtime: **[Bun](https://bun.sh)** >= 1.3.0.
 
 ```bash
 # Install Bun (skip if already installed) — pick one:
-curl -fsSL https://bun.sh/install | bash       # upstream installer
-brew install oven-sh/bun/bun                   # Homebrew (macOS / Linux)
+curl -fsSL https://bun.sh/install | bash          # Linux & macOS — upstream installer
+brew install oven-sh/bun/bun                      # Linux & macOS — Homebrew
+powershell -c "irm bun.sh/install.ps1 | iex"      # Windows — upstream installer (PowerShell)
 
 bun add -g @drakulavich/kesha-voice-kit
 kesha install       # downloads engine + models

--- a/README.md
+++ b/README.md
@@ -22,12 +22,22 @@
 
 Runtime: **[Bun](https://bun.sh)** >= 1.3.0.
 
-```bash
-# Install Bun (skip if already installed) — pick one:
-curl -fsSL https://bun.sh/install | bash          # Linux & macOS — upstream installer
-brew install oven-sh/bun/bun                      # Linux & macOS — Homebrew
-powershell -c "irm bun.sh/install.ps1 | iex"      # Windows — upstream installer (PowerShell)
+Install Bun (skip if already installed) — pick one:
 
+```bash
+# Linux & macOS
+curl -fsSL https://bun.sh/install | bash       # upstream installer
+brew install oven-sh/bun/bun                   # Homebrew
+```
+
+```powershell
+# Windows
+powershell -c "irm bun.sh/install.ps1 | iex"
+```
+
+Then install Kesha:
+
+```bash
 bun add -g @drakulavich/kesha-voice-kit
 kesha install       # downloads engine + models
 kesha audio.ogg     # transcript to stdout
@@ -37,7 +47,14 @@ Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-m
 
 ## Nix Install
 
-Alternative reproducible-build path on `aarch64-darwin` / `x86_64-linux`: `nix run github:drakulavich/kesha-voice-kit -- audio.ogg`. Full recipes (one-liner, profile install, engine-only, dev shell) live in [docs/nix-install.md](docs/nix-install.md).
+Alternative reproducible-build path on `aarch64-darwin` / `x86_64-linux`:
+
+```bash
+nix run github:drakulavich/kesha-voice-kit -- install      # downloads models (engine is bundled)
+nix run github:drakulavich/kesha-voice-kit -- audio.ogg    # transcribe
+```
+
+Full recipes (one-liner, profile install, engine-only, dev shell) live in [docs/nix-install.md](docs/nix-install.md).
 
 ## Speech-to-text
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 Runtime: **[Bun](https://bun.sh)** >= 1.3.0.
 
 ```bash
-curl -fsSL https://bun.sh/install | bash   # skip if Bun is already installed
+# Install Bun (skip if already installed) — pick one:
+curl -fsSL https://bun.sh/install | bash       # upstream installer
+brew install oven-sh/bun/bun                   # Homebrew (macOS / Linux)
 
 bun add -g @drakulavich/kesha-voice-kit
 kesha install       # downloads engine + models

--- a/README.md
+++ b/README.md
@@ -32,45 +32,9 @@ kesha audio.ogg     # transcript to stdout
 
 Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-mirror.md).
 
-## Nix Install (Recommended)
+## Nix Install
 
-**Prerequisites:** [Nix](https://nixos.org/download/) with flakes enabled. Supported systems: `aarch64-darwin`, `x86_64-linux`.
-
-### One-liner run (no install)
-```bash
-nix run github:drakulavich/kesha-voice-kit -- install      # downloads models (engine is bundled)
-nix run github:drakulavich/kesha-voice-kit -- audio.ogg    # transcribe
-```
-
-`nix run` resolves to `apps.default` (the `kesha` Bun CLI), which has the engine binary baked in via `KESHA_ENGINE_BIN`, so there's no separate engine download.
-
-### Install to profile (persistent)
-```bash
-nix profile install github:drakulavich/kesha-voice-kit
-kesha install       # downloads models
-kesha audio.ogg     # transcript to stdout
-```
-
-`packages.default` ships the Bun CLI (`kesha`, `parakeet`) wired to the Nix-built engine. After `nix profile install`, both shims are on `PATH` and run transcription, language detection, and TTS (including `macos-*` AVSpeech voices on darwin-arm64) identically to the npm install. Speaker diarization (`kesha install --diarize` / `--speakers`) is not yet wired into the Nix build — the `kesha-diarize` Swift sidecar needs network-fetched FluidAudio at build time, which the Nix sandbox forbids; use the Bun install path (`bun add -g @drakulavich/kesha-voice-kit`) on darwin-arm64 if you need that feature (tracked alongside [#199](https://github.com/drakulavich/kesha-voice-kit/issues/199)).
-
-### Engine only (no Bun, no Node)
-For users who just want the Rust binary:
-```bash
-nix build github:drakulavich/kesha-voice-kit#kesha-engine
-./result/bin/kesha-engine --help
-./result/bin/kesha-engine --capabilities-json   # see which backends compiled in
-```
-
-### Development shell
-```bash
-nix develop github:drakulavich/kesha-voice-kit
-# Now you have: pinned rustc/cargo (via rust-overlay), bun, protoc, cmake, pkg-config, libclang
-```
-
-**Why Nix?**
-- ✅ Reproducible builds across Linux/macOS
-- ✅ All native deps (onnxruntime, protobuf, abseil) handled automatically
-- ✅ No "works on my machine" — same `flake.nix` = identical results everywhere
+Alternative reproducible-build path on `aarch64-darwin` / `x86_64-linux`: `nix run github:drakulavich/kesha-voice-kit -- audio.ogg`. Full recipes (one-liner, profile install, engine-only, dev shell) live in [docs/nix-install.md](docs/nix-install.md).
 
 ## Speech-to-text
 

--- a/docs/nix-install.md
+++ b/docs/nix-install.md
@@ -1,0 +1,42 @@
+# Nix Install
+
+Alternative reproducible-build path for Kesha Voice Kit. The Bun install (`bun add -g @drakulavich/kesha-voice-kit`) remains the canonical install — npm publish + the `kesha-engine` binaries from GitHub Releases are what CI gates against. The Nix flake is a parallel artifact for users who already live in Nix.
+
+**Prerequisites:** [Nix](https://nixos.org/download/) with flakes enabled. Supported systems: `aarch64-darwin`, `x86_64-linux`.
+
+## One-liner run (no install)
+```bash
+nix run github:drakulavich/kesha-voice-kit -- install      # downloads models (engine is bundled)
+nix run github:drakulavich/kesha-voice-kit -- audio.ogg    # transcribe
+```
+
+`nix run` resolves to `apps.default` (the `kesha` Bun CLI), which has the engine binary baked in via `KESHA_ENGINE_BIN`, so there's no separate engine download.
+
+## Install to profile (persistent)
+```bash
+nix profile install github:drakulavich/kesha-voice-kit
+kesha install       # downloads models
+kesha audio.ogg     # transcript to stdout
+```
+
+`packages.default` ships the Bun CLI (`kesha`, `parakeet`) wired to the Nix-built engine. After `nix profile install`, both shims are on `PATH` and run transcription, language detection, and TTS (including `macos-*` AVSpeech voices on darwin-arm64) identically to the npm install. Speaker diarization (`kesha install --diarize` / `--speakers`) is not yet wired into the Nix build — the `kesha-diarize` Swift sidecar needs network-fetched FluidAudio at build time, which the Nix sandbox forbids; use the Bun install path (`bun add -g @drakulavich/kesha-voice-kit`) on darwin-arm64 if you need that feature (tracked alongside [#199](https://github.com/drakulavich/kesha-voice-kit/issues/199)).
+
+## Engine only (no Bun, no Node)
+For users who just want the Rust binary:
+```bash
+nix build github:drakulavich/kesha-voice-kit#kesha-engine
+./result/bin/kesha-engine --help
+./result/bin/kesha-engine --capabilities-json   # see which backends compiled in
+```
+
+## Development shell
+```bash
+nix develop github:drakulavich/kesha-voice-kit
+# Now you have: pinned rustc/cargo (via rust-overlay), bun, protoc, cmake, pkg-config, libclang
+```
+
+## Why Nix?
+
+- Reproducible builds across Linux/macOS
+- All native deps (onnxruntime, protobuf, abseil) handled automatically
+- No "works on my machine" — same `flake.nix` = identical results everywhere

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -282,7 +282,7 @@ export async function downloadEngine(
       throw new Error(
         "--diarize is not supported by the installed engine: it was built " +
           "without the 'system_diarize' feature (the Nix build is one such " +
-          "case — see README's Nix Install section).\n" +
+          "case — see docs/nix-install.md).\n" +
           "  Fix: install via the npm release with `bun add -g @drakulavich/kesha-voice-kit`, " +
           "which ships the diarize-enabled engine on darwin-arm64.",
       );


### PR DESCRIPTION
## Summary

README polish for the install/Quick Start surface. Three commits:

1. **\`docs: move Nix install section out of README, drop "Recommended"\`** — the "## Nix Install (Recommended)" subsection (~40 LOC, 4 install variants + "why Nix" block) was crowding the README hot path AND mis-labelling Nix as "Recommended" when npm is the canonical install. Extract to \`docs/nix-install.md\`, leave a 3-line pointer in README, update \`src/engine-install.ts\`'s --diarize error message to reference the new doc path.

2. **\`docs: add brew install option for Bun in Quick Start\`** — many macOS users already have Homebrew and would rather not pipe shell into a one-off installer. Surface \`brew install oven-sh/bun/bun\` next to the curl one-liner.

3. **\`docs: add Windows PowerShell install option for Bun\`** — Bun's homepage has a Windows path (\`powershell -c "irm bun.sh/install.ps1 | iex"\`). Surface it so Windows users don't bounce out of the Quick Start.

## Quick Start now

\`\`\`bash
curl -fsSL https://bun.sh/install | bash          # Linux & macOS — upstream installer
brew install oven-sh/bun/bun                      # Linux & macOS — Homebrew
powershell -c "irm bun.sh/install.ps1 | iex"      # Windows — upstream installer (PowerShell)

bun add -g @drakulavich/kesha-voice-kit
kesha install       # downloads engine + models
kesha audio.ogg     # transcript to stdout
\`\`\`

## Tests

Pure docs + one error-message string change. \`bun test\` 123/123 pass, \`bunx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)