### PR TITLE
chore(release): v1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.14.0"
+    "version": "1.15.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.14.0"
+version = "1.15.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
Bundles engine-touching work from main since v1.14.0 (2026-05-13 AM).

## What's in v1.15.0

### Engine

- **F5 refactor (#290)** — `transcribe/mod.rs` collapses three public wrappers into a `TranscribeOptions` struct. Guard rejects \`{with_speakers: true, with_segments: false}\` at entry.
- **Engine debug timestamp prefix (#293)** — `[debug/engine +Nms]` on every `dtrace!` line. T0 anchored at `main()` start so clap parsing + env probe show up.

### CLI

- **CLI debug timestamp prefix (#293)** — `[debug +Nms]` on `log.debug()` lines; each axis is independent per-process.
- **macOS Gatekeeper SIGKILL fix (#295)** — `kesha install` runs `codesign --force --sign -` AND `xattr -d com.apple.provenance` on every freshly-downloaded binary. Healed on the cache-valid path too — users who upgraded to macOS 15+ AFTER installing kesha can re-run `kesha install` without `--no-cache`.

### Release / infra

- **Auto npm publish + provenance (#291)** — `.github/workflows/npm-publish.yml` fires on `release: published`, runs `npm publish --provenance --access public` with sigstore-verified attestation. v1.15.0 is the first release to ship via this path (provided `NPM_TOKEN` secret is set).
- **Docs (#292, #294, #296)** — README Nix Install moved to `docs/nix-install.md`, brew + Windows Bun install options, CLAUDE.md lessons learned.

## Bumps

- \`package.json#version\`: 1.14.0 → 1.15.0
- \`package.json#keshaEngine.version\`: 1.14.0 → 1.15.0
- \`rust/Cargo.toml\` + \`rust/Cargo.lock\`: 1.14.0 → 1.15.0

## Release flow checklist (per CLAUDE.md)

- [ ] Merge to main
- [ ] \`git tag v1.15.0 && git push origin v1.15.0\` (triggers build-engine.yml)
- [ ] Wait for draft release → author notes via \`gh release edit --notes\`
- [ ] **Independent v1.15.0 validation** via \`gh release download v1.15.0 -p "kesha-engine-darwin-arm64" -D /tmp/v1.15.0-smoke\` (works on drafts; anonymous \`curl\` 404s). Run \`--version\` / \`--capabilities-json\` / real-synth WAV ≥ 50 KB
- [ ] \`gh release edit v1.15.0 --draft=false\` → fires `📦 npm Publish` workflow (provenance attestation)
- [ ] **Pre-requisite for the workflow**: `NPM_TOKEN` secret must be set in the repo. Without it the publish step fails; manual fallback is `npm publish --access public` from the maintainer's laptop. Verify with `gh secret list -R drakulavich/kesha-voice-kit` before un-drafting.
- [ ] Verify `npm view @drakulavich/kesha-voice-kit version` → 1.15.0 within ~60 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)