### PR TITLE
feat(install): warm up ASR backend at end of install (hide ANE cold-compile)

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -77,6 +77,14 @@ enum Commands {
         #[cfg(feature = "system_diarize")]
         #[arg(long)]
         diarize: bool,
+        /// Skip the ASR-backend warm-up step at the end of install. On macOS
+        /// (CoreML) the warm-up triggers the ~20-30 s Apple Neural Engine
+        /// model-compile so the first `kesha audio.ogg` invocation is fast.
+        /// Use this flag in scripted installs where the cold-start cost
+        /// belongs on the first real run, or to debug install-time issues
+        /// without the backend in the loop.
+        #[arg(long = "no-warmup", default_value_t = false)]
+        no_warmup: bool,
     },
     /// Synthesize speech from text (TTS)
     #[cfg(feature = "tts")]
@@ -448,6 +456,7 @@ fn main() -> Result<()> {
             vad,
             #[cfg(feature = "system_diarize")]
             diarize,
+            no_warmup,
         }) => {
             // Emit the "Model mirror active" banner once at the start of the
             // install run, regardless of which subset of models the flags
@@ -468,6 +477,29 @@ fn main() -> Result<()> {
             if diarize {
                 models::download_diarize(no_cache)?;
                 eprintln!("Diarization model installed.");
+            }
+            // ASR backend warm-up: instantiate the backend once so the
+            // expensive cold-start work — Apple Neural Engine model-compile
+            // on CoreML (~20-30 s for Parakeet TDT 0.6B), ORT session init
+            // on the ONNX path (~500 ms) — happens HERE, during the install
+            // step where the user is already waiting on multi-GB downloads.
+            // After this, the first real `kesha audio.ogg` is fast because
+            // the macOS CoreML cache is keyed by (model bytes, signing
+            // identity); the identity is stable across runs of the same
+            // binary, so the warm cache survives until the next
+            // `kesha install` re-signs (#295).
+            //
+            // Drop the backend handle immediately — no need to keep it
+            // alive past install; the warm cache lives in the OS, not in
+            // this process.
+            if !no_warmup {
+                let asr_dir = models::model_dir(models::ModelKind::Asr)
+                    .to_string_lossy()
+                    .into_owned();
+                eprintln!("Warming up ASR backend (one-time, ~20-30 s on macOS)...");
+                let t = std::time::Instant::now();
+                let _ = backend::create_backend(&asr_dir)?;
+                eprintln!("ASR backend warmed up (dt={}ms).", t.elapsed().as_millis());
             }
             eprintln!("Install complete.");
         }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -80,10 +80,12 @@ enum Commands {
         /// Skip the ASR-backend warm-up step at the end of install. On macOS
         /// (CoreML) the warm-up triggers the ~20-30 s Apple Neural Engine
         /// model-compile so the first `kesha audio.ogg` invocation is fast.
+        /// On the ONNX path (Linux/Windows) warm-up is ~500 ms — still worth
+        /// running since it surfaces missing-dep crashes at install time.
         /// Use this flag in scripted installs where the cold-start cost
         /// belongs on the first real run, or to debug install-time issues
         /// without the backend in the loop.
-        #[arg(long = "no-warmup", default_value_t = false)]
+        #[arg(long = "no-warmup")]
         no_warmup: bool,
     },
     /// Synthesize speech from text (TTS)
@@ -496,10 +498,34 @@ fn main() -> Result<()> {
                 let asr_dir = models::model_dir(models::ModelKind::Asr)
                     .to_string_lossy()
                     .into_owned();
-                eprintln!("Warming up ASR backend (one-time, ~20-30 s on macOS)...");
+                // Honest cost estimate per backend so the user knows what
+                // to expect during the pause. CoreML (macOS) pays the ANE
+                // compile (~20-30 s); ONNX (Linux/Windows + macOS without
+                // `coreml` feature) just loads an ORT session (~500 ms).
+                let cost_hint = if cfg!(feature = "coreml") {
+                    "one-time, ~20-30 s for the ANE compile on first install"
+                } else {
+                    "~500 ms for the ORT session init"
+                };
+                eprintln!("Warming up ASR backend ({cost_hint})...");
                 let t = std::time::Instant::now();
-                let _ = backend::create_backend(&asr_dir)?;
-                eprintln!("ASR backend warmed up (dt={}ms).", t.elapsed().as_millis());
+                // Warm-up failures are NON-FATAL (Greptile P1 on #298).
+                // All models are already on disk; the install succeeded
+                // and the user can still run `kesha audio.ogg`. The first
+                // real invocation will pay the cold-start cost we were
+                // trying to hide, but that's strictly no-worse than the
+                // pre-#298 behavior. Surface the cause on stderr so the
+                // user can investigate (typically: ANE permission glitch,
+                // CoreML cache directory unwritable, transient ORT init
+                // hiccup).
+                match backend::create_backend(&asr_dir) {
+                    Ok(_) => eprintln!("ASR backend warmed up (dt={}ms).", t.elapsed().as_millis()),
+                    Err(e) => eprintln!(
+                        "warning: ASR backend warm-up failed ({e}); install \
+                         still complete but the first `kesha audio.ogg` will \
+                         pay the cold-start cost."
+                    ),
+                }
             }
             eprintln!("Install complete.");
         }


### PR DESCRIPTION
## Summary

**Symptom (post-v1.14.0):** first \`kesha audio.ogg\` after \`kesha install\` takes ~25 s on macOS while the engine binary is fine on subsequent runs (~500 ms). The pause has no log line, looks like a hang.

**Root cause:** Apple Neural Engine compiles CoreML models to its proprietary format on first use after a process-identity change. The compiled artefact is cached under \`~/Library/Caches/com.apple.e5rt.e5bundlecache/\` keyed by \`(model bytes, process signing identity)\`. The cache is invalidated whenever the binary's ad-hoc signature changes — including the \`codesign --force --sign -\` step that the macOS-Gatekeeper fix from #295 runs on every fresh download.

**Fix:** at the end of \`kesha-engine install\`, instantiate the backend once via \`backend::create_backend\`. That triggers the ~20-30 s ANE compile during install (where the user is already waiting on multi-GB downloads). The compiled artefact is then cached; subsequent runs hit the warm cache and start in ~500 ms.

The backend handle is dropped immediately — warm cache lives in the OS, not in this process.

## Opt-out

New \`--no-warmup\` flag for:
- Scripted installs where the cold-start cost should land on the first real run instead.
- Debugging install-time issues without the backend in the loop.

## Why this matters together with #295

The Gatekeeper fix from #295 is what triggers the cache invalidation (re-signing changes the identity hash). Without #295 you'd hit a SIGKILL instead of a slow start. Together they make \`kesha install\` → \`kesha audio.ogg\` actually work end-to-end on macOS 15+ Sequoia, with the cold-compile happening at install time instead of first transcribe.

## Tests

- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo test --bin kesha-engine\` 226/226 pass (no behavior change in existing flows; warm-up is additive at the end of install)
- \`./kesha-engine install --help\` shows the new \`--no-warmup\` flag

## Release plan

This is engine-touching, so requires an engine release. Two options:
- Bundle into #297 (v1.15.0) by rebasing the release bump on top of this — single release captures both #295 and the warm-up.
- Ship as v1.16.0 separately — #297 unblocks first, this lands later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)