### PR TITLE
fix(cli): --format toon was silently producing plain text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,13 @@ export { installCommand } from "./cli/install";
 export { sayCommand } from "./cli/say";
 export { pickVoiceForLang } from "./voice-routing";
 export { statusCommand } from "./cli/status";
-export { mainCommand, detectLanguage, checkLanguageMismatch } from "./cli/main";
+export {
+  mainCommand,
+  detectLanguage,
+  checkLanguageMismatch,
+  resolveOutputFormat,
+} from "./cli/main";
+export type { ResolvedOutputFormat } from "./cli/main";
 export { runCli } from "./cli/dispatch";
 
 export type { TranscribeResult } from "./types";

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -81,6 +81,19 @@ export function resolveOutputFormat(input: {
       error: "--json and --toon are mutually exclusive (pick one output format).",
     };
   }
+  // `--format transcript` + boolean `--json` / `--toon` was previously
+  // accepted and silently produced the boolean's format (because the
+  // dispatch checked wantsJson/wantsToon first). Greptile P2 on #300
+  // flagged the silent override. Fail loudly with the same shape as
+  // the json/toon mutex — symmetric across all three formats.
+  if (wantsTranscript && (wantsJson || wantsToon)) {
+    return {
+      ok: false,
+      error:
+        "--format transcript is mutually exclusive with --json / --toon " +
+        "(pick one output format).",
+    };
+  }
   return { ok: true, wantsJson, wantsToon, wantsTranscript };
 }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -34,6 +34,56 @@ export function detectLanguage(text: string): string {
   return detect(text);
 }
 
+/**
+ * Pure validation + normalization of the output-format selection. Pulled
+ * out of the citty `run` handler so the contract is unit-testable without
+ * spawning the CLI binary; the handler just owns the side effects
+ * (log.error + process.exit) when this returns `{ ok: false }`.
+ *
+ * Inputs accept the three knobs the user can flip:
+ * - `--json` (boolean) — long-form alias for `--format json`
+ * - `--toon` (boolean) — long-form alias for `--format toon`
+ * - `--format <value>` — must be one of `transcript`, `json`, `toon`
+ *
+ * Mutex: `--json` and `--toon` cannot both be requested. Either via the
+ * booleans or `--format` cross-pollination (`--json --format toon` →
+ * error). The mutex check happens AFTER format validation, so unknown
+ * `--format` still surfaces with its own clearer error first.
+ */
+export type ResolvedOutputFormat =
+  | {
+      ok: true;
+      wantsJson: boolean;
+      wantsToon: boolean;
+      wantsTranscript: boolean;
+    }
+  | { ok: false; error: string };
+
+const SUPPORTED_FORMATS = ["transcript", "json", "toon"] as const;
+
+export function resolveOutputFormat(input: {
+  json?: boolean;
+  toon?: boolean;
+  format?: string;
+}): ResolvedOutputFormat {
+  if (input.format !== undefined && !SUPPORTED_FORMATS.includes(input.format as never)) {
+    return {
+      ok: false,
+      error: `unknown --format '${input.format}'. supported: ${SUPPORTED_FORMATS.join(", ")}`,
+    };
+  }
+  const wantsJson = !!input.json || input.format === "json";
+  const wantsToon = !!input.toon || input.format === "toon";
+  const wantsTranscript = input.format === "transcript";
+  if (wantsJson && wantsToon) {
+    return {
+      ok: false,
+      error: "--json and --toon are mutually exclusive (pick one output format).",
+    };
+  }
+  return { ok: true, wantsJson, wantsToon, wantsTranscript };
+}
+
 export function checkLanguageMismatch(expected: string | undefined, detected: string): string | null {
   if (!expected || !detected || expected === detected) return null;
   return `warning: expected language "${expected}" but detected "${detected}"`;
@@ -103,26 +153,20 @@ export const mainCommand = defineCommand({
     const files = args._;
 
     // Validate `--format <value>` and normalize into the boolean flags
-    // that the rest of this handler consults. `--format toon` was
-    // silently producing plain text before this normalization because
-    // none of the dispatch branches recognized the string (only the
-    // boolean `args.toon` flag was checked). Same shape as `--json`
-    // already being equivalent to `--format json`.
-    const SUPPORTED_FORMATS = ["transcript", "json", "toon"];
-    if (args.format !== undefined && !SUPPORTED_FORMATS.includes(args.format)) {
-      log.error(
-        `unknown --format '${args.format}'. supported: ${SUPPORTED_FORMATS.join(", ")}`,
-      );
+    // that the rest of this handler consults. Routing happens in
+    // `resolveOutputFormat` so the contract is unit-testable without
+    // spawning the CLI; the handler just owns the side-effect arms
+    // (log.error + process.exit).
+    const fmt = resolveOutputFormat({
+      json: args.json,
+      toon: args.toon,
+      format: args.format,
+    });
+    if (!fmt.ok) {
+      log.error(fmt.error);
       process.exit(2);
     }
-    const wantsJson = !!args.json || args.format === "json";
-    const wantsToon = !!args.toon || args.format === "toon";
-    const wantsTranscript = args.format === "transcript";
-
-    if (wantsJson && wantsToon) {
-      log.error("--json and --toon are mutually exclusive (pick one output format).");
-      process.exit(2);
-    }
+    const { wantsJson, wantsToon, wantsTranscript } = fmt;
 
     if (args.vad && args["no-vad"]) {
       log.error("--vad and --no-vad are mutually exclusive.");

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -76,7 +76,7 @@ export const mainCommand = defineCommand({
     },
     format: {
       type: "string",
-      description: "Output format: transcript (enriched text with lang/confidence)",
+      description: "Output format: transcript | json | toon (long-form alias for --json / --toon)",
     },
     lang: {
       type: "string",
@@ -102,7 +102,24 @@ export const mainCommand = defineCommand({
     if (args.debug) log.debugEnabled = true;
     const files = args._;
 
-    if ((args.json || args.format === "json") && args.toon) {
+    // Validate `--format <value>` and normalize into the boolean flags
+    // that the rest of this handler consults. `--format toon` was
+    // silently producing plain text before this normalization because
+    // none of the dispatch branches recognized the string (only the
+    // boolean `args.toon` flag was checked). Same shape as `--json`
+    // already being equivalent to `--format json`.
+    const SUPPORTED_FORMATS = ["transcript", "json", "toon"];
+    if (args.format !== undefined && !SUPPORTED_FORMATS.includes(args.format)) {
+      log.error(
+        `unknown --format '${args.format}'. supported: ${SUPPORTED_FORMATS.join(", ")}`,
+      );
+      process.exit(2);
+    }
+    const wantsJson = !!args.json || args.format === "json";
+    const wantsToon = !!args.toon || args.format === "toon";
+    const wantsTranscript = args.format === "transcript";
+
+    if (wantsJson && wantsToon) {
       log.error("--json and --toon are mutually exclusive (pick one output format).");
       process.exit(2);
     }
@@ -111,12 +128,12 @@ export const mainCommand = defineCommand({
       log.error("--vad and --no-vad are mutually exclusive.");
       process.exit(2);
     }
-    if (args.timestamps && !(args.json || args.toon || args.format === "json")) {
-      log.error("--timestamps requires --json, --toon, or --format json.");
+    if (args.timestamps && !(wantsJson || wantsToon)) {
+      log.error("--timestamps requires --json, --toon, or --format {json,toon}.");
       process.exit(2);
     }
-    if (args.speakers && !(args.json || args.toon || args.format === "json")) {
-      log.error("--speakers requires --json, --toon, or --format json.");
+    if (args.speakers && !(wantsJson || wantsToon)) {
+      log.error("--speakers requires --json, --toon, or --format {json,toon}.");
       process.exit(2);
     }
     const vadMode = args.vad ? "on" : args["no-vad"] ? "off" : "auto";
@@ -129,7 +146,7 @@ export const mainCommand = defineCommand({
     let hasError = false;
     const results: TranscribeResult[] = [];
 
-    const wantsLangId = !!(args.lang || args.verbose || args.json || args.toon || args.format === "transcript" || args.format === "json");
+    const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
 
     for (const file of files) {
       const startedAt = performance.now();
@@ -185,11 +202,11 @@ export const mainCommand = defineCommand({
       }
     }
 
-    if (args.json || args.format === "json") {
+    if (wantsJson) {
       process.stdout.write(formatJsonOutput(results));
-    } else if (args.toon) {
+    } else if (wantsToon) {
       process.stdout.write(formatToonOutput(results));
-    } else if (args.format === "transcript") {
+    } else if (wantsTranscript) {
       process.stdout.write(formatTranscriptOutput(results));
     } else if (args.verbose) {
       process.stdout.write(formatVerboseOutput(results));

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -360,6 +360,24 @@ describe("resolveOutputFormat (#300 regression)", () => {
       expect(r.ok).toBe(false);
       if (!r.ok) expect(r.error).toContain("mutually exclusive");
     });
+
+    test("--format transcript + --json → error (Greptile P2 on #300)", () => {
+      // Pre-fix: wantsTranscript was set but the dispatch checked
+      // wantsJson first → silent JSON output. Now rejected with a
+      // symmetric mutex message.
+      const r = resolveOutputFormat({ json: true, format: "transcript" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error).toContain("--format transcript");
+        expect(r.error).toContain("mutually exclusive");
+      }
+    });
+
+    test("--format transcript + --toon → error", () => {
+      const r = resolveOutputFormat({ toon: true, format: "transcript" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("mutually exclusive");
+    });
   });
 
   describe("unknown --format values are rejected", () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
-import { mainCommand, installCommand, statusCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch } from "../../src/cli";
+import { mainCommand, installCommand, statusCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat } from "../../src/cli";
 
 describe("CLI help", () => {
   test("main help contains usage and install info", async () => {
@@ -272,5 +272,132 @@ describe("JSON output with lang-id fields", () => {
     const parsed = JSON.parse(formatJsonOutput(results));
     expect(parsed[0].audioLanguage).toBeUndefined();
     expect(parsed[0].lang).toBe("en");
+  });
+});
+
+describe("resolveOutputFormat (#300 regression)", () => {
+  // Pre-#300 bug: `--format toon` set args.format to the string but the
+  // dispatch only checked the boolean args.toon flag, so output silently
+  // fell through to plain text. Same class hit unknown --format values
+  // and any cross-form mutex (e.g. --json --format toon). These tests
+  // lock in the contract behind `resolveOutputFormat`.
+
+  describe("boolean flags route to their format", () => {
+    test("--json sets wantsJson", () => {
+      const r = resolveOutputFormat({ json: true });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.wantsJson).toBe(true);
+        expect(r.wantsToon).toBe(false);
+        expect(r.wantsTranscript).toBe(false);
+      }
+    });
+
+    test("--toon sets wantsToon", () => {
+      const r = resolveOutputFormat({ toon: true });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.wantsToon).toBe(true);
+        expect(r.wantsJson).toBe(false);
+        expect(r.wantsTranscript).toBe(false);
+      }
+    });
+
+    test("no flags → all false (default plain-text)", () => {
+      const r = resolveOutputFormat({});
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.wantsJson).toBe(false);
+        expect(r.wantsToon).toBe(false);
+        expect(r.wantsTranscript).toBe(false);
+      }
+    });
+  });
+
+  describe("--format string is an alias for the boolean", () => {
+    test("--format json", () => {
+      const r = resolveOutputFormat({ format: "json" });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.wantsJson).toBe(true);
+    });
+
+    test("--format toon (the bug fixed in #300)", () => {
+      const r = resolveOutputFormat({ format: "toon" });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.wantsToon).toBe(true);
+        expect(r.wantsJson).toBe(false);
+        expect(r.wantsTranscript).toBe(false);
+      }
+    });
+
+    test("--format transcript", () => {
+      const r = resolveOutputFormat({ format: "transcript" });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.wantsTranscript).toBe(true);
+        expect(r.wantsJson).toBe(false);
+        expect(r.wantsToon).toBe(false);
+      }
+    });
+  });
+
+  describe("mutex: --json + --toon are exclusive", () => {
+    test("both booleans → error", () => {
+      const r = resolveOutputFormat({ json: true, toon: true });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("mutually exclusive");
+    });
+
+    test("boolean --json + --format toon → error (cross-form)", () => {
+      const r = resolveOutputFormat({ json: true, format: "toon" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("mutually exclusive");
+    });
+
+    test("boolean --toon + --format json → error (cross-form)", () => {
+      const r = resolveOutputFormat({ toon: true, format: "json" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("mutually exclusive");
+    });
+  });
+
+  describe("unknown --format values are rejected", () => {
+    test("--format gibberish → error", () => {
+      const r = resolveOutputFormat({ format: "gibberish" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error).toContain("unknown --format 'gibberish'");
+        expect(r.error).toContain("supported: transcript, json, toon");
+      }
+    });
+
+    test("--format \"\" → error (empty string is not a valid value)", () => {
+      const r = resolveOutputFormat({ format: "" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("unknown --format");
+    });
+
+    test("unknown format wins over mutex (clearer error first)", () => {
+      // --json + --format gibberish: report the unknown format,
+      // not the mutex — the user can't fix mutex until format is valid.
+      const r = resolveOutputFormat({ json: true, format: "gibberish" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("unknown --format");
+    });
+  });
+
+  describe("boolean + --format same value is harmless (idempotent)", () => {
+    test("--json --format json → wantsJson true, no mutex", () => {
+      const r = resolveOutputFormat({ json: true, format: "json" });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.wantsJson).toBe(true);
+    });
+
+    test("--toon --format toon → wantsToon true, no mutex", () => {
+      const r = resolveOutputFormat({ toon: true, format: "toon" });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.wantsToon).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

\`kesha --format toon file.ogg\` returned plain text instead of TOON-formatted output. Reproduced by drakulavich on v1.15.0.

## Root cause

\`args.format === "toon"\` had no routing branch. The dispatch only checked the boolean \`args.toon\` (the short \`--toon\` flag) and \`args.format === "json"\`. \`--format toon\` set \`args.format\` to the string but every branch missed it → output fell through to \`formatTextOutput\` → just the transcript line.

Same class affected unknown \`--format\` values: \`kesha --format gibberish file.ogg\` was silently treated as default plain text.

## Fix

Normalize \`--format\` up front into the boolean flags the rest of the handler consults:

1. Validate \`args.format\` against a whitelist (\`transcript\`, \`json\`, \`toon\`). Unknown values fail with \`unknown --format '<x>'. supported: ...\` and exit 2.
2. Extract \`wantsJson\`, \`wantsToon\`, \`wantsTranscript\` from \`(args.X OR args.format === "X")\` once at the top; use those booleans in every gate (timestamps / speakers / mutex / wantsLangId / output dispatch). Symmetric across all three formats.
3. Update the \`format\` arg description to list all three supported values.

## Live verification

\`\`\`bash
$ kesha --format toon /tmp/test_en.ogg | head -3
[1]:
  - file: /tmp/test_en.ogg
    text: "..."

$ kesha --format gibberish /tmp/test_en.ogg
unknown --format 'gibberish'. supported: transcript, json, toon
$ echo $?
2
\`\`\`

## Tests

- \`bun test\` 156/156 pass
- \`bunx tsc --noEmit\` clean

## Release plan

CLI-only patch. Bump \`package.json#version\` and cut a \`v1.15.1-cli\` marker release — \`gh release create v1.15.1-cli\` fires the \`📦 npm Publish\` workflow automatically (post-#291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)