### PR TITLE
ci: integrate Flakiness.io for bun + rust test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  # Flakiness.io CLI authenticates via GitHub's OIDC provider, no
+  # long-lived secret needed. Granted across all jobs so each test step
+  # can convert+upload its own junit.xml under matrix.os.
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -115,6 +119,15 @@ jobs:
           path: test-results/unit-${{ matrix.os }}.xml
           retention-days: 7
 
+      - name: 🪼 Upload to Flakiness.io
+        if: always()
+        shell: bash
+        run: |
+          curl -LsSf https://cli.flakiness.io/install.sh | sh
+          flakiness convert-junit test-results/unit-${{ matrix.os }}.xml \
+            --category bun --project Laputa/kesha-voice-kit
+          flakiness upload ./flakiness-report
+
   integration-tests:
     # Skip on release/* branches: this job downloads the released engine
     # binary (the version in `package.json#keshaEngine.version`), which
@@ -167,6 +180,15 @@ jobs:
           name: test-results-integration
           path: test-results/integration.xml
           retention-days: 7
+
+      - name: 🪼 Upload to Flakiness.io
+        if: always()
+        shell: bash
+        run: |
+          curl -LsSf https://cli.flakiness.io/install.sh | sh
+          flakiness convert-junit test-results/integration.xml \
+            --category bun --project Laputa/kesha-voice-kit
+          flakiness upload ./flakiness-report
 
   tts-e2e:
     # Runs whenever rust engine code, the TS CLI that drives `kesha say`,
@@ -226,7 +248,27 @@ jobs:
           KESHA_CACHE_DIR: ${{ env.KOKORO_CACHE }}
           KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/kesha-engine
           DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib
-        run: bun test tests/integration/say-e2e.test.ts
+        run: |
+          mkdir -p test-results
+          bun test tests/integration/say-e2e.test.ts \
+            --reporter=junit --reporter-outfile=test-results/tts-e2e.xml
+
+      - name: 📤 Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-tts-e2e
+          path: test-results/tts-e2e.xml
+          retention-days: 7
+
+      - name: 🪼 Upload to Flakiness.io
+        if: always()
+        shell: bash
+        run: |
+          curl -LsSf https://cli.flakiness.io/install.sh | sh
+          flakiness convert-junit test-results/tts-e2e.xml \
+            --category bun --project Laputa/kesha-voice-kit
+          flakiness upload ./flakiness-report
 
   raycast-lint:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,9 @@ jobs:
         if: always()
         shell: bash
         run: |
-          curl -LsSf https://cli.flakiness.io/install.sh | sh
-          flakiness convert-junit test-results/unit-${{ matrix.os }}.xml \
+          bunx flakiness convert-junit test-results/unit-${{ matrix.os }}.xml \
             --category bun --project Laputa/kesha-voice-kit
-          flakiness upload ./flakiness-report
+          bunx flakiness upload ./flakiness-report
 
   integration-tests:
     # Skip on release/* branches: this job downloads the released engine
@@ -185,10 +184,9 @@ jobs:
         if: always()
         shell: bash
         run: |
-          curl -LsSf https://cli.flakiness.io/install.sh | sh
-          flakiness convert-junit test-results/integration.xml \
+          bunx flakiness convert-junit test-results/integration.xml \
             --category bun --project Laputa/kesha-voice-kit
-          flakiness upload ./flakiness-report
+          bunx flakiness upload ./flakiness-report
 
   tts-e2e:
     # Runs whenever rust engine code, the TS CLI that drives `kesha say`,
@@ -265,10 +263,9 @@ jobs:
         if: always()
         shell: bash
         run: |
-          curl -LsSf https://cli.flakiness.io/install.sh | sh
-          flakiness convert-junit test-results/tts-e2e.xml \
+          bunx flakiness convert-junit test-results/tts-e2e.xml \
             --category bun --project Laputa/kesha-voice-kit
-          flakiness upload ./flakiness-report
+          bunx flakiness upload ./flakiness-report
 
   raycast-lint:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  # Flakiness.io CLI authenticates via GitHub's OIDC provider, no
-  # long-lived secret needed. Granted across all jobs so each test step
-  # can convert+upload its own junit.xml under matrix.os.
-  id-token: write
+  # `id-token: write` is NOT granted at workflow scope — it's elevated
+  # only on the three test jobs that actually upload to Flakiness.io
+  # (Greptile #301 P1 security finding). `changes`, `raycast-lint`,
+  # `nix-build`, and `pr-comment` run third-party actions and don't need
+  # OIDC capability.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -84,6 +85,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -120,7 +124,13 @@ jobs:
           retention-days: 7
 
       - name: 🪼 Upload to Flakiness.io
+        # `if: always()` only guarantees the step runs; it does NOT
+        # suppress this step's own exit code. `continue-on-error: true`
+        # is what keeps a Flakiness outage / OIDC handshake failure from
+        # marking the whole test job red (Greptile #301 P1). Telemetry
+        # upload is best-effort, not a release gate.
         if: always()
+        continue-on-error: true
         shell: bash
         run: |
           bunx flakiness convert-junit test-results/unit-${{ matrix.os }}.xml \
@@ -147,6 +157,9 @@ jobs:
       needs.unit-tests.result == 'success'
     runs-on: macos-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -182,6 +195,7 @@ jobs:
 
       - name: 🪼 Upload to Flakiness.io
         if: always()
+        continue-on-error: true
         shell: bash
         run: |
           bunx flakiness convert-junit test-results/integration.xml \
@@ -200,6 +214,9 @@ jobs:
     if: needs.changes.outputs.tts_e2e == 'true'
     runs-on: macos-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
     env:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
     steps:
@@ -261,6 +278,7 @@ jobs:
 
       - name: 🪼 Upload to Flakiness.io
         if: always()
+        continue-on-error: true
         shell: bash
         run: |
           bunx flakiness convert-junit test-results/tts-e2e.xml \

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     paths: ["rust/**"]
 
+permissions:
+  contents: read
+  # Flakiness.io CLI authenticates via GitHub's OIDC provider; the
+  # upload step in each matrix row requests its own token.
+  id-token: write
+
 jobs:
   test:
     strategy:
@@ -25,6 +31,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+
+      # `cargo nextest` replaces `cargo test` for the actual run — it
+      # parallelizes per-binary, surfaces flakiness explicitly, and emits
+      # JUnit XML via the `ci` profile (see rust/.config/nextest.toml).
+      # taiki-e/install-action caches a prebuilt binary per OS/arch so
+      # the install is ~1s on warm cache.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
 
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
@@ -98,3 +113,20 @@ jobs:
       - name: Run tests (with real Kokoro)
         shell: bash
         run: bash rust/ci/run-cargo-test.sh "$KOKORO_CACHE" "${{ runner.os }}"
+
+      - name: 📤 Upload JUnit
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-junit-${{ matrix.os }}
+          path: rust/target/nextest/ci/junit.xml
+          retention-days: 7
+
+      - name: 🪼 Upload to Flakiness.io
+        if: always()
+        shell: bash
+        run: |
+          curl -LsSf https://cli.flakiness.io/install.sh | sh
+          flakiness convert-junit rust/target/nextest/ci/junit.xml \
+            --category rust --project Laputa/kesha-voice-kit
+          flakiness upload ./flakiness-report

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -122,11 +122,17 @@ jobs:
           path: rust/target/nextest/ci/junit.xml
           retention-days: 7
 
+      # The npm Flakiness CLI runs everywhere bun runs, so unlike the
+      # platform-specific curl installer it covers windows-latest too.
+      # Setup-bun is a no-op when bun is already on PATH (cached on warm
+      # runs).
+      - uses: oven-sh/setup-bun@v2
+        if: always()
+
       - name: 🪼 Upload to Flakiness.io
         if: always()
         shell: bash
         run: |
-          curl -LsSf https://cli.flakiness.io/install.sh | sh
-          flakiness convert-junit rust/target/nextest/ci/junit.xml \
+          bunx flakiness convert-junit rust/target/nextest/ci/junit.xml \
             --category rust --project Laputa/kesha-voice-kit
-          flakiness upload ./flakiness-report
+          bunx flakiness upload ./flakiness-report

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -6,12 +6,16 @@ on:
 
 permissions:
   contents: read
-  # Flakiness.io CLI authenticates via GitHub's OIDC provider; the
-  # upload step in each matrix row requests its own token.
-  id-token: write
 
 jobs:
   test:
+    permissions:
+      contents: read
+      # Flakiness.io CLI authenticates via GitHub OIDC; scope the
+      # write capability to this job only so a future second job in
+      # this workflow doesn't inherit it implicitly (symmetric with
+      # the per-job scoping in ci.yml per Greptile #301).
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -130,7 +134,12 @@ jobs:
         if: always()
 
       - name: 🪼 Upload to Flakiness.io
+        # `if: always()` runs the step but doesn't suppress its exit
+        # code; `continue-on-error: true` keeps a Flakiness outage /
+        # OIDC handshake failure off the test-job verdict (Greptile
+        # #301 P1). Telemetry upload is best-effort, not a release gate.
         if: always()
+        continue-on-error: true
         shell: bash
         run: |
           bunx flakiness convert-junit rust/target/nextest/ci/junit.xml \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Kesha Voice Kit</h1>
 
 <p align="center">
-  <a href="https://github.com/drakulavich/kesha-voice-kit/actions/workflows/ci.yml"><img src="https://github.com/drakulavich/kesha-voice-kit/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://flakiness.io/Laputa/kesha-voice-kit"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fflakiness.io%2Fapi%2Fbadge%3Finput%3D%257B%2522badgeToken%2522%253A%2522badge-2IKMRRqUxh9P3w8Ym3Szf0%2522%257D" alt="Tests"></a>
   <a href="https://www.npmjs.com/package/@drakulavich/kesha-voice-kit"><img src="https://img.shields.io/npm/v/@drakulavich/kesha-voice-kit" alt="npm version"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
   <a href="https://bun.sh"><img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun" alt="Bun"></a>

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,0 +1,11 @@
+# cargo-nextest configuration.
+#
+# The `ci` profile is what `rust/ci/run-cargo-test.sh` runs in GitHub
+# Actions. It writes a JUnit XML report at `target/nextest/ci/junit.xml`
+# which the workflow then converts + uploads to Flakiness.io.
+#
+# Run locally with `cargo nextest run` (uses the default profile, no
+# JUnit emission); the `ci` profile is opt-in for CI environments.
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/rust/ci/run-cargo-test.sh
+++ b/rust/ci/run-cargo-test.sh
@@ -32,4 +32,4 @@ if [[ -f "$KOKORO_CACHE/models/vosk-ru/model.onnx" && -f "$KOKORO_CACHE/models/v
   echo "KESHA_CACHE_DIR=$KESHA_CACHE_DIR (Vosk gated tests enabled)"
 fi
 
-cargo test --verbose
+cargo nextest run --profile ci


### PR DESCRIPTION
## Summary

Wires Flakiness.io (https://flakiness.io/Laputa/kesha-voice-kit) into both CI workflows so every test run's JUnit XML gets uploaded for flakiness tracking. Authenticates via GitHub OIDC — no long-lived secret needed; both workflows now declare \`id-token: write\`.

## Changes

### Bun side (\`.github/workflows/ci.yml\`)

- Workflow-scope \`permissions.id-token: write\` added.
- **unit-tests** (matrix × OS): already produces \`test-results/unit-<os>.xml\`. New Flakiness upload step after the existing upload-artifact.
- **integration-tests**: already produces \`test-results/integration.xml\`. Same upload step.
- **tts-e2e**: previously ran \`bun test tests/integration/say-e2e.test.ts\` with no JUnit reporter. Added \`--reporter=junit --reporter-outfile=test-results/tts-e2e.xml\` to the test command, plus a new upload-artifact step alongside the Flakiness one.

All Flakiness steps run \`if: always()\` so failing tests still upload — that's the whole point.

### Rust side (\`.github/workflows/rust-test.yml\`)

- Top-level \`permissions: { contents: read, id-token: write }\` (the workflow had no explicit block; it was inheriting GH defaults).
- **cargo-nextest** replaces \`cargo test\` for the actual run. Installed via \`taiki-e/install-action@v2 tool: nextest\` (cached prebuilt, ~1 s warm).
- New \`rust/.config/nextest.toml\` defines a \`ci\` profile that writes JUnit to \`target/nextest/ci/junit.xml\`. The CI script runs with \`--profile ci\`; local \`cargo nextest run\` uses the default profile (no JUnit emission).
- Upload-artifact + Flakiness upload steps follow the test step, pointing at \`rust/target/nextest/ci/junit.xml\`, category \`rust\`.
- \`rust/ci/run-cargo-test.sh\`: \`cargo test --verbose\` → \`cargo nextest run --profile ci\`.

## Local impact (none)

- \`bun test\` continues to work as-is locally.
- Maintainers can keep running \`cargo test\` locally — nextest is CI-only via the \`ci\` profile.

## Verification needed before merge

CI on this PR is the first place either path actually runs through Flakiness.io. The \`flakiness upload\` step will exercise the OIDC handshake; if anything is misconfigured on the Flakiness.io side (project not yet provisioned, OIDC subject claim mismatch), the upload step will fail loudly but the \`if: always()\` placement means the test job's pass/fail verdict is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)