### PR TITLE
chore(release): v1.15.1 (CLI-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
CLI-only patch — engine binary at v1.15.0 unchanged.

## What's in v1.15.1

- **`--format toon` routing fix (#300)** — `kesha --format toon audio.ogg` silently produced plain text. Fixed via a pure `resolveOutputFormat` helper that normalizes all three formats (\`json\`, \`toon\`, \`transcript\`) into the boolean flags the dispatch consults. Unknown \`--format\` values exit 2 with a clear error. Cross-form mutex enforced (\`--format transcript --json\` etc.). 16 regression tests in \`tests/unit/cli.test.ts\`.
- **Flakiness.io CI integration (#301)** — every JUnit-emitting test step (bun unit-tests × matrix, integration-tests, tts-e2e, rust nextest × matrix) uploads to Flakiness.io via \`bunx flakiness\`, authenticated through GitHub OIDC. \`continue-on-error: true\` keeps Flakiness outages from blocking PR merges. README badge now shows Flakiness test health instead of GHA pass/fail.

## Bumps

- \`package.json#version\`: 1.15.0 → 1.15.1
- \`package.json#keshaEngine.version\`: 1.15.0 (unchanged — no rust changes)
- \`rust/Cargo.toml\` + \`rust/Cargo.lock\`: 1.15.0 (unchanged)

## Release flow checklist (per CLAUDE.md CLI-only patch)

- [ ] Merge to main
- [ ] \`gh release create v1.15.1-cli --title "v1.15.1 (CLI-only)" --notes "Engine: v1.15.0 (unchanged). Bundles #300 + #301."\` — creates a PUBLISHED (non-draft) release → fires the \`📦 npm Publish\` workflow → \`npm publish --provenance --access public\` runs automatically with sigstore-verified attestation
- [ ] The \`-cli\` suffix on the tag is excluded from \`build-engine.yml\`'s tag filter — no Rust rebuild
- [ ] Verify \`npm view @drakulavich/kesha-voice-kit version\` → 1.15.1 within ~60 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)