### PR TITLE
chore(release): v1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.15.0"
+    "version": "1.16.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.15.0"
+version = "1.16.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 


### PR DESCRIPTION
## Summary

Engine release. Bundles main since v1.15.1:

- **#303 — `kesha-textlang` Swift sidecar** replaces `swift -e` shell-out in `text_lang.rs`. Cold-path `detect-text-lang` drops from ~34.7 s (macOS 15+ Sequoia, Swift cache evicted) to ~411 ms; warm 200 ms → ~30 ms. New `kesha-textlang-darwin-arm64` release asset; `kesha install` codesigns + xattr-strips it alongside the engine. Opt-in `system_text_lang` cargo feature keeps minimal dev builds working without swiftc.
- **#304 — CI cleanup:** drops the sticky test-results PR comment helper.

Bumps:
- `package.json#version`: 1.15.1 → 1.16.0
- `package.json#keshaEngine.version`: 1.15.0 → 1.16.0
- `rust/Cargo.toml` + `rust/Cargo.lock`: 1.15.0 → 1.16.0

## Test plan

Post-merge (CLAUDE.md release flow):

- [ ] `git tag v1.16.0 && git push origin v1.16.0` → fires `build-engine.yml`
- [ ] Author release notes via `gh release edit --notes`
- [ ] Independent draft validation via `gh release download` (the gate):
  - [ ] `./kesha-engine --version` reports `kesha-engine 1.16.0`
  - [ ] `./kesha-engine --capabilities-json` includes every promised feature
  - [ ] TTS end-to-end: `kesha-engine say --voice en-am_michael --out en.wav` produces a >50 KB WAV
  - [ ] **NEW for this release:** `kesha-engine detect-text-lang "Hello world"` exits 0 with a `"code"` field — exercises the new `kesha-textlang` sidecar artifact
- [ ] `gh release edit v1.16.0 --draft=false` → fires `📦 npm Publish` workflow (provenance)
- [ ] `npm view @drakulavich/kesha-voice-kit version` reports `1.16.0` within ~60 s


---
_Generated by [Claude Code](https://claude.ai/code/session_011YM8CjwTofdx8MMEMK7zvT)_