### PR TITLE
ci(build-engine): workflow_dispatch can create tags (closes #306)

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -356,10 +356,11 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           body=$(git tag -l --format='%(contents)' "$TAG_NAME" || true)
+          EOF_MARKER=$(openssl rand -hex 16)
           {
-            echo "body<<KESHA_NOTES_EOF"
+            echo "body<<$EOF_MARKER"
             printf '%s\n' "$body"
-            echo "KESHA_NOTES_EOF"
+            echo "$EOF_MARKER"
           } >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -12,10 +12,16 @@ on:
       - "!v*-cli"
   workflow_dispatch:
     inputs:
+      tag:
+        description: "Tag to create + build (e.g. v1.17.0). Leave empty to build-only from `ref`."
+        required: false
       ref:
-        description: "Git ref to build (tag, branch, or SHA)"
+        description: "Git ref to tag from (commit SHA, branch). Defaults to main HEAD."
         required: false
         default: "main"
+      notes:
+        description: "Release notes body (Markdown). Stored as the annotated tag message; the release job reads it back to populate the draft body."
+        required: false
 
 permissions:
   contents: write
@@ -24,7 +30,69 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # Create + push the annotated tag from a workflow_dispatch with `inputs.tag`
+  # set. Pushing the tag fires this workflow again via `on.push.tags` (the
+  # "two-run" pattern, fix #306) — that second run executes the build matrix +
+  # release job below. Lets sandboxed automation cut a release without holding
+  # tag-push permission on the local git remote (the case that motivated #306
+  # after v1.16.0).
+  tag:
+    if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      # Shape + uniqueness validation BEFORE the tag value reaches any
+      # filesystem / argv site. `^v[0-9]+\.[0-9]+\.[0-9]+$` rejects empty,
+      # CLI-only marker tags (vX.Y.Z-cli), and shell-injection attempts.
+      # CLAUDE.md → TAG NAMES ARE ONE-USE forbids reusing a tag name.
+      - name: Validate tag shape and uniqueness
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if ! [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$INPUT_TAG' must match ^v[0-9]+.[0-9]+.[0-9]+$ (CLI-only marker tags vX.Y.Z-cli are not supported by this workflow)"
+            exit 1
+          fi
+          if git rev-parse "refs/tags/$INPUT_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $INPUT_TAG already exists. Tag names are one-use (CLAUDE.md → TAG NAMES ARE ONE-USE) — bump patch and retry."
+            exit 1
+          fi
+          echo "Tag $INPUT_TAG passes shape + uniqueness checks."
+
+      # `inputs.tag` and `inputs.notes` flow through `env:` rather than direct
+      # `${{ … }}` interpolation in the run: script. The workflow holds
+      # `contents: write`; an attacker-controlled value containing `$(cmd)` or
+      # `;` would otherwise execute arbitrary code with that permission. Pattern
+      # mirrors `.github/workflows/npm-publish.yml::Resolve tag` (post-#291).
+      # `git tag -F -` reads the message from stdin so newlines/shell metachars
+      # in INPUT_NOTES survive untouched (argv via `-m` would be a re-exposure).
+      - name: Create and push annotated tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_NOTES: ${{ inputs.notes }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          printf '%s' "$INPUT_NOTES" | git tag -a "$INPUT_TAG" -F -
+          git push origin "refs/tags/$INPUT_TAG"
+          echo "Pushed $INPUT_TAG. on.push.tags will now fire a second workflow run for build + release."
+
   build:
+    # Skip the matrix when the dispatch run is creating a tag (fix #306) —
+    # the push of that tag fires a second workflow run via `on.push.tags`
+    # which runs build + release with `github.ref` set to the new tag.
+    # Running the matrix twice wastes ~12 min and the dispatch-run build
+    # would have no `release` job to consume its artifacts anyway
+    # (release.if: startsWith(github.ref, 'refs/tags/v') would be false).
+    # When `inputs.tag` is empty, the dispatch is in build-only mode (today's
+    # behavior) — matrix runs from `inputs.ref`.
+    if: github.event_name != 'workflow_dispatch' || inputs.tag == ''
     strategy:
       fail-fast: false
       matrix:
@@ -259,14 +327,50 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      # Need the tag object available locally to read its annotation. Default
+      # actions/checkout doesn't fetch tag objects under `on.push.tags`, so
+      # `fetch-tags: true` is explicit. The `tag` job (fix #306) writes the
+      # release notes into the annotated tag's message; this checkout + the
+      # extract step below recover it. Lightweight tags (manual
+      # `git tag vX.Y.Z` from a laptop, no `-a`) produce an empty annotation,
+      # which falls through to today's empty-body behavior.
+      - name: Checkout at tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+          fetch-tags: true
+          fetch-depth: 0
+
+      # Multi-line heredoc form for $GITHUB_OUTPUT — a single-line
+      # `echo "body=…"` would truncate at the first newline. KESHA_NOTES_EOF
+      # is a magic marker chosen to be highly unlikely in user-authored
+      # release notes; a colliding marker would inject content but the
+      # release body is a doc field, not a shell context, so impact is
+      # cosmetic.
+      - name: Extract release notes from tag annotation
+        id: notes
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          body=$(git tag -l --format='%(contents)' "$TAG_NAME" || true)
+          {
+            echo "body<<KESHA_NOTES_EOF"
+            printf '%s\n' "$body"
+            echo "KESHA_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
           merge-multiple: true
+
       - name: Create draft release with binaries
         uses: softprops/action-gh-release@v3
         with:
+          body: ${{ steps.notes.outputs.body }}
           files: |
             kesha-engine-darwin-arm64
             kesha-engine-linux-x64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,17 @@ If the spike persists into project work, ask which env tool the user wants (uv, 
 1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (via `cargo check`), and `package.json#keshaEngine.version` in lockstep. Usually bump `package.json#version` too.
 2. Merge to main.
 3. `git tag vX.Y.Z && git push origin vX.Y.Z` — triggers `build-engine.yml`.
+
+   **Alternate path: `workflow_dispatch` (no tag-push permission required, fix #306).** Use this when running from a sandboxed remote that rejects tag pushes (Claude Code on the web, restricted git proxies). Authors the notes inline so they land with the draft — skips step 4 entirely.
+   ```bash
+   gh workflow run "🔨 Build Engine" \
+     -R drakulavich/kesha-voice-kit \
+     -f tag=vX.Y.Z \
+     -f ref=main \
+     -f notes="$(cat release-notes.md)"
+   ```
+   Mechanics: the dispatch run executes a `tag` job that creates an annotated tag (with `notes` as the tag message) and pushes via `GITHUB_TOKEN`. That push fires a second `build-engine.yml` run via `on.push.tags` which runs build + release as usual; the release job reads the tag annotation back via `git tag -l --format='%(contents)'` and passes it as the draft body. Tag-shape regex (`^v[0-9]+\.[0-9]+\.[0-9]+$`) and a `git rev-parse refs/tags/...` idempotency check fire before the tag is created — bad inputs fail fast without producing a tag.
+
 4. **Write release notes before publishing.** `build-engine.yml` creates a draft with EMPTY body via `softprops/action-gh-release`. Author the notes now:
    ```bash
    gh release edit vX.Y.Z --notes "$(cat <<'EOF'
@@ -77,7 +88,7 @@ If the spike persists into project work, ask which env tool the user wants (uv, 
    EOF
    )"
    ```
-   Use the v1.1.3 release as a template: features → platform support → breaking changes → shipped PRs → follow-up issues → upgrade instructions.
+   Use the v1.1.3 release as a template: features → platform support → breaking changes → shipped PRs → follow-up issues → upgrade instructions. **Skip this step if you used the `workflow_dispatch` path in step 3** — notes are already on the draft.
 
    **If you forgot and already published:** `gh release edit --notes` silently drops content on published releases (a `gh` CLI quirk — not a GitHub restriction). The `immutable: true` flag protects tag/assets, not the body. Escape hatch is a direct API PATCH:
    ```bash


### PR DESCRIPTION
## Summary

Adds a `tag` input to `build-engine.yml`'s `workflow_dispatch` so sandboxed automation can cut engine releases without holding tag-push permission on the local git remote — the exact gap that turned v1.16.0's release into a laptop trip.

**Two-run shape** (maintainer pick): the dispatch run executes a new `tag` job that creates an annotated tag and pushes via `GITHUB_TOKEN`. The push fires a second `build-engine.yml` run via the existing `on.push.tags` trigger; that run executes the build matrix + release job unchanged. **`notes` input** carries through: dispatch step writes notes into the annotated tag's message; release job reads them back via `git tag -l --format='%(contents)'` and passes them as `body:` to `softprops/action-gh-release@v3`. Draft lands with notes pre-filled, skipping the existing post-draft `gh release edit --notes` step.

Tag-push from a laptop (`git tag vX.Y.Z && git push`) is unchanged. Lightweight tags → empty annotation → empty release body (today's behavior). Build-only `workflow_dispatch` (with `tag` empty) also unchanged.

## Notable mechanics

- **Build double-run guard:** new `if:` on `build` (`github.event_name != 'workflow_dispatch' || inputs.tag == ''`) skips the matrix in the dispatch-tag-mode run; the auto-fired tag-push run picks it up. Without this guard the matrix would run twice on a tag-creating dispatch.
- **Security pattern** (env-passthrough, post-#291): every `${{ inputs.X }}` flows through an `env:` block before reaching `run:` scripts. Shape regex `^v[0-9]+\.[0-9]+\.[0-9]+$` and `git rev-parse` idempotency check fire before the tag is created. Notes message piped via stdin (`git tag -F -`) so newlines/shell metachars survive without escaping.
- **CLAUDE.md → RELEASE PROCESS** gains an "Alternate path: `workflow_dispatch`" callout under step 3.

## Test plan

- [x] `bun run check:workflows` — YAML parses clean
- [x] `grep -n 'inputs\.' .github/workflows/build-engine.yml` — every `${{ inputs.X }}` is inside an `env:` block or an `if:`/`with:` expression context; none inside `run:`
- [ ] Post-merge, exercise on the next engine release (v1.17.0): `gh workflow run "🔨 Build Engine" -f tag=v1.17.0 -f ref=main -f notes="$(cat notes.md)"`. Verify the auto-fired tag-push run produces a draft with notes pre-filled.
- [ ] Negative cases (dispatch with bad inputs):
  - `-f tag=v1.16.0` (existing tag) → `Validate tag shape and uniqueness` step exits 1 with the one-use error
  - `-f tag=1.17.0` (no `v` prefix) → shape regex exits 1
  - `-f tag='v1.17.0; rm -rf /'` → shape regex exits 1
  - `-f tag=''` → `tag` job skipped via `inputs.tag != ''`, workflow runs in today's build-only mode

Closes #306

---
_Generated by [Claude Code](https://claude.ai/code/session_011YM8CjwTofdx8MMEMK7zvT)_