### PR TITLE
refactor(cli): split main.rs into rust/src/cli/* per subcommand (#267 F6)

### DIFF
--- a/rust/src/cli/detect_lang.rs
+++ b/rust/src/cli/detect_lang.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+
+use crate::lang_id;
+
+pub fn run(audio_path: String) -> Result<()> {
+    let result = lang_id::detect_audio_language(&audio_path)?;
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}

--- a/rust/src/cli/detect_text_lang.rs
+++ b/rust/src/cli/detect_text_lang.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+
+use crate::text_lang;
+
+pub fn run(text: String) -> Result<()> {
+    let result = text_lang::detect_text_language(&text)?;
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -1,0 +1,81 @@
+use anyhow::Result;
+
+use crate::{backend, models};
+
+pub fn run(
+    no_cache: bool,
+    #[cfg(feature = "tts")] tts: bool,
+    vad: bool,
+    #[cfg(feature = "system_diarize")] diarize: bool,
+    no_warmup: bool,
+) -> Result<()> {
+    // Emit the "Model mirror active" banner once at the start of the
+    // install run, regardless of which subset of models the flags
+    // request. Push-down to `download_*` is more "magic" — each fn
+    // hides a stderr write behind its Ok(()) return.
+    models::init_mirror_logging();
+    models::install(no_cache)?;
+    #[cfg(feature = "tts")]
+    if tts {
+        models::download_tts(no_cache)?;
+        eprintln!("TTS models installed.");
+    }
+    if vad {
+        models::download_vad(no_cache)?;
+        eprintln!("VAD model installed.");
+    }
+    #[cfg(feature = "system_diarize")]
+    if diarize {
+        models::download_diarize(no_cache)?;
+        eprintln!("Diarization model installed.");
+    }
+    // ASR backend warm-up: instantiate the backend once so the
+    // expensive cold-start work — Apple Neural Engine model-compile
+    // on CoreML (~20-30 s for Parakeet TDT 0.6B), ORT session init
+    // on the ONNX path (~500 ms) — happens HERE, during the install
+    // step where the user is already waiting on multi-GB downloads.
+    // After this, the first real `kesha audio.ogg` is fast because
+    // the macOS CoreML cache is keyed by (model bytes, signing
+    // identity); the identity is stable across runs of the same
+    // binary, so the warm cache survives until the next
+    // `kesha install` re-signs (#295).
+    //
+    // Drop the backend handle immediately — no need to keep it
+    // alive past install; the warm cache lives in the OS, not in
+    // this process.
+    if !no_warmup {
+        let asr_dir = models::model_dir(models::ModelKind::Asr)
+            .to_string_lossy()
+            .into_owned();
+        // Honest cost estimate per backend so the user knows what
+        // to expect during the pause. CoreML (macOS) pays the ANE
+        // compile (~20-30 s); ONNX (Linux/Windows + macOS without
+        // `coreml` feature) just loads an ORT session (~500 ms).
+        let cost_hint = if cfg!(feature = "coreml") {
+            "one-time, ~20-30 s for the ANE compile on first install"
+        } else {
+            "~500 ms for the ORT session init"
+        };
+        eprintln!("Warming up ASR backend ({cost_hint})...");
+        let t = std::time::Instant::now();
+        // Warm-up failures are NON-FATAL (Greptile P1 on #298).
+        // All models are already on disk; the install succeeded
+        // and the user can still run `kesha audio.ogg`. The first
+        // real invocation will pay the cold-start cost we were
+        // trying to hide, but that's strictly no-worse than the
+        // pre-#298 behavior. Surface the cause on stderr so the
+        // user can investigate (typically: ANE permission glitch,
+        // CoreML cache directory unwritable, transient ORT init
+        // hiccup).
+        match backend::create_backend(&asr_dir) {
+            Ok(_) => eprintln!("ASR backend warmed up (dt={}ms).", t.elapsed().as_millis()),
+            Err(e) => eprintln!(
+                "warning: ASR backend warm-up failed ({e}); install \
+                 still complete but the first `kesha audio.ogg` will \
+                 pay the cold-start cost."
+            ),
+        }
+    }
+    eprintln!("Install complete.");
+    Ok(())
+}

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -1,0 +1,12 @@
+//! Per-subcommand dispatch modules for `kesha-engine`. Each `run(…)` here
+//! owns the side-effecting body of one [`crate::Commands`] arm; `main.rs`
+//! stays a thin parse + match table. Mirrors the TS-side `src/cli/*`
+//! shape (one file per `kesha` subcommand). Issue #267 F6.
+
+pub mod detect_lang;
+pub mod detect_text_lang;
+pub mod install;
+pub mod transcribe;
+
+#[cfg(feature = "tts")]
+pub mod say;

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -1,0 +1,262 @@
+use anyhow::Result;
+use std::path::PathBuf;
+
+use crate::{models, say_loop, tts};
+
+pub struct SayArgs {
+    pub text: Option<String>,
+    pub voice: Option<String>,
+    pub lang: Option<String>,
+    pub out: Option<PathBuf>,
+    pub rate: f32,
+    pub list_voices: bool,
+    pub ssml: bool,
+    pub format: Option<String>,
+    pub bitrate: Option<i32>,
+    pub sample_rate: Option<u32>,
+    pub model: Option<PathBuf>,
+    pub voice_file: Option<PathBuf>,
+    pub stdin_loop: bool,
+    pub no_expand_abbrev: bool,
+}
+
+/// Resolve the user-supplied `--format` / `--bitrate` / `--sample-rate` /
+/// `--out` combination into a single [`tts::OutputFormat`]. Mirrors the UX
+/// table from #223:
+///
+/// 1. If `--format` is given, parse it (`wav` | `ogg-opus`).
+/// 2. Otherwise, sniff the `--out` extension (`.wav` → wav, `.ogg`/`.opus`
+///    → ogg-opus).
+/// 3. Otherwise default to `Wav` — preserves the historical `kesha say > x`
+///    behaviour where stdout was always RIFF.
+///
+/// `--bitrate` / `--sample-rate` only matter for opus and override the
+/// defaults. When the user picked WAV but supplied either flag, we surface a
+/// clear error rather than silently dropping them.
+pub(crate) fn resolve_output_format(
+    format: Option<&str>,
+    bitrate: Option<i32>,
+    sample_rate: Option<u32>,
+    out: Option<&std::path::Path>,
+) -> Result<tts::OutputFormat, String> {
+    use std::str::FromStr;
+
+    // #275 D10: track which arm of the resolver fired so the dtrace at
+    // the bottom can surface `chosen=… source=…`. Three possible sources:
+    //   "--format"  — explicit flag wins.
+    //   "out-ext"   — sniffed from the `--out` extension.
+    //   "default"   — fallthrough (no flag, no `--out`, or unknown ext).
+    let (mut chosen, source): (tts::OutputFormat, &'static str) = match (format, out) {
+        (Some(f), _) => (tts::OutputFormat::from_str(f)?, "--format"),
+        (None, Some(p)) => {
+            let ext_fmt = p
+                .extension()
+                .and_then(|e| e.to_str())
+                .and_then(tts::encode::format_from_extension);
+            match ext_fmt {
+                Some(fmt) => (fmt, "out-ext"),
+                None => (tts::OutputFormat::default(), "default"),
+            }
+        }
+        (None, None) => (tts::OutputFormat::default(), "default"),
+    };
+
+    if let tts::OutputFormat::OggOpus {
+        bitrate: ref mut br,
+        sample_rate: ref mut sr,
+    } = chosen
+    {
+        if let Some(b) = bitrate {
+            *br = b;
+        }
+        if let Some(r) = sample_rate {
+            *sr = r;
+        }
+    } else if matches!(chosen, tts::OutputFormat::Wav)
+        && (bitrate.is_some() || sample_rate.is_some())
+    {
+        return Err("--bitrate / --sample-rate only apply to --format ogg-opus".to_string());
+    }
+
+    crate::dtrace!("format::resolved chosen={chosen:?} source={source}");
+    Ok(chosen)
+}
+
+fn list_kokoro_voices(cache: &std::path::Path) -> Vec<String> {
+    let dir = cache.join("models/kokoro-82m/voices");
+    std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().and_then(|s| s.to_str()) == Some("bin") {
+                p.file_stem().map(|s| format!("en-{}", s.to_string_lossy()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn list_vosk_ru_voices(cache: &std::path::Path) -> Vec<String> {
+    // Vosk-TTS Russian is a single multi-speaker model — once installed, all
+    // five baked-in speakers are available. Same gate as resolve_vosk_ru, so
+    // partial installs don't advertise voices that fail at synthesis time.
+    let dir = models::model_dir_at(models::ModelKind::VoskRu, cache);
+    if !models::is_cached_in(models::ModelKind::VoskRu, &dir) {
+        return Vec::new();
+    }
+    vec![
+        "ru-vosk-f01".into(),
+        "ru-vosk-f02".into(),
+        "ru-vosk-f03".into(),
+        "ru-vosk-m01".into(),
+        "ru-vosk-m02".into(),
+    ]
+}
+
+/// Map a TTS error to the documented exit code for `kesha say`.
+/// 2 = bad input, 4 = synthesis failure, 5 = text too long.
+/// (Voice-not-installed exits 1 directly from the resolver path.)
+fn exit_code_for_tts_err(e: &tts::TtsError) -> i32 {
+    match e {
+        tts::TtsError::EmptyText => 2,
+        tts::TtsError::TextTooLong { .. } => 5,
+        tts::TtsError::SynthesisFailed(_) => 4,
+    }
+}
+
+pub fn run(a: SayArgs) -> i32 {
+    use std::io::{Read, Write};
+
+    if a.list_voices {
+        let cache = models::cache_dir();
+        let mut voice_ids: Vec<String> = list_kokoro_voices(&cache)
+            .into_iter()
+            .chain(list_vosk_ru_voices(&cache))
+            .collect();
+        // macos-* voices live in the OS, not the cache — enumerate them via
+        // the AVSpeech helper (#141). Best-effort: if the helper is absent or
+        // errors out, we still show Kokoro/Vosk voices.
+        #[cfg(all(feature = "system_tts", target_os = "macos"))]
+        voice_ids.extend(tts::avspeech::list_voices(None));
+        voice_ids.sort();
+        if voice_ids.is_empty() {
+            println!("No voices installed. Run: kesha install --tts");
+        } else {
+            for id in voice_ids {
+                println!("{id}");
+            }
+        }
+        return 0;
+    }
+
+    if a.stdin_loop {
+        return say_loop::run();
+    }
+
+    let text_joined = match a.text {
+        Some(s) => s,
+        None => {
+            let mut buf = String::new();
+            if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+                eprintln!("error: failed to read stdin: {e}");
+                return 4;
+            }
+            buf.trim().to_string()
+        }
+    };
+
+    // `--model` + `--voice-file` are Kokoro-specific testing overrides.
+    // Pinned model/voice paths bypass the cache lookup.
+    let resolved = match (a.model, a.voice_file) {
+        (Some(model_path), Some(voice_path)) => tts::voices::ResolvedVoice::Kokoro {
+            model_path,
+            voice_path,
+            espeak_lang: "en-us",
+        },
+        (Some(_), None) | (None, Some(_)) => {
+            eprintln!("error: pass both --model and --voice-file or neither");
+            return 2;
+        }
+        (None, None) => {
+            let id = a.voice.as_deref().unwrap_or(tts::voices::DEFAULT_VOICE_ID);
+            match tts::voices::resolve_voice(&models::cache_dir(), id) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    return 1;
+                }
+            }
+        }
+    };
+
+    let espeak_lang = a
+        .lang
+        .clone()
+        .unwrap_or_else(|| resolved.espeak_lang().to_string());
+    let engine = match &resolved {
+        tts::voices::ResolvedVoice::Kokoro {
+            model_path,
+            voice_path,
+            ..
+        } => tts::EngineChoice::Kokoro {
+            model_path,
+            voice_path,
+            speed: a.rate,
+        },
+        tts::voices::ResolvedVoice::Vosk {
+            model_dir,
+            speaker_id,
+        } => tts::EngineChoice::Vosk {
+            model_dir,
+            speaker_id: *speaker_id,
+            speed: a.rate,
+        },
+        #[cfg(all(feature = "system_tts", target_os = "macos"))]
+        tts::voices::ResolvedVoice::AVSpeech { voice_id } => {
+            tts::EngineChoice::AVSpeech { voice_id }
+        }
+    };
+
+    let format = match resolve_output_format(
+        a.format.as_deref(),
+        a.bitrate,
+        a.sample_rate,
+        a.out.as_deref(),
+    ) {
+        Ok(f) => f,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            return 2;
+        }
+    };
+
+    let bytes = match tts::say(tts::SayOptions {
+        text: &text_joined,
+        lang: &espeak_lang,
+        engine,
+        ssml: a.ssml,
+        format,
+        expand_abbrev: !a.no_expand_abbrev,
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return exit_code_for_tts_err(&e);
+        }
+    };
+
+    let write_result = match a.out {
+        Some(p) => std::fs::write(&p, &bytes).map_err(|e| e.to_string()),
+        None => std::io::stdout()
+            .write_all(&bytes)
+            .map_err(|e| e.to_string()),
+    };
+    if let Err(msg) = write_result {
+        eprintln!("error: write failed: {msg}");
+        return 4;
+    }
+    0
+}

--- a/rust/src/cli/transcribe.rs
+++ b/rust/src/cli/transcribe.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+
+use crate::transcribe;
+
+pub fn run(audio_path: String, json: bool, vad: bool, no_vad: bool, speakers: bool) -> Result<()> {
+    if speakers && !json {
+        anyhow::bail!("--speakers requires --json");
+    }
+    let opts = transcribe::TranscribeOptions {
+        mode: transcribe::VadMode::from_flags(vad, no_vad),
+        with_segments: json,
+        with_speakers: speakers,
+    };
+    let output = transcribe::transcribe_with_options(&audio_path, &opts)?;
+    if json {
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("{}", output.text);
+    }
+    Ok(())
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 mod audio;
 mod backend;
 mod capabilities;
+mod cli;
 mod debug;
 mod lang_id;
 mod models;
@@ -143,270 +144,6 @@ enum Commands {
     },
 }
 
-#[cfg(feature = "tts")]
-struct SayArgs {
-    text: Option<String>,
-    voice: Option<String>,
-    lang: Option<String>,
-    out: Option<std::path::PathBuf>,
-    rate: f32,
-    list_voices: bool,
-    ssml: bool,
-    format: Option<String>,
-    bitrate: Option<i32>,
-    sample_rate: Option<u32>,
-    model: Option<std::path::PathBuf>,
-    voice_file: Option<std::path::PathBuf>,
-    stdin_loop: bool,
-    no_expand_abbrev: bool,
-}
-
-/// Resolve the user-supplied `--format` / `--bitrate` / `--sample-rate` /
-/// `--out` combination into a single [`tts::OutputFormat`]. Mirrors the UX
-/// table from #223:
-///
-/// 1. If `--format` is given, parse it (`wav` | `ogg-opus`).
-/// 2. Otherwise, sniff the `--out` extension (`.wav` → wav, `.ogg`/`.opus`
-///    → ogg-opus).
-/// 3. Otherwise default to `Wav` — preserves the historical `kesha say > x`
-///    behaviour where stdout was always RIFF.
-///
-/// `--bitrate` / `--sample-rate` only matter for opus and override the
-/// defaults. When the user picked WAV but supplied either flag, we surface a
-/// clear error rather than silently dropping them.
-#[cfg(feature = "tts")]
-pub(crate) fn resolve_output_format(
-    format: Option<&str>,
-    bitrate: Option<i32>,
-    sample_rate: Option<u32>,
-    out: Option<&std::path::Path>,
-) -> Result<tts::OutputFormat, String> {
-    use std::str::FromStr;
-
-    // #275 D10: track which arm of the resolver fired so the dtrace at
-    // the bottom can surface `chosen=… source=…`. Three possible sources:
-    //   "--format"  — explicit flag wins.
-    //   "out-ext"   — sniffed from the `--out` extension.
-    //   "default"   — fallthrough (no flag, no `--out`, or unknown ext).
-    let (mut chosen, source): (tts::OutputFormat, &'static str) = match (format, out) {
-        (Some(f), _) => (tts::OutputFormat::from_str(f)?, "--format"),
-        (None, Some(p)) => {
-            let ext_fmt = p
-                .extension()
-                .and_then(|e| e.to_str())
-                .and_then(tts::encode::format_from_extension);
-            match ext_fmt {
-                Some(fmt) => (fmt, "out-ext"),
-                None => (tts::OutputFormat::default(), "default"),
-            }
-        }
-        (None, None) => (tts::OutputFormat::default(), "default"),
-    };
-
-    if let tts::OutputFormat::OggOpus {
-        bitrate: ref mut br,
-        sample_rate: ref mut sr,
-    } = chosen
-    {
-        if let Some(b) = bitrate {
-            *br = b;
-        }
-        if let Some(r) = sample_rate {
-            *sr = r;
-        }
-    } else if matches!(chosen, tts::OutputFormat::Wav)
-        && (bitrate.is_some() || sample_rate.is_some())
-    {
-        return Err("--bitrate / --sample-rate only apply to --format ogg-opus".to_string());
-    }
-
-    crate::dtrace!("format::resolved chosen={chosen:?} source={source}");
-    Ok(chosen)
-}
-
-#[cfg(feature = "tts")]
-fn list_kokoro_voices(cache: &std::path::Path) -> Vec<String> {
-    let dir = cache.join("models/kokoro-82m/voices");
-    std::fs::read_dir(&dir)
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .filter_map(|e| {
-            let p = e.path();
-            if p.extension().and_then(|s| s.to_str()) == Some("bin") {
-                p.file_stem().map(|s| format!("en-{}", s.to_string_lossy()))
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-#[cfg(feature = "tts")]
-fn list_vosk_ru_voices(cache: &std::path::Path) -> Vec<String> {
-    // Vosk-TTS Russian is a single multi-speaker model — once installed, all
-    // five baked-in speakers are available. Same gate as resolve_vosk_ru, so
-    // partial installs don't advertise voices that fail at synthesis time.
-    let dir = models::model_dir_at(models::ModelKind::VoskRu, cache);
-    if !models::is_cached_in(models::ModelKind::VoskRu, &dir) {
-        return Vec::new();
-    }
-    vec![
-        "ru-vosk-f01".into(),
-        "ru-vosk-f02".into(),
-        "ru-vosk-f03".into(),
-        "ru-vosk-m01".into(),
-        "ru-vosk-m02".into(),
-    ]
-}
-
-/// Map a TTS error to the documented exit code for `kesha say`.
-/// 2 = bad input, 4 = synthesis failure, 5 = text too long.
-/// (Voice-not-installed exits 1 directly from the resolver path.)
-#[cfg(feature = "tts")]
-fn exit_code_for_tts_err(e: &tts::TtsError) -> i32 {
-    match e {
-        tts::TtsError::EmptyText => 2,
-        tts::TtsError::TextTooLong { .. } => 5,
-        tts::TtsError::SynthesisFailed(_) => 4,
-    }
-}
-
-#[cfg(feature = "tts")]
-fn run_say(a: SayArgs) -> i32 {
-    use std::io::{Read, Write};
-
-    if a.list_voices {
-        let cache = models::cache_dir();
-        let mut voice_ids: Vec<String> = list_kokoro_voices(&cache)
-            .into_iter()
-            .chain(list_vosk_ru_voices(&cache))
-            .collect();
-        // macos-* voices live in the OS, not the cache — enumerate them via
-        // the AVSpeech helper (#141). Best-effort: if the helper is absent or
-        // errors out, we still show Kokoro/Vosk voices.
-        #[cfg(all(feature = "system_tts", target_os = "macos"))]
-        voice_ids.extend(tts::avspeech::list_voices(None));
-        voice_ids.sort();
-        if voice_ids.is_empty() {
-            println!("No voices installed. Run: kesha install --tts");
-        } else {
-            for id in voice_ids {
-                println!("{id}");
-            }
-        }
-        return 0;
-    }
-
-    if a.stdin_loop {
-        return say_loop::run();
-    }
-
-    let text_joined = match a.text {
-        Some(s) => s,
-        None => {
-            let mut buf = String::new();
-            if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
-                eprintln!("error: failed to read stdin: {e}");
-                return 4;
-            }
-            buf.trim().to_string()
-        }
-    };
-
-    // `--model` + `--voice-file` are Kokoro-specific testing overrides.
-    // Pinned model/voice paths bypass the cache lookup.
-    let resolved = match (a.model, a.voice_file) {
-        (Some(model_path), Some(voice_path)) => tts::voices::ResolvedVoice::Kokoro {
-            model_path,
-            voice_path,
-            espeak_lang: "en-us",
-        },
-        (Some(_), None) | (None, Some(_)) => {
-            eprintln!("error: pass both --model and --voice-file or neither");
-            return 2;
-        }
-        (None, None) => {
-            let id = a.voice.as_deref().unwrap_or(tts::voices::DEFAULT_VOICE_ID);
-            match tts::voices::resolve_voice(&models::cache_dir(), id) {
-                Ok(r) => r,
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    return 1;
-                }
-            }
-        }
-    };
-
-    let espeak_lang = a
-        .lang
-        .clone()
-        .unwrap_or_else(|| resolved.espeak_lang().to_string());
-    let engine = match &resolved {
-        tts::voices::ResolvedVoice::Kokoro {
-            model_path,
-            voice_path,
-            ..
-        } => tts::EngineChoice::Kokoro {
-            model_path,
-            voice_path,
-            speed: a.rate,
-        },
-        tts::voices::ResolvedVoice::Vosk {
-            model_dir,
-            speaker_id,
-        } => tts::EngineChoice::Vosk {
-            model_dir,
-            speaker_id: *speaker_id,
-            speed: a.rate,
-        },
-        #[cfg(all(feature = "system_tts", target_os = "macos"))]
-        tts::voices::ResolvedVoice::AVSpeech { voice_id } => {
-            tts::EngineChoice::AVSpeech { voice_id }
-        }
-    };
-
-    let format = match resolve_output_format(
-        a.format.as_deref(),
-        a.bitrate,
-        a.sample_rate,
-        a.out.as_deref(),
-    ) {
-        Ok(f) => f,
-        Err(msg) => {
-            eprintln!("error: {msg}");
-            return 2;
-        }
-    };
-
-    let bytes = match tts::say(tts::SayOptions {
-        text: &text_joined,
-        lang: &espeak_lang,
-        engine,
-        ssml: a.ssml,
-        format,
-        expand_abbrev: !a.no_expand_abbrev,
-    }) {
-        Ok(w) => w,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return exit_code_for_tts_err(&e);
-        }
-    };
-
-    let write_result = match a.out {
-        Some(p) => std::fs::write(&p, &bytes).map_err(|e| e.to_string()),
-        None => std::io::stdout()
-            .write_all(&bytes)
-            .map_err(|e| e.to_string()),
-    };
-    if let Err(msg) = write_result {
-        eprintln!("error: write failed: {msg}");
-        return 4;
-    }
-    0
-}
-
 fn main() -> Result<()> {
     // Anchor the `KESHA_DEBUG=1` `+Nms` timeline before `Cli::parse()` so
     // clap parsing + env probes are counted toward the first `dtrace!`'s
@@ -427,30 +164,9 @@ fn main() -> Result<()> {
             vad,
             no_vad,
             speakers,
-        }) => {
-            if speakers && !json {
-                anyhow::bail!("--speakers requires --json");
-            }
-            let opts = transcribe::TranscribeOptions {
-                mode: transcribe::VadMode::from_flags(vad, no_vad),
-                with_segments: json,
-                with_speakers: speakers,
-            };
-            let output = transcribe::transcribe_with_options(&audio_path, &opts)?;
-            if json {
-                println!("{}", serde_json::to_string(&output)?);
-            } else {
-                println!("{}", output.text);
-            }
-        }
-        Some(Commands::DetectLang { audio_path }) => {
-            let result = lang_id::detect_audio_language(&audio_path)?;
-            println!("{}", serde_json::to_string(&result)?);
-        }
-        Some(Commands::DetectTextLang { text }) => {
-            let result = text_lang::detect_text_language(&text)?;
-            println!("{}", serde_json::to_string(&result)?);
-        }
+        }) => cli::transcribe::run(audio_path, json, vad, no_vad, speakers)?,
+        Some(Commands::DetectLang { audio_path }) => cli::detect_lang::run(audio_path)?,
+        Some(Commands::DetectTextLang { text }) => cli::detect_text_lang::run(text)?,
         Some(Commands::Install {
             no_cache,
             #[cfg(feature = "tts")]
@@ -459,76 +175,15 @@ fn main() -> Result<()> {
             #[cfg(feature = "system_diarize")]
             diarize,
             no_warmup,
-        }) => {
-            // Emit the "Model mirror active" banner once at the start of the
-            // install run, regardless of which subset of models the flags
-            // request. Push-down to `download_*` is more "magic" — each fn
-            // hides a stderr write behind its Ok(()) return.
-            models::init_mirror_logging();
-            models::install(no_cache)?;
+        }) => cli::install::run(
+            no_cache,
             #[cfg(feature = "tts")]
-            if tts {
-                models::download_tts(no_cache)?;
-                eprintln!("TTS models installed.");
-            }
-            if vad {
-                models::download_vad(no_cache)?;
-                eprintln!("VAD model installed.");
-            }
+            tts,
+            vad,
             #[cfg(feature = "system_diarize")]
-            if diarize {
-                models::download_diarize(no_cache)?;
-                eprintln!("Diarization model installed.");
-            }
-            // ASR backend warm-up: instantiate the backend once so the
-            // expensive cold-start work — Apple Neural Engine model-compile
-            // on CoreML (~20-30 s for Parakeet TDT 0.6B), ORT session init
-            // on the ONNX path (~500 ms) — happens HERE, during the install
-            // step where the user is already waiting on multi-GB downloads.
-            // After this, the first real `kesha audio.ogg` is fast because
-            // the macOS CoreML cache is keyed by (model bytes, signing
-            // identity); the identity is stable across runs of the same
-            // binary, so the warm cache survives until the next
-            // `kesha install` re-signs (#295).
-            //
-            // Drop the backend handle immediately — no need to keep it
-            // alive past install; the warm cache lives in the OS, not in
-            // this process.
-            if !no_warmup {
-                let asr_dir = models::model_dir(models::ModelKind::Asr)
-                    .to_string_lossy()
-                    .into_owned();
-                // Honest cost estimate per backend so the user knows what
-                // to expect during the pause. CoreML (macOS) pays the ANE
-                // compile (~20-30 s); ONNX (Linux/Windows + macOS without
-                // `coreml` feature) just loads an ORT session (~500 ms).
-                let cost_hint = if cfg!(feature = "coreml") {
-                    "one-time, ~20-30 s for the ANE compile on first install"
-                } else {
-                    "~500 ms for the ORT session init"
-                };
-                eprintln!("Warming up ASR backend ({cost_hint})...");
-                let t = std::time::Instant::now();
-                // Warm-up failures are NON-FATAL (Greptile P1 on #298).
-                // All models are already on disk; the install succeeded
-                // and the user can still run `kesha audio.ogg`. The first
-                // real invocation will pay the cold-start cost we were
-                // trying to hide, but that's strictly no-worse than the
-                // pre-#298 behavior. Surface the cause on stderr so the
-                // user can investigate (typically: ANE permission glitch,
-                // CoreML cache directory unwritable, transient ORT init
-                // hiccup).
-                match backend::create_backend(&asr_dir) {
-                    Ok(_) => eprintln!("ASR backend warmed up (dt={}ms).", t.elapsed().as_millis()),
-                    Err(e) => eprintln!(
-                        "warning: ASR backend warm-up failed ({e}); install \
-                         still complete but the first `kesha audio.ogg` will \
-                         pay the cold-start cost."
-                    ),
-                }
-            }
-            eprintln!("Install complete.");
-        }
+            diarize,
+            no_warmup,
+        )?,
         #[cfg(feature = "tts")]
         Some(Commands::Say {
             text,
@@ -546,7 +201,7 @@ fn main() -> Result<()> {
             stdin_loop,
             no_expand_abbrev,
         }) => {
-            std::process::exit(run_say(SayArgs {
+            std::process::exit(cli::say::run(cli::say::SayArgs {
                 text,
                 voice,
                 lang,

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -179,8 +179,12 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
         ));
     }
 
-    let format =
-        crate::resolve_output_format(req.format.as_deref(), req.bitrate, req.sample_rate, None)?;
+    let format = crate::cli::say::resolve_output_format(
+        req.format.as_deref(),
+        req.bitrate,
+        req.sample_rate,
+        None,
+    )?;
     let resolved =
         tts::voices::resolve_voice(&models::cache_dir(), &req.voice).map_err(|e| e.to_string())?;
     let espeak_lang: &str = req


### PR DESCRIPTION
## Summary

`main.rs` was 574 LOC mixing clap derive defs, three list-voices helpers, the 133-LOC `run_say` body, and the install warm-up logic. After this PR it's 207 LOC and contains only the `Cli` parser + `Commands` enum + `main()` dispatch table — matching the audit's \"thin parse + dispatch\" shape and mirroring the TS-side `src/cli/*` layout.

Pure mechanical file split. Zero behaviour change at the CLI surface or in the public Rust API; all subcommand outputs, exit codes, and clap help text identical.

## New module structure

- `rust/src/cli/mod.rs` — façade `pub mod` declarations only.
- `rust/src/cli/say.rs` (262 LOC) — `SayArgs`, `run_say` (→ `pub fn run`), `list_kokoro_voices`, `list_vosk_ru_voices`, `exit_code_for_tts_err`, and `resolve_output_format` (still `pub(crate)`; `say_loop.rs` calls through to it via the new path).
- `rust/src/cli/install.rs` (81 LOC) — `pub fn run(no_cache, tts, vad, diarize, no_warmup)` carrying the model-download + ASR-backend warm-up body. Conditional fields stay `#[cfg(feature = \"…\")]`-gated as before.
- `rust/src/cli/transcribe.rs` (21 LOC) — `pub fn run(audio_path, json, vad, no_vad, speakers)`.
- `rust/src/cli/detect_lang.rs` (9 LOC) — `pub fn run(audio_path)`.
- `rust/src/cli/detect_text_lang.rs` (9 LOC) — `pub fn run(text)`.

## What stays in `main.rs`

- `debug::init()` runs **before** `Cli::parse()` (anchors the dtrace! `+Nms` timeline; Greptile P2 on #293 fixed exactly this ordering).
- `--capabilities-json` early-return (no subcommand reach).
- A 5-arm `match cli.command` that hands every subcommand off to `cli::<sub>::run(...)`.
- `Commands` enum + per-arm clap attributes (kept inline so all clap derive definitions live next to the parser).

## say_loop change

`say_loop.rs` updated to call `crate::cli::say::resolve_output_format` instead of the previous `crate::resolve_output_format`. Same function, new path.

## Verification

- [x] `cargo nextest run --features tts` → **449 tests pass**, 0 skipped.
- [x] `cargo clippy --all-targets --features tts -- -D warnings` clean.
- [x] `cargo fmt --check` clean (rustfmt rewrapped `resolve_output_format` call in say_loop.rs across 5 lines + `cli/transcribe.rs::run` parameters onto one line — both stylistic, non-semantic).
- [x] `cargo build --features tts` clean.
- [ ] `cargo check --features coreml,tts --no-default-features` fails on a local Swift-toolchain issue inside `fluidaudio-rs` build.rs that reproduces on `main` without these changes; CI's macos-14 + pinned Xcode 16.2 handles it cleanly via rust-test.yml.

## Stat

```
 rust/src/cli/detect_lang.rs      |   9 +
 rust/src/cli/detect_text_lang.rs |   9 +
 rust/src/cli/install.rs          |  81 +++++++++
 rust/src/cli/mod.rs              |  12 ++
 rust/src/cli/say.rs              | 262 +++++++++++++++++++++++++++
 rust/src/cli/transcribe.rs       |  21 +++
 rust/src/main.rs                 | 369 ++-------------------------------------
 rust/src/say_loop.rs             |   8 +-
```

`main.rs` -359 LOC; the rest is module boilerplate + the bodies moved verbatim.

This is the third and final F-finding from #267 — closing the audit (P0 + actionable P1 + actionable P2 all shipped):

- P0: F1 (#270), F2 (#269), F3+F10+F13 (#268)
- P1: F4 (#273), F5 (#309), F6 (this PR), F7 (#271), F8 (#272 colocation + #308 integration move)
- P2: F9 (#287/#288/#289)
- P2 deferred: F14 (CLAUDE.md split) — opportunistic, tracked as a follow-up
- Surfaced during audit, tracked separately: warn-once bucket bug (`tts/warn.rs:33-36`) → follow-up issue

Refs #267