### PR TITLE
fix(tts/warn): reset warn-once scope per stdin-loop request (#311, #313 F15)

### DIFF
--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -167,6 +167,12 @@ pub fn run() -> i32 {
 }
 
 fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
+    // Reset the per-process warn-once scope so each request gets a fresh
+    // dedup baseline. Without this, a long-lived `--stdin-loop` process
+    // would silently swallow the second occurrence of any warning that
+    // had already fired earlier in its lifetime (#267 F15 / #311).
+    tts::warn::reset();
+
     // Apply the same input guards as one-shot tts::say(): empty + length cap.
     if req.text.is_empty() {
         return Err("text is empty".into());

--- a/rust/src/tts/warn.rs
+++ b/rust/src/tts/warn.rs
@@ -1,31 +1,33 @@
-//! Per-process warn-once helper.
+//! Scoped warn-once helper.
 //!
 //! Engine-agnostic: called from the SSML parser (`tts::ssml`), the Russian-
 //! Vosk normalization, and the Kokoro / Vosk defensive arms in `tts::say`.
-//! Emits a single stderr line per `key` per process. Two key shapes are
-//! supported via the relaxed `&str` signature:
+//! Emits a single stderr line per `key` per **scope**. A scope is bounded by:
+//!
+//! - one-shot CLI process — implicit (the process exits before a second
+//!   call could repeat); historical behavior.
+//! - one `say_loop::handle()` request — explicit, via [`reset()`] at the
+//!   top of each request, so a user feeding the same SSML twice over
+//!   the `--stdin-loop` protocol sees the warning twice. Without this,
+//!   long-lived processes silently swallowed the second invocation
+//!   (#267 F15 / #311).
+//!
+//! Two key shapes are supported via the relaxed `&str` signature:
 //!
 //! - **Constant keys** (e.g. `WARN_PROSODY_MID_UTTERANCE`) — preferred. The
-//!   set of distinct warnings is bounded; one allocation per process.
+//!   set of distinct warnings is bounded; one allocation per scope.
 //! - **Dynamic keys** (e.g. `phoneme[alphabet=x-sampa]`, `say-as[interpret-as=cardinal]`,
 //!   `unknown-tag-paragraph`) — used by SSML's open-ended attribute spaces.
-//!   One allocation per *unique* combination across the process lifetime.
+//!   One allocation per *unique* combination per scope.
 //!
 //! Lock poisoning is treated as fatal — at that point another thread panicked
 //! while holding the lock and the process is in an unrecoverable state.
 //!
-//! **Test-isolation caveat** (Greptile P2 on #284): the backing `HashSet` is a
-//! `static OnceLock`, so any key inserted by one `#[test]` persists for the
-//! whole process. Today's tests in this module use synthetic keys
-//! (`test-warn-once-key-*`) that don't collide with production keys, but the
-//! `tts::ssml::tests` block runs in the same `cargo test --lib` process and
-//! WILL insert real SSML warn keys (`prosody-mid-utterance`, `say-as[...]`,
-//! `phoneme[alphabet=...]`, etc.) into the shared set. A future test that
-//! asserts a key is *absent* before calling `parse()`, or that counts how
-//! many times a particular warning fires within a single test, would be
-//! order-dependent. If that comes up, add a `#[cfg(test)] pub(crate) fn
-//! reset_for_test()` here and call it in the test's `setUp` — don't try
-//! to work around it from the test side.
+//! **Test isolation:** `cargo nextest run` spawns a fresh process per test
+//! and gets the empty-scope baseline automatically. For `cargo test --lib`
+//! (single-process runner) test authors who need a clean scope inside one
+//! test can call [`reset()`] in the test's setup; the function is
+//! `pub(crate)` for this purpose.
 
 use std::collections::HashSet;
 use std::sync::{Mutex, OnceLock};
@@ -56,6 +58,21 @@ pub(crate) fn was_warned(key: &str) -> bool {
         .lock()
         .expect("was_warned: mutex poisoned")
         .contains(key)
+}
+
+/// Clear the warn-once scope. Subsequent `warn_once(key, msg)` calls for
+/// any previously-seen key will fire again. Called by `say_loop::handle`
+/// at the top of every request so each `--stdin-loop` invocation gets a
+/// fresh dedup scope (#267 F15 / #311). Safe to call concurrently with
+/// `warn_once` — the same Mutex serializes both.
+///
+/// `dead_code` is silenced because `say_loop` only links into the
+/// `kesha-engine` bin target, not into `lib.rs`'s library facade. The
+/// library target's only consumer is the test block above (`reset` is
+/// exercised by `reset_clears_the_scope_so_subsequent_warns_fire_again`).
+#[allow(dead_code)]
+pub(crate) fn reset() {
+    warned().lock().expect("reset: mutex poisoned").clear();
 }
 
 #[cfg(test)]
@@ -94,5 +111,25 @@ mod tests {
         let set = warned().lock().unwrap();
         assert!(set.contains("test-warn-once-key-2a"));
         assert!(set.contains("test-warn-once-key-2b"));
+    }
+
+    #[test]
+    fn reset_clears_the_scope_so_subsequent_warns_fire_again() {
+        // Use a key unique to this test so it doesn't collide with the dedup
+        // tests above when run in a shared process (cargo test --lib).
+        let key = "test-warn-once-reset-key";
+        warn_once(key, "first fire — should record the key");
+        assert!(was_warned(key), "key should be recorded after first warn");
+
+        reset();
+        assert!(
+            !was_warned(key),
+            "reset() should clear the scope, but key is still present"
+        );
+
+        // After reset, a second warn_once with the same key fires again
+        // (inserts into the cleared set).
+        warn_once(key, "second fire — should re-record after reset");
+        assert!(was_warned(key), "key should be recorded after second warn");
     }
 }

--- a/rust/tests/tts_ru_normalize.rs
+++ b/rust/tests/tts_ru_normalize.rs
@@ -354,7 +354,9 @@ fn emphasis_warn_fires_per_request_in_stdin_loop() {
     let mut eng = match LoopEngine::spawn() {
         Some(e) => e,
         None => {
-            eprintln!("skipping emphasis_warn_fires_per_request_in_stdin_loop: vosk-ru models not staged");
+            eprintln!(
+                "skipping emphasis_warn_fires_per_request_in_stdin_loop: vosk-ru models not staged"
+            );
             return;
         }
     };

--- a/rust/tests/tts_ru_normalize.rs
+++ b/rust/tests/tts_ru_normalize.rs
@@ -340,21 +340,27 @@ fn emphasis_marker_shifts_stress() {
     );
 }
 
-/// Issue #237 — verify that `warn_once("emphasis-no-plus", ...)` is
-/// deduplicated across multiple SSML calls within the same engine process.
-/// The stdin-loop daemon shares one Vosk session AND one warn-once HashSet,
-/// so multiple bad inputs must produce ONE stderr line, not N.
+/// Issue #237, updated by #267 F15 / #311 — verify that
+/// `warn_once("emphasis-no-plus", ...)` fires ONCE PER REQUEST in the
+/// stdin-loop daemon. The original #237 spec was "one stderr line total
+/// across all calls" because the warn-once HashSet was process-scoped;
+/// that turned out to silently swallow the second + third occurrence of
+/// the same bug, which is the opposite of what the user wants when they
+/// keep sending bad SSML over a long-lived `--stdin-loop` session
+/// (#311). The fix in `say_loop::handle` calls `tts::warn::reset` at
+/// the top of each request, so each call gets a fresh dedup scope.
 #[test]
-fn emphasis_warn_once_dedups_across_calls() {
+fn emphasis_warn_fires_per_request_in_stdin_loop() {
     let mut eng = match LoopEngine::spawn() {
         Some(e) => e,
         None => {
-            eprintln!("skipping emphasis_warn_once_dedups_across_calls: vosk-ru models not staged");
+            eprintln!("skipping emphasis_warn_fires_per_request_in_stdin_loop: vosk-ru models not staged");
             return;
         }
     };
 
-    // Three calls without `+` markers — should fire warn_once exactly once.
+    // Three calls without `+` markers — each call resets the warn scope,
+    // so the warning should fire three times (once per request).
     let _ = eng.synth(r#"<speak><emphasis>обычно</emphasis></speak>"#, true, false);
     let _ = eng.synth(
         r#"<speak><emphasis>другое слово</emphasis></speak>"#,
@@ -377,7 +383,7 @@ fn emphasis_warn_once_dedups_across_calls() {
         .count();
 
     assert_eq!(
-        warn_count, 1,
-        "expected exactly one emphasis-no-plus warning across 3 calls, got {warn_count}.\nstderr:\n{stderr}"
+        warn_count, 3,
+        "expected one emphasis-no-plus warning PER request (3 total across 3 calls), got {warn_count}.\nstderr:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Closes **#311**, first ship of #313 P0 bucket (F15).

`tts::warn::warn_once(key, msg)` deduplicated warnings against a global `OnceLock<Mutex<HashSet<String>>>` that never reset. For the one-shot CLI this is invisible — the process exits before a second call could repeat. But `kesha say --stdin-loop` is a long-lived daemon that handles many requests in one process: a user feeding the same bad SSML twice would see the warning fire once for request #1 and silently nothing for request #2..N.

## Fix

- **`tts/warn.rs`** — new `pub(crate) fn reset()` clears the HashSet under the existing Mutex. `#[allow(dead_code)]` because `say_loop` (the only production caller) only links into the `kesha-engine` bin target, not `lib.rs`'s library facade.
- **Module doc** — reworded from \"Per-process warn-once\" to \"Scoped warn-once\" with explicit one-shot-CLI vs stdin-loop-request scope definitions. Test-isolation caveat folded into the same prose since `cargo nextest run` provides fresh-process isolation per test.
- **`say_loop.rs::handle`** — calls `tts::warn::reset()` at the top of every request.
- **New unit test** — `reset_clears_the_scope_so_subsequent_warns_fire_again` using a unique key so it doesn't collide with the existing dedup tests in `cargo test --lib`.
- **`tts_ru_normalize.rs`** — renamed `emphasis_warn_once_dedups_across_calls` → `emphasis_warn_fires_per_request_in_stdin_loop` and flipped the assertion from \"expect 1 warning total\" to \"expect 3 warnings (one per request)\". The original test encoded the pre-fix bugged behavior as spec; the actually-desired behavior per #311 is the operator hearing about every broken request.

## Verification

- [x] `cargo nextest run --features tts --bin kesha-engine -- warn::` → 3/3 (dedup, multiple-keys, new reset test).
- [x] `cargo nextest run --features tts --test tts_ru_normalize -- emphasis_warn` → 1/1 (~27 s, Vosk warm-load).
- [x] `cargo nextest run --features tts` → **418 tests pass**, 0 skipped, 3 slow.
- [x] `cargo clippy --all-targets --features tts -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

## Behaviour change

User-visible for `--stdin-loop` users: more stderr output for repeated bad SSML inputs. The one-shot CLI surface is identical (scope was already process-wide; still process-wide for a process that exits after one synth/transcribe call).

## Reviewers' takeaways landed

- **Mara Bos**'s F15 (warn-once lifecycle): scope is now visible at the API level — `reset()` makes the per-call boundary explicit instead of buried in the process-lifetime contract.
- **Andrew Gallant**'s F15 (dedup at wrong layer): partially. We still dedup inside the library; the call-site can now flush it explicitly between batches. The fuller \"print everything, let the user filter\" stance is out-of-scope for this PR.

Refs #311, #267 F15, #313 P0