### PR TITLE
chore(ci): version-drift check across package.json + Cargo.toml (#313 F16)

### DIFF
--- a/.github/scripts/check-versions.ts
+++ b/.github/scripts/check-versions.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+/**
+ * Verify the three version sources stay aligned (#267 F16 / #313 P0):
+ *
+ *   - `package.json#version`              — npm-published CLI version
+ *   - `package.json#keshaEngine.version`  — engine binary version the CLI
+ *                                            downloads from GitHub Releases
+ *   - `rust/Cargo.toml#version`           — engine crate version
+ *
+ * The release runbook in CLAUDE.md bumps all three by hand and reviewers
+ * verify they agree. A silent drift between (b) and (c) means `kesha install`
+ * downloads a release that doesn't match the source the engine was built
+ * from — exactly the v1.1.0 incident where TTS shipped without being in the
+ * build matrix.
+ *
+ * Rules enforced:
+ *
+ *   1. `keshaEngine.version === Cargo.toml#version`. These two are the
+ *      "engine version" — the npm CLI uses (b) to pick the release tag,
+ *      and (c) is the source-of-truth on what `cargo build` produces. They
+ *      MUST match.
+ *
+ *   2. `package.json#version >= keshaEngine.version`. CLI-only patches
+ *      (docs, TS fix, plugin tweak) bump (a) ahead of (b) per the
+ *      "CLI AND ENGINE ARE VERSIONED INDEPENDENTLY" rule in CLAUDE.md.
+ *      Engine releases bump (a) in lockstep. Either way (a) is >= (b).
+ *
+ * Exit 0 on success (no output). Exit 1 on any rule violation, printing
+ * the offending values and the rule that was broken. Designed to be the
+ * cheapest possible pre-push / CI guard — no deps beyond the bun runtime.
+ *
+ * Run: `bun .github/scripts/check-versions.ts` (or `bun run check:versions`
+ * via package.json + `make versions`).
+ */
+import { readFileSync } from "node:fs";
+
+type SemVer = { major: number; minor: number; patch: number };
+
+function parseSemver(raw: string, label: string): SemVer {
+  const m = raw.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) {
+    console.error(`${label}: not a plain x.y.z semver (got '${raw}')`);
+    process.exit(1);
+  }
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+function cmp(a: SemVer, b: SemVer): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+function fmt(v: SemVer): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+const pkgRaw = JSON.parse(readFileSync("package.json", "utf8"));
+const cargoToml = readFileSync("rust/Cargo.toml", "utf8");
+
+// `version = "..."` inside the [package] table is the first `version = ` in
+// the file. Anchor the regex to the literal column-zero `version` so we
+// don't accidentally pick up a workspace-member's version or a dependency
+// version specifier inside a `[dependencies]` table.
+const cargoVersionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"$/m);
+if (!cargoVersionMatch) {
+  console.error("rust/Cargo.toml: missing top-level `version = \"x.y.z\"`");
+  process.exit(1);
+}
+
+const cli = parseSemver(pkgRaw.version, "package.json#version");
+const engine = parseSemver(
+  pkgRaw.keshaEngine?.version ?? "",
+  "package.json#keshaEngine.version",
+);
+const cargo = parseSemver(cargoVersionMatch[1], "rust/Cargo.toml#version");
+
+let failed = false;
+
+// Rule 1: engine.version === cargo#version
+if (cmp(engine, cargo) !== 0) {
+  console.error(
+    `rule 1 violated: package.json#keshaEngine.version (${fmt(engine)}) ` +
+      `must equal rust/Cargo.toml#version (${fmt(cargo)}). ` +
+      `The npm CLI uses keshaEngine.version to pick a GitHub Release tag; ` +
+      `Cargo.toml drives what's actually compiled. If they disagree, ` +
+      `\`kesha install\` downloads a binary that doesn't match the source.`,
+  );
+  failed = true;
+}
+
+// Rule 2: cli.version >= engine.version
+if (cmp(cli, engine) < 0) {
+  console.error(
+    `rule 2 violated: package.json#version (${fmt(cli)}) must be >= ` +
+      `package.json#keshaEngine.version (${fmt(engine)}). ` +
+      `CLI version is allowed to lead engine version for CLI-only patches ` +
+      `(see CLAUDE.md → "CLI AND ENGINE ARE VERSIONED INDEPENDENTLY"), ` +
+      `but it must never lag behind.`,
+  );
+  failed = true;
+}
+
+if (failed) {
+  console.error(
+    `\nResolved sources:\n  package.json#version:              ${fmt(cli)}\n  package.json#keshaEngine.version: ${fmt(engine)}\n  rust/Cargo.toml#version:          ${fmt(cargo)}`,
+  );
+  process.exit(1);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,12 @@ jobs:
               - 'package.json'
               - 'bun.lock'
               - 'tsconfig.json'
+              # `rust/Cargo.toml` is in the SUPERSET filter so the
+              # version-drift check (#267 F16) always fires on a
+              # Cargo-only version bump PR. Without it, `unit-tests`
+              # skipped entirely and the drift merged undetected
+              # (Greptile P1 on #315).
+              - 'rust/Cargo.toml'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
             integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: bunx tsc --noEmit
 
+      - name: 🔢 Check version drift (package.json + Cargo.toml)
+        if: matrix.os == 'ubuntu-latest'
+        run: bun run check:versions
+
       - name: 🔬 Type check (tsgo / TS 7 preview, advisory)
         if: matrix.os == 'ubuntu-latest'
         continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,11 @@ If the spike persists into project work, ask which env tool the user wants (uv, 
 
 `package.json#version` (CLI) and `package.json#keshaEngine.version` (engine, mirrored in `rust/Cargo.toml`) are **decoupled**. `src/engine-install.ts` downloads from `v${keshaEngine.version}`, falling back to `package.json#version`.
 
+CI gates against silent drift via `bun .github/scripts/check-versions.ts` (also `bun run check:versions` or `make versions` locally — runs in `ci.yml`'s "🔢 Check version drift" step on ubuntu, fast-fails before any test job). Two rules enforced (#267 F16):
+
+1. **`keshaEngine.version === rust/Cargo.toml#version`** — these are the same number, just stored twice. Drift here means `kesha install` downloads a release that doesn't match the source. (See "BUILD-ENGINE FEATURE MATRIX MIRRORS CARGO DEFAULTS" below for the v1.1.0 incident this guards against.)
+2. **`package.json#version >= keshaEngine.version`** — CLI is allowed to lead the engine for CLI-only patches but must never lag.
+
 **CLI-only patch** (docs, TS fix, plugin tweak):
 
 1. Bump only `package.json#version`. Leave `keshaEngine.version` and `rust/Cargo.toml` alone.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test unit integration rust-test lint lint-tsgo smoke-test release publish help
+.PHONY: install test unit integration rust-test lint lint-tsgo versions smoke-test release publish help
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -22,6 +22,9 @@ lint: ## Type-check with tsc
 
 lint-tsgo: ## Type-check with tsgo (TypeScript 7 native preview, advisory)
 	bunx tsgo --noEmit
+
+versions: ## Check version drift between package.json + Cargo.toml (#267 F16)
+	bun .github/scripts/check-versions.ts
 
 smoke-test: ## Run smoke tests against fixtures
 	bun link @drakulavich/kesha-voice-kit

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint": "bunx tsc --noEmit",
     "lint:tsgo": "bunx tsgo --noEmit",
     "check:workflows": "bun .github/scripts/check-workflows.ts",
+    "check:versions": "bun .github/scripts/check-versions.ts",
     "postinstall": "node scripts/postinstall.cjs"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Second ship of #313 P0 bucket (F16). Catches silent drift between the three version sources the release runbook bumps in lockstep by hand:

- `package.json#version` — npm-published CLI version
- `package.json#keshaEngine.version` — engine binary release tag the CLI fetches from GitHub Releases
- `rust/Cargo.toml#version` — engine crate version

The \"BUILD-ENGINE FEATURE MATRIX MIRRORS CARGO DEFAULTS\" callout in CLAUDE.md already documents the v1.1.0 incident where TTS shipped without being in the build matrix; this PR adds the version-drift counterpart.

## Rules enforced

1. **`package.json#keshaEngine.version === rust/Cargo.toml#version`** — drift here means `kesha install` downloads a release that doesn't match what `cargo build` produced.
2. **`package.json#version >= package.json#keshaEngine.version`** — CLI is allowed to lead engine version for CLI-only patches (per the \"CLI AND ENGINE ARE VERSIONED INDEPENDENTLY\" rule) but must never lag behind.

## Mechanics

- **`.github/scripts/check-versions.ts`** (109 LOC, bun-only) — no deps beyond `node:fs`. Single-purpose `parseSemver` + tuple `cmp` to keep the script standalone and reviewable.
- **`package.json#scripts.check:versions`** — `bun .github/scripts/check-versions.ts`.
- **`Makefile`** — new `make versions` target.
- **`.github/workflows/ci.yml`** — new \"🔢 Check version drift\" step in the unit-tests job, ubuntu-latest only, runs after type-check (~50 ms, fail-fast pre-test gate).
- **`CLAUDE.md`** — callout under RELEASE PROCESS naming both rules and cross-referencing the v1.1.0 build-matrix incident.

## Verification

- [x] `bun run check:versions` against current main state (all three at 1.16.0): PASS.
- [x] Drift scenarios exercised against a `/tmp` scratch repo:
  - CLI > engine, Cargo bumped without keshaEngine.version → rule 1 FAIL.
  - CLI < engine → rule 2 FAIL.
  - engine ≠ Cargo → rule 1 FAIL.
  - CLI-only patch (CLI 1.17.0, engine == Cargo == 1.16.0) → PASS.
- [x] `bun .github/scripts/check-workflows.ts` — ci.yml still parses.

## Test plan

- [ ] CI on this PR: the new \"🔢 Check version drift\" step appears in the unit-tests job and passes.
- [ ] Optional: deliberately push a follow-up commit that bumps only `package.json#version` (mimicking a CLI-only patch) and verify the check still passes.
- [ ] Greptile review verdict ≥ 4/5.

Refs #267 F16, #313 P0