### PR TITLE
chore(lib): declare no-public-API contract + publish=false (#313 F17)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,6 +3,10 @@ name = "kesha-engine"
 version = "1.16.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
+# Not for crates.io. The library target (`src/lib.rs`) exists only for the
+# in-tree integration tests; the binary (`src/main.rs`) is the public
+# surface and ships via GitHub Releases. See #267 F17 / #313 P0.
+publish = false
 
 [lib]
 name = "kesha_engine"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,31 @@
-//! Library surface for integration tests. Modules are also compiled into the
-//! `kesha-engine` binary — cargo handles the dual targets.
+//! Internal library target for in-crate consumers only — **NOT a public Rust API**.
+//!
+//! # No library contract
+//!
+//! `kesha-engine` ships as two artifacts:
+//!
+//! 1. The `kesha-engine` binary at `src/main.rs` — the public surface.
+//!    All real consumers go through this via the npm `kesha` CLI
+//!    wrapper, the OpenClaw plugin, or direct subprocess invocation.
+//! 2. This library target (`src/lib.rs`) — exists **only** so the
+//!    integration tests at `rust/tests/*.rs` can `use kesha_engine::*`
+//!    without spawning a subprocess for every assertion.
+//!
+//! There is **no semver promise** on any `pub` symbol in this crate.
+//! There is no CHANGELOG, no deprecation cycle, no stability gate.
+//! The modules below may be renamed, removed, restructured, or have
+//! their function signatures changed in any release — patch, minor, or
+//! major — without warning, because the only Rust callers are inside
+//! this repository.
+//!
+//! If you find this crate on crates.io: that's a mistake (the package
+//! is `publish = false`). If you need a stable Rust API to consume
+//! kesha-engine programmatically, please file an issue at
+//! <https://github.com/drakulavich/kesha-voice-kit/issues> — designing
+//! a public API contract is a separate decision that hasn't been made.
+//!
+//! See #267 F17 / #313 P0 for the audit thread that produced this
+//! disclaimer.
 
 pub mod audio;
 pub mod debug;


### PR DESCRIPTION
## Summary

Third (and final) ship of #313 P0 bucket. `rust/src/lib.rs` exposed five modules (`audio`, `debug`, `models`, `util`, `tts`) with no documented stability contract. The audit channelled Niko Matsakis + Carol Nichols asking \"is this library or not?\" — the actual answer is \"not, but the test harness needs it\". This PR declares that explicitly.

## Approach: withdrawal by documentation

The audit's \"rename `lib.rs` to `_internal.rs` + cfg-gate\" option would break the integration-test consume path (`rust/tests/*.rs` use `kesha_engine::*`) without a real win — anyone fork-and-depending could trivially work around it. Chose the lighter shape:

- **`rust/Cargo.toml`** — `publish = false` added to `[package]`. Structural guard against accidental `cargo publish`. Comment cross-references the lib.rs disclaimer.
- **`rust/src/lib.rs`** — rewrote the top-of-file doc-comment with an explicit \"no library contract\" prose block:
  - States the binary is the public surface; lib is for in-tree integration tests only.
  - \"No semver promise on any `pub` symbol\" + \"no CHANGELOG\" + \"no deprecation cycle\".
  - Cross-link to filing an issue for anyone who wants a stable Rust API — explicitly NOT promising one.

Zero code reshaping. Integration tests still import `kesha_engine::*` unchanged.

## Verification

- [x] `cargo build --features tts` clean.
- [x] `cargo clippy --all-targets --features tts -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo nextest run --features tts --test ssml_integration --test audio_format` → 36/36 pass.

## Closes #313 P0 bucket

With #314 (F15 warn-once lifecycle) and #315 (F16 version-drift check), this completes the three-finding P0 sweep from the audit. P1 + P2 remain in #313 for follow-up.

Refs #267 F17, #313 P0