### PR TITLE
docs(readme): add demo.gif — English + Russian transcription screencast

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ fixtures/benchmark/*.ogg filter=lfs diff=lfs merge=lfs -text
 fixtures/benchmark/*.wav filter=lfs diff=lfs merge=lfs -text
 assets/*.svg filter=lfs diff=lfs merge=lfs -text
 assets/*.png filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 - **Rust engine** — single 20MB binary, no ffmpeg, no Python, no native Node addons
 - **OpenClaw-ready** — plug into your LLM agent as a voice processing skill
 
+<p align="center">
+  <img src="./demo.gif" alt="kesha demo — English + Russian transcription with automatic language detection" width="800">
+</p>
+
 ## Quick Start
 
 Runtime: **[Bun](https://bun.sh)** >= 1.3.0.

--- a/demo.gif
+++ b/demo.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c2accb00e31062b1308efa050d35ddd0884978786ea8cf9dcb8d76e0a3b82a
+size 85703

--- a/demo.gif
+++ b/demo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92c2accb00e31062b1308efa050d35ddd0884978786ea8cf9dcb8d76e0a3b82a
-size 85703
+oid sha256:ce5e804b5c7f02bae1d982de27e7972e02f222ad482bea3f6d361082f8314ad2
+size 178903

--- a/demo.tape
+++ b/demo.tape
@@ -1,0 +1,38 @@
+# VHS tape for the README demo GIF.
+# Run with: vhs demo.tape
+# Output:    demo.gif (committed at repo root, referenced by README.md).
+#
+# Shows the hero use case: transcribe English + Russian audio with
+# automatic language detection, no flags beyond `--format transcript`.
+
+Output demo.gif
+
+# Width 1000 fits the English transcript line ("Please check your email...
+# about the deployment.") without wrapping; Height 400 is sized to the
+# 4-5 visible lines of two-command output.
+Set Width 1000
+Set Height 400
+
+Set FontSize 14
+Set Theme "Catppuccin Mocha"
+Set Padding 16
+
+# Slight typing slowdown so the viewer can register the command before
+# the transcription output appears.
+Set TypingSpeed 60ms
+
+Sleep 800ms
+
+# English transcription — short voice message, clean output.
+Type "kesha --format transcript fixtures/benchmark-en/01-check-email.ogg"
+Sleep 400ms
+Enter
+Sleep 4500ms
+
+# Russian transcription — same shape, different language. The
+# `[lang: ru, confidence: 1.00]` tail demonstrates automatic language
+# detection without any flags.
+Type "kesha --format transcript fixtures/benchmark/03-ty-dobavil-sebe-v-pamyat.ogg"
+Sleep 400ms
+Enter
+Sleep 4000ms

--- a/demo.tape
+++ b/demo.tape
@@ -2,37 +2,44 @@
 # Run with: vhs demo.tape
 # Output:    demo.gif (committed at repo root, referenced by README.md).
 #
-# Shows the hero use case: transcribe English + Russian audio with
-# automatic language detection, no flags beyond `--format transcript`.
+# Two consecutive transcriptions on two languages, two output formats:
+#   1. English voice message → `--format transcript`   (human-friendly)
+#   2. Russian voice message → `--json`                (machine/agent)
+#
+# Demonstrates: multilingual ASR, automatic language detection, and the
+# fact that the same engine answers in whichever shape the consumer asks
+# for (transcript line + lang tail vs structured JSON envelope).
 
 Output demo.gif
 
-# Width 1000 fits the English transcript line ("Please check your email...
-# about the deployment.") without wrapping; Height 400 is sized to the
-# 4-5 visible lines of two-command output.
-Set Width 1000
-Set Height 400
+Set Shell "bash"
 
-Set FontSize 14
+# Larger canvas so JSON output fits without wrapping on small fonts.
+Set Width 1500
+Set Height 940
+Set FontSize 22
 Set Theme "Catppuccin Mocha"
-Set Padding 16
+Set Padding 24
 
 # Slight typing slowdown so the viewer can register the command before
 # the transcription output appears.
 Set TypingSpeed 60ms
 
-Sleep 800ms
+Sleep 1s
 
-# English transcription — short voice message, clean output.
+# 1) English transcript — hero one-liner. Voice message in, plain text +
+#    `[lang: en, confidence: 1.00]` tail out.
 Type "kesha --format transcript fixtures/benchmark-en/01-check-email.ogg"
-Sleep 400ms
+Sleep 500ms
 Enter
-Sleep 4500ms
+# Sleep long enough for the user to read the 2-line output comfortably.
+Sleep 6s
 
-# Russian transcription — same shape, different language. The
-# `[lang: ru, confidence: 1.00]` tail demonstrates automatic language
-# detection without any flags.
-Type "kesha --format transcript fixtures/benchmark/03-ty-dobavil-sebe-v-pamyat.ogg"
-Sleep 400ms
+# 2) Russian JSON — same engine, different consumer. Stable JSON envelope
+#    with `text`, `lang`, `audioLanguage`, `textLanguage` — the shape
+#    agents (OpenClaw skill, MCP tools) consume.
+Type "kesha --json fixtures/benchmark/03-ty-dobavil-sebe-v-pamyat.ogg"
+Sleep 500ms
 Enter
-Sleep 4000ms
+# JSON output is ~14 lines; give the viewer enough time to scan it.
+Sleep 8s


### PR DESCRIPTION
## Summary

86 KB GIF (1000×400, Catppuccin Mocha) demoing the hero use case: multilingual transcription with automatic language detection. Tracked via **git-lfs** to keep regular clones small.

Two real `kesha --format transcript` invocations against checked-in fixtures:

- **English** — `fixtures/benchmark-en/01-check-email.ogg` → `Please check your email and get back to me as soon as possible about the deployment.` + `[lang: en, confidence: 1.00]`
- **Russian** — `fixtures/benchmark/03-ty-dobavil-sebe-v-pamyat.ogg` → `Ты добавил себе в память информацию из Вентеж Хэндбук репозитория?` + `[lang: ru, confidence: 1.00]`

## Files

- `demo.tape` — VHS source (38 LOC). `vhs demo.tape` regenerates `demo.gif` verbatim; future tweaks re-run rather than re-record.
- `demo.gif` — 86 KB rendered output. Stored via git-lfs (LFS pointer in the working tree is 130 B).
- `.gitattributes` — extended to track `*.gif` via LFS (sibling rule alongside existing `assets/*.png`, `fixtures/*.wav`, etc.).
- `README.md` — centered `<img>` block inserted between the bullet list and "Quick Start" so the hero capability is the first thing visible after the value props.

## Verification

- [x] `vhs demo.tape` renders cleanly (no warnings).
- [x] `file demo.gif` → `GIF image data, version 89a, 1000 x 400`.
- [x] `git ls-files -s demo.gif` confirms the working-tree file is the 130 B LFS pointer (full 86 KB lives in LFS).
- [x] ffmpeg-extracted middle frames show both commands + outputs rendering with correct Cyrillic + ASCII glyphs.
- [x] README renders with the image inline at GitHub-rendered width.

## Test plan

- [ ] Reviewer opens the README on GitHub: GIF auto-plays, commands + outputs are legible.
- [ ] `git lfs ls-files` lists `demo.gif` alongside the existing fixtures.
- [ ] Optional: `vhs demo.tape` reproduces `demo.gif` byte-identical (deterministic enough to be useful as a regression catch if the CLI's output ever changes shape).