### PR TITLE
refactor(transcribe): typestate builder for TranscribeOptions (F18)

### DIFF
--- a/rust/src/cli/transcribe.rs
+++ b/rust/src/cli/transcribe.rs
@@ -1,15 +1,20 @@
 use anyhow::Result;
 
-use crate::transcribe;
+use crate::transcribe::{self, TranscribeOptionsBuilder, VadMode};
 
 pub fn run(audio_path: String, json: bool, vad: bool, no_vad: bool, speakers: bool) -> Result<()> {
     if speakers && !json {
         anyhow::bail!("--speakers requires --json");
     }
-    let opts = transcribe::TranscribeOptions {
-        mode: transcribe::VadMode::from_flags(vad, no_vad),
-        with_segments: json,
-        with_speakers: speakers,
+    let mode = VadMode::from_flags(vad, no_vad);
+    let opts = if json {
+        let mut b = TranscribeOptionsBuilder::new().vad(mode).with_segments();
+        if speakers {
+            b = b.with_speakers();
+        }
+        b.build()
+    } else {
+        TranscribeOptionsBuilder::new().vad(mode).build()
     };
     let output = transcribe::transcribe_with_options(&audio_path, &opts)?;
     if json {

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(all(feature = "system_diarize", target_os = "macos"))]
 pub(crate) mod diarize;
+mod options;
+
+pub use options::TranscribeOptionsBuilder;
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -93,6 +96,11 @@ pub struct TranscriptionOutput {
 /// `transcribe_output_with_speakers`) that grew with each new flag (#267 F5).
 ///
 /// New flags should land here as fields, not as a new top-level wrapper.
+///
+/// Prefer [`TranscribeOptionsBuilder`] over direct struct construction —
+/// the builder lifts the `with_speakers => with_segments` constraint into
+/// the type system (F18). The runtime [`anyhow::ensure!`] guard inside
+/// [`transcribe_with_options`] still fires on direct misuse.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TranscribeOptions {
     /// VAD preprocessing selector (Auto / On / Off).

--- a/rust/src/transcribe/options.rs
+++ b/rust/src/transcribe/options.rs
@@ -1,0 +1,149 @@
+//! Type-state builder for [`TranscribeOptions`] (F18).
+//!
+//! The runtime guard in [`super::transcribe_with_options`] (`anyhow::ensure!`)
+//! catches `with_speakers && !with_segments` at the API boundary. The
+//! builder lifts that constraint into the type system: `with_speakers()`
+//! is only callable in the `WithSegments` state, so the misuse becomes
+//! a compile error at every call site that goes through the builder.
+//!
+//! The runtime guard stays in place as defence-in-depth — direct struct
+//! construction (the public fields are still public) bypasses the
+//! builder. Closes the type-state half of the #290 follow-up; the
+//! `anyhow::ensure!` half remains.
+
+use std::marker::PhantomData;
+
+use super::{TranscribeOptions, VadMode};
+
+pub mod marker {
+    /// Builder state: segments not yet enabled. `with_speakers()` is unavailable.
+    pub struct NoSegments;
+    /// Builder state: segments enabled. `with_speakers()` is available.
+    pub struct WithSegments;
+}
+
+/// Type-state builder for [`TranscribeOptions`]. Start with
+/// [`TranscribeOptionsBuilder::new`] and chain `vad`, `with_segments`,
+/// `with_speakers` in any order — `with_speakers` is only available
+/// after the `with_segments` transition.
+#[derive(Debug)]
+pub struct TranscribeOptionsBuilder<S = marker::NoSegments> {
+    mode: VadMode,
+    with_speakers: bool,
+    _state: PhantomData<S>,
+}
+
+impl Default for TranscribeOptionsBuilder<marker::NoSegments> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TranscribeOptionsBuilder<marker::NoSegments> {
+    /// Start a new builder. Defaults match [`TranscribeOptions::default`]:
+    /// `VadMode::Auto`, no segments, no speakers.
+    pub fn new() -> Self {
+        Self {
+            mode: VadMode::Auto,
+            with_speakers: false,
+            _state: PhantomData,
+        }
+    }
+
+    /// Override the VAD preprocessing mode.
+    pub fn vad(mut self, mode: VadMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Transition to the `WithSegments` state: per-utterance segments
+    /// will be populated. Required before `with_speakers` becomes available.
+    pub fn with_segments(self) -> TranscribeOptionsBuilder<marker::WithSegments> {
+        TranscribeOptionsBuilder {
+            mode: self.mode,
+            with_speakers: false,
+            _state: PhantomData,
+        }
+    }
+
+    /// Finalise into a [`TranscribeOptions`] with text-only output.
+    pub fn build(self) -> TranscribeOptions {
+        TranscribeOptions {
+            mode: self.mode,
+            with_segments: false,
+            with_speakers: false,
+        }
+    }
+}
+
+impl TranscribeOptionsBuilder<marker::WithSegments> {
+    /// Enable speaker diarization labels on each segment. Only callable
+    /// in the `WithSegments` state — the type-state mirrors the runtime
+    /// `anyhow::ensure!` guard in [`super::transcribe_with_options`].
+    pub fn with_speakers(mut self) -> Self {
+        self.with_speakers = true;
+        self
+    }
+
+    /// Finalise into a [`TranscribeOptions`] with segments enabled
+    /// (and speakers if [`Self::with_speakers`] was called).
+    pub fn build(self) -> TranscribeOptions {
+        TranscribeOptions {
+            mode: self.mode,
+            with_segments: true,
+            with_speakers: self.with_speakers,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_new_matches_struct_default() {
+        let from_builder = TranscribeOptionsBuilder::new().build();
+        let from_default = TranscribeOptions::default();
+        assert_eq!(from_builder.mode, from_default.mode);
+        assert_eq!(from_builder.with_segments, from_default.with_segments);
+        assert_eq!(from_builder.with_speakers, from_default.with_speakers);
+    }
+
+    #[test]
+    fn no_segments_path_produces_text_only_options() {
+        let opts = TranscribeOptionsBuilder::new().vad(VadMode::Off).build();
+        assert_eq!(opts.mode, VadMode::Off);
+        assert!(!opts.with_segments);
+        assert!(!opts.with_speakers);
+    }
+
+    #[test]
+    fn with_segments_alone_keeps_speakers_off() {
+        let opts = TranscribeOptionsBuilder::new()
+            .vad(VadMode::On)
+            .with_segments()
+            .build();
+        assert_eq!(opts.mode, VadMode::On);
+        assert!(opts.with_segments);
+        assert!(!opts.with_speakers);
+    }
+
+    #[test]
+    fn with_speakers_after_with_segments_enables_both() {
+        let opts = TranscribeOptionsBuilder::new()
+            .with_segments()
+            .with_speakers()
+            .build();
+        assert!(opts.with_segments);
+        assert!(opts.with_speakers);
+    }
+
+    #[test]
+    fn default_impl_matches_new() {
+        let from_default: TranscribeOptionsBuilder = TranscribeOptionsBuilder::default();
+        let opts = from_default.build();
+        assert_eq!(opts.mode, VadMode::Auto);
+        assert!(!opts.with_segments);
+        assert!(!opts.with_speakers);
+    }
+}

--- a/rust/src/transcribe/options.rs
+++ b/rust/src/transcribe/options.rs
@@ -77,6 +77,22 @@ impl TranscribeOptionsBuilder<marker::NoSegments> {
 }
 
 impl TranscribeOptionsBuilder<marker::WithSegments> {
+    /// Override the VAD preprocessing mode. Mirrors the same method on
+    /// the `NoSegments` state so call-site ordering doesn't matter:
+    /// `Builder::new().with_segments().vad(VadMode::On)` produces the
+    /// same options as `Builder::new().vad(VadMode::On).with_segments()`.
+    /// Greptile P2 on #318.
+    ///
+    /// `#[allow(dead_code)]` because today's only call site
+    /// (`cli/transcribe.rs::run`) chains `vad()` BEFORE `with_segments()`
+    /// — the method exists for ergonomics + symmetry with the
+    /// `NoSegments` impl, not for an existing consumer.
+    #[allow(dead_code)]
+    pub fn vad(mut self, mode: VadMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
     /// Enable speaker diarization labels on each segment. Only callable
     /// in the `WithSegments` state — the type-state mirrors the runtime
     /// `anyhow::ensure!` guard in [`super::transcribe_with_options`].
@@ -145,5 +161,26 @@ mod tests {
         assert_eq!(opts.mode, VadMode::Auto);
         assert!(!opts.with_segments);
         assert!(!opts.with_speakers);
+    }
+
+    #[test]
+    fn vad_is_callable_in_both_states_with_identical_results() {
+        // `vad()` is available before AND after `with_segments()`. Greptile
+        // P2 on #318 flagged the original "only NoSegments has vad()"
+        // as a foot-gun; lock the order-independence in.
+        let pre = TranscribeOptionsBuilder::new()
+            .vad(VadMode::On)
+            .with_segments()
+            .with_speakers()
+            .build();
+        let post = TranscribeOptionsBuilder::new()
+            .with_segments()
+            .vad(VadMode::On)
+            .with_speakers()
+            .build();
+        assert_eq!(pre.mode, VadMode::On);
+        assert_eq!(post.mode, VadMode::On);
+        assert!(pre.with_segments && post.with_segments);
+        assert!(pre.with_speakers && post.with_speakers);
     }
 }

--- a/rust/src/transcribe/options.rs
+++ b/rust/src/transcribe/options.rs
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 
 use super::{TranscribeOptions, VadMode};
 
-pub mod marker {
+pub(crate) mod marker {
     /// Builder state: segments not yet enabled. `with_speakers()` is unavailable.
     pub struct NoSegments;
     /// Builder state: segments enabled. `with_speakers()` is available.


### PR DESCRIPTION
## Summary

Lifts the `with_speakers => with_segments` constraint from a runtime `anyhow::ensure!` (#290 P1) into the type system via a phantom-typed builder.

- `TranscribeOptionsBuilder<NoSegments>::with_speakers()` is **not defined** — the misuse becomes a compile error at every call site that goes through the builder.
- `TranscribeOptionsBuilder<WithSegments>::with_speakers()` is available — that's the only path where speaker labels are well-defined.
- One-way state transition: `with_segments()` consumes `Builder<NoSegments>` and returns `Builder<WithSegments>`. No way to "turn segments off" after enabling speakers.

The runtime `anyhow::ensure!` guard in `transcribe_with_options` stays in place as defence-in-depth: the public fields on `TranscribeOptions` are still public, and direct struct construction bypasses the builder. The existing `transcribe_with_options_rejects_speakers_without_segments` test continues to pin that contract.

`cli/transcribe.rs` is migrated to the builder so the construction site exercises the new type-state path. The pre-existing `if speakers && !json { bail!(...) }` guard in the CLI is preserved (clap-level → builder is downstream of it).

## Test plan

- [ ] CI: `cargo test transcribe::options` covers the new 5 unit tests (default match, segments-without-speakers, segments+speakers, vad propagation, default impl)
- [ ] CI: `transcribe_with_options_rejects_speakers_without_segments` still pins the runtime guard
- [ ] Local: `cargo fmt --check` and `cargo clippy --all-targets --features tts -- -D warnings` pass (verified)
- [ ] Note: local `cargo test` blocked by ort-sys download (network sandbox) — relying on CI for the runtime check

Refs #290 (the runtime guard introduced by the original Greptile P1 finding).

https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2)_