### PR TITLE
refactor(audio): normalize symphonia hint extension to lowercase (F21)

### DIFF
--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -24,6 +24,27 @@ fn get_codec_registry() -> CodecRegistry {
     registry
 }
 
+/// Build a [`Hint`] from a file path's extension, normalised to lowercase.
+///
+/// Symphonia's internal extension matching is case-insensitive today,
+/// but normalising at the boundary is a defensive zero-cost guard
+/// against an upstream contract change. Inputs like `recording.OGG`
+/// from Windows downloads or `.M4A` from a screen-recorder export
+/// continue to probe correctly even if symphonia tightens the match.
+///
+/// Returns an empty [`Hint`] when the path has no extension or the
+/// extension is non-UTF-8.
+fn build_hint(path: &str) -> Hint {
+    let mut hint = Hint::new();
+    if let Some(ext) = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+    {
+        hint.with_extension(&ext.to_ascii_lowercase());
+    }
+    hint
+}
+
 /// Open `path`, probe format + select the first supported audio track.
 /// Shared by `decode_audio` and `probe_duration_seconds` so container
 /// detection + error messages live in one place.
@@ -31,13 +52,7 @@ fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameter
     let src = std::fs::File::open(path).with_context(|| format!("file not found: {path}"))?;
     let mss = MediaSourceStream::new(Box::new(src), Default::default());
 
-    let mut hint = Hint::new();
-    if let Some(ext) = std::path::Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-    {
-        hint.with_extension(ext);
-    }
+    let hint = build_hint(path);
 
     let mut probe = Probe::default();
     symphonia::default::register_enabled_formats(&mut probe);

--- a/rust/tests/audio_format.rs
+++ b/rust/tests/audio_format.rs
@@ -56,3 +56,27 @@ fn ensure_audio_track_accepts_isomp4_aac_fixture() {
         "expected Some duration for the silence.m4a fixture, got None"
     );
 }
+
+#[test]
+fn ensure_audio_track_accepts_uppercase_extension() {
+    // F21: `build_hint` lowercases the extension before handing it to
+    // symphonia. Symphonia's matching is case-insensitive today, but
+    // normalising at the boundary is a defensive zero-cost guard. This
+    // test pins the normalisation: copy the m4a fixture to a tempfile
+    // with `.M4A` (uppercase) and verify probe still succeeds. If a
+    // future refactor drops the lowercase pass and symphonia tightens
+    // its matching upstream, this test goes red.
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("silence.m4a");
+    let tmp = tempfile::Builder::new()
+        .prefix("kesha-uppercase-ext-")
+        .suffix(".M4A")
+        .tempfile()
+        .expect("create tempfile with uppercase extension");
+    std::fs::copy(&fixture, tmp.path()).expect("copy fixture into uppercase tempfile");
+
+    audio::ensure_audio_track(tmp.path().to_str().unwrap())
+        .expect("uppercase .M4A extension should still probe successfully");
+}


### PR DESCRIPTION
## Summary

Extracts the inline `Hint` construction in `audio::open_format` into a small `build_hint(path)` helper and lowercases the extension before handing it to symphonia.

- Symphonia's extension matching is case-insensitive today, but normalising at the boundary is a defensive zero-cost guard against an upstream contract change.
- Single point to extend later (e.g. `Hint::with_mime_type` for the FluidAudio temp-WAV path) when we need to.
- Inputs like `recording.OGG` (Windows downloads) or `.M4A` (screen-recorder exports) continue to probe correctly even if symphonia tightens its match.

## Test plan

- [ ] New regression test `ensure_audio_track_accepts_uppercase_extension` copies the existing `silence.m4a` fixture to a tempfile with `.M4A` and verifies `ensure_audio_track` succeeds
- [ ] Existing `ensure_audio_track_accepts_isomp4_aac_fixture` continues to pass (no behaviour change on lowercase path)
- [ ] Local: `cargo fmt --check` and `cargo clippy --all-targets --features tts -- -D warnings` pass (verified)

https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2)_