### PR TITLE
refactor(tests): extract shared helpers into tests/common (F20)

### DIFF
--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,0 +1,86 @@
+//! Shared helpers for the integration tests under `rust/tests/*.rs`.
+//!
+//! Cargo compiles each `tests/*.rs` into its own test binary, and treats
+//! `tests/<name>.rs` as one of those binaries — so this module lives at
+//! `tests/common/mod.rs` (not `tests/common.rs`) to avoid being built as
+//! a standalone test target.
+//!
+//! Each test file opts in via `mod common;` at its top. Not every file
+//! uses every helper, so `#![allow(dead_code)]` keeps the per-binary
+//! `unused` lint quiet without wrapping each helper individually.
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+/// Path to the freshly-built `kesha-engine` binary as embedded by cargo via
+/// `env!("CARGO_BIN_EXE_kesha-engine")`. Use directly with
+/// [`std::process::Command::new`] — `Command::new` accepts `&str`.
+pub fn engine_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_kesha-engine")
+}
+
+/// `KOKORO_MODEL` + `KOKORO_VOICE` env-var skip gate.
+///
+/// Returns `Some((model, voice))` when both vars are set, `None` otherwise.
+/// The historical pattern: tests that need a real Kokoro model + voice file
+/// skip silently on CI runs that don't stage them. Callers print the skip
+/// reason themselves so each test owns its own message.
+pub fn kokoro_paths_or_skip() -> Option<(String, String)> {
+    match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
+        (Ok(m), Ok(v)) => Some((m, v)),
+        _ => None,
+    }
+}
+
+/// Cache-based skip gate for Kokoro: returns the cache base
+/// (`KESHA_CACHE_DIR` if set, else `~/.cache/kesha`) when both
+/// `models/kokoro-82m/model.onnx` and the default male voice
+/// `models/kokoro-82m/voices/am_michael.bin` are present. Returns
+/// `None` otherwise.
+///
+/// Default voice is the male `am_michael` per CLAUDE.md
+/// "DEFAULT TTS VOICES MUST BE MALE".
+pub fn kokoro_cache_dir_or_skip() -> Option<PathBuf> {
+    let base = cache_base();
+    let model = base.join("models/kokoro-82m/model.onnx");
+    let voice = base.join("models/kokoro-82m/voices/am_michael.bin");
+    if model.exists() && voice.exists() {
+        Some(base)
+    } else {
+        None
+    }
+}
+
+/// Cache-based skip gate for Vosk-RU: returns the cache base
+/// (`KESHA_CACHE_DIR` if set, else `~/.cache/kesha`) when all three
+/// runtime files (`model.onnx`, `dictionary`, `bert/model.onnx`) are
+/// present under `models/vosk-ru`. Returns `None` otherwise.
+///
+/// Returning the base (rather than the model dir) lets callers both
+/// reuse it as `KESHA_CACHE_DIR` for child processes AND derive the
+/// model dir via `.join("models/vosk-ru")`.
+pub fn vosk_ru_cache_dir_or_skip() -> Option<PathBuf> {
+    let base = cache_base();
+    let model_dir = base.join("models/vosk-ru");
+    if model_dir.join("model.onnx").exists()
+        && model_dir.join("dictionary").exists()
+        && model_dir.join("bert/model.onnx").exists()
+    {
+        Some(base)
+    } else {
+        None
+    }
+}
+
+/// Resolve the cache base used by every cache-based skip gate.
+/// `KESHA_CACHE_DIR` if set, else `$HOME/.cache/kesha`. Falls back to
+/// `/tmp/.cache/kesha` if `HOME` is unset (matches the historical
+/// behaviour of the per-test helpers we're replacing).
+fn cache_base() -> PathBuf {
+    if let Ok(dir) = std::env::var("KESHA_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home).join(".cache/kesha")
+}

--- a/rust/tests/diarize_e2e.rs
+++ b/rust/tests/diarize_e2e.rs
@@ -15,15 +15,13 @@
 
 #![cfg(feature = "system_diarize")]
 
+mod common;
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn engine_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_kesha-engine"))
-}
-
-fn say(exe: &Path, text: &str, voice: &str, out: &Path) -> bool {
-    Command::new(exe)
+fn say(text: &str, voice: &str, out: &Path) -> bool {
+    Command::new(common::engine_bin())
         .args(["say", "--voice", voice, "--out", out.to_str().unwrap()])
         .arg(text)
         .status()
@@ -60,7 +58,7 @@ fn concat_wavs(inputs: &[PathBuf], out: &Path) {
 
 #[test]
 fn two_speaker_dialogue_yields_two_clusters() {
-    let exe = engine_binary();
+    let exe = PathBuf::from(common::engine_bin());
     if !exe.exists() {
         eprintln!("skipping: engine binary not found at {}", exe.display());
         return;
@@ -81,17 +79,14 @@ fn two_speaker_dialogue_yields_two_clusters() {
     // sufficiently different voices for diarization to cluster them apart, and an
     // American male + American female pair satisfies that constraint cleanly.
     if !say(
-        &exe,
         "Hello everyone, this is the first speaker beginning the call.",
         "en-am_michael",
         &p1a,
     ) || !say(
-        &exe,
         "Hi, this is the second speaker responding now.",
         "en-af_heart",
         &p2,
     ) || !say(
-        &exe,
         "Yes thanks for joining, the first speaker again.",
         "en-am_michael",
         &p1b,

--- a/rust/tests/tts_e2e.rs
+++ b/rust/tests/tts_e2e.rs
@@ -3,18 +3,17 @@
 
 #![cfg(feature = "tts")]
 
+mod common;
+
 use std::path::Path;
 
 use kesha_engine::tts::{self, EngineChoice, OutputFormat, SayOptions, TtsError};
 
 #[test]
 fn kokoro_hello_world_produces_wav() {
-    let (model, voice) = match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => (m, v),
-        _ => {
-            eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
-            return;
-        }
+    let Some((model, voice)) = common::kokoro_paths_or_skip() else {
+        eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
+        return;
     };
     let wav = tts::say(SayOptions {
         text: "Hello, world",
@@ -74,12 +73,9 @@ fn too_long_errors() {
 
 #[test]
 fn kokoro_ssml_with_break_produces_wav() {
-    let (model, voice) = match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => (m, v),
-        _ => {
-            eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
-            return;
-        }
+    let Some((model, voice)) = common::kokoro_paths_or_skip() else {
+        eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
+        return;
     };
     let wav = tts::say(SayOptions {
         text: r#"<speak>Hello <break time="300ms"/> world</speak>"#,

--- a/rust/tests/tts_en_normalize.rs
+++ b/rust/tests/tts_en_normalize.rs
@@ -10,37 +10,10 @@
 
 #![cfg(feature = "tts")]
 
+mod common;
+
 use std::io::{Read, Write};
-use std::path::PathBuf;
 use std::process::{Command, Stdio};
-
-// =============================================================================
-// Skip gate
-// =============================================================================
-
-/// Return the Kokoro model path if the required runtime files are present;
-/// otherwise return None so callers can skip gracefully.
-///
-/// Strategy: use KESHA_CACHE_DIR when set (matches CI / local dev fixture
-/// layout), otherwise fall back to the default `~/.cache/kesha`. This mirrors
-/// what `models::cache_dir()` does in production.
-fn kokoro_model_path_or_skip() -> Option<PathBuf> {
-    let base = if let Ok(dir) = std::env::var("KESHA_CACHE_DIR") {
-        PathBuf::from(dir)
-    } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        PathBuf::from(home).join(".cache/kesha")
-    };
-
-    let model = base.join("models/kokoro-82m/model.onnx");
-    let voice = base.join("models/kokoro-82m/voices/am_michael.bin");
-
-    if model.exists() && voice.exists() {
-        Some(base)
-    } else {
-        None
-    }
-}
 
 // =============================================================================
 // stdin-loop engine wrapper
@@ -65,9 +38,8 @@ impl KokoroLoopEngine {
     /// Spawn the engine subprocess. Returns `None` when the Kokoro models are
     /// not installed (same skip gate as the other Kokoro tests).
     fn spawn() -> Option<Self> {
-        kokoro_model_path_or_skip()?;
-        let bin = env!("CARGO_BIN_EXE_kesha-engine");
-        let mut child = Command::new(bin)
+        common::kokoro_cache_dir_or_skip()?;
+        let mut child = Command::new(common::engine_bin())
             .args(["say", "--voice", "en-am_michael", "--stdin-loop"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/rust/tests/tts_prosody_rate.rs
+++ b/rust/tests/tts_prosody_rate.rs
@@ -6,15 +6,13 @@
 
 #![cfg(feature = "tts")]
 
-use std::path::{Path, PathBuf};
+mod common;
+
+use std::path::Path;
 use std::process::Command;
 
-fn engine_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_kesha-engine"))
-}
-
 fn say_ssml(voice: &str, ssml: &str, out: &Path) -> bool {
-    Command::new(engine_binary())
+    Command::new(common::engine_bin())
         .args([
             "say",
             "--voice",
@@ -111,7 +109,7 @@ fn macos_prosody_rate_ssml_rejected() {
         .unwrap();
     let out = tmp.path().join("macos.wav");
     let ssml = r#"<speak><prosody rate="fast">Hello there.</prosody></speak>"#;
-    let result = Command::new(engine_binary())
+    let result = Command::new(common::engine_bin())
         .args([
             "say",
             "--voice",

--- a/rust/tests/tts_ru_normalize.rs
+++ b/rust/tests/tts_ru_normalize.rs
@@ -12,6 +12,8 @@
 
 #![cfg(feature = "tts")]
 
+mod common;
+
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -21,35 +23,6 @@ use kesha_engine::tts::{self, EngineChoice, OutputFormat, SayOptions};
 // =============================================================================
 // Shared helpers
 // =============================================================================
-
-/// Return the vosk-ru model dir if the required runtime files are present;
-/// otherwise return None so callers can skip gracefully.
-///
-/// Strategy: use KESHA_CACHE_DIR when set (matches CI / local dev fixture
-/// layout), otherwise fall back to the default `~/.cache/kesha`. This mirrors
-/// what `models::vosk_ru_model_dir()` does in production — no staging copy
-/// needed because these tests are read-only.
-fn vosk_model_dir_or_skip() -> Option<PathBuf> {
-    let base = if let Ok(dir) = std::env::var("KESHA_CACHE_DIR") {
-        PathBuf::from(dir)
-    } else {
-        // Same logic as models::cache_dir() for the default path.
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        PathBuf::from(home).join(".cache/kesha")
-    };
-
-    let model_dir = base.join("models/vosk-ru");
-
-    // Mirror models::is_vosk_ru_cached() — keep gates aligned.
-    if model_dir.join("model.onnx").exists()
-        && model_dir.join("dictionary").exists()
-        && model_dir.join("bert/model.onnx").exists()
-    {
-        Some(model_dir)
-    } else {
-        None
-    }
-}
 
 /// Cold synthesis via `tts::say()` — kept for direct-call regression coverage.
 fn synth_cold(text: &str, ssml: bool, expand_abbrev: bool, model_dir: &PathBuf) -> Vec<u8> {
@@ -94,8 +67,7 @@ impl LoopEngine {
     /// Spawn the engine subprocess. Returns `None` when the vosk-ru models
     /// are not installed (same skip gate as the cold-path tests).
     fn spawn() -> Option<Self> {
-        vosk_model_dir_or_skip()?;
-        let bin = env!("CARGO_BIN_EXE_kesha-engine");
+        common::vosk_ru_cache_dir_or_skip()?;
         // Capture stderr to a tempfile so tests can assert warn-once dedup. (#237)
         let stderr_path = std::env::temp_dir().join(format!(
             "kesha-loop-test-{}-{}.stderr.log",
@@ -106,7 +78,7 @@ impl LoopEngine {
                 .unwrap_or(0),
         ));
         let stderr_file = std::fs::File::create(&stderr_path).expect("create stderr log");
-        let mut child = Command::new(bin)
+        let mut child = Command::new(common::engine_bin())
             .args(["say", "--voice", "ru-vosk-m02", "--stdin-loop"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -210,15 +182,13 @@ impl Drop for LoopEngine {
 /// ФСБ has no vowels → always spells.
 #[test]
 fn auto_expand_plain_fsb_is_longer_than_noexpand() {
-    let model_dir = match vosk_model_dir_or_skip() {
-        Some(d) => d,
-        None => {
-            eprintln!(
-                "skipping auto_expand_plain_fsb_is_longer_than_noexpand: vosk-ru models not found"
-            );
-            return;
-        }
+    let Some(base) = common::vosk_ru_cache_dir_or_skip() else {
+        eprintln!(
+            "skipping auto_expand_plain_fsb_is_longer_than_noexpand: vosk-ru models not found"
+        );
+        return;
     };
+    let model_dir = base.join("models/vosk-ru");
 
     let expanded = synth_cold(
         "ФСБ", /*ssml=*/ false, /*expand_abbrev=*/ true, &model_dir,

--- a/rust/tests/tts_smoke.rs
+++ b/rust/tests/tts_smoke.rs
@@ -1,11 +1,12 @@
 #![cfg(feature = "tts")]
 
+mod common;
+
 use std::process::Command;
 
 #[test]
 fn capabilities_advertises_tts() {
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .arg("--capabilities-json")
         .output()
         .expect("run");
@@ -19,8 +20,7 @@ fn capabilities_advertises_tts() {
 
 #[test]
 fn install_has_tts_flag() {
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .args(["install", "--help"])
         .output()
         .expect("run");
@@ -34,8 +34,7 @@ fn install_has_tts_flag() {
 
 #[test]
 fn say_subcommand_exists() {
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .args(["say", "--help"])
         .output()
         .expect("run");
@@ -51,15 +50,11 @@ fn say_subcommand_exists() {
 
 #[test]
 fn say_with_explicit_paths_produces_wav() {
-    let (model, voice) = match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => (m, v),
-        _ => {
-            eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
-            return;
-        }
+    let Some((model, voice)) = common::kokoro_paths_or_skip() else {
+        eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
+        return;
     };
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .args([
             "say",
             "Hello, world",
@@ -88,18 +83,14 @@ fn say_with_explicit_paths_produces_wav() {
 
 #[test]
 fn say_reads_stdin_when_no_positional() {
-    let (model, voice) = match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => (m, v),
-        _ => {
-            eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
-            return;
-        }
+    let Some((model, voice)) = common::kokoro_paths_or_skip() else {
+        eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
+        return;
     };
     use std::io::Write;
     use std::process::Stdio;
 
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let mut child = Command::new(bin)
+    let mut child = Command::new(common::engine_bin())
         .args([
             "say",
             "--model",
@@ -131,8 +122,7 @@ fn say_reads_stdin_when_no_positional() {
 
 #[test]
 fn empty_text_exits_2() {
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .args([
             "say",
             "",
@@ -154,8 +144,7 @@ fn empty_text_exits_2() {
 #[test]
 fn missing_voice_in_cache_exits_1_with_install_hint() {
     let tmp = tempfile::tempdir().unwrap();
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .env("KESHA_CACHE_DIR", tmp.path())
         .args(["say", "Hi"])
         .output()
@@ -175,12 +164,9 @@ fn missing_voice_in_cache_exits_1_with_install_hint() {
 
 #[test]
 fn resolves_from_cache_when_installed() {
-    let (model, voice) = match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => (m, v),
-        _ => {
-            eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
-            return;
-        }
+    let Some((model, voice)) = common::kokoro_paths_or_skip() else {
+        eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
+        return;
     };
     // misaki-rs is embedded — no G2P model cache required post-#213.
     let tmp = tempfile::tempdir().unwrap();
@@ -194,8 +180,7 @@ fn resolves_from_cache_when_installed() {
     // run-cargo-test.sh now points at am_michael.bin.
     std::fs::copy(&voice, voices_dir.join("am_michael.bin")).unwrap();
 
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .env("KESHA_CACHE_DIR", tmp.path())
         .env("DYLD_FALLBACK_LIBRARY_PATH", "/opt/homebrew/lib")
         .args(["say", "Hello"])
@@ -212,8 +197,7 @@ fn resolves_from_cache_when_installed() {
 #[test]
 fn list_voices_empty_on_fresh_cache() {
     let tmp = tempfile::tempdir().unwrap();
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .env("KESHA_CACHE_DIR", tmp.path())
         .args(["say", "--list-voices"])
         .output()
@@ -232,8 +216,7 @@ fn list_voices_shows_installed() {
     let voices_dir = tmp.path().join("models/kokoro-82m/voices");
     std::fs::create_dir_all(&voices_dir).unwrap();
     std::fs::write(voices_dir.join("af_heart.bin"), b"").unwrap();
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .env("KESHA_CACHE_DIR", tmp.path())
         .args(["say", "--list-voices"])
         .output()
@@ -248,9 +231,8 @@ fn list_voices_shows_installed() {
 
 #[test]
 fn text_too_long_exits_5() {
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
     let huge = "a".repeat(10_000);
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .args([
             "say",
             &huge,
@@ -272,10 +254,9 @@ fn text_too_long_exits_5() {
 #[test]
 fn synthesis_failure_exits_4() {
     // Missing model file at runtime -> SynthesisFailed -> exit 4
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
     let voice_tmp = tempfile::NamedTempFile::new().unwrap();
     std::fs::write(voice_tmp.path(), vec![0u8; 510 * 256 * 4]).unwrap();
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .args([
             "say",
             "Hi",
@@ -296,16 +277,12 @@ fn synthesis_failure_exits_4() {
 
 #[test]
 fn say_writes_to_file_with_out_flag() {
-    let (model, voice) = match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => (m, v),
-        _ => {
-            eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
-            return;
-        }
+    let Some((model, voice)) = common::kokoro_paths_or_skip() else {
+        eprintln!("skipping: set KOKORO_MODEL + KOKORO_VOICE");
+        return;
     };
     let tmp = tempfile::NamedTempFile::new().unwrap();
-    let bin = env!("CARGO_BIN_EXE_kesha-engine");
-    let out = Command::new(bin)
+    let out = Command::new(common::engine_bin())
         .args([
             "say",
             "Hi",

--- a/rust/tests/tts_stdin_loop.rs
+++ b/rust/tests/tts_stdin_loop.rs
@@ -13,8 +13,10 @@
 
 #![cfg(feature = "tts")]
 
+mod common;
+
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::time::Duration;
 
@@ -62,8 +64,7 @@ impl LoopChild {
     }
 
     fn spawn_with_cache(cache_dir: Option<&std::path::Path>) -> Self {
-        let bin = env!("CARGO_BIN_EXE_kesha-engine");
-        let mut cmd = Command::new(bin);
+        let mut cmd = Command::new(common::engine_bin());
         // Stderr is `null` so ORT runtime warnings can't fill a 64 KB pipe
         // we never drain — that would deadlock the engine on its next write
         // and the test would hang forever waiting for a frame.
@@ -156,32 +157,6 @@ fn unknown_voice_returns_err_frame_with_request_id() {
 // Real synthesis (gated on env vars set by run_smoke_tests / smoke harness)
 // ---------------------------------------------------------------------------
 
-fn kokoro_paths() -> Option<(String, String)> {
-    match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => Some((m, v)),
-        _ => None,
-    }
-}
-
-fn vosk_cache_dir_or_skip() -> Option<PathBuf> {
-    let base = if let Ok(dir) = std::env::var("KESHA_CACHE_DIR") {
-        PathBuf::from(dir)
-    } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        PathBuf::from(home).join(".cache/kesha")
-    };
-
-    let model_dir = base.join("models/vosk-ru");
-    if model_dir.join("model.onnx").exists()
-        && model_dir.join("dictionary").exists()
-        && model_dir.join("bert/model.onnx").exists()
-    {
-        Some(base)
-    } else {
-        None
-    }
-}
-
 fn synth_vosk_reference(text: &str, ssml: bool, model_dir: &Path) -> Vec<u8> {
     tts::say(SayOptions {
         text,
@@ -206,7 +181,7 @@ fn loop_synthesises_kokoro_and_caches_session() {
     // (`$KESHA_CACHE_DIR/models/kokoro-82m/{model.onnx,voices/am_michael.bin}`)
     // and point the spawned engine at it. Same approach as
     // `tts_smoke.rs::resolves_from_cache_when_installed`.
-    let Some((model, voice)) = kokoro_paths() else {
+    let Some((model, voice)) = common::kokoro_paths_or_skip() else {
         eprintln!("skipping: KOKORO_MODEL + KOKORO_VOICE not set");
         return;
     };
@@ -258,7 +233,7 @@ fn loop_synthesises_kokoro_and_caches_session() {
 
 #[test]
 fn loop_applies_russian_acronym_normalization_for_vosk() {
-    let Some(cache_dir) = vosk_cache_dir_or_skip() else {
+    let Some(cache_dir) = common::vosk_ru_cache_dir_or_skip() else {
         eprintln!("skipping: vosk-ru models not found");
         return;
     };


### PR DESCRIPTION
## Summary

Three patterns were duplicated across the integration test suite:

1. `env!("CARGO_BIN_EXE_kesha-engine")` — repeated literally in 6 of the 11 test binaries (often multiple times per file), sometimes wrapped in a local `engine_binary() -> PathBuf` helper.
2. The `KOKORO_MODEL` + `KOKORO_VOICE` env-var skip gate — copied verbatim in 3 test binaries.
3. The `KESHA_CACHE_DIR` / `HOME`-fallback "is the model installed?" check for Kokoro and Vosk-RU — duplicated across 4 test binaries with subtle return-type differences (some returned the cache base, others the model dir).

Moves all three into `rust/tests/common/mod.rs` (the path is required — `tests/common.rs` would be built as a separate test binary by cargo) and migrates the 7 affected test files. Per-test duplication drops by ~117 lines (182 deletions vs 65 insertions on test files; the helper module adds ~85 lines).

**No behaviour changes.** Every helper preserves the historical skip condition exactly. The `vosk_ru_cache_dir_or_skip` helper returns the cache base (the strictly-more-powerful shape); the one caller that previously consumed only the model dir derives it via `.join("models/vosk-ru")` at the call site.

## Helpers

- `engine_bin() -> &'static str`
- `kokoro_paths_or_skip() -> Option<(String, String)>` (env-based)
- `kokoro_cache_dir_or_skip() -> Option<PathBuf>` (cache-based)
- `vosk_ru_cache_dir_or_skip() -> Option<PathBuf>` (cache-based)

The `LoopChild` / `KokoroLoopEngine` / `LoopEngine` wrappers in `tts_stdin_loop.rs` / `tts_en_normalize.rs` / `tts_ru_normalize.rs` are intentionally **not** extracted — they have subtle test-specific differences (stderr capture vs null, voice id, struct fields). Extraction can land in a follow-up if the duplication becomes a real maintenance burden.

## Test plan

- [ ] CI: `cargo nextest list` produces the same test list before/after (no test names changed)
- [ ] CI: `cargo nextest run --features tts` stays green
- [ ] Local: `cargo fmt --check` and `cargo clippy --all-targets --features tts -- -D warnings` pass (verified)

https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2)_