### PR TITLE
feat(debug): NDJSON dtrace events on dedicated fd via KESHA_DEBUG_FD (F19)

### DIFF
--- a/rust/src/debug.rs
+++ b/rust/src/debug.rs
@@ -165,25 +165,46 @@ fn json_sink() -> Option<&'static Mutex<File>> {
     None
 }
 
+/// Returns `true` when [`trace_json`] would write to a configured sink.
+///
+/// Public so the [`dtrace_json!`] macro can short-circuit the
+/// `serde_json::json!` allocation when the sink is inactive — matching
+/// the zero-heap-allocation contract of the text-path [`dtrace!`]
+/// macro (Greptile P2 on #321).
+pub fn json_sink_is_active() -> bool {
+    json_sink().is_some()
+}
+
 /// Emit one structured NDJSON event to the JSON sink, if configured.
 ///
 /// `event` is the dotted event name (e.g. `"asr.backend_loaded"`).
-/// `fields` is a JSON object built with [`serde_json::json!`] —
-/// arbitrary serialisable shape. Two reserved keys are added by the
+/// `fields` MUST be a [`serde_json::Value::Object`] — a non-object
+/// payload trips a `debug_assert!` in dev/test builds and is coerced
+/// to an empty map in release. Two reserved keys are added by the
 /// writer and override any caller-provided values of the same name:
 /// `t_ms` (process-relative timestamp from [`engine_t0`]) and `event`.
 ///
-/// No-op when `KESHA_DEBUG_FD` is unset or invalid. The `fields` value
-/// is constructed by the caller before the no-op check fires — call
-/// sites should use the [`dtrace_json!`] macro instead, which gates
-/// the construction on the same check.
+/// No-op when `KESHA_DEBUG_FD` is unset or invalid. Call sites should
+/// use the [`dtrace_json!`] macro instead — it gates `serde_json::json!`
+/// construction on [`json_sink_is_active`] so disabled events pay
+/// nothing.
 pub fn trace_json(event: &str, fields: serde_json::Value) {
     let Some(sink) = json_sink() else {
         return;
     };
     let mut payload = match fields {
         serde_json::Value::Object(map) => map,
-        _ => serde_json::Map::new(),
+        other => {
+            // Non-object payloads are call-site bugs (the macro grammar
+            // accepts them today but the writer can't merge them with
+            // `t_ms` / `event`). Catch in dev/test; degrade to empty
+            // map in release so production stays panic-free.
+            debug_assert!(
+                false,
+                "dtrace_json! expects a JSON object payload, got: {other:?}"
+            );
+            serde_json::Map::new()
+        }
     };
     let t = engine_t0().elapsed().as_millis();
     payload.insert(
@@ -210,7 +231,7 @@ pub fn trace_json(event: &str, fields: serde_json::Value) {
     }
 }
 
-/// Emit a structured NDJSON event when [`json_sink`] is configured.
+/// Emit a structured NDJSON event when [`json_sink_is_active`].
 ///
 /// Usage:
 /// ```ignore
@@ -218,13 +239,15 @@ pub fn trace_json(event: &str, fields: serde_json::Value) {
 /// dtrace_json!("vad.detect", { "dt_ms": dt, "segments": spans.len() });
 /// ```
 ///
-/// Cheap when off: the `serde_json::json!` value still allocates, so
-/// gate any expensive field computation on `cfg!(debug_assertions)` or
-/// behind a `let value = …` block when the cost matters at the call site.
+/// Zero-cost when the sink is unset: the `if json_sink_is_active()`
+/// gate sits in front of `serde_json::json!`, so disabled events skip
+/// the heap allocation that the eager form (Greptile P2 on #321) had.
 #[macro_export]
 macro_rules! dtrace_json {
     ($event:expr, $fields:tt) => {
-        $crate::debug::trace_json($event, ::serde_json::json!($fields))
+        if $crate::debug::json_sink_is_active() {
+            $crate::debug::trace_json($event, ::serde_json::json!($fields))
+        }
     };
 }
 

--- a/rust/src/debug.rs
+++ b/rust/src/debug.rs
@@ -18,8 +18,35 @@
 //! to see WHEN each line fired on its own process timeline; for the
 //! span between two events on the same side, the inline `dt=Nms` token
 //! inside the message remains the right number.
+//!
+//! # Structured NDJSON sink (`KESHA_DEBUG_FD`, F19)
+//!
+//! `[debug/engine ...]` lines on stderr are great for humans but mix
+//! with `eprintln!("hint: ...")` / `eprintln!("warning: ...")` progress
+//! that the CLI surfaces to the user. For machine consumers (tooling,
+//! CI logs, perf dashboards) we want a clean stream of structured
+//! events on a dedicated channel.
+//!
+//! Set `KESHA_DEBUG_FD=N` to a valid file-descriptor integer that the
+//! parent process opened before exec — e.g. `kesha-engine ... 3>trace.ndjson`
+//! makes fd=3 a writable pipe. Each [`dtrace_json!`] call then emits one
+//! JSON line:
+//!
+//! ```text
+//! {"t_ms": 12, "event": "asr.backend_loaded", "dt_ms": 8}
+//! {"t_ms": 354, "event": "asr.transcribe.end", "dt_ms": 340, "chars": 42}
+//! ```
+//!
+//! Independent of `KESHA_DEBUG`: both can be on simultaneously (text
+//! to stderr AND JSON to fd=3), or just one, or neither. The text
+//! path is preserved for back-compat with `KESHA_DEBUG=1 kesha ...`
+//! workflows; the JSON path is opt-in via the env var.
 
-use std::sync::OnceLock;
+use std::fs::File;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 /// Values that turn `KESHA_DEBUG` OFF — empty, `"0"`, `"false"`, `"no"`,
@@ -86,6 +113,118 @@ pub fn trace_fmt(args: std::fmt::Arguments<'_>) {
 macro_rules! dtrace {
     ($($arg:tt)*) => {
         $crate::debug::trace_fmt(format_args!($($arg)*))
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Structured NDJSON sink — F19
+// ---------------------------------------------------------------------------
+
+/// Resolved JSON sink. `None` means `KESHA_DEBUG_FD` was unset / invalid
+/// at process start; further calls to [`trace_json`] are no-ops without
+/// even formatting the JSON payload.
+///
+/// `Mutex<File>` — not `BufWriter` — because each NDJSON line MUST hit
+/// the kernel as one `write(2)` so concurrent threads can't interleave
+/// half-lines into the consumer's pipe. Lines stay well under
+/// `PIPE_BUF` (4096 on Linux), so a single `write_all` is one syscall
+/// in practice.
+static JSON_SINK: OnceLock<Option<Mutex<File>>> = OnceLock::new();
+
+#[cfg(unix)]
+fn json_sink() -> Option<&'static Mutex<File>> {
+    JSON_SINK
+        .get_or_init(|| {
+            let raw = std::env::var("KESHA_DEBUG_FD").ok()?;
+            let fd: i32 = raw.trim().parse().ok()?;
+            // stdin/stdout/stderr are off-limits — they belong to the
+            // text-CLI contract. Refuse them so a stray `KESHA_DEBUG_FD=2`
+            // can't poison stderr with NDJSON.
+            if fd < 3 {
+                return None;
+            }
+            // SAFETY: `fd` is an integer the parent process passed via env.
+            // The contract is: the parent opened `fd` before exec (e.g. via
+            // shell `3>file` redirection or a `posix_spawn`-style FD action)
+            // and won't close it for the engine's lifetime. If the parent
+            // lied, the first `write(2)` returns EBADF and we silently drop
+            // the line — no panic, no abort. The fd is owned by us from
+            // here on; std drops the underlying close on `File` Drop.
+            let file = unsafe { File::from_raw_fd(fd) };
+            Some(Mutex::new(file))
+        })
+        .as_ref()
+}
+
+#[cfg(not(unix))]
+fn json_sink() -> Option<&'static Mutex<File>> {
+    // The fd-from-int trick is POSIX-specific. On Windows, `KESHA_DEBUG_FD`
+    // is a no-op for now; users can keep relying on the stderr text path
+    // via `KESHA_DEBUG=1`. Future Windows support would parse a HANDLE
+    // instead — out of scope until there's a concrete user request.
+    None
+}
+
+/// Emit one structured NDJSON event to the JSON sink, if configured.
+///
+/// `event` is the dotted event name (e.g. `"asr.backend_loaded"`).
+/// `fields` is a JSON object built with [`serde_json::json!`] —
+/// arbitrary serialisable shape. Two reserved keys are added by the
+/// writer and override any caller-provided values of the same name:
+/// `t_ms` (process-relative timestamp from [`engine_t0`]) and `event`.
+///
+/// No-op when `KESHA_DEBUG_FD` is unset or invalid. The `fields` value
+/// is constructed by the caller before the no-op check fires — call
+/// sites should use the [`dtrace_json!`] macro instead, which gates
+/// the construction on the same check.
+pub fn trace_json(event: &str, fields: serde_json::Value) {
+    let Some(sink) = json_sink() else {
+        return;
+    };
+    let mut payload = match fields {
+        serde_json::Value::Object(map) => map,
+        _ => serde_json::Map::new(),
+    };
+    let t = engine_t0().elapsed().as_millis();
+    payload.insert(
+        "t_ms".into(),
+        serde_json::Value::Number(serde_json::Number::from(t as u64)),
+    );
+    payload.insert("event".into(), serde_json::Value::String(event.into()));
+    let mut line = serde_json::to_vec(&payload).unwrap_or_else(|_| {
+        // Serialisation of a JSON `Map<String, Value>` is infallible in
+        // practice (no float NaN/Inf paths possible from this side); the
+        // fallback here keeps `trace_json` panic-free if upstream
+        // serde_json ever returns Err.
+        Vec::new()
+    });
+    if line.is_empty() {
+        return;
+    }
+    line.push(b'\n');
+    if let Ok(mut guard) = sink.lock() {
+        // Best-effort: write failures (EBADF, broken pipe, full disk)
+        // silently drop the line. The structured trace is observability,
+        // not a contract — surfacing IO errors here would just spam stderr.
+        let _ = guard.write_all(&line);
+    }
+}
+
+/// Emit a structured NDJSON event when [`json_sink`] is configured.
+///
+/// Usage:
+/// ```ignore
+/// dtrace_json!("asr.backend_loaded", { "dt_ms": elapsed.as_millis() });
+/// dtrace_json!("vad.detect", { "dt_ms": dt, "segments": spans.len() });
+/// ```
+///
+/// Cheap when off: the `serde_json::json!` value still allocates, so
+/// gate any expensive field computation on `cfg!(debug_assertions)` or
+/// behind a `let value = …` block when the cost matters at the call site.
+#[macro_export]
+macro_rules! dtrace_json {
+    ($event:expr, $fields:tt) => {
+        $crate::debug::trace_json($event, ::serde_json::json!($fields))
     };
 }
 

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -8,9 +8,9 @@ use std::time::Instant;
 
 use crate::audio;
 use crate::backend;
-use crate::dtrace;
 use crate::models;
 use crate::vad::{VadConfig, VadDetector, SAMPLE_RATE as VAD_SAMPLE_RATE};
+use crate::{dtrace, dtrace_json};
 
 /// Capability-flag string surfaced via `--capabilities-json`. Single source of
 /// truth so the engine, the TS CLI gate, and the integration tests can't drift.
@@ -248,7 +248,9 @@ fn transcribe_plain(
 ) -> Result<TranscriptionOutput> {
     let t0 = Instant::now();
     let mut be = backend::create_backend(model_dir)?;
-    dtrace!("asr::backend_loaded dt={}ms", t0.elapsed().as_millis());
+    let dt_ms = t0.elapsed().as_millis() as u64;
+    dtrace!("asr::backend_loaded dt={dt_ms}ms");
+    dtrace_json!("asr.backend_loaded", { "dt_ms": dt_ms });
     let t1 = Instant::now();
     let text = be.transcribe(audio_path)?;
     dtrace!(

--- a/rust/tests/debug_ndjson_fd.rs
+++ b/rust/tests/debug_ndjson_fd.rs
@@ -1,0 +1,54 @@
+//! Integration test for the F19 NDJSON sink: `KESHA_DEBUG_FD=N` makes
+//! [`kesha_engine::debug::trace_json`] write structured events to fd `N`.
+//!
+//! Lives as its own integration binary so the process-wide env-var +
+//! `OnceLock<JSON_SINK>` state can't bleed into other test binaries.
+//! Each `cargo test` integration binary runs in its own process.
+
+#![cfg(unix)]
+
+use std::io::{Read, Seek, SeekFrom};
+use std::os::fd::IntoRawFd;
+
+#[test]
+fn json_sink_emits_ndjson_with_event_and_t_ms_to_configured_fd() {
+    let mut tmp = tempfile::tempfile().expect("tempfile");
+    // `try_clone()` shares the underlying kernel descriptor; `into_raw_fd()`
+    // hands ownership of the duplicate to the test environment so the
+    // `OnceLock`-stored `File` inside `debug.rs` can close it on Drop
+    // without affecting our `tmp` reader.
+    let dup = tmp.try_clone().expect("dup tempfile");
+    let fd = dup.into_raw_fd();
+
+    // Set BEFORE the first `trace_json` call — `json_sink()` reads the
+    // env once via `OnceLock::get_or_init`. Subsequent changes are
+    // silently ignored, which is intentional (the writer's fd identity
+    // must be stable for the engine's lifetime).
+    std::env::set_var("KESHA_DEBUG_FD", fd.to_string());
+
+    kesha_engine::debug::trace_json("test.first", serde_json::json!({"x": 1, "label": "ok"}));
+    kesha_engine::debug::trace_json("test.second", serde_json::json!({"y": 2}));
+
+    tmp.seek(SeekFrom::Start(0)).expect("seek to start");
+    let mut contents = String::new();
+    tmp.read_to_string(&mut contents).expect("read tempfile");
+
+    let lines: Vec<&str> = contents.trim_end_matches('\n').split('\n').collect();
+    assert_eq!(lines.len(), 2, "expected 2 NDJSON lines, got: {contents:?}");
+
+    let v1: serde_json::Value = serde_json::from_str(lines[0]).expect("line 1 valid JSON");
+    assert_eq!(v1["event"], "test.first");
+    assert_eq!(v1["x"], 1);
+    assert_eq!(v1["label"], "ok");
+    assert!(v1["t_ms"].is_u64(), "t_ms missing on line 1: {v1}");
+
+    let v2: serde_json::Value = serde_json::from_str(lines[1]).expect("line 2 valid JSON");
+    assert_eq!(v2["event"], "test.second");
+    assert_eq!(v2["y"], 2);
+    assert!(v2["t_ms"].is_u64(), "t_ms missing on line 2: {v2}");
+
+    // Best-effort cleanup. `OnceLock` already captured the fd, so removing
+    // the env after the fact doesn't disable the sink — but it keeps the
+    // process env tidy for any subsequent `Bun.spawn`-style children.
+    std::env::remove_var("KESHA_DEBUG_FD");
+}

--- a/rust/tests/debug_ndjson_fd.rs
+++ b/rust/tests/debug_ndjson_fd.rs
@@ -24,7 +24,16 @@ fn json_sink_emits_ndjson_with_event_and_t_ms_to_configured_fd() {
     // env once via `OnceLock::get_or_init`. Subsequent changes are
     // silently ignored, which is intentional (the writer's fd identity
     // must be stable for the engine's lifetime).
-    std::env::set_var("KESHA_DEBUG_FD", fd.to_string());
+    //
+    // SAFETY: `std::env::set_var` is marked `unsafe` from Rust 1.84+
+    // because concurrent setenv/getenv in a multi-threaded process is
+    // UB on POSIX. This test runs as its own integration binary
+    // (`#![cfg(unix)]` only, single `#[test]` per file) and CI runs it
+    // under nextest — process-per-test isolation. No other thread is
+    // alive when this call happens. Greptile P2 on #321.
+    unsafe {
+        std::env::set_var("KESHA_DEBUG_FD", fd.to_string());
+    }
 
     kesha_engine::debug::trace_json("test.first", serde_json::json!({"x": 1, "label": "ok"}));
     kesha_engine::debug::trace_json("test.second", serde_json::json!({"y": 2}));


### PR DESCRIPTION
## Summary

Stderr currently mixes human-readable progress (`hint: ...`, `warning: ...`) with `dtrace!` debug lines under `KESHA_DEBUG=1`. That's fine for humans but bad for machine consumers (tooling, CI log parsers, perf dashboards) who want a clean stream of structured events on a dedicated channel.

Adds a parallel structured sink:

- **`KESHA_DEBUG_FD=N`** — `N` is a file-descriptor integer that the parent opened before exec (e.g. `kesha-engine ... 3>trace.ndjson` via shell, or `posix_spawn` FD actions via tooling). Refuses fds `0`/`1`/`2` so a stray `KESHA_DEBUG_FD=2` can't poison the stderr text contract.
- **`dtrace_json!("event.name", { "key": value })`** — emits one NDJSON line per call, with `t_ms` (process-relative) and `event` fields added by the writer. Each line hits the kernel as one `write(2)` via `Mutex<File>` so concurrent threads can't interleave half-lines into the consumer's pipe.
- **`dtrace!`** (the existing text path) is **untouched**. Both can be enabled simultaneously, neither, or just one — the env vars are independent. Existing `KESHA_DEBUG=1 kesha ...` workflows keep working.

`transcribe::transcribe_plain` migrated as the demo call site (`asr.backend_loaded`) so `trace_json` has a real caller in the binary build (otherwise `dead_code` fires under `-D warnings`). The original `dtrace!` line stays alongside.

## Today's user-facing path

```sh
KESHA_DEBUG_FD=3 kesha-engine transcribe a.ogg 3>trace.ndjson
jq -c '.' < trace.ndjson
```

## Deferred — TS-side `Bun.spawn` pipe

The original plan called for a `--trace-file <path>` CLI flag that captures fd=3 via `Bun.spawn` `stdio[3]='pipe'` and forwards to the file. That's **not** in this PR — Bun's `stdio[3]` behaviour for custom fds needs runtime verification on a real Bun install before shipping. Tracking as a follow-up; today's shell-redirection path is enough for tooling consumers.

## Test plan

- [ ] CI: new integration binary `tests/debug_ndjson_fd.rs` — opens a tempfile, dups its fd, sets `KESHA_DEBUG_FD`, calls `trace_json` twice, re-reads and asserts two valid NDJSON lines with the expected `event` and `t_ms` fields. Own binary (not a unit test in `debug.rs`) so the process-wide env + `OnceLock<JSON_SINK>` state can't bleed into other tests
- [ ] CI: existing `debug::tests` (`KESHA_DEBUG` parsing) continue to pass
- [ ] Local: `cargo fmt --check` and `cargo clippy --all-targets --features tts -- -D warnings` pass (verified)
- [ ] Note: local `cargo test` blocked by ort-sys download (network sandbox) — relying on CI for the runtime check

https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJxPfgwJqG9GT8rQV85cm2)_