### PR TITLE
feat(wrapper): forward KESHA_DEBUG_FD through Bun.spawn (#321 follow-up)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -54,6 +54,17 @@ export function isEngineInstalled(): boolean {
 type SpawnStdioEntry = "inherit" | "pipe" | "ignore" | number;
 
 /**
+ * Upper bound on the fd number we'll forward (#323 Greptile P2).
+ *
+ * The `stdio` array is index-addressed, so `KESHA_DEBUG_FD=1000000` would
+ * allocate a million-entry array of `"ignore"` strings before the spawn.
+ * 1024 is the conservative POSIX `RLIMIT_NOFILE` default — anything
+ * above it can't be open in the parent anyway, so capping is a no-op
+ * for legitimate users and a DoS guard for bogus input.
+ */
+const MAX_FORWARDED_FD = 1024;
+
+/**
  * Build a `stdio` array for `Bun.spawn`, forwarding `KESHA_DEBUG_FD` (#321 F19).
  *
  * The engine's NDJSON debug sink looks for `KESHA_DEBUG_FD=N` and writes
@@ -80,7 +91,7 @@ export function spawnStdioWithDebugFd(
   const envFd = process.env.KESHA_DEBUG_FD;
   if (!envFd) return base;
   const fd = Number(envFd);
-  if (!Number.isInteger(fd) || fd < 3) return base;
+  if (!Number.isInteger(fd) || fd < 3 || fd > MAX_FORWARDED_FD) return base;
   const out: SpawnStdioEntry[] = [...base];
   while (out.length < fd) out.push("ignore");
   out[fd] = fd;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -50,18 +50,59 @@ export function isEngineInstalled(): boolean {
   return existsSync(getEngineBinPath());
 }
 
+/** A Bun.spawn `stdio` array entry: per-fd action or inherit-by-number. */
+type SpawnStdioEntry = "inherit" | "pipe" | "ignore" | number;
+
+/**
+ * Build a `stdio` array for `Bun.spawn`, forwarding `KESHA_DEBUG_FD` (#321 F19).
+ *
+ * The engine's NDJSON debug sink looks for `KESHA_DEBUG_FD=N` and writes
+ * structured events to fd `N`. Bun.spawn closes all non-stdio fds in the
+ * child by default, so a bare `KESHA_DEBUG_FD=3 kesha ...` would propagate
+ * the env var but the kernel-level fd 3 wouldn't reach the engine — the
+ * sink would silently no-op.
+ *
+ * This helper forwards the parent's fd N to the same number in the child
+ * by extending the stdio array with `"ignore"` padding up to index N and
+ * setting `stdio[N] = N` (Bun's "inherit parent fd identity" form).
+ *
+ * Returns `base` unchanged when:
+ *   - `KESHA_DEBUG_FD` is unset / empty.
+ *   - The value isn't a non-negative integer.
+ *   - The value is 0/1/2 (covered by base stdin/stdout/stderr entries).
+ *
+ * Exported so `synth.ts` (the `kesha say` spawn site) can share the
+ * forwarding logic without duplicating the env-parse code.
+ */
+export function spawnStdioWithDebugFd(
+  base: [SpawnStdioEntry, SpawnStdioEntry, SpawnStdioEntry],
+): [SpawnStdioEntry, SpawnStdioEntry, SpawnStdioEntry, ...SpawnStdioEntry[]] {
+  const envFd = process.env.KESHA_DEBUG_FD;
+  if (!envFd) return base;
+  const fd = Number(envFd);
+  if (!Number.isInteger(fd) || fd < 3) return base;
+  const out: SpawnStdioEntry[] = [...base];
+  while (out.length < fd) out.push("ignore");
+  out[fd] = fd;
+  return out as [SpawnStdioEntry, SpawnStdioEntry, SpawnStdioEntry, ...SpawnStdioEntry[]];
+}
+
 async function runEngine(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const binPath = getEngineBinPath();
   const startedAt = performance.now();
   log.debug(`spawn ${binPath} ${args.join(" ")}`);
   const proc = Bun.spawn([binPath, ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
+    stdio: spawnStdioWithDebugFd(["ignore", "pipe", "pipe"]),
   });
+  // `stdio: [...]` widens stdout/stderr into a union; indices 1/2 are
+  // pinned to "pipe" by the helper, so the narrow ReadableStream type
+  // is correct. Cast to drop the spurious `number` arm.
+  const stdoutStream = proc.stdout as ReadableStream<Uint8Array>;
+  const stderrStream = proc.stderr as ReadableStream<Uint8Array>;
 
   const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
+    new Response(stdoutStream).text(),
+    new Response(stderrStream).text(),
     proc.exited,
   ]);
 

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,4 +1,10 @@
-import { getEngineBinPath, isEngineInstalled, getEngineCapabilities, type EngineCapabilities } from "./engine";
+import {
+  getEngineBinPath,
+  isEngineInstalled,
+  getEngineCapabilities,
+  spawnStdioWithDebugFd,
+  type EngineCapabilities,
+} from "./engine";
 import { log } from "./log";
 
 /**
@@ -109,21 +115,27 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
   const startedAt = performance.now();
   log.debug(`spawn ${getEngineBinPath()} ${args.join(" ")} (text: ${opts.text?.length ?? 0} chars)`);
   const proc = Bun.spawn([getEngineBinPath(), ...args], {
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
+    stdio: spawnStdioWithDebugFd(["pipe", "pipe", "pipe"]),
   });
+  // The `stdio: [...]` form widens stdin/stdout/stderr into a union
+  // (Bun.spawn can't infer that indices 0/1/2 are always "pipe" given
+  // the helper's return type). All three are guaranteed `FileSink` /
+  // `ReadableStream` here because the helper preserves index 0/1/2
+  // from the base tuple. Narrow back via cast.
+  const stdin = proc.stdin as Bun.FileSink;
+  const stdout = proc.stdout as ReadableStream<Uint8Array>;
+  const stderr = proc.stderr as ReadableStream<Uint8Array>;
 
   if (opts.text !== undefined && opts.text.length > 0) {
-    proc.stdin.write(opts.text);
-    await proc.stdin.end();
+    stdin.write(opts.text);
+    await stdin.end();
   } else {
-    await proc.stdin.end();
+    await stdin.end();
   }
 
   const [stdoutBuf, stderrText, exitCode] = await Promise.all([
-    new Response(proc.stdout).arrayBuffer(),
-    new Response(proc.stderr).text(),
+    new Response(stdout).arrayBuffer(),
+    new Response(stderr).text(),
     proc.exited,
   ]);
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "bun:test";
-import { parseLangResult, getEngineBinPath } from "../../src/engine";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { parseLangResult, getEngineBinPath, spawnStdioWithDebugFd } from "../../src/engine";
 
 describe("engine", () => {
   test("getEngineBinPath returns path under .cache kesha", () => {
@@ -22,5 +22,70 @@ describe("engine", () => {
 
   test("parseLangResult returns null for missing code field", () => {
     expect(parseLangResult('{"confidence":0.94}')).toBeNull();
+  });
+});
+
+describe("spawnStdioWithDebugFd", () => {
+  let savedFd: string | undefined;
+  beforeEach(() => {
+    savedFd = process.env.KESHA_DEBUG_FD;
+    delete process.env.KESHA_DEBUG_FD;
+  });
+  afterEach(() => {
+    if (savedFd === undefined) {
+      delete process.env.KESHA_DEBUG_FD;
+    } else {
+      process.env.KESHA_DEBUG_FD = savedFd;
+    }
+  });
+
+  test("returns base unchanged when KESHA_DEBUG_FD is unset", () => {
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
+  });
+
+  test("returns base unchanged on empty value (env exists but blank)", () => {
+    process.env.KESHA_DEBUG_FD = "";
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
+  });
+
+  test("returns base unchanged on non-numeric value (garbage)", () => {
+    process.env.KESHA_DEBUG_FD = "abc";
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
+  });
+
+  test("returns base unchanged for stdio range fd (0/1/2)", () => {
+    for (const fd of ["0", "1", "2"]) {
+      process.env.KESHA_DEBUG_FD = fd;
+      expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
+    }
+  });
+
+  test("forwards parent fd 3 as child fd 3 (no padding needed)", () => {
+    process.env.KESHA_DEBUG_FD = "3";
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe", 3]);
+  });
+
+  test("pads with ignore up to the target fd and identity-maps it", () => {
+    process.env.KESHA_DEBUG_FD = "5";
+    // fd 5 needs ignore at slots 3, 4 then identity-map at 5.
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual([
+      "ignore",
+      "pipe",
+      "pipe",
+      "ignore",
+      "ignore",
+      5,
+    ]);
+  });
+
+  test("preserves alternative base stdin choices (e.g. say-side 'pipe')", () => {
+    process.env.KESHA_DEBUG_FD = "3";
+    // `kesha say` opens stdin to write the text payload through.
+    expect(spawnStdioWithDebugFd(["pipe", "pipe", "pipe"])).toEqual(["pipe", "pipe", "pipe", 3]);
+  });
+
+  test("returns base unchanged on negative fd", () => {
+    process.env.KESHA_DEBUG_FD = "-1";
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
   });
 });

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -88,4 +88,16 @@ describe("spawnStdioWithDebugFd", () => {
     process.env.KESHA_DEBUG_FD = "-1";
     expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
   });
+
+  test("returns base unchanged on decimal fd (Number.isInteger rejects)", () => {
+    process.env.KESHA_DEBUG_FD = "3.5";
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
+  });
+
+  test("returns base unchanged on fd above MAX_FORWARDED_FD (#323 P2)", () => {
+    // 1024 is the cap; anything higher would allocate a giant `ignore`
+    // padding array. Legitimate users never have an fd this high.
+    process.env.KESHA_DEBUG_FD = "1000000";
+    expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
+  });
 });


### PR DESCRIPTION
## Summary

The engine's NDJSON debug sink (F19, PR #321) reads `KESHA_DEBUG_FD=N` and writes structured events to fd N. **Bun.spawn closes all non-stdio fds in the child by default** — so a bare `KESHA_DEBUG_FD=3 kesha audio.ogg 3>/tmp/events.ndjson` propagated the env var but the kernel-level fd 3 didn't reach the engine, and the sink silently no-op'd.

This PR adds wrapper-side fd forwarding so the feature is usable through the npm CLI, not just direct `kesha-engine` invocations.

## Mechanics

- **`src/engine.ts`** — new `spawnStdioWithDebugFd(base)` helper. Reads `process.env.KESHA_DEBUG_FD`, parses it, and when `N >= 3` returns a `stdio: [...]` array padded with `"ignore"` up to index `N` and `stdio[N] = N` (Bun's \"inherit parent fd at identity number\" form). Returns `base` unchanged for missing / blank / non-numeric / stdio-range values.
- **`runEngine`** (transcribe + detect-lang + detect-text-lang + `--capabilities-json`) — switched from flat `stdout: \"pipe\", stderr: \"pipe\"` to `stdio: spawnStdioWithDebugFd([\"ignore\", \"pipe\", \"pipe\"])`. The flat form doesn't allow extra fds.
- **`src/synth.ts::say()`** (the `kesha say` engine spawn) — same treatment with `[\"pipe\", \"pipe\", \"pipe\"]` since it pipes the text payload through stdin.
- TS narrowing: `stdio: [...]` widens `proc.stdin/stdout/stderr` into a union the type-checker can't narrow back. Cast at the use sites with brief comments explaining why the cast is sound.

## Tests

8 new bun-test cases in `tests/unit/engine.test.ts` cover the helper's env-handling:

- unset → base
- empty string → base
- non-numeric (`abc`) → base
- stdio range (`0`/`1`/`2`) → base
- negative → base
- `KESHA_DEBUG_FD=3` → `[base..., 3]` (no padding)
- `KESHA_DEBUG_FD=5` → `[base..., \"ignore\", \"ignore\", 5]` (padded)
- alternative base stdin (`[\"pipe\", \"pipe\", \"pipe\"]`) preserved

## Verification

- [x] `bun test tests/unit/engine.test.ts` → 13/13 pass.
- [x] `bunx tsc --noEmit` clean.

## End-to-end use after merge

```bash
KESHA_DEBUG_FD=3 kesha audio.ogg 3>/tmp/events.ndjson
cat /tmp/events.ndjson
# {\"event\":\"asr.backend_loaded\",\"t_ms\":397,\"dt_ms\":397}
# ...
```

## Test plan

- [ ] CI: unit tests on ubuntu/macos/windows pass the new spawn cases.
- [ ] Manual: against a built engine with #321 merged, exercise the redirect end-to-end and confirm NDJSON lines hit the redirected file.
- [ ] Greptile review verdict ≥ 4/5.

Refs #321 (F19 engine-side support), #313 P1