### PR TITLE
fix(cli): fail fast on invalid CLI inputs

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,4 +1,5 @@
 import { runMain } from "citty";
+import { existsSync } from "fs";
 import { log } from "../log";
 import { suggestCommand } from "../suggest-command";
 import { installCommand } from "./install";
@@ -7,6 +8,10 @@ import { statusCommand } from "./status";
 import { mainCommand } from "./main";
 
 const SUBCOMMANDS = ["install", "status", "say"];
+
+function isPathLike(arg: string): boolean {
+  return arg.includes(".") || arg.includes("/") || existsSync(arg);
+}
 
 export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
   const [firstArg, ...restArgs] = rawArgs;
@@ -26,14 +31,17 @@ export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
     return;
   }
 
-  // Check for unknown subcommands (non-flag, non-file-path args)
-  if (firstArg && !firstArg.startsWith("-") && !firstArg.includes(".") && !firstArg.includes("/")) {
+  // Check for unknown subcommands (non-flag, non-file-path args).
+  // Extensionless existing files remain valid transcription inputs; missing
+  // bare tokens are more likely command typos and should not start the engine.
+  if (firstArg && !firstArg.startsWith("-") && !isPathLike(firstArg)) {
     const suggestion = suggestCommand(firstArg, SUBCOMMANDS);
+    log.error(`unknown command '${firstArg}'`);
     if (suggestion && suggestion !== firstArg) {
-      log.error(`unknown command '${firstArg}'`);
       log.warn(`(Did you mean ${suggestion}?)`);
-      process.exit(1);
     }
+    log.warn(`If this is an audio file, pass a path like './${firstArg}'.`);
+    process.exit(1);
   }
 
   await runMain(mainCommand, { rawArgs });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { existsSync } from "fs";
 import { detect } from "tinyld";
 import { transcribeWithSegments } from "../transcribe";
 import { detectAudioLanguageEngine, detectTextLanguageEngine } from "../engine";
@@ -206,6 +207,12 @@ export const mainCommand = defineCommand({
     const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
 
     for (const file of files) {
+      if (!existsSync(file)) {
+        hasError = true;
+        log.error(`${file}: File not found`);
+        continue;
+      }
+
       const startedAt = performance.now();
       try {
         // Run audio lang-id and transcription concurrently.

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect } from "bun:test";
-import { mkdtempSync } from "fs";
+import { afterEach, describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
 const CWD = import.meta.dir + "/../..";
 const CLI_TIMEOUT_MS = 4_000;
+const tempDirs: string[] = [];
 
 async function runCli(
   args: string[],
@@ -52,8 +53,15 @@ async function runCli(
 
 function emptyKeshaEnv(): Record<string, string> {
   const dir = mkdtempSync(join(tmpdir(), "kesha-empty-cli-"));
+  tempDirs.push(dir);
   return { HOME: dir, KESHA_CACHE_DIR: dir };
 }
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("e2e-cli", () => {
   test("--version prints version and exits 0", async () => {
@@ -126,7 +134,7 @@ describe("e2e-cli", () => {
     expect(stderr).toContain("unknown command 'xyzxyzxyz'");
     expect(output).not.toContain("Did you mean");
     expect(output).not.toContain("FluidAudio");
-    expect(output.toLowerCase()).not.toContain("audio file not found");
+    expect(output.toLowerCase()).not.toContain("file not found");
   });
 
   test("--json + --toon are mutually exclusive → exit 2 (#138)", async () => {

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -1,21 +1,58 @@
 import { describe, test, expect } from "bun:test";
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 
 const CWD = import.meta.dir + "/../..";
+const CLI_TIMEOUT_MS = 4_000;
 
-async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+async function runCli(
+  args: string[],
+  opts: { env?: Record<string, string> } = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
     stdout: "pipe",
     stderr: "pipe",
     cwd: CWD,
+    env: opts.env ? { ...process.env, ...opts.env } : process.env,
   });
 
+  const stdoutPromise = new Response(proc.stdout).text();
+  const stderrPromise = new Response(proc.stderr).text();
+  let timeout: Timer | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeout = setTimeout(() => resolve("timeout"), CLI_TIMEOUT_MS);
+  });
+  const exitOrTimeout = await Promise.race([proc.exited, timeoutPromise]);
+  if (timeout) clearTimeout(timeout);
+
+  if (exitOrTimeout === "timeout") {
+    proc.kill();
+  }
+
   const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
+    stdoutPromise,
+    stderrPromise,
     proc.exited,
   ]);
 
+  if (exitOrTimeout === "timeout") {
+    throw new Error(
+      [
+        `CLI timed out after ${CLI_TIMEOUT_MS}ms: kesha ${args.join(" ")}`,
+        `exitCode=${exitCode}`,
+        `stdout=${stdout.trim()}`,
+        `stderr=${stderr.trim()}`,
+      ].join("\n"),
+    );
+  }
+
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+function emptyKeshaEnv(): Record<string, string> {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-empty-cli-"));
+  return { HOME: dir, KESHA_CACHE_DIR: dir };
 }
 
 describe("e2e-cli", () => {
@@ -59,6 +96,15 @@ describe("e2e-cli", () => {
     expect(stderr.toLowerCase()).toContain("file not found");
   });
 
+  test("missing file is reported before checking whether engine is installed", async () => {
+    const { stderr, exitCode } = await runCli(["nonexistent.wav"], {
+      env: emptyKeshaEnv(),
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr.toLowerCase()).toContain("file not found");
+    expect(stderr).not.toContain("No transcription backend is installed");
+  });
+
   test("multiple missing files with --json outputs empty array", async () => {
     const { stdout, stderr, exitCode } = await runCli(["--json", "a.wav", "b.wav"]);
     expect(exitCode).toBe(1);
@@ -73,10 +119,14 @@ describe("e2e-cli", () => {
     expect(stderr).toContain("Did you mean");
   });
 
-  test("gibberish subcommand shows no suggestion", async () => {
-    const { stdout, stderr } = await runCli(["xyzxyzxyz"]);
+  test("gibberish bare token fails as an unknown command without engine startup", async () => {
+    const { stdout, stderr, exitCode } = await runCli(["xyzxyzxyz"]);
     const output = stdout + stderr;
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("unknown command 'xyzxyzxyz'");
     expect(output).not.toContain("Did you mean");
+    expect(output).not.toContain("FluidAudio");
+    expect(output.toLowerCase()).not.toContain("audio file not found");
   });
 
   test("--json + --toon are mutually exclusive → exit 2 (#138)", async () => {


### PR DESCRIPTION
## Summary

- fail missing transcription files in the TS CLI wrapper before starting `kesha-engine`
- classify missing bare tokens as unknown commands instead of forwarding them as audio paths
- add timeout-aware CLI integration helper diagnostics and regression coverage for the P0 UX/DX paths

## Test Plan

- [x] `bunx tsc --noEmit`
- [x] `bun run test:unit`
- [x] `bun run test:integration`
- [x] `git diff --check`

Refs #324
