### PR TITLE
fix(status): keep status diagnostic-only

### DIFF
--- a/src/star.ts
+++ b/src/star.ts
@@ -57,14 +57,13 @@ export function hasStarMarker(binPath: string): boolean {
 }
 
 /**
- * Prompt the user to star the repo if and only if `shouldShowStarPrompt`
- * agrees (first install + major-or-minor bumps, never on patch). Records
+ * Prompt the user to star the repo during `kesha install` if and only if
+ * `shouldShowStarPrompt` agrees (first install + major-or-minor bumps,
+ * never on patch). Records
  * the prompt against the current version up front so a single run never
  * prompts twice — failures from the gh subprocess below don't reopen the
- * gate. Shared by `kesha install` and `kesha status` so opt-in installs
- * (`--tts`, `--diarize`) and `status` reuse the same marker; a user who
- * saw the prompt on the base install won't see it again on the opt-in or
- * the status check.
+ * gate. Install variants (`--tts`, `--diarize`) reuse the same marker; status
+ * stays diagnostic-only and does not consume this slot.
  *
  * No-ops when the gate says skip, when `currentVersion` is null, or when
  * the user has already starred. When `gh` is missing or unauthenticated,

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,10 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { isEngineInstalled, getEngineBinPath, getEngineCapabilities } from "./engine";
 import { log } from "./log";
-import { maybeAskForStar } from "./star";
 import pc from "picocolors";
-
-const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
 
 function humanBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -91,14 +88,6 @@ export async function showStatus(): Promise<void> {
     log.warn('Run "kesha install" to download the engine and models.');
     return;
   }
-
-  // Star prompt at the very end. Same gate + marker as `kesha install`, so a
-  // user prompted by either path won't be re-prompted by the other within the
-  // same major.minor. Headless `kesha install` (no `gh`, or no tty) leaves no
-  // marker only when the prompt path itself errored out — readStarSeen still
-  // sees the marker in the common case.
-  const currentVersion = typeof pkg.version === "string" ? pkg.version : null;
-  await maybeAskForStar(binPath, currentVersion, log);
 }
 
 function showDiskUsage(binPath: string): void {

--- a/src/status.ts
+++ b/src/status.ts
@@ -52,7 +52,12 @@ export async function showStatus(): Promise<void> {
   log.info(formatStatusLine("Binary", installed ? binPath : null, installed));
 
   if (installed) {
-    const caps = await getEngineCapabilities();
+    let caps: Awaited<ReturnType<typeof getEngineCapabilities>> = null;
+    try {
+      caps = await getEngineCapabilities();
+    } catch {
+      caps = null;
+    }
     if (caps) {
       log.info(formatStatusLine("Backend", caps.backend, true));
       log.info(formatStatusLine("Protocol", `v${caps.protocolVersion}`, true));

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -68,14 +68,17 @@ describe("showStatus", () => {
   const savedCacheDir = process.env.KESHA_CACHE_DIR;
   const savedHome = process.env.HOME;
 
-  afterEach(() => {
+  function restoreEnv() {
     if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
     else process.env.KESHA_ENGINE_BIN = savedEngineBin;
     if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
     else process.env.KESHA_CACHE_DIR = savedCacheDir;
     if (savedHome === undefined) delete process.env.HOME;
     else process.env.HOME = savedHome;
-  });
+  }
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
 
   test("does not consume the star prompt marker slot", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-test-"));

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { formatStatusLine, activeModelMirror, showStatus } from "../../src/status";
@@ -85,16 +85,7 @@ describe("showStatus", () => {
     const binDir = join(dir, "engine", "bin");
     mkdirSync(binDir, { recursive: true });
     const binPath = join(binDir, "kesha-engine");
-    writeFileSync(
-      binPath,
-      [
-        "#!/bin/sh",
-        "if [ \"$1\" = \"--capabilities-json\" ]; then",
-        "  echo '{\"protocolVersion\":2,\"backend\":\"test\",\"features\":[\"transcribe\"]}'",
-        "fi",
-      ].join("\n"),
-    );
-    chmodSync(binPath, 0o755);
+    writeFileSync(binPath, "not a real executable");
 
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = dir;

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { formatStatusLine, activeModelMirror } from "../../src/status";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { formatStatusLine, activeModelMirror, showStatus } from "../../src/status";
+import { starSeenPath } from "../../src/star";
 
 describe("formatStatusLine", () => {
   test("formats installed component", () => {
@@ -56,5 +60,54 @@ describe("activeModelMirror (#121)", () => {
   test("strips trailing slashes to match the Rust side", () => {
     process.env.KESHA_MODEL_MIRROR = "https://mirror.example.com/kesha///";
     expect(activeModelMirror()).toBe("https://mirror.example.com/kesha");
+  });
+});
+
+describe("showStatus", () => {
+  const savedEngineBin = process.env.KESHA_ENGINE_BIN;
+  const savedCacheDir = process.env.KESHA_CACHE_DIR;
+  const savedHome = process.env.HOME;
+
+  afterEach(() => {
+    if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
+    else process.env.KESHA_ENGINE_BIN = savedEngineBin;
+    if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
+    else process.env.KESHA_CACHE_DIR = savedCacheDir;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+  });
+
+  test("does not consume the star prompt marker slot", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-test-"));
+    const binDir = join(dir, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFileSync(
+      binPath,
+      [
+        "#!/bin/sh",
+        "if [ \"$1\" = \"--capabilities-json\" ]; then",
+        "  echo '{\"protocolVersion\":2,\"backend\":\"test\",\"features\":[\"transcribe\"]}'",
+        "fi",
+      ].join("\n"),
+    );
+    chmodSync(binPath, 0o755);
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = dir;
+    process.env.HOME = dir;
+
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = () => {};
+    console.error = () => {};
+    try {
+      await showStatus();
+      expect(existsSync(starSeenPath(binPath))).toBe(false);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- keep `kesha status` diagnostic-only by removing the star prompt side effect
- preserve the star prompt flow for `kesha install`
- add regression coverage that `showStatus()` does not consume the `.star-seen` marker slot

## Test Plan

- [x] `bun test tests/unit/status.test.ts`
- [x] `bunx tsc --noEmit`
- [x] `bun run test:unit`
- [x] `bun test tests/integration/e2e-cli.test.ts tests/integration/say.test.ts`
- [x] `bun run test:integration`
- [x] `git diff --check`

Refs #324
