### PR TITLE
fix(cli): use canonical install hint

### DIFF
--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -33,9 +33,10 @@ export async function transcribeWithSegments(
     throw new Error(
       "Error: No transcription backend is installed\n\n" +
       "╔══════════════════════════════════════════════════════════╗\n" +
-      "║ Please run the following command to get started:         ║\n" +
+      "║ Please run the following commands to get started:        ║\n" +
       "║                                                          ║\n" +
-      "║     bunx @drakulavich/kesha-voice-kit install               ║\n" +
+      "║     bun add -g @drakulavich/kesha-voice-kit             ║\n" +
+      "║     kesha install                                       ║\n" +
       "╚══════════════════════════════════════════════════════════╝",
     );
   }

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -35,8 +35,8 @@ export async function transcribeWithSegments(
       "╔══════════════════════════════════════════════════════════╗\n" +
       "║ Please run the following commands to get started:        ║\n" +
       "║                                                          ║\n" +
-      "║     bun add -g @drakulavich/kesha-voice-kit             ║\n" +
-      "║     kesha install                                       ║\n" +
+      "║     bun add -g @drakulavich/kesha-voice-kit              ║\n" +
+      "║     kesha install                                        ║\n" +
       "╚══════════════════════════════════════════════════════════╝",
     );
   }

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { transcribe } from "../../src/lib";
+import { transcribe as transcribeWrapper } from "../../src/transcribe";
 
 describe("lib API", () => {
   it("rejects missing file", async () => {
@@ -21,5 +22,24 @@ describe("lib API", () => {
     const e = new SayError("msg", 1, "stderr");
     expect(e.exitCode).toBe(1);
     expect(e.stderr).toBe("stderr");
+  });
+
+  it("uses canonical Bun install commands when transcription backend is missing", async () => {
+    const saved = process.env.KESHA_ENGINE_BIN;
+    process.env.KESHA_ENGINE_BIN = `/tmp/kesha-missing-engine-${Date.now()}`;
+    try {
+      let message = "";
+      try {
+        await transcribeWrapper("audio.wav");
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+      expect(message).toContain("bun add -g @drakulavich/kesha-voice-kit");
+      expect(message).toContain("kesha install");
+      expect(message).not.toContain("bunx");
+    } finally {
+      if (saved === undefined) delete process.env.KESHA_ENGINE_BIN;
+      else process.env.KESHA_ENGINE_BIN = saved;
+    }
   });
 });


### PR DESCRIPTION
## Summary

- replace the stale first-run `bunx ... install` transcription hint with the canonical Bun global install flow
- tell users to run `bun add -g @drakulavich/kesha-voice-kit` followed by `kesha install`
- add regression coverage so backend-missing errors do not reintroduce `bunx`

## Test Plan

- [x] `bun test tests/unit/lib.test.ts`
- [x] `bunx tsc --noEmit`
- [x] `bun run test:unit`
- [x] `bun test tests/integration/e2e-cli.test.ts tests/integration/say.test.ts`
- [x] `git diff --check`

Refs #324
