### PR TITLE
chore(release): bump version to 1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.16.0"
+    "version": "1.17.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kesha-engine"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.16.0"
+version = "1.17.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## Summary
- Bump CLI package version to 1.17.0.
- Bump bundled engine version to 1.17.0 in package.json, rust/Cargo.toml, and rust/Cargo.lock.
- Prepare a full engine release because main includes Rust changes after v1.16.0.

## Verification
- bun run check:versions
- bun test
- bunx tsc --noEmit
- cd rust && cargo check
- cd rust && cargo fmt --check
- cd rust && cargo clippy --all-targets --features tts -- -D warnings
- cd rust && cargo nextest run --features tts

Refs #324, #326