### PR TITLE
fix(cli): report say --out progress on stderr

### DIFF
--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -136,8 +136,15 @@ export const sayCommand = defineCommand({
 
     try {
       const startedAt = performance.now();
+      if (opts.out) {
+        const voiceLabel = opts.voice ?? "default voice";
+        console.error(`Synthesizing ${voiceLabel} -> ${opts.out}...`);
+      }
       const audio = await say(opts);
       const ttsTimeMs = Math.round(performance.now() - startedAt);
+      if (opts.out) {
+        console.error(`Saved ${opts.out} (${ttsTimeMs}ms)`);
+      }
       if (args.verbose) {
         // stderr — stdout may carry raw audio bytes when --out is omitted.
         console.error(`TTS time: ${ttsTimeMs}ms`);

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -145,7 +145,7 @@ export const sayCommand = defineCommand({
       if (opts.out) {
         console.error(`Saved ${opts.out} (${ttsTimeMs}ms)`);
       }
-      if (args.verbose) {
+      if (args.verbose && !opts.out) {
         // stderr — stdout may carry raw audio bytes when --out is omitted.
         console.error(`TTS time: ${ttsTimeMs}ms`);
       }

--- a/tests/integration/say.test.ts
+++ b/tests/integration/say.test.ts
@@ -1,7 +1,29 @@
 import { describe, it, expect } from "bun:test";
 import { spawn } from "bun";
+import { chmodSync, mkdirSync } from "fs";
 
 const CLI_PATH = new URL("../../bin/kesha.js", import.meta.url).pathname;
+
+async function createFakeEngine(dir: string): Promise<string> {
+  mkdirSync(dir, { recursive: true });
+  const enginePath = `${dir}/kesha-engine`;
+  await Bun.write(enginePath, `#!/usr/bin/env bun
+const args = Bun.argv.slice(2);
+if (args[0] !== "say") {
+  console.error("unexpected args: " + args.join(" "));
+  process.exit(2);
+}
+const outIndex = args.indexOf("--out");
+await new Response(Bun.stdin.stream()).text();
+if (outIndex >= 0) {
+  await Bun.write(args[outIndex + 1], new Uint8Array([82, 73, 70, 70, 0, 0, 0, 0]));
+} else {
+  process.stdout.write(new Uint8Array([82, 73, 70, 70, 0, 0, 0, 0]));
+}
+`);
+  chmodSync(enginePath, 0o755);
+  return enginePath;
+}
 
 describe("kesha say (CLI)", () => {
   it("--help exits 0 and mentions --voice", async () => {
@@ -27,5 +49,41 @@ describe("kesha say (CLI)", () => {
     // Engine not installed exits 1 from the TS wrapper; stderr should point at install.
     expect([1, 4]).toContain(exit);
     expect(stderr).toMatch(/install/);
+  });
+
+  it("say --out reports stderr progress while keeping stdout empty", async () => {
+    const dir = `/tmp/kesha-fake-engine-${Date.now()}-${Math.random()}`;
+    const enginePath = await createFakeEngine(dir);
+    const outPath = `${dir}/reply.wav`;
+    const proc = spawn([
+      "bun",
+      CLI_PATH,
+      "say",
+      "--voice",
+      "ru-vosk-m02",
+      "--out",
+      outPath,
+      "Привет",
+    ], {
+      env: {
+        ...process.env,
+        KESHA_CACHE_DIR: dir,
+        KESHA_ENGINE_BIN: enginePath,
+        HOME: dir,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(await proc.exited).toBe(0);
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const bytes = new Uint8Array(await Bun.file(outPath).arrayBuffer());
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Synthesizing ru-vosk-m02 ->");
+    expect(stderr).toContain(outPath);
+    expect(stderr).toMatch(/Saved .*reply\.wav \(\d+ms\)/);
+    expect(new TextDecoder().decode(bytes.slice(0, 4))).toBe("RIFF");
   });
 });

--- a/tests/integration/say.test.ts
+++ b/tests/integration/say.test.ts
@@ -86,4 +86,36 @@ describe("kesha say (CLI)", () => {
     expect(stderr).toMatch(/Saved .*reply\.wav \(\d+ms\)/);
     expect(new TextDecoder().decode(bytes.slice(0, 4))).toBe("RIFF");
   });
+
+  it("--verbose --out does not duplicate timing output", async () => {
+    const dir = `/tmp/kesha-fake-engine-${Date.now()}-${Math.random()}`;
+    const enginePath = await createFakeEngine(dir);
+    const outPath = `${dir}/reply.wav`;
+    const proc = spawn([
+      "bun",
+      CLI_PATH,
+      "say",
+      "--voice",
+      "ru-vosk-m02",
+      "--out",
+      outPath,
+      "--verbose",
+      "Привет",
+    ], {
+      env: {
+        ...process.env,
+        KESHA_CACHE_DIR: dir,
+        KESHA_ENGINE_BIN: enginePath,
+        HOME: dir,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(await proc.exited).toBe(0);
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(stderr).toMatch(/Saved .*reply\.wav \(\d+ms\)/);
+    expect(stderr).not.toContain("TTS time:");
+  });
 });


### PR DESCRIPTION
## Summary
- prints a start line to stderr when `kesha say --out` begins synthesis
- prints a saved line with elapsed time after successful file output
- keeps stdout empty in `--out` mode and preserves raw-audio stdout mode when `--out` is omitted

## Test Plan
- `bun test tests/integration/say.test.ts`
- `bunx tsc --noEmit`
- `bun run check:versions`
- `git diff --check`
- `bun test` (186 pass, 4 skip, 0 fail)
- manual smoke: `bun run src/cli.ts say --voice ru-vosk-m02 --out /tmp/kesha-progress-smoke.wav "Привет."` -> stderr progress, empty stdout, valid WAV

Rust tests were not run because this is a TypeScript CLI-only change.
