### PR TITLE
fix(cli): report progress for redirected transcription

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -205,6 +205,7 @@ export const mainCommand = defineCommand({
     const results: TranscribeResult[] = [];
 
     const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
+    const reportProgress = process.stdout.isTTY !== true;
 
     for (const file of files) {
       if (!existsSync(file)) {
@@ -215,6 +216,9 @@ export const mainCommand = defineCommand({
 
       const startedAt = performance.now();
       try {
+        if (reportProgress) {
+          console.error(`Transcribing ${file}...`);
+        }
         // Run audio lang-id and transcription concurrently.
         const [audioResult, transcript] = await Promise.all([
           wantsLangId ? detectAudioLanguageEngine(file) : Promise.resolve(null),
@@ -247,18 +251,22 @@ export const mainCommand = defineCommand({
         const mismatchWarning = checkLanguageMismatch(args.lang, lang);
         if (mismatchWarning) log.warn(`${file}: ${mismatchWarning}`);
 
+        const sttTimeMs = Math.round(performance.now() - startedAt);
         const result: TranscribeResult = {
           file,
           text,
           lang,
           audioLanguage,
           textLanguage: textLanguage ?? (tinyldLang ? { code: tinyldLang, confidence: 0 } : undefined),
-          sttTimeMs: Math.round(performance.now() - startedAt),
+          sttTimeMs,
         };
-        if (args.timestamps) {
+        if (args.timestamps || args.speakers) {
           result.segments = segments;
         }
         results.push(result);
+        if (reportProgress) {
+          console.error(`Transcribed ${file} (${sttTimeMs}ms)`);
+        }
       } catch (err: unknown) {
         hasError = true;
         const message = err instanceof Error ? err.message : String(err);

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, test, expect } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -55,6 +55,48 @@ function emptyKeshaEnv(): Record<string, string> {
   const dir = mkdtempSync(join(tmpdir(), "kesha-empty-cli-"));
   tempDirs.push(dir);
   return { HOME: dir, KESHA_CACHE_DIR: dir };
+}
+
+function createFakeEngine(dir: string): string {
+  const enginePath = join(dir, "kesha-engine");
+  writeFileSync(
+    enginePath,
+    `#!/usr/bin/env bun
+const args = Bun.argv.slice(2);
+
+if (args[0] === "--capabilities-json") {
+  console.log(JSON.stringify({
+    protocolVersion: 1,
+    backend: "fake",
+    features: ["transcribe.segments", "transcribe.diarize"],
+  }));
+  process.exit(0);
+}
+
+if (args[0] === "detect-lang") {
+  console.log(JSON.stringify({ code: "ru", confidence: 0.99 }));
+  process.exit(0);
+}
+
+if (args[0] === "detect-text-lang") {
+  console.log(JSON.stringify({ code: "ru", confidence: 0.98 }));
+  process.exit(0);
+}
+
+if (args[0] === "transcribe") {
+  console.log(JSON.stringify({
+    text: "Привет с воркшопа",
+    segments: [{ start: 0, end: 1.2, text: "Привет с воркшопа", speaker: 0 }],
+  }));
+  process.exit(0);
+}
+
+console.error("unexpected fake engine args: " + JSON.stringify(args));
+process.exit(2);
+`,
+  );
+  chmodSync(enginePath, 0o755);
+  return enginePath;
 }
 
 afterEach(() => {
@@ -150,5 +192,33 @@ describe("e2e-cli", () => {
     const { stderr, exitCode } = await runCli(["--timestamps", "a.wav"]);
     expect(exitCode).toBe(2);
     expect(stderr).toContain("--timestamps requires");
+  });
+
+  test("redirected --json --speakers reports progress on stderr and keeps stdout JSON", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fake-cli-"));
+    tempDirs.push(dir);
+    const enginePath = createFakeEngine(dir);
+    const mediaPath = join(dir, "workshop.mp4");
+    writeFileSync(mediaPath, "fake media");
+
+    const { stdout, stderr, exitCode } = await runCli(
+      [mediaPath, "--json", "--speakers"],
+      {
+        env: {
+          HOME: dir,
+          KESHA_CACHE_DIR: dir,
+          KESHA_ENGINE_BIN: enginePath,
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain(`Transcribing ${mediaPath}...`);
+    expect(stderr).toMatch(/Transcribed .*workshop\.mp4 \(\d+ms\)/);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].text).toBe("Привет с воркшопа");
+    expect(parsed[0].segments[0].speaker).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- print per-file transcription start/done progress to stderr when stdout is redirected or piped
- keep stdout as clean JSON/TOON/transcript/text output for commands like `kesha video.mp4 --json --speakers > workshop.txt`
- make `--speakers` include `segments` in formatted output, matching the existing help text that says it implies timestamps

## Test Plan
- [x] `bun test tests/integration/e2e-cli.test.ts`
- [x] `bun test`
- [x] `bunx tsc --noEmit`
- [x] `bun run check:versions`
- [x] `git diff --check`