### PR TITLE
List CLI subcommands in main help

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -109,8 +109,11 @@ export const mainCommand = defineCommand({
     version: pkg.version,
     description:
       "Kesha Voice Kit — open-source voice toolkit for Apple Silicon.\n" +
-      "  Run 'kesha install [--no-cache]' to download engine and models.\n" +
-      "  Run 'kesha status' to inspect installed backend.",
+      "\n" +
+      "Commands:\n" +
+      "  install    Download engine and models.\n" +
+      "  status     Inspect installed backend.\n" +
+      "  say        Synthesize speech from text.",
   },
   args: {
     json: {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -200,7 +200,12 @@ export const mainCommand = defineCommand({
     const vadMode = args.vad ? "on" : args["no-vad"] ? "off" : "auto";
 
     if (files.length === 0) {
-      log.info("Usage: kesha <audio_file> [audio_file ...]\n       kesha install [--no-cache]\n       kesha status");
+      log.info(
+        "Usage: kesha <audio_file> [audio_file ...]\n" +
+          "       kesha install [--no-cache]\n" +
+          "       kesha status\n" +
+          "       kesha say <text>",
+      );
       process.exit(1);
     }
 

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -131,6 +131,9 @@ describe("e2e-cli", () => {
     const { stdout, exitCode } = await runCli([]);
     expect(exitCode).toBe(1);
     expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("kesha install");
+    expect(stdout).toContain("kesha status");
+    expect(stdout).toContain("kesha say");
   });
 
   test("--help shows description and flags", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -10,6 +10,14 @@ describe("CLI help", () => {
     expect(usage).toContain("install");
   });
 
+  test("main help shows subcommand inventory (#324)", async () => {
+    const usage = await renderUsage(mainCommand);
+    expect(usage).toContain("Commands:");
+    expect(usage).toContain("install    Download engine and models.");
+    expect(usage).toContain("status     Inspect installed backend.");
+    expect(usage).toContain("say        Synthesize speech from text.");
+  });
+
   test("install help contains backend and cache options", async () => {
     const usage = await renderUsage(installCommand);
     expect(usage).toContain("--coreml");


### PR DESCRIPTION
## Summary
- replace prose-only install/status hints in `kesha --help` with a dedicated `Commands:` inventory
- include `install`, `status`, and `say` with one-line descriptions
- add a unit assertion for the command inventory

## Notes
- P0.4 and P0.5 from #324 are already present on current `main`: `status` does not consume the star prompt marker, and missing-backend guidance uses `bun add -g` + `kesha install`.

## Verification
- bun test tests/unit/cli.test.ts
- bun test tests/integration/e2e-cli.test.ts
- bunx tsc --noEmit

Refs #324 (P1.6)