### PR TITLE
docs: add TweetClaw voice workflow

### DIFF
--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -25,4 +25,22 @@ Your agent receives a voice message in Telegram/WhatsApp/Slack, Kesha transcribe
 [lang: ru, confidence: 1.00]
 ```
 
+## Compose with X/Twitter workflows
+
+Kesha handles local voice input and speech output. To let an OpenClaw agent turn a transcribed voice brief into public X/Twitter research, tweet search, or a reviewed tweet draft, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) separately:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+Useful voice-driven prompts:
+
+- "Transcribe this voice note, search tweets about the named launch keywords, and summarize what people are saying."
+- "Turn this voice memo into a tweet draft. Ask me before posting."
+- "Read the latest monitor alert aloud as an OGG voice note."
+
+Keep the Xquik API key out of voice transcripts, prompts, and shared logs. Review every TweetClaw write action before posting, replying, following, sending DMs, or changing account state.
+
 Manage the plugin with `openclaw plugins list`, `openclaw plugins disable kesha-voice-kit`, or `openclaw plugins uninstall kesha-voice-kit`.


### PR DESCRIPTION
## Summary
- Add a focused companion workflow to `docs/openclaw.md` for pairing Kesha transcription/TTS with TweetClaw X/Twitter research and reviewed draft actions.
- Keep Kesha scoped to local voice processing and call out secret hygiene plus write-action review.

## Validation
- `git diff --check`
- Link sweep for `README.md`, `docs/openclaw.md`, and `package.json` URLs. All returned 200 except the npm package webpage, which returned 403 to curl while `npm view @drakulavich/kesha-voice-kit` succeeded.
- `npm view @xquik/tweetclaw version repository.url homepage openclaw --json`
- Duplicate search across open and closed issues/PRs for TweetClaw, @xquik/tweetclaw, Xquik, xquik, x-twitter-scraper, GitHub/npm URLs, and ClawHub wording returned 0 results.