### PR TITLE
Document OpenClaw CLI audio route in skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,6 +26,39 @@ Local voice toolkit: transcribe voice messages to text, synthesize speech, detec
 - **Need to send a voice note (Telegram, WhatsApp, Signal, Discord)**: synthesize directly into the messenger-native format with `kesha say "<text>" --format ogg-opus --out reply.ogg`. Default is mono 24 kHz @ 32 kbps — what Telegram `sendVoice` expects. No `ffmpeg` round-trip needed.
 - **Need to detect what language a file is in** before choosing a pipeline: `kesha --json audio.ogg` returns both audio-based and text-based language detection with confidence scores.
 
+## OpenClaw plugin setup
+
+Install the plugin, then explicitly route OpenClaw audio understanding through the CLI model entry. The plugin registration makes Kesha discoverable, but real voice-message transcription uses `tools.media.audio.models` with a `type: "cli"` entry.
+
+```bash
+bun add -g @drakulavich/kesha-voice-kit
+kesha install
+openclaw plugins install @drakulavich/kesha-voice-kit
+openclaw config set tools.media.audio.enabled true
+openclaw config set tools.media.audio.models \
+  '[{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}]'
+```
+
+Use `--format transcript` for OpenClaw's normal voice-message path: stdout is compact text plus language metadata, while progress and errors stay off the transcript payload.
+
+For agents that need timestamped segments, switch the model entry to JSON output and allow a longer timeout:
+
+```bash
+openclaw config set tools.media.audio.models \
+  '[{"type":"cli","command":"kesha","args":["--json","--timestamps","{{MediaPath}}"],"timeoutSeconds":30}]'
+```
+
+Verification checklist:
+
+```bash
+which kesha
+kesha status
+openclaw plugins list
+openclaw config get tools.media.audio.models
+```
+
+Do not rely on `openclaw.plugin.json` to patch `tools.media.audio.models`; OpenClaw ignores non-schema fields such as `configPatch`. Keep the CLI route in user config.
+
 ## STT: transcribe audio
 
 ```bash

--- a/openclaw-plugin.cjs
+++ b/openclaw-plugin.cjs
@@ -6,7 +6,7 @@
 // 25 languages, no cloud, ~19x faster than Whisper.
 //
 // The same `kesha` CLI also produces messenger-ready voice notes via
-// `kesha say --text "..." --format ogg-opus --out reply.ogg` (Telegram /
+// `kesha say "..." --format ogg-opus --out reply.ogg` (Telegram /
 // Discord ingest OGG/Opus directly — no transcoding needed). Not wired into
 // OpenClaw's media-understanding capability here; invoke it from a hook or
 // agent tool when you want Kesha to speak.


### PR DESCRIPTION
## Summary
- document the actual OpenClaw audio route in `SKILL.md`: `tools.media.audio.models` with a `type: cli` Kesha entry
- include the canonical transcript config, timestamped JSON variant, and verification checklist
- fix the stale `kesha say --text` example in the plugin comment

## Verification
- rg -- "--text|configPatch|tools\.media\.audio\.models|--format\",\"transcript|openclaw config get" SKILL.md openclaw-plugin.cjs docs/openclaw.md CLAUDE.md