### PR TITLE
Release v1.17.1 CLI-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package.json version to 1.17.1
- keep keshaEngine.version and rust/Cargo.toml at 1.17.0
- release current CLI/docs changes as a CLI-only patch with unchanged engine assets

## Included since v1.17.0
- local anonymous Stats tracking (#335)
- CLI negative-path reliability and timeout diagnostics (#336)
- main help command inventory (#337)
- OpenClaw skill route docs (#339)
- JJ/LFS agent guidance (#340)

## Verification
- bun .github/scripts/check-versions.ts
- bunx tsc --noEmit
- bun test tests/unit/ tests/integration/e2e-cli.test.ts