### PR TITLE
Route Darwin Kokoro through FluidAudio

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -107,7 +107,7 @@ jobs:
           # rust/src/transcribe/diarize.rs::sidecar_path).
           - os: macos-14
             target: aarch64-apple-darwin
-            features: coreml,tts,system_tts,system_diarize,system_text_lang
+            features: coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang
             binary: kesha-engine-darwin-arm64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -228,6 +228,19 @@ jobs:
           # first, then plain kesha-diarize. The release-asset name is the
           # platform-suffixed one — same convention as say-avspeech-*.
 
+      - name: Stage FluidAudio Kokoro sidecar (macOS)
+        if: matrix.os == 'macos-14'
+        shell: bash
+        run: |
+          sidecar=$(find "rust/target/${{ matrix.target }}/release/build" -name kesha-kokoro -type f | head -1)
+          if [ -z "$sidecar" ]; then
+            echo "kesha-kokoro sidecar not found — system_kokoro feature may not have compiled" >&2
+            exit 1
+          fi
+          echo "Sidecar at: $sidecar"
+          cp "$sidecar" ./kesha-kokoro
+          cp "$sidecar" kesha-kokoro-darwin-arm64
+
       # detect-text-lang fast-path sidecar: replaces the per-call `swift -e`
       # shell-out. Always built on macOS by `rust/build.rs::build_text_lang_helper`
       # (no feature gate; `text_lang` itself is macOS-only at runtime).
@@ -253,9 +266,10 @@ jobs:
         # MATRIX MIRRORS CARGO DEFAULTS".
         #
         # macOS additionally checks that `say --list-voices` surfaces at
-        # least one `macos-*` entry — that exercises the Swift sidecar's
-        # --list-voices mode end-to-end, so a broken sidecar fails the
-        # build instead of shipping in a release.
+        # least one `macos-*` entry and one FluidAudio-backed Kokoro voice.
+        # That exercises the Swift sidecar voice-listing paths end-to-end,
+        # so a broken sidecar fails the build instead of shipping in a
+        # release.
         run: |
           chmod +x "${{ matrix.binary }}"
           caps=$("./${{ matrix.binary }}" --capabilities-json)
@@ -268,6 +282,11 @@ jobs:
             voices=$("./${{ matrix.binary }}" say --list-voices)
             echo "$voices" | grep -q '^macos-' || {
               echo "expected at least one macos-* voice, got:" >&2
+              echo "$voices" >&2
+              exit 1
+            }
+            echo "$voices" | grep -q '^en-am_michael' || {
+              echo "expected FluidAudio Kokoro voice en-am_michael, got:" >&2
               echo "$voices" >&2
               exit 1
             }
@@ -315,6 +334,13 @@ jobs:
         with:
           name: kesha-diarize-darwin-arm64
           path: kesha-diarize-darwin-arm64
+
+      - name: Upload FluidAudio Kokoro sidecar (macOS)
+        if: matrix.os == 'macos-14'
+        uses: actions/upload-artifact@v7
+        with:
+          name: kesha-kokoro-darwin-arm64
+          path: kesha-kokoro-darwin-arm64
 
       - name: Upload kesha-textlang sidecar (macOS)
         if: matrix.os == 'macos-14'
@@ -377,6 +403,7 @@ jobs:
             kesha-engine-linux-x64
             kesha-engine-windows-x64.exe
             say-avspeech-darwin-arm64
+            kesha-kokoro-darwin-arm64
             kesha-diarize-darwin-arm64
             kesha-textlang-darwin-arm64
           draft: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.f32le
 fixtures/corrupt.bin
 swift/.build/
+swift/*/.build/
 rust/target/
 .worktrees/
 tmp-lang-id-output/

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Each segment gets a `speaker` integer (cluster ID, stable within one file). Linu
 
 ## Text-to-speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian) — voice auto-picks from the text's language:
+Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian) — voice auto-picks from the text's language. On darwin-arm64, Kokoro uses FluidAudio CoreML instead of ONNX:
 
 ```bash
 kesha install --tts                      # ~990MB (Kokoro + Vosk-TTS RU, opt-in)
@@ -158,7 +158,7 @@ See [BENCHMARK.md](BENCHMARK.md) for the full per-file breakdown (Russian + Engl
 | SpeechBrain ECAPA-TDNN | Audio language detection | ~86MB | [HuggingFace](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa) |
 | Apple NLLanguageRecognizer | Text language detection | built-in | macOS system framework |
 | Silero VAD v5 (opt-in) | Voice activity detection | ~2.3MB | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) |
-| Kokoro-82M / Vosk-TTS (opt-in) | Text-to-speech | ~990MB | [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M) · [Vosk-TTS](https://github.com/alphacep/vosk-tts) |
+| Kokoro-82M / Vosk-TTS (opt-in) | Text-to-speech | ~990MB | [FluidAudio Kokoro](https://github.com/FluidInference/FluidAudio) on darwin-arm64; ONNX Kokoro elsewhere · [Vosk-TTS](https://github.com/alphacep/vosk-tts) |
 
 All models run through `kesha-engine` — a Rust binary using [FluidAudio](https://github.com/FluidInference/FluidAudio) (CoreML) on Apple Silicon and [ort](https://github.com/pykeio/ort) (ONNX Runtime) on other platforms.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,7 +22,7 @@ Local voice toolkit: transcribe voice messages to text, synthesize speech, detec
 ## When to use
 
 - **Voice memo arrived** (Telegram, WhatsApp, Slack, Signal .ogg/.opus/.m4a): transcribe with `kesha --json <path>` and branch on the detected language.
-- **Need to reply with audio (file playback)**: synthesize with `kesha say "<text>" > reply.wav`. Auto-routes by detected language (Kokoro-82M for English, Vosk-TTS for Russian). For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
+- **Need to reply with audio (file playback)**: synthesize with `kesha say "<text>" > reply.wav`. Auto-routes by detected language (Kokoro-82M for English, Vosk-TTS for Russian). On darwin-arm64, English Kokoro uses FluidAudio CoreML instead of ONNX. For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
 - **Need to send a voice note (Telegram, WhatsApp, Signal, Discord)**: synthesize directly into the messenger-native format with `kesha say "<text>" --format ogg-opus --out reply.ogg`. Default is mono 24 kHz @ 32 kbps — what Telegram `sendVoice` expects. No `ffmpeg` round-trip needed.
 - **Need to detect what language a file is in** before choosing a pipeline: `kesha --json audio.ogg` returns both audio-based and text-based language detection with confidence scores.
 
@@ -153,7 +153,7 @@ No system deps — English G2P is embedded (`misaki-rs`); Russian G2P is bundled
 
 **Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
 
-**Text-to-speech:** English (Kokoro-82M, ~70 voices), Russian (Vosk-TTS, 5 baked-in speakers — default `ru-vosk-m02`), plus any macOS system voice via `--voice macos-*`.
+**Text-to-speech:** English (Kokoro-82M; FluidAudio CoreML on darwin-arm64, ONNX elsewhere), Russian (Vosk-TTS, 5 baked-in speakers — default `ru-vosk-m02`), plus any macOS system voice via `--voice macos-*`.
 
 ## Performance
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,9 +1,9 @@
 # Text-to-Speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override.
+Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, English Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path.
 
 ```bash
-kesha install --tts                 # ~990MB (Kokoro + Vosk-TTS RU, opt-in)
+kesha install --tts                 # TTS models, opt-in (Darwin Kokoro uses FluidAudio cache)
 kesha say "Hello, world" > hello.wav
 kesha say "Привет, мир" > privet.wav    # auto-routes (Milena on darwin, ru-vosk-m02 elsewhere)
 echo "long text" | kesha say > reply.wav
@@ -15,14 +15,14 @@ kesha say --list-voices
 Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Vosk). OGG/Opus and MP3 are tracked in follow-up issues.
 
 Grapheme-to-phoneme:
-- **English** uses [misaki-rs](https://github.com/MicheleYin/misaki-rs) — a self-contained Rust port of [hexgrad/misaki](https://github.com/hexgrad/misaki) (the G2P Kokoro was trained against). Lexicon and POS-tagger weights are embedded at compile time, no system deps. Out-of-vocabulary words spell letter-by-letter — proper-noun fallback is tracked as a follow-up.
+- **English** uses FluidAudio Kokoro CoreML on darwin-arm64 release builds. Other platforms use [misaki-rs](https://github.com/MicheleYin/misaki-rs) plus the ONNX Kokoro model.
 - **Russian** is handled internally by [Vosk-TTS](https://github.com/alphacep/vosk-tts) — text normalisation, stress, palatalisation, and a BERT prosody model all run inside the bundled ONNX (no separate G2P pass, no system `espeak-ng` dependency).
 - **Other languages**: not supported by the on-disk engines we ship today — tracked per-language in [#212](https://github.com/drakulavich/kesha-voice-kit/issues/212).
 
 Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am_michael` for English Kokoro, `ru-vosk-m02` for Russian Vosk on Linux/Windows. The darwin Russian fallback uses `Milena` (AVSpeech, female) for the zero-install path; pass `--voice ru-vosk-m02` to opt into Vosk on macOS too.
 
 **Supported voices:**
-- English: `en-am_michael` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/` (`am_*`/`bm_*` male, `af_*`/`bf_*` female).
+- English: `en-am_michael` (default). Darwin FluidAudio builds expose the supported FluidAudio Kokoro American-English voices via `kesha say --list-voices`; ONNX builds also see any `.bin` voice you add under `~/.cache/kesha/models/kokoro-82m/voices/`.
 - Russian: 5 Vosk-TTS speakers baked into the multi-speaker model — `ru-vosk-m02` (default, male), `ru-vosk-m01` (male), `ru-vosk-f01`/`f02`/`f03` (female).
 - macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
 
@@ -117,7 +117,7 @@ Range clamped to 0.5×–2.0×; values outside the range are clamped silently. `
 - Relative percent (`+25%` / `-25%`) is NOT supported. The upstream `ssml-parser` strips the sign on parse, so `+N%` would silently produce the absolute `N%` rate. `kesha say --ssml` rejects relative-percent input with a clear error pointing users at absolute percent or named values. Tracked as a v2 follow-up on [#236](https://github.com/drakulavich/kesha-voice-kit/issues/236).
 - Mid-utterance prosody (`<speak>Hi <prosody rate="fast">there</prosody> bye</speak>`) emits a `prosody-mid-utterance` stderr warning and synthesizes the full text at default rate. A leading or trailing structural sibling (`<break/>`, `<say-as>`, `<phoneme>`) outside the `<prosody>` also triggers the mid-utterance path. Per-segment splitting is a v2 follow-up — requires verifying boundary cuts don't produce click/pop. Tracked in [#236](https://github.com/drakulavich/kesha-voice-kit/issues/236).
 - Nested `<prosody>` warns once (`prosody-nested`) and drops the inner attributes; inner content flows at the outer rate.
-- AVSpeech (`macos-*`) voices don't accept SSML yet (#141 follow-up); `--ssml` on a `macos-*` voice errors out before any prosody handling runs.
+- AVSpeech (`macos-*`) and Darwin FluidAudio Kokoro (`en-*` on darwin-arm64 release builds) don't accept SSML yet; `--ssml` errors out before any prosody handling runs.
 - `<prosody pitch>` and `<prosody volume>` are NOT supported in v1 — they warn-once and strip. See #236 for the v2 design considerations.
 
 Engine reports `tts.prosody_rate: true` in `--capabilities-json`. Closes [#236](https://github.com/drakulavich/kesha-voice-kit/issues/236) (rate-only conservative scope; pitch + volume deferred).
@@ -139,8 +139,8 @@ kesha say --ssml --voice ru-vosk-m02 '<speak>Привет <break time="1s"/> м�
 | `<say-as interpret-as="characters">…</say-as>` | ✅ honored on `ru-vosk-*` (#232) and `en-*` (#244) — letter-spells via the embedded table; stripped with stderr warning on AVSpeech |
 | `<say-as interpret-as="cardinal\|ordinal\|date\|telephone\|...">` | ⚠️ stripped with stderr warning (contained text still synthesized); separate concern |
 | `<emphasis>` | ✅ honored on `ru-vosk-*` (#233) — `+vowel` markers shift stress; `level="none"` suppresses. Stripped + warned on Kokoro / AVSpeech (no `+`-marker analog) |
-| `<phoneme alphabet="ipa" ph="…">` | ✅ honored on Kokoro — bypasses G2P, feeds IPA directly to inference (#193) |
-| `<prosody rate>` | ✅ honored on `ru-vosk-*` and `en-*` voices when wrapping the whole utterance — see the section above (#236). Mid-utterance / sibling-flanked: warned + stripped. |
+| `<phoneme alphabet="ipa" ph="…">` | ✅ honored on ONNX Kokoro — bypasses G2P, feeds IPA directly to inference (#193). Not yet supported by Darwin FluidAudio Kokoro. |
+| `<prosody rate>` | ✅ honored on `ru-vosk-*` and ONNX `en-*` voices when wrapping the whole utterance — see the section above (#236). Mid-utterance / sibling-flanked: warned + stripped. |
 | `<prosody pitch/volume>` | ⚠️ stripped with stderr warning; v2 follow-up tracked in [#236](https://github.com/drakulavich/kesha-voice-kit/issues/236) |
 | `<!DOCTYPE>` | ❌ rejected (hardening against XXE) |
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,10 @@ tts = ["dep:hound", "dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg"]
 # Opt-in — builds a Swift sidecar via swiftc in build.rs. Silently no-op on
 # non-macOS targets even when enabled.
 system_tts = ["tts"]
+# macOS arm64 Kokoro via FluidAudio CoreML sidecar. Keeps Linux/Windows on the
+# existing ONNX Kokoro path while darwin-arm64 release builds avoid ONNX for
+# English TTS.
+system_kokoro = ["tts"]
 # darwin-arm64 speaker diarization via FluidAudio (#199). Requires FluidAudio's
 # diarization SDK and companion helper binary. Darwin-only.
 system_diarize = []

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -15,6 +15,15 @@ fn main() {
     #[cfg(all(feature = "system_tts", target_os = "macos"))]
     build_avspeech_helper();
 
+    // `system_kokoro`: compile the FluidAudio Kokoro helper on macOS arm64.
+    // Writes the sidecar binary to $OUT_DIR/kesha-kokoro.
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    build_kokoro_sidecar();
+
     // `system_diarize` (#199): compile the kesha-diarize Swift sidecar on macOS arm64.
     // Writes the sidecar binary to $OUT_DIR/kesha-diarize. Silently no-op on
     // other targets so `--features system_diarize` works in cross-platform builds.
@@ -32,6 +41,52 @@ fn main() {
     // path in text_lang.rs). Silently no-op on Linux/Windows.
     #[cfg(all(feature = "system_text_lang", target_os = "macos"))]
     build_text_lang_helper();
+}
+
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn build_kokoro_sidecar() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let swift_pkg = manifest_dir.parent().unwrap().join("swift/kesha-kokoro");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_bin = out_dir.join("kesha-kokoro");
+
+    println!("cargo:rerun-if-changed={}", swift_pkg.display());
+    println!(
+        "cargo:rerun-if-changed={}/Sources/kesha-kokoro/main.swift",
+        swift_pkg.display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}/Package.swift",
+        swift_pkg.display()
+    );
+
+    let status = Command::new("swift")
+        .arg("build")
+        .arg("--configuration")
+        .arg("release")
+        .arg("--package-path")
+        .arg(&swift_pkg)
+        .status()
+        .expect(
+            "swift not found — install Xcode command-line tools or disable --features system_kokoro",
+        );
+    assert!(
+        status.success(),
+        "swift build failed for kesha-kokoro at {}",
+        swift_pkg.display()
+    );
+
+    let built = swift_pkg.join(".build/release/kesha-kokoro");
+    std::fs::copy(&built, &out_bin).expect("failed to copy kesha-kokoro sidecar to OUT_DIR");
+
+    println!("cargo:rustc-env=KESHA_KOKORO_HELPER={}", out_bin.display());
 }
 
 #[cfg(all(feature = "system_tts", target_os = "macos"))]

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -82,21 +82,32 @@ pub(crate) fn resolve_output_format(
     Ok(chosen)
 }
 
-fn list_kokoro_voices(cache: &std::path::Path) -> Vec<String> {
-    let dir = cache.join("models/kokoro-82m/voices");
-    std::fs::read_dir(&dir)
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .filter_map(|e| {
-            let p = e.path();
-            if p.extension().and_then(|s| s.to_str()) == Some("bin") {
-                p.file_stem().map(|s| format!("en-{}", s.to_string_lossy()))
-            } else {
-                None
-            }
-        })
-        .collect()
+fn list_kokoro_voices(_cache: &std::path::Path) -> Vec<String> {
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    {
+        return tts::fluid_kokoro::available_voice_ids();
+    }
+    #[allow(unreachable_code)]
+    {
+        let dir = _cache.join("models/kokoro-82m/voices");
+        std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let p = e.path();
+                if p.extension().and_then(|s| s.to_str()) == Some("bin") {
+                    p.file_stem().map(|s| format!("en-{}", s.to_string_lossy()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 fn list_vosk_ru_voices(cache: &std::path::Path) -> Vec<String> {
@@ -206,6 +217,17 @@ pub fn run(a: SayArgs) -> i32 {
             voice_path,
             speed: a.rate,
         },
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        tts::voices::ResolvedVoice::FluidKokoro { voice_id, .. } => {
+            tts::EngineChoice::FluidKokoro {
+                voice_id,
+                speed: a.rate,
+            }
+        }
         tts::voices::ResolvedVoice::Vosk {
             model_dir,
             speaker_id,

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -118,7 +118,17 @@ const LANG_ID_FILES: &[ModelFile] = &[
 
 #[cfg(feature = "tts")]
 pub fn kokoro_manifest() -> Vec<ModelFile> {
-    vec![
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    {
+        return Vec::new();
+    }
+    #[allow(unreachable_code)]
+    {
+        vec![
         ModelFile {
             // The HF onnx-community variant produces unintelligible audio with
             // `af_heart` — confirmed by audio bisection, see #207. Use the
@@ -139,6 +149,7 @@ pub fn kokoro_manifest() -> Vec<ModelFile> {
             sha256: "1d1f21dd8da39c30705cd4c75d039d265e9bc4a2a93ed09bc9e1b1225eb95ba1",
         },
     ]
+    }
 }
 
 /// Vosk-TTS multi-speaker Russian model, mirrored to HF at
@@ -573,11 +584,26 @@ mod tts_tests {
     #[test]
     fn kokoro_manifest_has_expected_files() {
         let m = kokoro_manifest();
-        assert!(m.iter().any(|f| f.rel_path.ends_with("model.onnx")));
-        assert!(m.iter().any(|f| f.rel_path.ends_with("am_michael.bin")));
-        for f in &m {
-            assert_eq!(f.sha256.len(), 64, "{:?} sha256 not 64 hex chars", f);
-            assert!(f.url.starts_with("https://"), "{f:?} url not https");
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        {
+            assert!(m.is_empty());
+        }
+        #[cfg(not(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        )))]
+        {
+            assert!(m.iter().any(|f| f.rel_path.ends_with("model.onnx")));
+            assert!(m.iter().any(|f| f.rel_path.ends_with("am_michael.bin")));
+            for f in &m {
+                assert_eq!(f.sha256.len(), 64, "{:?} sha256 not 64 hex chars", f);
+                assert!(f.url.starts_with("https://"), "{f:?} url not https");
+            }
         }
     }
 

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -273,6 +273,28 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
                     .map_err(|e| format!("encode: {e}"))
             }
         }
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        tts::voices::ResolvedVoice::FluidKokoro { voice_id, .. } => {
+            if req.ssml {
+                return Err("SSML is not yet supported with FluidAudio Kokoro voices".into());
+            }
+            tts::say(tts::SayOptions {
+                text: &req.text,
+                lang: espeak_lang,
+                engine: tts::EngineChoice::FluidKokoro {
+                    voice_id: &voice_id,
+                    speed: req.rate,
+                },
+                ssml: false,
+                format,
+                expand_abbrev: req.expand_abbrev,
+            })
+            .map_err(|e| e.to_string())
+        }
         tts::voices::ResolvedVoice::Vosk {
             model_dir,
             speaker_id,

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -1,0 +1,149 @@
+//! FluidAudio Kokoro backend — macOS arm64, behind `system_kokoro`.
+//!
+//! The public `fluidaudio-rs` crate does not expose Kokoro TTS yet, so Kesha
+//! shells out to a small Swift sidecar that links FluidAudio directly. This
+//! mirrors the AVSpeech/diarize sidecar pattern and keeps non-Darwin builds on
+//! the existing ONNX Kokoro implementation.
+
+#![cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+// FluidAudio 0.14.5 voice snapshot. Keep this list in sync with
+// swift/kesha-kokoro/Package.resolved whenever the FluidAudio pin changes.
+const VOICES: &[&str] = &[
+    "af_alloy",
+    "af_aoede",
+    "af_bella",
+    "af_heart",
+    "af_jessica",
+    "af_kore",
+    "af_nicole",
+    "af_nova",
+    "af_river",
+    "af_sarah",
+    "af_sky",
+    "am_adam",
+    "am_echo",
+    "am_eric",
+    "am_fenrir",
+    "am_liam",
+    "am_michael",
+    "am_onyx",
+    "am_puck",
+    "am_santa",
+];
+
+pub fn available_voice_ids() -> Vec<String> {
+    VOICES.iter().map(|v| format!("en-{v}")).collect()
+}
+
+pub fn supports_voice(name: &str) -> bool {
+    VOICES.contains(&name)
+}
+
+pub fn helper_path() -> PathBuf {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            for name in ["kesha-kokoro", "kesha-kokoro-darwin-arm64"] {
+                let sibling = parent.join(name);
+                if sibling.exists() {
+                    return sibling;
+                }
+            }
+        }
+    }
+    PathBuf::from(env!("KESHA_KOKORO_HELPER"))
+}
+
+pub fn synthesize(
+    text: &str,
+    voice_id: &str,
+    speed: f32,
+    helper: Option<&Path>,
+) -> anyhow::Result<Vec<u8>> {
+    if text.is_empty() {
+        anyhow::bail!("fluid-kokoro: text is empty");
+    }
+    let bin = helper.map(PathBuf::from).unwrap_or_else(helper_path);
+    let speed_arg = format!("{speed:.3}");
+
+    let mut child = Command::new(&bin)
+        .arg("--voice")
+        .arg(voice_id)
+        .arg("--speed")
+        .arg(speed_arg)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("spawn {}: {e}", bin.display()))?;
+
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("fluid-kokoro: stdin unavailable"))?
+        .write_all(text.as_bytes())?;
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "fluid-kokoro helper exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fake_helper(tmp: &TempDir, script: &str) -> PathBuf {
+        let path = tmp.path().join("fake-fluid-kokoro.sh");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "#!/bin/sh").unwrap();
+        writeln!(f, "{script}").unwrap();
+        drop(f);
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path
+    }
+
+    #[test]
+    fn lists_supported_kesha_voice_ids() {
+        let voices = available_voice_ids();
+        assert!(voices.contains(&"en-am_michael".to_string()));
+        assert!(voices.contains(&"en-af_heart".to_string()));
+    }
+
+    #[test]
+    fn helper_stdout_is_returned_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        let helper = fake_helper(&tmp, r#"cat >/dev/null; printf 'RIFFmock'"#);
+        let bytes = synthesize("hello", "am_michael", 1.0, Some(&helper)).unwrap();
+        assert_eq!(&bytes, b"RIFFmock");
+    }
+
+    #[test]
+    fn helper_nonzero_exit_surfaces_stderr() {
+        let tmp = TempDir::new().unwrap();
+        let helper = fake_helper(&tmp, r#"echo 'voice not found: xyz' >&2; exit 2"#);
+        let err = synthesize("hello", "xyz", 1.0, Some(&helper))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("voice not found"), "msg: {err}");
+        assert!(err.contains("exited"), "msg: {err}");
+    }
+}

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -10,6 +10,12 @@ use std::path::Path;
 
 pub mod en;
 pub mod encode;
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub mod fluid_kokoro;
 pub mod g2p;
 pub mod kokoro;
 pub mod ru;
@@ -50,6 +56,13 @@ pub enum EngineChoice<'a> {
         voice_path: &'a Path,
         speed: f32,
     },
+    /// Kokoro via FluidAudio CoreML sidecar on darwin-arm64.
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    FluidKokoro { voice_id: &'a str, speed: f32 },
     /// macOS AVSpeechSynthesizer via the Swift sidecar (#141).
     /// `voice_id` is forwarded verbatim (an Apple identifier or a language code).
     #[cfg(all(feature = "system_tts", target_os = "macos"))]

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -88,6 +88,12 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
     }
     let engine_label: &str = match &opts.engine {
         EngineChoice::Kokoro { .. } => "kokoro",
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        EngineChoice::FluidKokoro { .. } => "fluid-kokoro",
         EngineChoice::Vosk { .. } => "vosk",
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         EngineChoice::AVSpeech { .. } => "avspeech",
@@ -97,6 +103,22 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         opts.lang,
         opts.ssml
     );
+
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    if let EngineChoice::FluidKokoro { voice_id, speed } = &opts.engine {
+        if opts.ssml {
+            return Err(TtsError::SynthesisFailed(
+                "SSML is not yet supported with FluidAudio Kokoro voices".into(),
+            ));
+        }
+        let wav_bytes = super::fluid_kokoro::synthesize(opts.text, voice_id, *speed, None)
+            .map_err(|e| TtsError::SynthesisFailed(format!("fluid-kokoro: {e}")))?;
+        return transcode_to(&wav_bytes, opts.format);
+    }
 
     // AVSpeech does its own G2P + synthesis inside Swift; skip espeak G2P entirely.
     #[cfg(all(feature = "system_tts", target_os = "macos"))]
@@ -185,6 +207,12 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         } => say_with_kokoro(&ipa, model_path, voice_path, speed, opts.format),
         // Vosk and AVSpeech are handled by early-returns above. Keep guard arms
         // so the match stays exhaustive when those features are enabled.
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        EngineChoice::FluidKokoro { .. } => unreachable!("handled by early return above"),
         EngineChoice::Vosk { .. } => unreachable!("handled by early return above"),
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         EngineChoice::AVSpeech { .. } => unreachable!("handled by early return above"),
@@ -216,6 +244,14 @@ fn say_ssml(opts: &SayOptions) -> Result<Vec<u8>, TtsError> {
             opts.format,
             opts.expand_abbrev,
         ),
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        EngineChoice::FluidKokoro { .. } => {
+            unreachable!("FluidAudio Kokoro + SSML rejected in say() early return")
+        }
         // Vosk + SSML is handled by the early-return in say(); this arm keeps the match exhaustive.
         EngineChoice::Vosk { .. } => unreachable!("handled by early return in say()"),
         // AVSpeech + SSML is rejected up-front in `say()`; this arm keeps the match exhaustive.
@@ -515,26 +551,40 @@ fn encode_or_fail(
         .map_err(|e| TtsError::SynthesisFailed(format!("encode: {e}")))
 }
 
-/// Decode WAV bytes the AVSpeech sidecar handed back to PCM, then re-encode in
-/// the caller's chosen format. WAV → WAV is a no-op short-circuit so we don't
-/// pay a hound round-trip for the historical default path.
-#[cfg(all(feature = "system_tts", target_os = "macos"))]
+/// Decode WAV bytes a Swift sidecar handed back to PCM, then re-encode in the
+/// caller's chosen format. WAV → WAV is a no-op short-circuit so we don't pay a
+/// hound round-trip for the historical default path.
+#[cfg(any(
+    all(feature = "system_tts", target_os = "macos"),
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )
+))]
 fn transcode_to(wav_bytes: &[u8], format: OutputFormat) -> Result<Vec<u8>, TtsError> {
     if matches!(format, OutputFormat::Wav) {
         return Ok(wav_bytes.to_vec());
     }
     let reader = hound::WavReader::new(std::io::Cursor::new(wav_bytes))
-        .map_err(|e| TtsError::SynthesisFailed(format!("avspeech wav decode: {e}")))?;
+        .map_err(|e| TtsError::SynthesisFailed(format!("sidecar wav decode: {e}")))?;
     let spec = reader.spec();
     let samples = wav_to_mono_f32(reader)
-        .map_err(|e| TtsError::SynthesisFailed(format!("avspeech wav decode: {e}")))?;
+        .map_err(|e| TtsError::SynthesisFailed(format!("sidecar wav decode: {e}")))?;
     encode_or_fail(&samples, spec.sample_rate, format)
 }
 
 /// Read all samples from a WAV reader, mixing stereo to mono and converting
 /// integer PCM to f32. AVSpeech emits 22.05 kHz 16-bit mono on macOS today,
 /// but we keep this generic so a future sidecar change doesn't break us.
-#[cfg(all(feature = "system_tts", target_os = "macos"))]
+#[cfg(any(
+    all(feature = "system_tts", target_os = "macos"),
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )
+))]
 fn wav_to_mono_f32<R: std::io::Read>(mut reader: hound::WavReader<R>) -> anyhow::Result<Vec<f32>> {
     let spec = reader.spec();
     let channels = spec.channels as usize;

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -49,6 +49,16 @@ pub enum ResolvedVoice {
         voice_path: std::path::PathBuf,
         espeak_lang: &'static str,
     },
+    /// Kokoro via FluidAudio CoreML sidecar on darwin-arm64.
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    FluidKokoro {
+        voice_id: String,
+        espeak_lang: &'static str,
+    },
     /// Vosk-TTS multi-speaker Russian (replaces Piper-ru per spec/PR for #210).
     Vosk {
         model_dir: std::path::PathBuf,
@@ -66,6 +76,12 @@ impl ResolvedVoice {
     pub fn espeak_lang(&self) -> &'static str {
         match self {
             Self::Kokoro { espeak_lang, .. } => espeak_lang,
+            #[cfg(all(
+                feature = "system_kokoro",
+                target_os = "macos",
+                target_arch = "aarch64"
+            ))]
+            Self::FluidKokoro { espeak_lang, .. } => espeak_lang,
             Self::Vosk { .. } => "",
             // AVSpeech does its own G2P; the espeak language tag is unused.
             #[cfg(all(feature = "system_tts", target_os = "macos"))]
@@ -108,25 +124,44 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
     }
 }
 
-fn resolve_kokoro(cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Result<ResolvedVoice> {
-    let model_path = cache_dir.join("models/kokoro-82m/model.onnx");
-    let voice_path = cache_dir
-        .join("models/kokoro-82m/voices")
-        .join(format!("{name}.bin"));
-    if !voice_path.exists() {
-        anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+fn resolve_kokoro(_cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Result<ResolvedVoice> {
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    {
+        if !crate::tts::fluid_kokoro::supports_voice(name) {
+            anyhow::bail!(
+                "unknown FluidAudio Kokoro voice '{voice_id}'. run: kesha say --list-voices"
+            );
+        }
+        return Ok(ResolvedVoice::FluidKokoro {
+            voice_id: name.to_string(),
+            espeak_lang: "en-us",
+        });
     }
-    if !model_path.exists() {
-        anyhow::bail!(
-            "kokoro model not installed at {}. run: kesha install --tts",
-            model_path.display()
-        );
+    #[allow(unreachable_code)]
+    {
+        let model_path = _cache_dir.join("models/kokoro-82m/model.onnx");
+        let voice_path = _cache_dir
+            .join("models/kokoro-82m/voices")
+            .join(format!("{name}.bin"));
+        if !voice_path.exists() {
+            anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+        }
+        if !model_path.exists() {
+            anyhow::bail!(
+                "kokoro model not installed at {}. run: kesha install --tts",
+                model_path.display()
+            );
+        }
+        Ok(ResolvedVoice::Kokoro {
+            model_path,
+            voice_path,
+            espeak_lang: "en-us",
+        })
     }
-    Ok(ResolvedVoice::Kokoro {
-        model_path,
-        voice_path,
-        espeak_lang: "en-us",
-    })
 }
 
 fn resolve_vosk_ru(
@@ -209,6 +244,11 @@ mod tests {
         assert_eq!(s[VOICE_COLS - 1], 8.0);
     }
 
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
     fn populate_cache(cache: &Path) {
         let voices = cache.join("models/kokoro-82m/voices");
         std::fs::create_dir_all(&voices).unwrap();
@@ -216,6 +256,11 @@ mod tests {
         std::fs::write(cache.join("models/kokoro-82m/model.onnx"), b"dummy").unwrap();
     }
 
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
     #[test]
     fn resolve_installed_kokoro_voice() {
         let tmp = tempfile::tempdir().unwrap();
@@ -232,6 +277,27 @@ mod tests {
                 assert_eq!(espeak_lang, "en-us");
             }
             other => panic!("expected Kokoro, got {other:?}"),
+        }
+    }
+
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    #[test]
+    fn resolve_kokoro_voice_uses_fluid_audio_on_darwin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let r = resolve_voice(tmp.path(), "en-am_michael").unwrap();
+        match r {
+            ResolvedVoice::FluidKokoro {
+                voice_id,
+                espeak_lang,
+            } => {
+                assert_eq!(voice_id, "am_michael");
+                assert_eq!(espeak_lang, "en-us");
+            }
+            other => panic!("expected FluidKokoro, got {other:?}"),
         }
     }
 

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from "path";
-import { existsSync, mkdirSync, chmodSync, accessSync, constants } from "fs";
+import { tmpdir } from "os";
+import { existsSync, mkdirSync, chmodSync, accessSync, constants, rmSync } from "fs";
 import {
   getEngineBinPath,
   getEngineCapabilities,
@@ -73,6 +74,13 @@ const SIDECARS: SidecarSpec[] = [
     displayName: "Diarization sidecar",
     availableHint: "--speakers available",
     unavailableHint: "--speakers unavailable",
+  },
+  {
+    fileBasename: "kesha-kokoro",
+    assetName: "kesha-kokoro-darwin-arm64",
+    displayName: "FluidAudio Kokoro sidecar",
+    availableHint: "Kokoro uses FluidAudio CoreML",
+    unavailableHint: "en-* Kokoro voices unavailable on Darwin",
   },
   {
     // Runtime resolver looks for plain `kesha-textlang` next to the engine
@@ -218,6 +226,76 @@ async function downloadSidecar(
     log.warn(
       `${spec.displayName} install failed (${e instanceof Error ? e.message : e}); ${spec.unavailableHint}.`,
     );
+  }
+}
+
+async function warmDarwinKokoro(binPath: string): Promise<void> {
+  if (process.platform !== "darwin" || process.arch !== "arm64") return;
+  const sidecarPath = join(dirname(binPath), "kesha-kokoro");
+  if (!existsSync(sidecarPath)) return;
+
+  const outPath = join(tmpdir(), `kesha-kokoro-warmup-${process.pid}.wav`);
+  log.progress("Warming FluidAudio Kokoro CoreML cache...");
+
+  const startedAt = performance.now();
+  const proc = Bun.spawn(
+    [
+      binPath,
+      "say",
+      "--voice",
+      "en-am_michael",
+      "--out",
+      outPath,
+      "Kesha warmup.",
+    ],
+    {
+      stdout: "ignore",
+      stderr: "pipe",
+    },
+  );
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, 180_000);
+
+  let stderr = "";
+  try {
+    const stderrStream = proc.stderr as ReadableStream<Uint8Array>;
+    const [stderrText, exitCode] = await Promise.all([
+      new Response(stderrStream).text(),
+      proc.exited,
+    ]);
+    stderr = stderrText.trim();
+
+    if (timedOut) {
+      log.warn("FluidAudio Kokoro warmup timed out; first `kesha say en-*` may still be slow.");
+      return;
+    }
+    if (exitCode !== 0) {
+      log.warn(
+        `FluidAudio Kokoro warmup failed${stderr ? `: ${stderr}` : ""}; first ` +
+          "`kesha say en-*` may still be slow.",
+      );
+      return;
+    }
+
+    log.success(
+      `FluidAudio Kokoro warmed (${Math.round(performance.now() - startedAt)}ms).`,
+    );
+  } catch (e) {
+    log.warn(
+      `FluidAudio Kokoro warmup failed (${e instanceof Error ? e.message : e}); ` +
+        "first `kesha say en-*` may still be slow.",
+    );
+  } finally {
+    clearTimeout(timer);
+    try {
+      rmSync(outPath, { force: true });
+    } catch {
+      // best-effort cleanup only
+    }
   }
 }
 
@@ -425,6 +503,10 @@ export async function downloadEngine(
   if (proc.exitCode !== 0) {
     const detail = stderr.trim();
     throw new Error(detail ? `Failed to install models: ${detail}` : "Failed to install models");
+  }
+
+  if (options.tts) {
+    await warmDarwinKokoro(binPath);
   }
 
   log.success("Backend installed successfully.");

--- a/swift/kesha-kokoro/Package.resolved
+++ b/swift/kesha-kokoro/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "30d1936d71c3ae679a21187579a3618a56fed75fb118dd802f7eaf34970fe6e5",
+  "pins" : [
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "state" : {
+        "revision" : "ce59fb14b8b8978b196f6a34282e20ea6762d164",
+        "version" : "0.14.5"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/swift/kesha-kokoro/Package.swift
+++ b/swift/kesha-kokoro/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "kesha-kokoro",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(
+            url: "https://github.com/FluidInference/FluidAudio.git",
+            exact: "0.14.5"
+        ),
+    ],
+    targets: [
+        .executableTarget(
+            name: "kesha-kokoro",
+            dependencies: ["FluidAudio"]
+        )
+    ]
+)

--- a/swift/kesha-kokoro/Sources/kesha-kokoro/main.swift
+++ b/swift/kesha-kokoro/Sources/kesha-kokoro/main.swift
@@ -1,0 +1,67 @@
+import Foundation
+import FluidAudio
+
+func usage() -> Never {
+    FileHandle.standardError.write(Data(
+        "usage: kesha-kokoro [--voice <voice>] [--speed <0.5-2.0>] [text]\n".utf8
+    ))
+    exit(2)
+}
+
+var voice = "am_michael"
+var speed: Float = 1.0
+var positional: [String] = []
+var i = 1
+let args = CommandLine.arguments
+
+while i < args.count {
+    switch args[i] {
+    case "--voice":
+        guard i + 1 < args.count else { usage() }
+        voice = args[i + 1]
+        i += 2
+    case "--speed":
+        guard i + 1 < args.count, let parsed = Float(args[i + 1]) else { usage() }
+        speed = parsed
+        i += 2
+    case "--help", "-h":
+        usage()
+    default:
+        positional.append(args[i])
+        i += 1
+    }
+}
+
+let text: String
+if !positional.isEmpty {
+    text = positional.joined(separator: " ")
+} else {
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    text = String(data: data, encoding: .utf8) ?? ""
+}
+
+let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+guard !trimmed.isEmpty else {
+    FileHandle.standardError.write(Data("empty text\n".utf8))
+    exit(2)
+}
+
+let clampedSpeed = min(max(speed, 0.5), 2.0)
+let manager = KokoroTtsManager(defaultVoice: voice)
+
+do {
+    try await manager.initialize(preloadVoices: [voice])
+    let wav = try await manager.synthesize(
+        text: trimmed,
+        voice: voice,
+        voiceSpeed: clampedSpeed
+    )
+    guard !wav.isEmpty else {
+        FileHandle.standardError.write(Data("error: FluidAudio Kokoro returned no audio\n".utf8))
+        exit(1)
+    }
+    FileHandle.standardOutput.write(wav)
+} catch {
+    FileHandle.standardError.write(Data("error: FluidAudio Kokoro failed: \(error)\n".utf8))
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- add a Darwin arm64 `system_kokoro` path that routes built-in `en-*` Kokoro voices through a new FluidAudio Swift sidecar instead of requiring Kesha ONNX Kokoro files
- keep the existing ONNX Kokoro path for Linux/Windows and explicit custom `--model/--voice-file` usage
- ship `kesha-kokoro-darwin-arm64` from the engine release workflow, install it with the engine bundle, and document the Darwin FluidAudio behavior and SSML limitation

## Tests
- `swift package resolve --package-path swift/kesha-kokoro`
- `swift build --configuration release --package-path swift/kesha-kokoro`
- `./swift/kesha-kokoro/.build/release/kesha-kokoro --help` (prints usage; exits 2)
- `cargo check --no-default-features --features onnx,tts`
- `cargo check --no-default-features --features tts,system_tts,system_kokoro,system_text_lang` (passes with existing `argmax` dead-code warning)
- `cargo test --no-default-features --features onnx,tts voices`
- `cargo test --no-default-features --features tts,system_tts,system_kokoro,system_text_lang fluid_kokoro` (passes with existing `argmax` dead-code warning)
- `bunx tsc --noEmit`
- `bun .github/scripts/check-workflows.ts`

## Known local blocker
- `cargo check --no-default-features --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang` fails locally before this new sidecar code, inside the existing `fluidaudio-rs v0.1.0` ASR Swift bridge with Swift 6 strict-concurrency errors in `StreamingAsrManager.swift`.
