### PR TITLE
fix(ci): publish release checksums and safe preflight

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -370,40 +370,39 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      # Multi-line heredoc form for $GITHUB_OUTPUT — a single-line
-      # `echo "body=…"` would truncate at the first newline. KESHA_NOTES_EOF
-      # is a magic marker chosen to be highly unlikely in user-authored
-      # release notes; a colliding marker would inject content but the
-      # release body is a doc field, not a shell context, so impact is
-      # cosmetic.
-      - name: Extract release notes from tag annotation
-        id: notes
+      - name: Prepare release notes from tag annotation
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          body=$(git tag -l --format='%(contents)' "$TAG_NAME" || true)
-          EOF_MARKER=$(openssl rand -hex 16)
-          {
-            echo "body<<$EOF_MARKER"
-            printf '%s\n' "$body"
-            echo "$EOF_MARKER"
-          } >> "$GITHUB_OUTPUT"
+          git tag -l --format='%(contents)' "$TAG_NAME" > release-notes.md
+          cat >> release-notes.md <<EOF
+
+          ### Verify release assets
+
+          Download the published binaries and checksums, then verify them:
+
+          \`\`\`bash
+          gh release download $TAG_NAME -p SHA256SUMS -p 'kesha-*' -p 'say-*'
+          sha256sum -c SHA256SUMS
+          \`\`\`
+          EOF
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
           merge-multiple: true
+          path: release-assets
+
+      - name: Generate release checksums
+        shell: bash
+        run: |
+          cd release-assets
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
 
       - name: Create draft release with binaries
         uses: softprops/action-gh-release@v3
         with:
-          body: ${{ steps.notes.outputs.body }}
-          files: |
-            kesha-engine-darwin-arm64
-            kesha-engine-linux-x64
-            kesha-engine-windows-x64.exe
-            say-avspeech-darwin-arm64
-            kesha-kokoro-darwin-arm64
-            kesha-diarize-darwin-arm64
-            kesha-textlang-darwin-arm64
+          body_path: release-notes.md
+          files: release-assets/*
           draft: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       tts_e2e: ${{ steps.filter.outputs.tts_e2e }}
       raycast: ${{ steps.filter.outputs.raycast }}
       nix: ${{ steps.filter.outputs.nix }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -93,6 +94,26 @@ jobs:
               - 'rust/**'
               - 'package.json'
               - '.github/workflows/ci.yml'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/scripts/check-workflows.ts'
+              - 'package.json'
+              - 'bun.lock'
+
+  workflow-lint:
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      - name: 🔍 Check workflow YAML
+        run: bun run check:workflows
 
   unit-tests:
     needs: changes
@@ -385,4 +406,3 @@ jobs:
 
       - name: 🚬 Smoke
         run: ./result/bin/kesha-engine --version
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test unit integration rust-test lint lint-tsgo versions smoke-test release publish help
+.PHONY: install check test unit integration rust-test lint lint-tsgo versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -7,6 +7,8 @@ install: ## Install dependencies
 	bun install
 
 test: unit integration ## Run all tests
+
+check: lint versions test ## Run local checks that mirror the cheap CI gates
 
 unit: ## Run unit tests
 	bun run test:unit
@@ -39,8 +41,11 @@ smoke-test-tts: ## Run smoke tests with TTS
 benchmark: ## Run benchmark (openai-whisper vs faster-whisper vs Kesha)
 	bun scripts/benchmark.ts
 
-release: lint test smoke-test ## Verify everything before publish
-	@echo "All checks passed. Ready to publish."
+release-preflight: check smoke-test ## Verify locally before cutting a GitHub release
+	@echo "Release preflight passed. Cut/publish via the GitHub release workflow, not npm publish."
 
-publish: release ## Publish to npm
-	npm publish --access public
+release: release-preflight ## Backward-compatible alias for release-preflight
+
+release-notes: ## Print an existing release body: make release-notes TAG=vX.Y.Z
+	@test -n "$(TAG)" || (echo "usage: make release-notes TAG=vX.Y.Z" >&2; exit 2)
+	gh release view "$(TAG)" --json body --jq .body


### PR DESCRIPTION
## Summary

- generate SHA256SUMS for every engine release asset and attach it to the draft release
- append release-note verification commands that use `gh release download` and `sha256sum -c`
- replace the dangerous direct `make publish -> npm publish` path with `check`, `release-preflight`, and `release-notes` targets
- add a `workflow-lint` CI job so workflow edits run `bun run check:workflows` instead of silently skipping all checks

Refs #344.

## Checks

- `bun .github/scripts/check-workflows.ts`
- `bun .github/scripts/check-versions.ts`
- `bunx tsc --noEmit`
- `make help`
- `bun run test:unit`
- simulated `sha256sum -c SHA256SUMS` over release asset names
