### PR TITLE
feat(ci): publish Docker image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.jj
+.github
+.cache
+.kokoro-spike
+node_modules
+raycast/node_modules
+rust/target
+swift/**/.build
+dist
+coverage
+test-results
+flakiness-report
+*.log
+*.tmp
+.DS_Store

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,13 @@ updates:
         update-types:
           - minor
           - patch
+
+  # Docker base image updates.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,98 @@
+name: "🐳 Docker"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - compose.yml
+      - package.json
+      - bun.lock
+      - bin/**
+      - src/**
+      - fixtures/benchmark/**
+      - fixtures/benchmark-en/**
+      - .github/workflows/docker.yml
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/drakulavich/kesha-voice-kit
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🔍 Detect Docker-relevant changes
+        if: github.event_name == 'push' && github.ref_type == 'branch'
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            docker:
+              - Dockerfile
+              - .dockerignore
+              - compose.yml
+              - package.json
+              - bun.lock
+              - bin/**
+              - src/**
+              - fixtures/benchmark/**
+              - fixtures/benchmark-en/**
+              - .github/workflows/docker.yml
+
+      - name: 🔨 Build image for PR smoke
+        if: github.event_name == 'pull_request'
+        run: docker build --platform linux/amd64 -t kesha-voice-kit:ci .
+
+      - name: 🚬 Smoke PR image
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm kesha-voice-kit:ci --version
+          docker run --rm kesha-voice-kit:ci status
+
+      - name: 🔐 Login to GHCR
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏷️ Docker metadata
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: 📦 Build and publish image
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM oven/bun:1.3.13-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    KESHA_CACHE_DIR=/cache/kesha
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
+COPY bin ./bin
+COPY src ./src
+COPY fixtures/benchmark ./fixtures/benchmark
+COPY fixtures/benchmark-en ./fixtures/benchmark-en
+COPY BENCHMARK.md LICENSE NOTICES.md README.md SKILL.md ./
+COPY openclaw.plugin.json openclaw-plugin.cjs ./
+
+RUN chmod +x /app/bin/kesha.js \
+  && ln -s /app/bin/kesha.js /usr/local/bin/kesha \
+  && ln -s /app/bin/kesha.js /usr/local/bin/parakeet \
+  && mkdir -p /cache/kesha /work \
+  && chown -R bun:bun /app /cache /work
+
+USER bun
+WORKDIR /work
+
+ENTRYPOINT ["kesha"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,31 @@ nix run github:drakulavich/kesha-voice-kit -- audio.ogg    # transcribe
 
 Full recipes (one-liner, profile install, engine-only, dev shell) live in [docs/nix-install.md](docs/nix-install.md).
 
+## Docker
+
+Linux x64 CLI image, published to GHCR:
+
+```bash
+docker run --rm \
+  -v kesha-cache:/cache/kesha \
+  -v "$PWD:/work" -w /work \
+  ghcr.io/drakulavich/kesha-voice-kit:latest install
+
+docker run --rm \
+  -v kesha-cache:/cache/kesha \
+  -v "$PWD:/work" -w /work \
+  ghcr.io/drakulavich/kesha-voice-kit:latest audio.ogg
+```
+
+The image keeps model downloads and the engine cache under `/cache/kesha`.
+Mount that path as a named volume so `kesha install`, TTS models, VAD, and future
+runs reuse the same cache. `compose.yml` provides the same layout:
+
+```bash
+docker compose run --rm kesha install
+docker compose run --rm kesha audio.ogg
+```
+
 ## Speech-to-text
 
 ```bash

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,13 @@
+services:
+  kesha:
+    image: ghcr.io/drakulavich/kesha-voice-kit:latest
+    build: .
+    working_dir: /work
+    environment:
+      KESHA_CACHE_DIR: /cache/kesha
+    volumes:
+      - kesha-cache:/cache/kesha
+      - .:/work
+
+volumes:
+  kesha-cache:


### PR DESCRIPTION
## Summary

- add a Linux x64 Docker CLI image for Kesha with `/cache/kesha` as the persistent model/engine cache
- publish the image to GHCR from `main` and version tags, with PR build + smoke coverage
- add `compose.yml`, README Docker usage, and Dependabot tracking for the Docker base image

Refs #344.

## Checks

- `bun .github/scripts/check-workflows.ts`
- `bun .github/scripts/check-versions.ts`
- `bunx tsc --noEmit`
- `bun bin/kesha.js status`

Docker build smoke is deferred to PR CI because the local Docker daemon is not running (`docker.sock` missing).
