### PR TITLE
ci(release): publish SBOM and sigstore bundles

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -355,6 +355,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       # Need the tag object available locally to read its annotation. Default
       # actions/checkout doesn't fetch tag objects under `on.push.tags`, so
@@ -382,10 +383,31 @@ jobs:
           Download the published binaries and checksums, then verify them:
 
           \`\`\`bash
-          gh release download $TAG_NAME -p SHA256SUMS -p 'kesha-*' -p 'say-*'
+          gh release download $TAG_NAME -p SHA256SUMS -p '*.sigstore.json' -p 'kesha-*' -p 'say-*'
           sha256sum -c SHA256SUMS
+
+          cosign verify-blob \\
+            --bundle kesha-engine-darwin-arm64.sigstore.json \\
+            --certificate-identity "https://github.com/drakulavich/kesha-voice-kit/.github/workflows/build-engine.yml@refs/tags/$TAG_NAME" \\
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
+            kesha-engine-darwin-arm64
           \`\`\`
+
+          The release also includes a source SBOM: \`kesha-voice-kit-$TAG_NAME.spdx.json\`.
           EOF
+
+      - name: Prepare release asset directory
+        run: mkdir -p release-assets
+
+      - name: Generate source SBOM
+        uses: anchore/sbom-action@v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: release-assets/kesha-voice-kit-${{ github.ref_name }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+          dependency-snapshot: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -397,8 +419,24 @@ jobs:
         shell: bash
         run: |
           cd release-assets
-          sha256sum * > SHA256SUMS
+          tmp="$(mktemp)"
+          find . -maxdepth 1 -type f ! -name '*.sigstore.json' ! -name 'SHA256SUMS' -print0 \
+            | sort -z \
+            | xargs -0 sha256sum > "$tmp"
+          mv "$tmp" SHA256SUMS
           cat SHA256SUMS
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Sign release assets
+        shell: bash
+        run: |
+          cd release-assets
+          while IFS= read -r -d '' asset; do
+            name="${asset#./}"
+            cosign sign-blob --yes --bundle "${name}.sigstore.json" "$name"
+          done < <(find . -maxdepth 1 -type f ! -name '*.sigstore.json' -print0 | sort -z)
 
       - name: Create draft release with binaries
         uses: softprops/action-gh-release@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,17 @@ CI gates against silent drift via `bun .github/scripts/check-versions.ts` (also 
    gh api -X PATCH "repos/OWNER/REPO/releases/$RELEASE_ID" --input body.json
    ```
    v1.1.3 shipped with empty notes and was recovered this way.
-5. Validate the draft assets BEFORE un-drafting (see the "make smoke-test ALONE DOES NOT VALIDATE" section below). Authenticated `gh release download vX.Y.Z -p "kesha-engine-darwin-arm64" -D <smoke-dir>` works on drafts; anonymous `curl` does not (see "DRAFT RELEASE ASSET URLS ARE NOT PUBLIC").
+5. Validate the draft assets BEFORE un-drafting (see the "make smoke-test ALONE DOES NOT VALIDATE" section below). Authenticated `gh release download vX.Y.Z -p "kesha-engine-darwin-arm64" -D <smoke-dir>` works on drafts; anonymous `curl` does not (see "DRAFT RELEASE ASSET URLS ARE NOT PUBLIC"). Release drafts must include `SHA256SUMS`, one `*.sigstore.json` bundle per non-signature asset, and `kesha-voice-kit-vX.Y.Z.spdx.json`. Verify at least the primary engine binary before publishing:
+   ```bash
+   gh release download vX.Y.Z -p SHA256SUMS -p '*.sigstore.json' -p 'kesha-*' -p 'say-*' -D <smoke-dir>
+   cd <smoke-dir>
+   sha256sum -c SHA256SUMS
+   cosign verify-blob \
+     --bundle kesha-engine-darwin-arm64.sigstore.json \
+     --certificate-identity "https://github.com/drakulavich/kesha-voice-kit/.github/workflows/build-engine.yml@refs/tags/vX.Y.Z" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     kesha-engine-darwin-arm64
+   ```
 6. `make smoke-test` locally is still useful but only sees the OLD globally-installed engine — treat it as a sanity check, not a release gate. The gate is step 5.
 7. Publish the draft: `gh release edit vX.Y.Z --draft=false`. This fires the `📦 npm Publish` workflow (`release: published` event) which runs `npm publish --provenance --access public` with provenance attestation. Verify within ~60 s: `npm view @drakulavich/kesha-voice-kit version` should report `X.Y.Z`. Manual fallback if the workflow is broken: `npm publish --access public` from the maintainer's laptop.
 


### PR DESCRIPTION
## Summary

- publish an SPDX JSON source SBOM with engine release assets
- sign every non-signature release asset with keyless Sigstore bundles
- keep SHA256SUMS focused on real assets and document checksum/signature verification

Refs #344

## Validation

- bun .github/scripts/check-workflows.ts
- bunx tsc --noEmit
- bun .github/scripts/check-versions.ts
- git diff --check

Note: actionlint is not installed locally in this environment.