### PR TITLE
ci(release): publish release manifest

### DIFF
--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const REPOSITORY = "drakulavich/kesha-voice-kit";
+const MANIFEST_NAME = "kesha-release-manifest.json";
+
+const ENGINE_ASSETS = [
+  {
+    id: "darwin-arm64",
+    os: "darwin",
+    arch: "arm64",
+    status: "supported",
+    engineAsset: "kesha-engine-darwin-arm64",
+    install: { directory: "engine/bin", filename: "kesha-engine" },
+  },
+  {
+    id: "linux-x64",
+    os: "linux",
+    arch: "x64",
+    status: "supported",
+    engineAsset: "kesha-engine-linux-x64",
+    install: { directory: "engine/bin", filename: "kesha-engine" },
+  },
+  {
+    id: "windows-x64",
+    os: "win32",
+    arch: "x64",
+    status: "release-artifact-only",
+    engineAsset: "kesha-engine-windows-x64.exe",
+    note: "Release workflow builds this artifact, but the Bun installer currently blocks Windows x64.",
+  },
+];
+
+const DARWIN_SIDECARS = [
+  {
+    name: "say-avspeech-darwin-arm64",
+    install: { directory: "engine/bin", filename: "say-avspeech" },
+  },
+  {
+    name: "kesha-diarize-darwin-arm64",
+    install: { directory: "engine/bin", filename: "kesha-diarize-darwin-arm64" },
+  },
+  {
+    name: "kesha-kokoro-darwin-arm64",
+    install: { directory: "engine/bin", filename: "kesha-kokoro" },
+  },
+  {
+    name: "kesha-textlang-darwin-arm64",
+    install: { directory: "engine/bin", filename: "kesha-textlang" },
+  },
+];
+
+function usage() {
+  console.error(
+    "usage: node .github/scripts/release-manifest.mjs [--tag vX.Y.Z] [--out path] [--check]",
+  );
+  process.exit(2);
+}
+
+function getArg(name) {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return undefined;
+  const value = process.argv[i + 1];
+  if (!value || value.startsWith("--")) usage();
+  return value;
+}
+
+function hasArg(name) {
+  return process.argv.includes(name);
+}
+
+function readPackage() {
+  return JSON.parse(readFileSync("package.json", "utf8"));
+}
+
+function asset(name, kind, platforms, install, checksummed = true) {
+  return {
+    name,
+    kind,
+    platforms,
+    ...(install ? { install } : {}),
+    checksummed,
+    signatureBundle: `${name}.sigstore.json`,
+  };
+}
+
+function buildManifest(tag) {
+  const pkg = readPackage();
+  const engineVersion = pkg.keshaEngine?.version ?? pkg.version;
+  if (typeof pkg.version !== "string" || typeof engineVersion !== "string") {
+    throw new Error("package.json must contain version and keshaEngine.version strings");
+  }
+
+  const sbomName = `kesha-voice-kit-${tag}.spdx.json`;
+  const assets = [
+    ...ENGINE_ASSETS.map((p) => asset(p.engineAsset, "engine", [p.id], p.install)),
+    ...DARWIN_SIDECARS.map((s) => asset(s.name, "sidecar", ["darwin-arm64"], s.install)),
+    asset(sbomName, "sbom", []),
+    asset(MANIFEST_NAME, "manifest", []),
+    asset("SHA256SUMS", "checksum", [], undefined, false),
+  ];
+
+  return {
+    schemaVersion: 1,
+    repository: REPOSITORY,
+    tag,
+    cliVersion: pkg.version,
+    engineVersion,
+    packaging: {
+      runtime: "bun",
+      userInstall: "bun add -g @drakulavich/kesha-voice-kit",
+      manifestPurpose:
+        "Release metadata for future package-manager channels; it does not replace the Bun-first user install path.",
+    },
+    verification: {
+      checksumAsset: "SHA256SUMS",
+      sigstoreBundleSuffix: ".sigstore.json",
+    },
+    platforms: ENGINE_ASSETS.map((p) => ({
+      id: p.id,
+      os: p.os,
+      arch: p.arch,
+      status: p.status,
+      engineAsset: p.engineAsset,
+      ...(p.note ? { note: p.note } : {}),
+    })),
+    assets,
+  };
+}
+
+function assertIncludes(source, needle, file) {
+  if (!source.includes(needle)) {
+    throw new Error(`${file} is missing release manifest token: ${needle}`);
+  }
+}
+
+function validateSourceConsistency(manifest) {
+  const installer = readFileSync("src/engine-install.ts", "utf8");
+  const workflow = readFileSync(".github/workflows/build-engine.yml", "utf8");
+
+  for (const p of ENGINE_ASSETS) {
+    if (p.status === "supported") {
+      assertIncludes(installer, p.engineAsset, "src/engine-install.ts");
+    }
+    assertIncludes(workflow, p.engineAsset, ".github/workflows/build-engine.yml");
+  }
+
+  for (const s of DARWIN_SIDECARS) {
+    assertIncludes(installer, `assetName: "${s.name}"`, "src/engine-install.ts");
+    assertIncludes(installer, `fileBasename: "${s.install.filename}"`, "src/engine-install.ts");
+    assertIncludes(workflow, s.name, ".github/workflows/build-engine.yml");
+  }
+
+  assertIncludes(workflow, "SHA256SUMS", ".github/workflows/build-engine.yml");
+  assertIncludes(workflow, ".sigstore.json", ".github/workflows/build-engine.yml");
+
+  const names = new Set();
+  for (const a of manifest.assets) {
+    if (names.has(a.name)) throw new Error(`duplicate release manifest asset: ${a.name}`);
+    names.add(a.name);
+    if (!a.signatureBundle.endsWith(manifest.verification.sigstoreBundleSuffix)) {
+      throw new Error(`bad sigstore bundle name for ${a.name}: ${a.signatureBundle}`);
+    }
+  }
+}
+
+const pkg = readPackage();
+const defaultTag = `v${pkg.keshaEngine?.version ?? pkg.version}`;
+const tag = getArg("--tag") ?? defaultTag;
+if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
+  throw new Error(`release manifest tag must look like vX.Y.Z, got: ${tag}`);
+}
+
+const manifest = buildManifest(tag);
+validateSourceConsistency(manifest);
+
+const out = getArg("--out");
+if (out) {
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(manifest, null, 2)}\n`);
+} else if (!hasArg("--check")) {
+  process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+}

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -383,7 +383,7 @@ jobs:
           Download the published binaries and checksums, then verify them:
 
           \`\`\`bash
-          gh release download $TAG_NAME -p SHA256SUMS -p '*.sigstore.json' -p 'kesha-*' -p 'say-*'
+          gh release download $TAG_NAME -p SHA256SUMS -p kesha-release-manifest.json -p '*.sigstore.json' -p 'kesha-*' -p 'say-*'
           sha256sum -c SHA256SUMS
 
           cosign verify-blob \\
@@ -393,7 +393,8 @@ jobs:
             kesha-engine-darwin-arm64
           \`\`\`
 
-          The release also includes a source SBOM: \`kesha-voice-kit-$TAG_NAME.spdx.json\`.
+          The release also includes packaging metadata in \`kesha-release-manifest.json\`
+          and a source SBOM in \`kesha-voice-kit-$TAG_NAME.spdx.json\`.
           EOF
 
       - name: Prepare release asset directory
@@ -414,6 +415,11 @@ jobs:
         with:
           merge-multiple: true
           path: release-assets
+
+      - name: Generate release manifest
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: node .github/scripts/release-manifest.mjs --tag "$TAG_NAME" --out release-assets/kesha-release-manifest.json
 
       - name: Generate release checksums
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
-              - '.github/scripts/check-workflows.ts'
+              - '.github/scripts/**'
               - 'package.json'
               - 'bun.lock'
 
@@ -114,6 +114,9 @@ jobs:
 
       - name: 🔍 Check workflow YAML
         run: bun run check:workflows
+
+      - name: 🧾 Check release manifest metadata
+        run: bun run check:release-manifest
 
   unit-tests:
     needs: changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@ CI gates against silent drift via `bun .github/scripts/check-versions.ts` (also 
    gh api -X PATCH "repos/OWNER/REPO/releases/$RELEASE_ID" --input body.json
    ```
    v1.1.3 shipped with empty notes and was recovered this way.
-5. Validate the draft assets BEFORE un-drafting (see the "make smoke-test ALONE DOES NOT VALIDATE" section below). Authenticated `gh release download vX.Y.Z -p "kesha-engine-darwin-arm64" -D <smoke-dir>` works on drafts; anonymous `curl` does not (see "DRAFT RELEASE ASSET URLS ARE NOT PUBLIC"). Release drafts must include `SHA256SUMS`, one `*.sigstore.json` bundle per non-signature asset, and `kesha-voice-kit-vX.Y.Z.spdx.json`. Verify at least the primary engine binary before publishing:
+5. Validate the draft assets BEFORE un-drafting (see the "make smoke-test ALONE DOES NOT VALIDATE" section below). Authenticated `gh release download vX.Y.Z -p "kesha-engine-darwin-arm64" -D <smoke-dir>` works on drafts; anonymous `curl` does not (see "DRAFT RELEASE ASSET URLS ARE NOT PUBLIC"). Release drafts must include `SHA256SUMS`, `kesha-release-manifest.json`, one `*.sigstore.json` bundle per non-signature asset, and `kesha-voice-kit-vX.Y.Z.spdx.json`. Verify at least the primary engine binary before publishing:
    ```bash
-   gh release download vX.Y.Z -p SHA256SUMS -p '*.sigstore.json' -p 'kesha-*' -p 'say-*' -D <smoke-dir>
+   gh release download vX.Y.Z -p SHA256SUMS -p kesha-release-manifest.json -p '*.sigstore.json' -p 'kesha-*' -p 'say-*' -D <smoke-dir>
    cd <smoke-dir>
    sha256sum -c SHA256SUMS
    cosign verify-blob \
@@ -374,6 +374,19 @@ Operational lessons from the 2026-05-16 setup:
   Replace with your own credentials; do not use the repo owner's details.
 - If the repo already has `.jj`, do not reclone. Keep the existing colocated
   checkout, set the config, run `git lfs pull`, then verify with `jj status`.
+- If the repo already has `.jj`, do not create a separate Git worktree just to
+  isolate agent work. Start with `jj status` / `jj log`, create a new JJ change
+  or bookmark for the task, and use Git worktrees only when the user explicitly
+  asks for one or JJ is unavailable/broken.
+- Disk model: JJ changes/bookmarks are cheap because history and operations are
+  shared in the repo; extra workspaces are more expensive because each one has
+  its own checked-out working tree. Expect disk use to scale roughly as shared
+  repo objects plus one source checkout per workspace, plus duplicated
+  generated artifacts (`node_modules`, `rust/target`, temp caches, materialized
+  LFS files) inside each workspace. Prefer a new JJ change/bookmark for normal
+  agent isolation, and create additional JJ workspaces only when two physical
+  checkouts are genuinely needed (long test in one tree, parallel comparison,
+  etc.).
 - Treat Git as the source of truth if JJ behavior looks suspicious:
   `git status --short --branch` should be clean before making release or PR
   decisions.

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -1,0 +1,37 @@
+# Release Manifest
+
+`kesha-release-manifest.json` is packaging metadata published with every engine
+release. It is a small, stable JSON contract for future package-manager channels
+such as Homebrew, deb, or rpm.
+
+The manifest does not replace the user-facing Bun install path:
+
+```bash
+bun add -g @drakulavich/kesha-voice-kit
+kesha install
+```
+
+## Contents
+
+The manifest records:
+
+- the repository, release tag, CLI version, and engine version
+- released engine binaries and macOS sidecars
+- the install layout used by `kesha install`
+- supported platform status for package managers
+- checksum and Sigstore bundle naming conventions
+
+`SHA256SUMS` and Sigstore bundles cover the manifest itself, so downstream
+packaging can verify the metadata before consuming it.
+
+## Validation
+
+Run the local consistency check after changing release asset names, install
+layout, or release workflow packaging:
+
+```bash
+bun run check:release-manifest
+```
+
+The check fails if manifest metadata drifts from `src/engine-install.ts` or
+`.github/workflows/build-engine.yml`.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint": "bunx tsc --noEmit",
     "lint:tsgo": "bunx tsgo --noEmit",
     "check:workflows": "bun .github/scripts/check-workflows.ts",
+    "check:release-manifest": "bun .github/scripts/release-manifest.mjs --check",
     "check:versions": "bun .github/scripts/check-versions.ts",
     "postinstall": "node scripts/postinstall.cjs"
   },


### PR DESCRIPTION
## Summary

- generate `kesha-release-manifest.json` as release packaging metadata
- include the manifest in release checksums and Sigstore signing
- add a manifest consistency check against install/release asset names
- document that Bun remains the user-facing install path while the manifest supports future package-manager channels
- capture JJ agent lessons: prefer JJ changes/bookmarks over extra Git worktrees, and note workspace disk-use tradeoffs

Refs #344

## Validation

- `bun test`
- `bun run check:workflows`
- `bun run check:release-manifest`
- `bun run check:versions`
- `bunx tsc --noEmit`
- `git diff --check`