### PR TITLE
P0: add doctor diagnostics command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 // Thin re-export shim. The CLI subcommands live in ./cli/*.ts since #180;
 // tests and lib.ts keep importing from "./cli" via these re-exports so the
 // public surface is unchanged.
+export { doctorCommand } from "./cli/doctor";
 export { installCommand } from "./cli/install";
 export { sayCommand } from "./cli/say";
 export { pickVoiceForLang } from "./voice-routing";
@@ -25,6 +26,13 @@ export {
   formatVerboseOutput,
 } from "./format";
 export { formatToonOutput } from "./toon";
+export {
+  collectDoctorReport,
+  formatDoctorReport,
+  redactDiagnosticValue,
+} from "./doctor";
+export type { DoctorReport } from "./doctor";
+export { keshaCacheDir } from "./paths";
 
 import { runCli } from "./cli/dispatch";
 

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -2,13 +2,14 @@ import { runMain } from "citty";
 import { existsSync } from "fs";
 import { log } from "../log";
 import { suggestCommand } from "../suggest-command";
+import { doctorCommand } from "./doctor";
 import { installCommand } from "./install";
 import { sayCommand } from "./say";
 import { statsCommand } from "./stats";
 import { statusCommand } from "./status";
 import { mainCommand } from "./main";
 
-const SUBCOMMANDS = ["install", "status", "say", "stats"];
+const SUBCOMMANDS = ["doctor", "install", "status", "say", "stats"];
 
 function isPathLike(arg: string): boolean {
   return arg.includes(".") || arg.includes("/") || existsSync(arg);
@@ -16,6 +17,11 @@ function isPathLike(arg: string): boolean {
 
 export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
   const [firstArg, ...restArgs] = rawArgs;
+
+  if (firstArg === "doctor") {
+    await runMain(doctorCommand, { rawArgs: restArgs });
+    return;
+  }
 
   if (firstArg === "install") {
     await runMain(installCommand, { rawArgs: restArgs });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,35 @@
+import { defineCommand } from "citty";
+import { collectDoctorReport, formatDoctorReport } from "../doctor";
+import { log } from "../log";
+
+interface DoctorCommandArgs {
+  json: boolean;
+  redact: boolean;
+}
+
+export const doctorCommand = defineCommand({
+  meta: {
+    name: "doctor",
+    description: "Collect support diagnostics without changing local state",
+  },
+  args: {
+    json: {
+      type: "boolean",
+      description: "Output diagnostics as JSON",
+      default: false,
+    },
+    redact: {
+      type: "boolean",
+      description: "Redact secrets and user-home paths from diagnostic output",
+      default: false,
+    },
+  },
+  async run({ args }: { args: DoctorCommandArgs }) {
+    const report = await collectDoctorReport({ redact: args.redact });
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    log.info(formatDoctorReport(report));
+  },
+});

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -112,6 +112,7 @@ export const mainCommand = defineCommand({
       "Kesha Voice Kit — open-source voice toolkit for Apple Silicon.\n" +
       "\n" +
       "Commands:\n" +
+      "  doctor     Collect support diagnostics.\n" +
       "  install    Download engine and models.\n" +
       "  status     Inspect installed backend.\n" +
       "  say        Synthesize speech from text.\n" +
@@ -204,6 +205,7 @@ export const mainCommand = defineCommand({
     if (files.length === 0) {
       log.info(
         "Usage: kesha <audio_file> [audio_file ...]\n" +
+          "       kesha doctor [--json] [--redact]\n" +
           "       kesha install [--no-cache]\n" +
           "       kesha status\n" +
           "       kesha say <text>\n" +

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,375 @@
+import { existsSync, readdirSync, statSync } from "fs";
+import { dirname, join, sep } from "path";
+import { homedir } from "os";
+import {
+  getEngineBinPath,
+  getEngineCapabilities,
+  isEngineInstalled,
+  type EngineCapabilities,
+} from "./engine";
+import { readInstalledEngineVersion } from "./engine-version-marker";
+import { keshaCacheDir } from "./paths";
+import { getStatsStatus, type StatsStatus } from "./stats";
+
+const KNOWN_ENV_KEYS = [
+  "KESHA_ENGINE_BIN",
+  "KESHA_CACHE_DIR",
+  "KESHA_MODEL_MIRROR",
+  "KESHA_STATS_DB",
+  "KESHA_DEBUG",
+  "KESHA_DEBUG_FD",
+] as const;
+
+interface DoctorOptions {
+  redact?: boolean;
+}
+
+interface PathSummary {
+  path: string;
+  exists: boolean;
+  sizeBytes: number;
+}
+
+interface CacheComponent extends PathSummary {
+  label: string;
+}
+
+interface OptionalComponent extends PathSummary {
+  name: string;
+  note?: string;
+}
+
+export interface DoctorReport {
+  generatedAt: string;
+  redacted: boolean;
+  package: {
+    name: string;
+    version: string;
+  };
+  runtime: {
+    bunVersion: string;
+    platform: string;
+    arch: string;
+  };
+  engine: {
+    path: string;
+    installed: boolean;
+    versionMarker: string | null;
+    capabilities: EngineCapabilities | null;
+    probeError: string | null;
+  };
+  cache: {
+    path: string;
+    exists: boolean;
+    totalBytes: number;
+    components: CacheComponent[];
+  };
+  optionalComponents: OptionalComponent[];
+  stats: StatsStatus | (Partial<StatsStatus> & { error: string });
+  env: Record<string, string | null>;
+}
+
+function diagnosticHomeDir(): string {
+  return process.env.HOME ?? homedir();
+}
+
+function humanBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let n = bytes / 1024;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
+}
+
+function dirSizeBytes(path: string): number {
+  let total = 0;
+  try {
+    const st = statSync(path);
+    if (st.isFile()) return st.size;
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const p = join(path, entry.name);
+      total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size;
+    }
+  } catch {
+    return total;
+  }
+  return total;
+}
+
+function pathSummary(path: string): PathSummary {
+  return {
+    path,
+    exists: existsSync(path),
+    sizeBytes: dirSizeBytes(path),
+  };
+}
+
+function isSecretKey(key: string): boolean {
+  const secretParts = ["TOKEN", "KEY", "SECRET", "PASSWORD", "CREDENTIAL", "AUTH"];
+  return key
+    .split(/[^a-z0-9]+/i)
+    .some((part) => secretParts.includes(part.toUpperCase()));
+}
+
+function redactUrl(value: string): string | null {
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return null;
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, value.endsWith("/") ? "/" : "");
+  } catch {
+    return null;
+  }
+}
+
+function redactHomePaths(value: string, homeDir: string): string | null {
+  const normalizedValue = value.replaceAll("\\", "/").replace(/\/+$/, "");
+  const normalizedHome = homeDir.replaceAll("\\", "/").replace(/\/+$/, "");
+  const compareValue = process.platform === "win32" ? normalizedValue.toLowerCase() : normalizedValue;
+  const compareHome = process.platform === "win32" ? normalizedHome.toLowerCase() : normalizedHome;
+
+  if (compareValue === compareHome) return "~";
+  if (compareValue.startsWith(`${compareHome}/`)) {
+    return `~${normalizedValue.slice(normalizedHome.length)}`;
+  }
+  const escapedHome = normalizedHome.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const homePattern = new RegExp(`${escapedHome}(?=$|/)`, process.platform === "win32" ? "gi" : "g");
+  const redacted = normalizedValue.replace(homePattern, (_match, offset: number) => {
+    const previous = normalizedValue[offset - 1];
+    return previous && !/[\s"'(:=]/.test(previous) ? "/~" : "~";
+  });
+  return redacted === normalizedValue ? null : redacted;
+}
+
+export function redactDiagnosticValue(
+  key: string,
+  value: string | null,
+  homeDir = diagnosticHomeDir(),
+): string | null {
+  if (value === null) return null;
+  if (isSecretKey(key)) return "[REDACTED]";
+
+  const url = redactUrl(value);
+  if (url) {
+    const redactedUrlPaths = homeDir ? redactHomePaths(url, homeDir) : null;
+    return redactedUrlPaths ?? url;
+  }
+
+  if (homeDir) {
+    const redactedHomePaths = redactHomePaths(value, homeDir);
+    if (redactedHomePaths !== null) return redactedHomePaths;
+  }
+  return value;
+}
+
+function redactPath(path: string, redact: boolean): string {
+  return redact ? redactDiagnosticValue("path", path) ?? path : path;
+}
+
+function redactString(key: string, value: string | null, redact: boolean): string | null {
+  return redact ? redactDiagnosticValue(key, value) : value;
+}
+
+function redactComponent<T extends PathSummary>(component: T, redact: boolean): T {
+  if (!redact) return component;
+  return { ...component, path: redactPath(component.path, true) };
+}
+
+async function readPackageInfo(): Promise<{ name: string; version: string }> {
+  const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
+  return {
+    name: typeof pkg.name === "string" ? pkg.name : "unknown",
+    version: typeof pkg.version === "string" ? pkg.version : "unknown",
+  };
+}
+
+async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
+  const binPath = getEngineBinPath();
+  const installed = isEngineInstalled();
+  let capabilities: EngineCapabilities | null = null;
+  let probeError: string | null = null;
+
+  if (installed) {
+    try {
+      capabilities = await getEngineCapabilities();
+      if (!capabilities) probeError = "capabilities probe returned no data";
+    } catch (err) {
+      probeError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  return {
+    path: redactPath(binPath, redact),
+    installed,
+    versionMarker: readInstalledEngineVersion(binPath),
+    capabilities,
+    probeError: redactString("probeError", probeError, redact),
+  };
+}
+
+function collectCache(redact: boolean): DoctorReport["cache"] {
+  const cache = keshaCacheDir();
+  const binPath = getEngineBinPath();
+  const engineDir = dirname(dirname(binPath));
+  const components: CacheComponent[] = [
+    { label: "Engine", ...pathSummary(engineDir) },
+    { label: "ASR (Parakeet)", ...pathSummary(join(cache, "models/parakeet-tdt-v3")) },
+    { label: "Language ID", ...pathSummary(join(cache, "models/lang-id-ecapa")) },
+    { label: "VAD (Silero)", ...pathSummary(join(cache, "models/silero-vad")) },
+    { label: "TTS (Kokoro)", ...pathSummary(join(cache, "models/kokoro-82m")) },
+    { label: "TTS (Vosk)", ...pathSummary(join(cache, "models/vosk-ru")) },
+  ];
+  const engineInsideCache = engineDir === cache || engineDir.startsWith(`${cache}${sep}`);
+  const engineOutsideCache = engineInsideCache ? 0 : dirSizeBytes(engineDir);
+
+  return {
+    path: redactPath(cache, redact),
+    exists: existsSync(cache),
+    totalBytes: dirSizeBytes(cache) + engineOutsideCache,
+    components: components.map((component) => redactComponent(component, redact)),
+  };
+}
+
+function collectOptionalComponents(redact: boolean): OptionalComponent[] {
+  const cache = keshaCacheDir();
+  const sidecarDir = dirname(getEngineBinPath());
+  const components: OptionalComponent[] = [
+    {
+      name: "VAD (Silero)",
+      note: "enabled with `kesha install --vad`",
+      ...pathSummary(join(cache, "models/silero-vad")),
+    },
+    {
+      name: "TTS (Kokoro)",
+      note: "enabled with `kesha install --tts`",
+      ...pathSummary(join(cache, "models/kokoro-82m")),
+    },
+    {
+      name: "TTS (Vosk RU)",
+      note: "enabled with `kesha install --tts`",
+      ...pathSummary(join(cache, "models/vosk-ru")),
+    },
+    {
+      name: "Diarization sidecar",
+      note: "darwin-arm64 only",
+      ...pathSummary(join(sidecarDir, "kesha-diarize-darwin-arm64")),
+    },
+    {
+      name: "AVSpeech sidecar",
+      note: "macOS voices",
+      ...pathSummary(join(sidecarDir, "say-avspeech")),
+    },
+    {
+      name: "FluidAudio Kokoro sidecar",
+      note: "darwin-arm64 Kokoro",
+      ...pathSummary(join(sidecarDir, "kesha-kokoro")),
+    },
+    {
+      name: "Text language sidecar",
+      note: "darwin text language fast path",
+      ...pathSummary(join(sidecarDir, "kesha-textlang")),
+    },
+  ];
+  return components.map((component) => redactComponent(component, redact));
+}
+
+function collectStats(redact: boolean): DoctorReport["stats"] {
+  try {
+    const status = getStatsStatus();
+    return redact
+      ? { ...status, dbPath: redactPath(status.dbPath, true) }
+      : status;
+  } catch (err) {
+    return {
+      error: redactString("statsError", err instanceof Error ? err.message : String(err), redact) ?? "unknown",
+    };
+  }
+}
+
+function collectEnv(redact: boolean): DoctorReport["env"] {
+  const env: Record<string, string | null> = {};
+  for (const key of KNOWN_ENV_KEYS) {
+    env[key] = redactString(key, process.env[key] ?? null, redact);
+  }
+  return env;
+}
+
+export async function collectDoctorReport(
+  options: DoctorOptions = {},
+): Promise<DoctorReport> {
+  const redact = options.redact === true;
+  return {
+    generatedAt: new Date().toISOString(),
+    redacted: redact,
+    package: await readPackageInfo(),
+    runtime: {
+      bunVersion: Bun.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    engine: await collectEngine(redact),
+    cache: collectCache(redact),
+    optionalComponents: collectOptionalComponents(redact),
+    stats: collectStats(redact),
+    env: collectEnv(redact),
+  };
+}
+
+function formatInstalled(installed: boolean): string {
+  return installed ? "installed" : "missing";
+}
+
+export function formatDoctorReport(report: DoctorReport): string {
+  const lines = [
+    "Kesha Doctor",
+    "",
+    "Runtime:",
+    `  Package: ${report.package.name} ${report.package.version}`,
+    `  Bun: ${report.runtime.bunVersion}`,
+    `  Platform: ${report.runtime.platform} ${report.runtime.arch}`,
+    "",
+    "Engine:",
+    `  Binary: ${report.engine.path} (${formatInstalled(report.engine.installed)})`,
+    `  Version marker: ${report.engine.versionMarker ?? "missing"}`,
+    `  Capabilities: ${
+      report.engine.capabilities
+        ? `${report.engine.capabilities.backend}, protocol v${report.engine.capabilities.protocolVersion}, ${report.engine.capabilities.features.join(", ")}`
+        : report.engine.probeError ?? "not available"
+    }`,
+    "",
+    `Cache: ${report.cache.path} (${report.cache.exists ? humanBytes(report.cache.totalBytes) : "missing"})`,
+  ];
+
+  for (const component of report.cache.components) {
+    lines.push(`  ${component.label}: ${component.exists ? humanBytes(component.sizeBytes) : "missing"}`);
+  }
+
+  lines.push("", "Optional components:");
+  for (const component of report.optionalComponents) {
+    const note = component.note ? ` - ${component.note}` : "";
+    lines.push(`  ${component.name}: ${formatInstalled(component.exists)}${note}`);
+  }
+
+  lines.push("", "Stats:");
+  if ("error" in report.stats) {
+    lines.push(`  Error: ${report.stats.error}`);
+  } else {
+    lines.push(`  Enabled: ${report.stats.enabled ? "yes" : "no"}`);
+    lines.push(`  Database: ${report.stats.dbPath}`);
+    lines.push(`  Runs: ${report.stats.runCount}`);
+  }
+
+  lines.push("", "Environment:");
+  for (const [key, value] of Object.entries(report.env)) {
+    lines.push(`  ${key}: ${value ?? "unset"}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,7 +1,6 @@
-import { join } from "path";
-import { homedir } from "os";
 import { existsSync, statSync } from "fs";
 import { log } from "./log";
+import { defaultEngineBinPath } from "./paths";
 
 /**
  * Capability-flag string surfaced via `kesha-engine --capabilities-json`. Single
@@ -35,15 +34,13 @@ export interface TranscriptionOutput {
   segments: TranscriptionSegment[];
 }
 
-const DEFAULT_ENGINE_BIN_PATH = join(homedir(), ".cache", "kesha", "engine", "bin", "kesha-engine");
-
 /**
  * Path to the `kesha-engine` binary. Defaults to the install location under
- * `~/.cache/kesha/engine/bin/`. The `KESHA_ENGINE_BIN` env var overrides — useful
+ * the Kesha cache directory. The `KESHA_ENGINE_BIN` env var overrides — useful
  * for running against a freshly-built engine during development or in e2e tests.
  */
 export function getEngineBinPath(): string {
-  return process.env.KESHA_ENGINE_BIN ?? DEFAULT_ENGINE_BIN_PATH;
+  return process.env.KESHA_ENGINE_BIN ?? defaultEngineBinPath();
 }
 
 export function isEngineInstalled(): boolean {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,10 @@
+import { homedir } from "os";
+import { join } from "path";
+
+export function keshaCacheDir(): string {
+  return process.env.KESHA_CACHE_DIR ?? join(homedir(), ".cache", "kesha");
+}
+
+export function defaultEngineBinPath(): string {
+  return join(keshaCacheDir(), "engine", "bin", "kesha-engine");
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,8 +1,8 @@
 import { readdirSync, statSync } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 import { isEngineInstalled, getEngineBinPath, getEngineCapabilities } from "./engine";
 import { log } from "./log";
+import { keshaCacheDir } from "./paths";
 import pc from "picocolors";
 
 function humanBytes(bytes: number): string {
@@ -96,7 +96,7 @@ export async function showStatus(): Promise<void> {
 }
 
 function showDiskUsage(binPath: string): void {
-  const cache = kesheCacheDir();
+  const cache = keshaCacheDir();
   // Engine binary lives under `<cache>/engine/bin/` (managed by the TS CLI's
   // engine-install) while all models live under `<cache>/models/` (managed by
   // the Rust engine). Point at `engine/` (two levels up from the binary) so
@@ -150,10 +150,6 @@ function showDiskUsage(binPath: string): void {
   log.info("");
 }
 
-function kesheCacheDir(): string {
-  return process.env.KESHA_CACHE_DIR ?? join(homedir(), ".cache", "kesha");
-}
-
 /**
  * Read the effective `KESHA_MODEL_MIRROR` base URL (#121). Returns null when
  * unset, empty, or whitespace. Matches the Rust side's `model_mirror()` in
@@ -167,7 +163,7 @@ export function activeModelMirror(): string | null {
 }
 
 function listInstalledVoices(): string[] {
-  const cache = kesheCacheDir();
+  const cache = keshaCacheDir();
   const voices: string[] = [];
   try {
     const kokoro = readdirSync(join(cache, "models", "kokoro-82m", "voices"));

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
-import { mainCommand, installCommand, statusCommand, statsCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat } from "../../src/cli";
+import { mainCommand, doctorCommand, installCommand, statusCommand, statsCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat } from "../../src/cli";
 
 describe("CLI help", () => {
   test("main help contains usage and install info", async () => {
@@ -13,6 +13,7 @@ describe("CLI help", () => {
   test("main help shows subcommand inventory (#324)", async () => {
     const usage = await renderUsage(mainCommand);
     expect(usage).toContain("Commands:");
+    expect(usage).toContain("doctor     Collect support diagnostics.");
     expect(usage).toContain("install    Download engine and models.");
     expect(usage).toContain("status     Inspect installed backend.");
     expect(usage).toContain("say        Synthesize speech from text.");
@@ -24,6 +25,13 @@ describe("CLI help", () => {
     expect(usage).toContain("--coreml");
     expect(usage).toContain("--onnx");
     expect(usage).toContain("--no-cache");
+  });
+
+  test("doctor help contains JSON and redaction options (#345 P0)", async () => {
+    const usage = await renderUsage(doctorCommand);
+    expect(usage).toContain("--json");
+    expect(usage).toContain("--redact");
+    expect(usage).toContain("support diagnostics");
   });
 
   test("main help contains --json flag", async () => {

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  collectDoctorReport,
+  formatDoctorReport,
+  redactDiagnosticValue,
+} from "../../src/doctor";
+
+describe("redactDiagnosticValue", () => {
+  test("redacts secret-like keys", () => {
+    expect(redactDiagnosticValue("API_KEY", "secret", "/tmp/home")).toBe("[REDACTED]");
+    expect(redactDiagnosticValue("GITHUB_TOKEN", "secret", "/tmp/home")).toBe("[REDACTED]");
+    expect(redactDiagnosticValue("MONKEY_MODE", "banana", "/tmp/home")).toBe("banana");
+  });
+
+  test("redacts home directory paths", () => {
+    expect(redactDiagnosticValue("KESHA_CACHE_DIR", "/tmp/home/.cache/kesha", "/tmp/home")).toBe("~/.cache/kesha");
+    expect(redactDiagnosticValue("KESHA_CACHE_DIR", "/tmp/home", "/tmp/home")).toBe("~");
+    expect(
+      redactDiagnosticValue(
+        "KESHA_CACHE_DIR",
+        "C:\\Users\\Runner\\.cache\\kesha",
+        "C:\\Users\\Runner",
+      ),
+    ).toBe("~/.cache/kesha");
+    expect(
+      redactDiagnosticValue(
+        "probeError",
+        "spawn /tmp/home/.cache/kesha/engine/bin/kesha-engine ENOENT",
+        "/tmp/home",
+      ),
+    ).toBe("spawn ~/.cache/kesha/engine/bin/kesha-engine ENOENT");
+  });
+
+  test("strips credentials and query strings from URLs", () => {
+    expect(
+      redactDiagnosticValue(
+        "KESHA_MODEL_MIRROR",
+        "https://user:pass@example.com/kesha?token=abc#frag",
+        "/tmp/home",
+      ),
+    ).toBe("https://example.com/kesha");
+    expect(
+      redactDiagnosticValue(
+        "KESHA_MODEL_MIRROR",
+        "https://user:pass@example.com/tmp/home/mirror?token=abc",
+        "/tmp/home",
+      ),
+    ).toBe("https://example.com/~/mirror");
+  });
+});
+
+describe("collectDoctorReport", () => {
+  const savedEnv = {
+    HOME: process.env.HOME,
+    KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN,
+    KESHA_CACHE_DIR: process.env.KESHA_CACHE_DIR,
+    KESHA_MODEL_MIRROR: process.env.KESHA_MODEL_MIRROR,
+    KESHA_STATS_DB: process.env.KESHA_STATS_DB,
+    KESHA_DEBUG: process.env.KESHA_DEBUG,
+    KESHA_DEBUG_FD: process.env.KESHA_DEBUG_FD,
+  };
+
+  function restoreEnv() {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  test("reports missing engine without throwing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-doctor-test-"));
+    try {
+      process.env.HOME = dir;
+      process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+      process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+      process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+      process.env.KESHA_MODEL_MIRROR = "https://user:pass@example.com/kesha?token=abc";
+      process.env.KESHA_DEBUG = "1";
+
+      mkdirSync(join(dir, ".cache", "kesha", "models", "silero-vad"), { recursive: true });
+      writeFileSync(join(dir, ".cache", "kesha", "models", "silero-vad", "model.onnx"), "vad");
+
+      const report = await collectDoctorReport({ redact: true });
+      expect(report.redacted).toBe(true);
+      expect(report.engine.installed).toBe(false);
+      expect(report.engine.path).toBe("~/engine/bin/kesha-engine");
+      expect(report.cache.path).toBe("~/.cache/kesha");
+      expect(report.cache.totalBytes).toBeGreaterThan(0);
+      expect(report.env.KESHA_MODEL_MIRROR).toBe("https://example.com/kesha");
+      expect(report.env.KESHA_DEBUG).toBe("1");
+      expect("runCount" in report.stats).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("formats a human-readable report", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-doctor-format-test-"));
+    try {
+      process.env.HOME = dir;
+      process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+      process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+      process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+
+      const output = formatDoctorReport(await collectDoctorReport({ redact: true }));
+      expect(output).toContain("Kesha Doctor");
+      expect(output).toContain("Runtime:");
+      expect(output).toContain("Engine:");
+      expect(output).toContain("Environment:");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
 import { parseLangResult, getEngineBinPath, spawnStdioWithDebugFd } from "../../src/engine";
 
 describe("engine", () => {
@@ -6,6 +7,21 @@ describe("engine", () => {
     const path = getEngineBinPath();
     expect(path).toMatch(/\.cache[/\\]kesha/);
     expect(path).toContain("kesha-engine");
+  });
+
+  test("getEngineBinPath follows KESHA_CACHE_DIR", () => {
+    const savedCacheDir = process.env.KESHA_CACHE_DIR;
+    const savedEngineBin = process.env.KESHA_ENGINE_BIN;
+    try {
+      delete process.env.KESHA_ENGINE_BIN;
+      process.env.KESHA_CACHE_DIR = "/tmp/kesha-cache";
+      expect(getEngineBinPath()).toBe(join("/tmp/kesha-cache", "engine", "bin", "kesha-engine"));
+    } finally {
+      if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
+      else process.env.KESHA_CACHE_DIR = savedCacheDir;
+      if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
+      else process.env.KESHA_ENGINE_BIN = savedEngineBin;
+    }
   });
 
   test("parseLangResult parses valid JSON", () => {


### PR DESCRIPTION
## Summary
- add `kesha doctor` with human-readable output plus `--json` and `--redact` flags
- collect runtime, engine, cache/model, optional component, stats, and known environment diagnostics without downloading or mutating state
- redact secret-like values, URL credentials/query strings, and home-directory paths for support-safe output

Refs #345

## Validation
- `bun test`
- `bun run test:unit`
- `bunx tsc --noEmit`
- `git diff --check`
- `bun bin/kesha.js doctor --json --redact`

## Follow-up
- support-bundle packaging remains deferred; this PR ships the diagnostic command contract first.