### PR TITLE
feat(packaging): add Homebrew formula foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       raycast: ${{ steps.filter.outputs.raycast }}
       nix: ${{ steps.filter.outputs.nix }}
       workflows: ${{ steps.filter.outputs.workflows }}
+      homebrew: ${{ steps.filter.outputs.homebrew }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -100,6 +101,10 @@ jobs:
               - '.github/scripts/**'
               - 'package.json'
               - 'bun.lock'
+            homebrew:
+              - 'Formula/**'
+              - 'docs/homebrew.md'
+              - '.github/workflows/ci.yml'
 
   workflow-lint:
     needs: changes
@@ -117,6 +122,36 @@ jobs:
 
       - name: 🧾 Check release manifest metadata
         run: bun run check:release-manifest
+
+  homebrew-formula:
+    needs: changes
+    if: needs.changes.outputs.homebrew == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🍞 Tap Bun formula
+        run: brew tap oven-sh/bun
+
+      - name: 🧪 Create local test tap
+        run: |
+          brew tap-new local/kesha
+          cp Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/kesha-voice-kit.rb"
+
+      - name: 📦 Install formula
+        run: brew install --build-from-source local/kesha/kesha-voice-kit
+
+      - name: 🔍 Audit formula
+        run: brew audit --strict --formula local/kesha/kesha-voice-kit
+
+      - name: 🚬 Test formula
+        run: brew test local/kesha/kesha-voice-kit
+
+      - name: 🧹 Uninstall formula
+        if: always()
+        run: brew uninstall local/kesha/kesha-voice-kit || true
 
   unit-tests:
     needs: changes

--- a/Formula/kesha-voice-kit.rb
+++ b/Formula/kesha-voice-kit.rb
@@ -1,0 +1,34 @@
+class KeshaVoiceKit < Formula
+  desc "Local speech-to-text, text-to-speech, and language detection toolkit"
+  homepage "https://github.com/drakulavich/kesha-voice-kit"
+  url "https://github.com/drakulavich/kesha-voice-kit/archive/refs/tags/v1.18.0.tar.gz"
+  sha256 "4c55e0e813f192970729dddcc11e6e85979fbec7a888bad2695c4aa88524ab14"
+  license "MIT"
+
+  depends_on "oven-sh/bun/bun"
+
+  def install
+    libexec.install "bin", "src", "package.json", "bun.lock", "tsconfig.json"
+    libexec.install "openclaw.plugin.json", "openclaw-plugin.cjs"
+    libexec.install "LICENSE", "NOTICES.md", "README.md"
+
+    cd libexec do
+      system "bun", "install", "--production", "--frozen-lockfile", "--ignore-scripts"
+    end
+
+    (bin/"kesha").write <<~EOS
+      #!/bin/bash
+      exec "#{Formula["oven-sh/bun/bun"].opt_bin}/bun" "#{libexec}/bin/kesha.js" "$@"
+    EOS
+
+    (bin/"parakeet").write <<~EOS
+      #!/bin/bash
+      exec "#{Formula["oven-sh/bun/bun"].opt_bin}/bun" "#{libexec}/bin/kesha.js" "$@"
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/kesha --version")
+    assert_match version.to_s, shell_output("#{bin}/parakeet --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ kesha audio.ogg     # transcript to stdout
 
 Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-mirror.md).
 
+## Homebrew Formula
+
+Kesha has an in-repo Homebrew formula foundation for tap validation. It installs
+the Bun-based CLI wrapper; engine and model downloads remain explicit:
+
+```bash
+brew tap oven-sh/bun
+brew tap-new local/kesha
+cp Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/"
+brew install local/kesha/kesha-voice-kit
+kesha install
+kesha audio.ogg
+```
+
+See [Homebrew formula](docs/homebrew.md) for package scope and tap status.
+
 ## Support diagnostics
 
 Kesha can collect local diagnostics without downloading models or mutating cache state:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,45 @@
+# Homebrew Formula
+
+Kesha's Homebrew formula installs the Bun-based CLI wrapper. It does not
+download the Rust engine or models during `brew install`; keep that explicit
+with `kesha install`.
+
+## Local Tap Validation
+
+The first Homebrew slice keeps the formula in this repository while the public
+tap automation is still future work. Homebrew requires formulae to be installed
+from a tap, so validate the formula through a local test tap:
+
+```bash
+brew tap oven-sh/bun
+brew tap-new local/kesha
+cp Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/"
+brew install local/kesha/kesha-voice-kit
+kesha install
+kesha audio.ogg
+```
+
+The formula depends on Bun from the official Bun tap and exposes both `kesha`
+and the backward-compatible `parakeet` alias.
+
+## Package Scope
+
+Homebrew installs:
+
+- the TypeScript CLI wrapper
+- production Bun dependencies
+- the `kesha` and `parakeet` commands
+
+`kesha install` still downloads release assets into the Kesha cache. This keeps
+the package install lightweight and preserves the no-surprise-downloads release
+contract used by the Bun and Docker install paths.
+
+## Future Public Tap
+
+The intended user-facing path is a dedicated tap, for example:
+
+```bash
+brew install drakulavich/kesha/kesha-voice-kit
+```
+
+Until that tap exists, use the local tap validation path above.


### PR DESCRIPTION
## Summary
- add an in-repo Homebrew formula for the Bun-based Kesha CLI wrapper
- document local tap validation and future public tap scope
- add a macOS CI job that validates the formula through a local test tap

Refs #344

## Validation
- ruby -c Formula/kesha-voice-kit.rb
- bun run check:workflows
- bun run check:release-manifest
- bunx tsc --noEmit
- bun test tests/unit/
- bun test
- brew tap oven-sh/bun && brew tap-new local/kesha && brew install --build-from-source local/kesha/kesha-voice-kit && brew test local/kesha/kesha-voice-kit && brew audit --strict --online --formula local/kesha/kesha-voice-kit