### PR TITLE
ci(packaging): publish Homebrew tap updates

### DIFF
--- a/.github/scripts/update-homebrew-tap.mjs
+++ b/.github/scripts/update-homebrew-tap.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const REPOSITORY = "drakulavich/kesha-voice-kit";
+const FORMULA_REL = "Formula/kesha-voice-kit.rb";
+
+function usage() {
+  console.error(
+    "usage: node .github/scripts/update-homebrew-tap.mjs --tag vX.Y.Z --tap-dir path",
+  );
+  process.exit(2);
+}
+
+function getArg(name) {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return undefined;
+  const value = process.argv[i + 1];
+  if (!value || value.startsWith("--")) usage();
+  return value;
+}
+
+async function sha256ForUrl(url) {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`could not fetch ${url}: HTTP ${res.status}`);
+  }
+  const bytes = Buffer.from(await res.arrayBuffer());
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function replaceOne(source, pattern, replacement, label) {
+  if (!pattern.test(source)) throw new Error(`formula is missing ${label}`);
+  return source.replace(pattern, replacement);
+}
+
+const tag = getArg("--tag");
+const tapDir = getArg("--tap-dir");
+if (!tag || !tapDir) usage();
+if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
+  throw new Error(`Homebrew tap updates only support stable vX.Y.Z tags, got: ${tag}`);
+}
+
+const tarballUrl = `https://github.com/${REPOSITORY}/archive/refs/tags/${tag}.tar.gz`;
+const sha256 = await sha256ForUrl(tarballUrl);
+const formulaPath = join(tapDir, FORMULA_REL);
+let formula = readFileSync(formulaPath, "utf8");
+
+formula = replaceOne(
+  formula,
+  /^  url ".*"$/m,
+  `  url "${tarballUrl}"`,
+  "url",
+);
+formula = replaceOne(
+  formula,
+  /^  sha256 "[a-f0-9]{64}"$/m,
+  `  sha256 "${sha256}"`,
+  "sha256",
+);
+
+mkdirSync(dirname(formulaPath), { recursive: true });
+writeFileSync(formulaPath, formula);
+console.log(`Updated ${FORMULA_REL} for ${tag}`);
+console.log(`url: ${tarballUrl}`);
+console.log(`sha256: ${sha256}`);

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,92 @@
+name: "🍺 Homebrew Tap"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Stable release tag to publish to Homebrew (vX.Y.Z)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    env:
+      TAP_REPO: drakulavich/homebrew-kesha
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$RELEASE_TAG"
+          fi
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping Homebrew tap update for non-stable tag: $tag"
+            exit 0
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout source tag
+        if: steps.tag.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Require tap token
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          test -n "$HOMEBREW_TAP_TOKEN" || {
+            echo "::error::HOMEBREW_TAP_TOKEN is required to update $TAP_REPO"
+            exit 1
+          }
+
+      - name: Clone tap
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://github.com/$TAP_REPO.git" tap
+          git -C tap remote set-url origin "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/$TAP_REPO.git"
+
+      - name: Update formula
+        if: steps.tag.outputs.skip != 'true'
+        run: node .github/scripts/update-homebrew-tap.mjs --tag "${{ steps.tag.outputs.tag }}" --tap-dir tap
+
+      - name: Validate updated formula
+        if: steps.tag.outputs.skip != 'true'
+        run: |
+          brew tap oven-sh/bun
+          brew tap-new local/kesha
+          cp tap/Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/kesha-voice-kit.rb"
+          brew install --build-from-source local/kesha/kesha-voice-kit
+          brew audit --strict --formula local/kesha/kesha-voice-kit
+          brew test local/kesha/kesha-voice-kit
+
+      - name: Commit and push tap update
+        if: steps.tag.outputs.skip != 'true'
+        run: |
+          cd tap
+          if git diff --quiet -- Formula/kesha-voice-kit.rb; then
+            echo "Homebrew formula already matches ${{ steps.tag.outputs.tag }}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/kesha-voice-kit.rb
+          git commit -m "Update Kesha Voice Kit to ${{ steps.tag.outputs.tag }}"
+          git push origin main

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
+      - name: Setup Node.js
+        if: steps.tag.outputs.skip != 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
       - name: Require tap token
         if: steps.tag.outputs.skip != 'true'
         env:
@@ -81,6 +87,7 @@ jobs:
         if: steps.tag.outputs.skip != 'true'
         run: |
           cd tap
+          tap_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's#^origin/##')"
           if git diff --quiet -- Formula/kesha-voice-kit.rb; then
             echo "Homebrew formula already matches ${{ steps.tag.outputs.tag }}"
             exit 0
@@ -89,4 +96,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/kesha-voice-kit.rb
           git commit -m "Update Kesha Voice Kit to ${{ steps.tag.outputs.tag }}"
-          git push origin main
+          git push origin "HEAD:$tap_branch"

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -88,6 +88,10 @@ jobs:
         run: |
           cd tap
           tap_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's#^origin/##')"
+          test -n "$tap_branch" || {
+            echo "::error::Could not resolve default branch for $TAP_REPO"
+            exit 1
+          }
           if git diff --quiet -- Formula/kesha-voice-kit.rb; then
             echo "Homebrew formula already matches ${{ steps.tag.outputs.tag }}"
             exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,12 @@ CI gates against silent drift via `bun .github/scripts/check-versions.ts` (also 
 6. `make smoke-test` locally is still useful but only sees the OLD globally-installed engine — treat it as a sanity check, not a release gate. The gate is step 5.
 7. Publish the draft: `gh release edit vX.Y.Z --draft=false`. This fires the `📦 npm Publish` workflow (`release: published` event) which runs `npm publish --provenance --access public` with provenance attestation. Verify within ~60 s: `npm view @drakulavich/kesha-voice-kit version` should report `X.Y.Z`. Manual fallback if the workflow is broken: `npm publish --access public` from the maintainer's laptop.
 
+8. Stable `vX.Y.Z` releases also update the public Homebrew tap
+   `drakulavich/homebrew-kesha` via the `🍺 Homebrew Tap` workflow. Required
+   secret: `HOMEBREW_TAP_TOKEN`, a fine-scoped token with write access only to
+   the tap repository. CLI-only `vX.Y.Z-cli` marker releases are intentionally
+   skipped for now.
+
 ### NPM PUBLISH IS AUTOMATED WITH PROVENANCE ATTESTATION
 
 Post-#291: un-drafting a GitHub release fires `.github/workflows/npm-publish.yml`, which runs `npm publish --provenance --access public` from GHA. No more `npm publish` from the maintainer's laptop in the happy path.

--- a/README.md
+++ b/README.md
@@ -51,21 +51,20 @@ kesha audio.ogg     # transcript to stdout
 
 Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-mirror.md).
 
-## Homebrew Formula
+## Homebrew Install
 
-Kesha has an in-repo Homebrew formula foundation for tap validation. It installs
-the Bun-based CLI wrapper; engine and model downloads remain explicit:
+Homebrew installs the Bun-based CLI wrapper. Engine and model downloads remain
+explicit:
 
 ```bash
 brew tap oven-sh/bun
-brew tap-new local/kesha
-cp Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/"
-brew install local/kesha/kesha-voice-kit
+brew install drakulavich/kesha/kesha-voice-kit
 kesha install
 kesha audio.ogg
 ```
 
-See [Homebrew formula](docs/homebrew.md) for package scope and tap status.
+See [Homebrew install](docs/homebrew.md) for package scope and maintainer
+validation.
 
 ## Support diagnostics
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,20 +1,14 @@
-# Homebrew Formula
+# Homebrew Install
 
 Kesha's Homebrew formula installs the Bun-based CLI wrapper. It does not
 download the Rust engine or models during `brew install`; keep that explicit
 with `kesha install`.
 
-## Local Tap Validation
-
-The first Homebrew slice keeps the formula in this repository while the public
-tap automation is still future work. Homebrew requires formulae to be installed
-from a tap, so validate the formula through a local test tap:
+## Install
 
 ```bash
 brew tap oven-sh/bun
-brew tap-new local/kesha
-cp Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/"
-brew install local/kesha/kesha-voice-kit
+brew install drakulavich/kesha/kesha-voice-kit
 kesha install
 kesha audio.ogg
 ```
@@ -34,12 +28,29 @@ Homebrew installs:
 the package install lightweight and preserves the no-surprise-downloads release
 contract used by the Bun and Docker install paths.
 
-## Future Public Tap
+## Maintainer Validation
 
-The intended user-facing path is a dedicated tap, for example:
+The source formula remains in this repository and is mirrored into
+`drakulavich/homebrew-kesha` for users. To validate formula edits before a
+release:
+
+```bash
+brew tap oven-sh/bun
+brew tap-new local/kesha
+cp Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/"
+brew install local/kesha/kesha-voice-kit
+brew test local/kesha/kesha-voice-kit
+brew audit --strict --formula local/kesha/kesha-voice-kit
+```
+
+The public tap itself can be validated with:
 
 ```bash
 brew install drakulavich/kesha/kesha-voice-kit
+brew test drakulavich/kesha/kesha-voice-kit
+brew audit --strict --formula drakulavich/kesha/kesha-voice-kit
 ```
 
-Until that tap exists, use the local tap validation path above.
+Stable `vX.Y.Z` releases update the public tap through the `Homebrew Tap`
+workflow. The workflow requires the `HOMEBREW_TAP_TOKEN` repository secret with
+write access to `drakulavich/homebrew-kesha`.


### PR DESCRIPTION
## Summary
- create and validate the public tap repo: https://github.com/drakulavich/homebrew-kesha
- add stable-release automation that updates the tap formula URL and sha256
- switch Homebrew docs from local tap validation to the public install path

Refs #344

## Validation
- ruby -c Formula/kesha-voice-kit.rb
- bun run check:workflows
- bun run check:release-manifest
- bunx tsc --noEmit
- bun test
- node .github/scripts/update-homebrew-tap.mjs --tag v1.18.0 --tap-dir /tmp/homebrew-kesha
- public tap validation: brew tap oven-sh/bun && brew tap drakulavich/kesha && brew install --build-from-source drakulavich/kesha/kesha-voice-kit && brew test drakulavich/kesha/kesha-voice-kit && brew audit --strict --formula drakulavich/kesha/kesha-voice-kit
- tap repo CI is green: https://github.com/drakulavich/homebrew-kesha/actions/runs/25986660859

## Follow-up before live releases
- Add HOMEBREW_TAP_TOKEN to this repo as a fine-scoped token with write access to drakulavich/homebrew-kesha.