### PR TITLE
docs(packaging): rename public Homebrew tap

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -77,11 +77,11 @@ jobs:
         if: steps.tag.outputs.skip != 'true'
         run: |
           brew tap oven-sh/bun
-          brew tap-new local/kesha
-          cp tap/Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/kesha-voice-kit.rb"
-          brew install --build-from-source local/kesha/kesha-voice-kit
-          brew audit --strict --formula local/kesha/kesha-voice-kit
-          brew test local/kesha/kesha-voice-kit
+          brew tap-new local/tap
+          cp tap/Formula/kesha-voice-kit.rb "$(brew --repository local/tap)/Formula/kesha-voice-kit.rb"
+          brew install --build-from-source local/tap/kesha-voice-kit
+          brew audit --strict --formula local/tap/kesha-voice-kit
+          brew test local/tap/kesha-voice-kit
 
       - name: Commit and push tap update
         if: steps.tag.outputs.skip != 'true'

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     env:
-      TAP_REPO: drakulavich/homebrew-kesha
+      TAP_REPO: drakulavich/homebrew-tap
     steps:
       - name: Resolve tag
         id: tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ CI gates against silent drift via `bun .github/scripts/check-versions.ts` (also 
 7. Publish the draft: `gh release edit vX.Y.Z --draft=false`. This fires the `📦 npm Publish` workflow (`release: published` event) which runs `npm publish --provenance --access public` with provenance attestation. Verify within ~60 s: `npm view @drakulavich/kesha-voice-kit version` should report `X.Y.Z`. Manual fallback if the workflow is broken: `npm publish --access public` from the maintainer's laptop.
 
 8. Stable `vX.Y.Z` releases also update the public Homebrew tap
-   `drakulavich/homebrew-kesha` via the `🍺 Homebrew Tap` workflow. Required
+   `drakulavich/homebrew-tap` via the `🍺 Homebrew Tap` workflow. Required
    secret: `HOMEBREW_TAP_TOKEN`, a fine-scoped token with write access only to
    the tap repository. CLI-only `vX.Y.Z-cli` marker releases are intentionally
    skipped for now.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ explicit:
 
 ```bash
 brew tap oven-sh/bun
-brew install drakulavich/kesha/kesha-voice-kit
+brew install drakulavich/tap/kesha-voice-kit
 kesha install
 kesha audio.ogg
 ```

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -8,7 +8,7 @@ with `kesha install`.
 
 ```bash
 brew tap oven-sh/bun
-brew install drakulavich/kesha/kesha-voice-kit
+brew install drakulavich/tap/kesha-voice-kit
 kesha install
 kesha audio.ogg
 ```
@@ -31,26 +31,26 @@ contract used by the Bun and Docker install paths.
 ## Maintainer Validation
 
 The source formula remains in this repository and is mirrored into
-`drakulavich/homebrew-kesha` for users. To validate formula edits before a
+`drakulavich/homebrew-tap` for users. To validate formula edits before a
 release:
 
 ```bash
 brew tap oven-sh/bun
-brew tap-new local/kesha
-cp Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/"
-brew install local/kesha/kesha-voice-kit
-brew test local/kesha/kesha-voice-kit
-brew audit --strict --formula local/kesha/kesha-voice-kit
+brew tap-new local/tap
+cp Formula/kesha-voice-kit.rb "$(brew --repository local/tap)/Formula/"
+brew install local/tap/kesha-voice-kit
+brew test local/tap/kesha-voice-kit
+brew audit --strict --formula local/tap/kesha-voice-kit
 ```
 
 The public tap itself can be validated with:
 
 ```bash
-brew install drakulavich/kesha/kesha-voice-kit
-brew test drakulavich/kesha/kesha-voice-kit
-brew audit --strict --formula drakulavich/kesha/kesha-voice-kit
+brew install drakulavich/tap/kesha-voice-kit
+brew test drakulavich/tap/kesha-voice-kit
+brew audit --strict --formula drakulavich/tap/kesha-voice-kit
 ```
 
 Stable `vX.Y.Z` releases update the public tap through the `Homebrew Tap`
 workflow. The workflow requires the `HOMEBREW_TAP_TOKEN` repository secret with
-write access to `drakulavich/homebrew-kesha`.
+write access to `drakulavich/homebrew-tap`.


### PR DESCRIPTION
## Summary
- rename the public tap repository to https://github.com/drakulavich/homebrew-tap
- update Homebrew install docs to use the generic tap path: drakulavich/tap/kesha-voice-kit
- point release automation at drakulavich/homebrew-tap

Refs #344

## Validation
- ruby -c Formula/kesha-voice-kit.rb in drakulavich/homebrew-tap
- tap repo CI is green: https://github.com/drakulavich/homebrew-tap/actions/runs/25987332993
- public tap validation: brew tap oven-sh/bun && brew tap drakulavich/tap && brew install --build-from-source drakulavich/tap/kesha-voice-kit && brew test drakulavich/tap/kesha-voice-kit && brew audit --strict --formula drakulavich/tap/kesha-voice-kit
- node .github/scripts/update-homebrew-tap.mjs --tag v1.18.0 --tap-dir /tmp/homebrew-tap
- bun run check:workflows
- bun run check:release-manifest
- bunx tsc --noEmit
- bun test

## Follow-up before live releases
- Add HOMEBREW_TAP_TOKEN to this repo as a fine-scoped token with write access to drakulavich/homebrew-tap.