### PR TITLE
docs(github): add issue forms for support reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Report a reproducible Kesha CLI, engine, TTS, VAD, Stats, or integration bug.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please do not attach private audio, transcripts, or Stats databases.
+        Run `kesha doctor --json --redact` or attach a `kesha support-bundle --output kesha-support.tar.gz` archive so the issue includes versions, platform, cache state, and safe environment details.
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: Paste the exact command, script, or integration config that failed.
+      placeholder: kesha --json --timestamps audio.ogg
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include stderr/stdout snippets and the exit code. Redact paths or content if needed.
+      placeholder: |
+        Exit code:
+        Stdout:
+        Stderr:
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Paste `kesha doctor --json --redact` output or say that a support bundle is attached.
+      render: text
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS arm64
+        - Linux x64
+        - Windows x64
+        - Nix flake
+        - Docker image
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: debug
+    attributes:
+      label: Debug log
+      description: If relevant, rerun with `KESHA_DEBUG=1` and paste only non-private stderr lines.
+      render: text
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I did not attach private audio, transcripts, model files, or the Stats database.
+          required: true
+        - label: I redacted secrets, personal paths, and private content from pasted logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support diagnostics guide
+    url: https://github.com/drakulavich/kesha-voice-kit#support-diagnostics
+    about: Run doctor or support-bundle before filing install, runtime, or performance reports.

--- a/.github/ISSUE_TEMPLATE/install_support.yml
+++ b/.github/ISSUE_TEMPLATE/install_support.yml
@@ -1,0 +1,83 @@
+name: Install or cache problem
+description: Report install, upgrade, model cache, mirror, Homebrew, Nix, Docker, or platform setup failures.
+title: "install: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Install reports are much easier to fix with the preflight output and sanitized diagnostics.
+        Please run `kesha install --plan` with the same flags you used, then run `kesha doctor --json --redact`.
+  - type: textarea
+    id: install_command
+    attributes:
+      label: Install command
+      description: Paste the exact install or upgrade command.
+      placeholder: kesha install --tts --vad
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: Install plan output
+      description: Paste `kesha install --plan` output with the same flags, for example `kesha install --plan --tts --vad`.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: failure
+    attributes:
+      label: Failure output
+      description: Include stdout, stderr, exit code, failed URL or checksum text if present.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Paste `kesha doctor --json --redact` output or say that a support bundle is attached.
+      render: text
+    validations:
+      required: true
+  - type: dropdown
+    id: install_path
+    attributes:
+      label: Install path
+      options:
+        - Bun global package
+        - Homebrew
+        - Nix flake
+        - Docker image
+        - Local checkout
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS arm64
+        - Linux x64
+        - Windows x64
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: mirror
+    attributes:
+      label: Model mirror or proxy
+      description: If `KESHA_MODEL_MIRROR`, a corporate proxy, or an offline cache is involved, describe it without secrets.
+      placeholder: none
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I redacted tokens, proxy credentials, private paths, and machine-specific secrets.
+          required: true
+        - label: I did not attach model files or cache directories.
+          required: true

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -1,0 +1,81 @@
+name: Performance or quality report
+description: Report slow runs, regressions, bad transcripts, language detection misses, diarization issues, or TTS quality problems.
+title: "perf: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please do not upload private audio. If the audio cannot be shared, include duration, codec/container, language, and the redacted diagnostics instead.
+        Kesha Stats can help without storing content: run `kesha stats week` and paste the relevant summary if Stats is enabled.
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: Paste the exact command and flags.
+      placeholder: kesha --json --vad --speakers meeting.m4a
+    validations:
+      required: true
+  - type: textarea
+    id: input_shape
+    attributes:
+      label: Input shape
+      description: Duration, codec/container, language, number of speakers, silence/noise level, and whether the audio can be shared.
+      placeholder: 12 min, m4a, Russian, 2 speakers, office noise, cannot share audio
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: Runtime, transcript quality issue, wrong language, bad speaker labels, TTS artifact, or other observed behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What output, quality, or runtime did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: stats
+    attributes:
+      label: Stats summary
+      description: Paste `kesha stats week` or `kesha stats errors` if available. Do not paste raw audio or transcripts.
+      render: text
+    validations:
+      required: false
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Paste `kesha doctor --json --redact` output or say that a support bundle is attached.
+      render: text
+    validations:
+      required: true
+  - type: dropdown
+    id: feature
+    attributes:
+      label: Feature area
+      options:
+        - Speech-to-text
+        - Audio language detection
+        - VAD
+        - Speaker diarization
+        - Text-to-speech
+        - SSML
+        - OpenClaw integration
+        - Raycast integration
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I did not attach private audio, private transcripts, model files, or the Stats database.
+          required: true
+        - label: I redacted personal content from examples and logs.
+          required: true


### PR DESCRIPTION
## Summary

- add GitHub issue forms for bugs, install/cache failures, and performance/quality reports
- require command, expected/actual behavior, platform, redacted diagnostics, and privacy confirmation
- point reporters at `kesha doctor --json --redact`, `kesha support-bundle`, `kesha install --plan`, and Stats summaries where relevant

Refs #345

## Validation

- `bun --eval 'import { parse } from "yaml"; for (const path of [".github/ISSUE_TEMPLATE/config.yml", ".github/ISSUE_TEMPLATE/bug_report.yml", ".github/ISSUE_TEMPLATE/install_support.yml", ".github/ISSUE_TEMPLATE/performance.yml"]) { const doc = parse(await Bun.file(path).text()); if (!doc) throw new Error(`${path}: empty`); console.log(`${path}: ok`); }'`
