### PR TITLE
ci(packaging): build Linux deb and rpm packages

### DIFF
--- a/.github/scripts/build-linux-packages.mjs
+++ b/.github/scripts/build-linux-packages.mjs
@@ -2,15 +2,13 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { LINUX_PACKAGE_RELEASE, validateLinuxPackageVersion } from "./linux-package-names.mjs";
 
 const OUT_DIR = "dist/linux-packages";
-const PACKAGE_RELEASE = "1";
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 const version = pkg.version;
 
-if (typeof version !== "string" || !/^[0-9]+\.[0-9]+\.[0-9]+/.test(version)) {
-  throw new Error(`package.json#version must be a package-compatible semver, got: ${version}`);
-}
+validateLinuxPackageVersion(version);
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -37,7 +35,7 @@ run("bun", [
 
 const nfpmEnv = {
   KESHA_VERSION: version,
-  KESHA_PACKAGE_RELEASE: PACKAGE_RELEASE,
+  KESHA_PACKAGE_RELEASE: LINUX_PACKAGE_RELEASE,
 };
 for (const packager of ["deb", "rpm"]) {
   run("nfpm", [

--- a/.github/scripts/build-linux-packages.mjs
+++ b/.github/scripts/build-linux-packages.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const OUT_DIR = "dist/linux-packages";
+const PACKAGE_RELEASE = "1";
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+const version = pkg.version;
+
+if (typeof version !== "string" || !/^[0-9]+\.[0-9]+\.[0-9]+/.test(version)) {
+  throw new Error(`package.json#version must be a package-compatible semver, got: ${version}`);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    env: { ...process.env, ...options.env },
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} exited ${result.status}`);
+  }
+}
+
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+
+const binary = join(OUT_DIR, "kesha");
+run("bun", [
+  "build",
+  "--compile",
+  "--target=bun-linux-x64",
+  `--outfile=${binary}`,
+  "./bin/kesha.js",
+]);
+
+const nfpmEnv = {
+  KESHA_VERSION: version,
+  KESHA_PACKAGE_RELEASE: PACKAGE_RELEASE,
+};
+for (const packager of ["deb", "rpm"]) {
+  run("nfpm", [
+    "package",
+    "--config",
+    "packaging/nfpm.yaml",
+    "--packager",
+    packager,
+    "--target",
+    OUT_DIR,
+  ], { env: nfpmEnv });
+}

--- a/.github/scripts/linux-package-names.mjs
+++ b/.github/scripts/linux-package-names.mjs
@@ -1,0 +1,15 @@
+export const LINUX_PACKAGE_RELEASE = "1";
+
+export function validateLinuxPackageVersion(version) {
+  if (typeof version !== "string" || !/^[0-9]+\.[0-9]+\.[0-9]+$/.test(version)) {
+    throw new Error(`package version must be stable X.Y.Z, got: ${version}`);
+  }
+}
+
+export function linuxPackageNames(version) {
+  validateLinuxPackageVersion(version);
+  return {
+    deb: `kesha-voice-kit_${version}-${LINUX_PACKAGE_RELEASE}_amd64.deb`,
+    rpm: `kesha-voice-kit-${version}-${LINUX_PACKAGE_RELEASE}.x86_64.rpm`,
+  };
+}

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { linuxPackageNames } from "./linux-package-names.mjs";
 
 const REPOSITORY = "drakulavich/kesha-voice-kit";
 const MANIFEST_NAME = "kesha-release-manifest.json";
@@ -52,23 +53,24 @@ const DARWIN_SIDECARS = [
 ];
 
 function linuxPackageAssets(version) {
+  const packages = linuxPackageNames(version);
   return [
     {
-      name: `kesha-voice-kit_${version}-1_amd64.deb`,
+      name: packages.deb,
       kind: "package",
       platforms: ["linux-x64"],
       install: {
         packageManager: "apt",
-        command: `sudo apt install ./kesha-voice-kit_${version}-1_amd64.deb`,
+        command: `sudo apt install ./${packages.deb}`,
       },
     },
     {
-      name: `kesha-voice-kit-${version}-1.x86_64.rpm`,
+      name: packages.rpm,
       kind: "package",
       platforms: ["linux-x64"],
       install: {
         packageManager: "dnf",
-        command: `sudo dnf install ./kesha-voice-kit-${version}-1.x86_64.rpm`,
+        command: `sudo dnf install ./${packages.rpm}`,
       },
     },
   ];
@@ -185,9 +187,12 @@ function validateSourceConsistency(manifest) {
   assertIncludes(workflow, "dist/linux-packages/*.{deb,rpm}", ".github/workflows/build-engine.yml");
 
   const packageScript = readFileSync(".github/scripts/build-linux-packages.mjs", "utf8");
+  const packageNames = readFileSync(".github/scripts/linux-package-names.mjs", "utf8");
   const nfpmConfig = readFileSync("packaging/nfpm.yaml", "utf8");
   assertIncludes(packageScript, "--target=bun-linux-x64", ".github/scripts/build-linux-packages.mjs");
   assertIncludes(packageScript, "packaging/nfpm.yaml", ".github/scripts/build-linux-packages.mjs");
+  assertIncludes(packageScript, "LINUX_PACKAGE_RELEASE", ".github/scripts/build-linux-packages.mjs");
+  assertIncludes(packageNames, "LINUX_PACKAGE_RELEASE", ".github/scripts/linux-package-names.mjs");
   assertIncludes(nfpmConfig, "dst: /usr/bin/kesha", "packaging/nfpm.yaml");
   assertIncludes(nfpmConfig, "dst: /usr/bin/parakeet", "packaging/nfpm.yaml");
 

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -51,6 +51,29 @@ const DARWIN_SIDECARS = [
   },
 ];
 
+function linuxPackageAssets(version) {
+  return [
+    {
+      name: `kesha-voice-kit_${version}-1_amd64.deb`,
+      kind: "package",
+      platforms: ["linux-x64"],
+      install: {
+        packageManager: "apt",
+        command: `sudo apt install ./kesha-voice-kit_${version}-1_amd64.deb`,
+      },
+    },
+    {
+      name: `kesha-voice-kit-${version}-1.x86_64.rpm`,
+      kind: "package",
+      platforms: ["linux-x64"],
+      install: {
+        packageManager: "dnf",
+        command: `sudo dnf install ./kesha-voice-kit-${version}-1.x86_64.rpm`,
+      },
+    },
+  ];
+}
+
 function usage() {
   console.error(
     "usage: node .github/scripts/release-manifest.mjs [--tag vX.Y.Z] [--out path] [--check]",
@@ -93,9 +116,13 @@ function buildManifest(tag) {
   }
 
   const sbomName = `kesha-voice-kit-${tag}.spdx.json`;
+  const packageVersion = tag.slice(1);
   const assets = [
     ...ENGINE_ASSETS.map((p) => asset(p.engineAsset, "engine", [p.id], p.install)),
     ...DARWIN_SIDECARS.map((s) => asset(s.name, "sidecar", ["darwin-arm64"], s.install)),
+    ...linuxPackageAssets(packageVersion).map((p) =>
+      asset(p.name, p.kind, p.platforms, p.install),
+    ),
     asset(sbomName, "sbom", []),
     asset(MANIFEST_NAME, "manifest", []),
     asset("SHA256SUMS", "checksum", [], undefined, false),
@@ -111,7 +138,7 @@ function buildManifest(tag) {
       runtime: "bun",
       userInstall: "bun add -g @drakulavich/kesha-voice-kit",
       manifestPurpose:
-        "Release metadata for future package-manager channels; it does not replace the Bun-first user install path.",
+        "Release metadata for package-manager channels; it does not replace the Bun-first user install path.",
     },
     verification: {
       checksumAsset: "SHA256SUMS",
@@ -154,6 +181,15 @@ function validateSourceConsistency(manifest) {
 
   assertIncludes(workflow, "SHA256SUMS", ".github/workflows/build-engine.yml");
   assertIncludes(workflow, ".sigstore.json", ".github/workflows/build-engine.yml");
+  assertIncludes(workflow, "build-linux-packages.mjs", ".github/workflows/build-engine.yml");
+  assertIncludes(workflow, "dist/linux-packages/*.{deb,rpm}", ".github/workflows/build-engine.yml");
+
+  const packageScript = readFileSync(".github/scripts/build-linux-packages.mjs", "utf8");
+  const nfpmConfig = readFileSync("packaging/nfpm.yaml", "utf8");
+  assertIncludes(packageScript, "--target=bun-linux-x64", ".github/scripts/build-linux-packages.mjs");
+  assertIncludes(packageScript, "packaging/nfpm.yaml", ".github/scripts/build-linux-packages.mjs");
+  assertIncludes(nfpmConfig, "dst: /usr/bin/kesha", "packaging/nfpm.yaml");
+  assertIncludes(nfpmConfig, "dst: /usr/bin/parakeet", "packaging/nfpm.yaml");
 
   const names = new Set();
   for (const a of manifest.assets) {

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -118,7 +118,14 @@ function buildManifest(tag) {
   }
 
   const sbomName = `kesha-voice-kit-${tag}.spdx.json`;
-  const packageVersion = tag.slice(1);
+  const tagVersion = tag.slice(1);
+  if (tagVersion !== pkg.version) {
+    throw new Error(
+      `release tag ${tag} must match package.json#version (${pkg.version}) for Linux package filenames`,
+    );
+  }
+
+  const packageVersion = pkg.version;
   const assets = [
     ...ENGINE_ASSETS.map((p) => asset(p.engineAsset, "engine", [p.id], p.install)),
     ...DARWIN_SIDECARS.map((s) => asset(s.name, "sidecar", ["darwin-arm64"], s.install)),

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -410,11 +410,30 @@ jobs:
           upload-release-assets: false
           dependency-snapshot: false
 
+      - name: Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: "1.3.13"
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install nFPM
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
+
+      - name: Build Linux deb/rpm packages
+        run: node .github/scripts/build-linux-packages.mjs
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: release-assets
+
+      - name: Stage Linux packages
+        run: cp dist/linux-packages/*.{deb,rpm} release-assets/
 
       - name: Generate release manifest
         env:

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - packaging/**
       - .github/scripts/build-linux-packages.mjs
+      - .github/scripts/linux-package-names.mjs
       - .github/workflows/linux-packages.yml
       - .github/workflows/build-engine.yml
       - .github/actions/setup-bun/action.yml
@@ -23,6 +24,7 @@ on:
     paths:
       - packaging/**
       - .github/scripts/build-linux-packages.mjs
+      - .github/scripts/linux-package-names.mjs
       - .github/workflows/linux-packages.yml
       - .github/workflows/build-engine.yml
       - .github/actions/setup-bun/action.yml

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -1,0 +1,84 @@
+name: "📦 Linux Packages"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - packaging/**
+      - .github/scripts/build-linux-packages.mjs
+      - .github/workflows/linux-packages.yml
+      - .github/workflows/build-engine.yml
+      - .github/actions/setup-bun/action.yml
+      - package.json
+      - bun.lock
+      - tsconfig.json
+      - bin/**
+      - src/**
+      - README.md
+      - docs/linux-packages.md
+      - LICENSE
+      - NOTICES.md
+  push:
+    branches: [main]
+    paths:
+      - packaging/**
+      - .github/scripts/build-linux-packages.mjs
+      - .github/workflows/linux-packages.yml
+      - .github/workflows/build-engine.yml
+      - .github/actions/setup-bun/action.yml
+      - package.json
+      - bun.lock
+      - tsconfig.json
+      - bin/**
+      - src/**
+      - README.md
+      - docs/linux-packages.md
+      - LICENSE
+      - NOTICES.md
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: "1.3.13"
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install nFPM
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
+
+      - name: Build packages
+        run: node .github/scripts/build-linux-packages.mjs
+
+      - name: Inspect package metadata
+        run: |
+          dpkg-deb --info dist/linux-packages/*.deb
+          dpkg-deb --contents dist/linux-packages/*.deb
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends rpm
+          rpm -qip dist/linux-packages/*.rpm
+          rpm -qlp dist/linux-packages/*.rpm
+
+      - name: Smoke deb install
+        run: |
+          sudo apt install -y ./dist/linux-packages/*.deb
+          kesha --version
+          parakeet --version
+          kesha install --plan
+          sudo apt remove -y kesha-voice-kit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,12 @@ CI gates against silent drift via `bun .github/scripts/check-versions.ts` (also 
    secret: `HOMEBREW_TAP_TOKEN`, a fine-scoped token with write access only to
    the tap repository. CLI-only `vX.Y.Z-cli` marker releases are intentionally
    skipped for now.
+9. Stable engine releases (not `vX.Y.Z-cli` marker releases) also attach Linux
+   x64 `.deb` and `.rpm` packages.
+   They are built in `build-engine.yml` before `SHA256SUMS` and Sigstore
+   signing, so the packages are covered by the normal release verification
+   flow. The packages install the standalone CLI wrapper only; `kesha install`
+   remains the explicit engine/model download step.
 
 ### NPM PUBLISH IS AUTOMATED WITH PROVENANCE ATTESTATION
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ docker compose run --rm kesha install
 docker compose run --rm kesha audio.ogg
 ```
 
+## Linux Packages
+
+Stable engine releases also publish `.deb` and `.rpm` packages for Linux x64.
+They install the standalone CLI wrapper; engine and model downloads remain explicit:
+
+```bash
+kesha install
+kesha audio.ogg
+```
+
+See [Linux packages](docs/linux-packages.md) for install commands and package
+scope.
+
 ## Speech-to-text
 
 ```bash

--- a/docs/linux-packages.md
+++ b/docs/linux-packages.md
@@ -1,0 +1,51 @@
+# Linux Packages
+
+Kesha publishes `.deb` and `.rpm` packages for Linux x64 on stable engine
+releases. They install a standalone Bun-compiled CLI wrapper as `kesha` and
+the backward-compatible `parakeet` alias. Engine binaries and models are still
+downloaded explicitly with `kesha install`.
+
+## Debian / Ubuntu
+
+```bash
+gh release download vX.Y.Z \
+  -R drakulavich/kesha-voice-kit \
+  -p 'kesha-voice-kit_*_amd64.deb'
+sudo apt install ./kesha-voice-kit_*_amd64.deb
+kesha install
+kesha audio.ogg
+```
+
+## Fedora / RHEL
+
+```bash
+gh release download vX.Y.Z \
+  -R drakulavich/kesha-voice-kit \
+  -p 'kesha-voice-kit-*.x86_64.rpm'
+sudo dnf install ./kesha-voice-kit-*.x86_64.rpm
+kesha install
+kesha audio.ogg
+```
+
+## Package Scope
+
+The Linux packages install:
+
+- `/usr/bin/kesha`
+- `/usr/bin/parakeet`
+- license, notices, and README under `/usr/share/doc/kesha-voice-kit`
+
+They depend on `ca-certificates` so `kesha install` can download release assets
+and model files over HTTPS. They do not install the Rust engine or model files
+during package installation.
+
+## Maintainer Validation
+
+```bash
+go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
+node .github/scripts/build-linux-packages.mjs
+sudo apt install ./dist/linux-packages/kesha-voice-kit_*_amd64.deb
+kesha --version
+kesha install --plan
+sudo apt remove kesha-voice-kit
+```

--- a/docs/linux-packages.md
+++ b/docs/linux-packages.md
@@ -41,6 +41,9 @@ during package installation.
 
 ## Maintainer Validation
 
+Packaging uses [nFPM](https://nfpm.goreleaser.com/) to emit both formats from
+the same config.
+
 ```bash
 go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
 node .github/scripts/build-linux-packages.mjs

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -1,8 +1,8 @@
 # Release Manifest
 
 `kesha-release-manifest.json` is packaging metadata published with every engine
-release. It is a small, stable JSON contract for future package-manager channels
-such as Homebrew, deb, or rpm.
+release. It is a small, stable JSON contract for package-manager channels such
+as Homebrew, deb, or rpm.
 
 The manifest does not replace the user-facing Bun install path:
 
@@ -17,6 +17,7 @@ The manifest records:
 
 - the repository, release tag, CLI version, and engine version
 - released engine binaries and macOS sidecars
+- released Linux `.deb` and `.rpm` packages
 - the install layout used by `kesha install`
 - supported platform status for package managers
 - checksum and Sigstore bundle naming conventions

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,42 @@
+name: kesha-voice-kit
+arch: amd64
+platform: linux
+version: ${KESHA_VERSION}
+version_schema: semver
+release: ${KESHA_PACKAGE_RELEASE}
+section: utils
+priority: optional
+maintainer: Anton Yakutovich <129260+drakulavich@users.noreply.github.com>
+description: Local speech-to-text, text-to-speech, and language detection toolkit.
+vendor: drakulavich
+homepage: https://github.com/drakulavich/kesha-voice-kit
+license: MIT
+
+contents:
+  - src: dist/linux-packages/kesha
+    dst: /usr/bin/kesha
+    file_info:
+      mode: 0755
+  - src: /usr/bin/kesha
+    dst: /usr/bin/parakeet
+    type: symlink
+  - src: LICENSE
+    dst: /usr/share/doc/kesha-voice-kit/LICENSE
+    file_info:
+      mode: 0644
+  - src: NOTICES.md
+    dst: /usr/share/doc/kesha-voice-kit/NOTICES.md
+    file_info:
+      mode: 0644
+  - src: README.md
+    dst: /usr/share/doc/kesha-voice-kit/README.md
+    file_info:
+      mode: 0644
+
+overrides:
+  deb:
+    depends:
+      - ca-certificates
+  rpm:
+    depends:
+      - ca-certificates

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -4,6 +4,7 @@ import { getEngineBinPath } from "../engine";
 import { renderInstallPlan } from "../install-plan";
 import { maybeAskForStar } from "../star";
 import { log } from "../log";
+import { packageVersion } from "../package-info";
 
 interface InstallCommandArgs {
   coreml: boolean;
@@ -14,8 +15,6 @@ interface InstallCommandArgs {
   diarize: boolean;
   plan: boolean;
 }
-
-const pkg = await Bun.file(new URL("../../package.json", import.meta.url)).json();
 
 function resolveBackendFlag(coreml: boolean, onnx: boolean): string | undefined {
   if (coreml && onnx) {
@@ -48,8 +47,7 @@ async function performInstall(
   }
   try {
     await downloadEngine(noCache, backend, { tts, vad, diarize });
-    const currentVersion = typeof pkg.version === "string" ? pkg.version : null;
-    await maybeAskForStar(getEngineBinPath(), currentVersion, log);
+    await maybeAskForStar(getEngineBinPath(), packageVersion, log);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     log.error(message);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -12,10 +12,9 @@ import {
   formatTranscriptOutput,
   formatVerboseOutput,
 } from "../format";
+import { packageVersion } from "../package-info";
 import { formatToonOutput } from "../toon";
 import { artifactFromFile, createStatsRecorder } from "../stats";
-
-const pkg = await Bun.file(new URL("../../package.json", import.meta.url)).json();
 
 interface MainCommandArgs {
   _: string[];
@@ -107,7 +106,7 @@ export function checkLanguageMismatch(expected: string | undefined, detected: st
 export const mainCommand = defineCommand({
   meta: {
     name: "kesha",
-    version: pkg.version,
+    version: packageVersion,
     description:
       "Kesha Voice Kit — open-source voice toolkit for Apple Silicon.\n" +
       "\n" +

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -9,6 +9,7 @@ import {
 } from "./engine";
 import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
+import { packageName, packageVersion } from "./package-info";
 import { getStatsStatus, type StatsStatus } from "./stats";
 
 const KNOWN_ENV_KEYS = [
@@ -182,11 +183,10 @@ function redactComponent<T extends PathSummary>(component: T, redact: boolean): 
   return { ...component, path: redactPath(component.path, true) };
 }
 
-async function readPackageInfo(): Promise<{ name: string; version: string }> {
-  const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
+function readPackageInfo(): { name: string; version: string } {
   return {
-    name: typeof pkg.name === "string" ? pkg.name : "unknown",
-    version: typeof pkg.version === "string" ? pkg.version : "unknown",
+    name: packageName,
+    version: packageVersion,
   };
 }
 
@@ -308,7 +308,7 @@ export async function collectDoctorReport(
   return {
     generatedAt: new Date().toISOString(),
     redacted: redact,
-    package: await readPackageInfo(),
+    package: readPackageInfo(),
     runtime: {
       bunVersion: Bun.version,
       platform: process.platform,

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -7,6 +7,7 @@ import {
   TRANSCRIBE_DIARIZE_FEATURE,
 } from "./engine";
 import { log } from "./log";
+import { engineVersion } from "./package-info";
 import { streamResponseToFile } from "./progress";
 import {
   readInstalledEngineVersion,
@@ -315,17 +316,6 @@ export async function downloadEngine(
   options: InstallOptions = {},
 ): Promise<string> {
   const binPath = getEngineBinPath();
-  const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
-  // The engine version is tracked separately from the CLI version so
-  // CLI-only patch releases don't require cutting a new GitHub release
-  // + Rust rebuild. Fall back to the CLI version for backwards compat.
-  const engineVersion =
-    typeof pkg.keshaEngine?.version === "string"
-      ? pkg.keshaEngine.version
-      : typeof pkg.version === "string"
-        ? pkg.version
-        : "unknown";
-
   const installedVersion = readInstalledEngineVersion(binPath);
   const engineDir = dirname(binPath);
 

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "path";
 import { getEngineBinPath } from "./engine";
 import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
+import { engineVersion, packageVersion } from "./package-info";
 
 export interface InstallPlanOptions {
   noCache?: boolean;
@@ -153,16 +154,7 @@ function bundleComponent(
   };
 }
 
-async function packageInfo(): Promise<{ version: string; engineVersion: string }> {
-  const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
-  const version = typeof pkg.version === "string" ? pkg.version : "unknown";
-  const engineVersion =
-    typeof pkg.keshaEngine?.version === "string" ? pkg.keshaEngine.version : version;
-  return { version, engineVersion };
-}
-
 export async function renderInstallPlan(options: InstallPlanOptions = {}): Promise<string> {
-  const { version, engineVersion } = await packageInfo();
   const cacheRoot = keshaCacheDir();
   const binPath = getEngineBinPath();
   const engineDir = dirname(binPath);
@@ -313,7 +305,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
   const lines = [
     "Kesha install plan",
     "",
-    `Package: @drakulavich/kesha-voice-kit ${version}`,
+    `Package: @drakulavich/kesha-voice-kit ${packageVersion}`,
     `Engine release: v${engineVersion}`,
     `Platform: ${process.platform} ${process.arch}`,
     `Cache: ${cacheRoot}`,

--- a/src/package-info.ts
+++ b/src/package-info.ts
@@ -1,0 +1,6 @@
+import pkg from "../package.json" with { type: "json" };
+
+export const packageName = typeof pkg.name === "string" ? pkg.name : "unknown";
+export const packageVersion = typeof pkg.version === "string" ? pkg.version : "unknown";
+export const engineVersion =
+  typeof pkg.keshaEngine?.version === "string" ? pkg.keshaEngine.version : packageVersion;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,8 +1,9 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readFileSync, statSync } from "fs";
+import { existsSync, mkdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { dirname, extname, join } from "path";
 import { log } from "./log";
+import { packageVersion } from "./package-info";
 
 const SCHEMA_VERSION = 1;
 const MAX_ERROR_MESSAGE_CHARS = 300;
@@ -845,12 +846,5 @@ function escapeRegExp(input: string): string {
 }
 
 function readPackageVersion(): string {
-  try {
-    const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
-      version?: unknown;
-    };
-    return typeof pkg.version === "string" ? pkg.version : "unknown";
-  } catch {
-    return "unknown";
-  }
+  return packageVersion;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "types": ["bun-types"],
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- add nFPM packaging for Linux x64 .deb and .rpm release assets
- compile the CLI into a standalone Bun Linux x64 binary for OS packages
- stage packages in build-engine before SHA256SUMS and Sigstore signing
- add a Linux Packages CI workflow that builds, inspects, and smoke-installs the .deb
- document Linux package install scope and commands

Refs #344

## Validation
- bun run check:workflows
- bun run check:release-manifest
- bunx tsc --noEmit
- bun test
- PATH="/tmp/kesha-nfpm-bin:/Users/anton/.codex/tmp/arg0/codex-arg0zNBRb9:/Users/anton/.bun/bin:/Users/anton/.local/bin:/Users/anton/.pyenv/shims:/Users/anton/.sdkman/candidates/java/current/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/anton/.cargo/bin:./node_modules/.bin:/Users/anton/go/bin:/opt/homebrew/opt/go/libexec/bin:/Applications/Codex.app/Contents/Resources" node .github/scripts/build-linux-packages.mjs
- standalone compile smoke: bun build --compile --target=bun-linux-x64 plus local Darwin compile smoke for --version/status/install --plan
- local .deb inspection: ar/tar control and data payload include /usr/bin/kesha, /usr/bin/parakeet, and docs
- local .rpm inspection: bsdtar lists /usr/bin/kesha, /usr/bin/parakeet, and docs

## Notes
- Packages install only the standalone CLI wrapper. Engine and model downloads remain explicit via kesha install.
- HOMEBREW_TAP_TOKEN remains a separate manual prerequisite for Homebrew automation.