### PR TITLE
feat(cli): add structured JSON error output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,11 @@ export {
 export type { ResolvedOutputFormat } from "./cli/main";
 export { runCli } from "./cli/dispatch";
 
-export type { TranscribeResult } from "./types";
+export type {
+  TranscribeErrorRecord,
+  TranscribeJsonOutput,
+  TranscribeResult,
+} from "./types";
 export {
   formatJsonOutput,
   formatTextOutput,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,7 +5,7 @@ import { transcribeWithSegments } from "../transcribe";
 import { detectAudioLanguageEngine, detectTextLanguageEngine } from "../engine";
 import type { LangDetectResult } from "../engine";
 import { log } from "../log";
-import type { TranscribeResult } from "../types";
+import type { TranscribeErrorRecord, TranscribeResult } from "../types";
 import {
   formatJsonOutput,
   formatTextOutput,
@@ -28,6 +28,7 @@ interface MainCommandArgs {
   no_vad?: boolean;
   timestamps: boolean;
   speakers: boolean;
+  "include-errors": boolean;
   format?: string;
   lang?: string;
 }
@@ -141,6 +142,11 @@ export const mainCommand = defineCommand({
       description: "Include speaker labels in transcript segments. Requires --json / --toon / --format json. Implies --timestamps. Currently darwin-arm64 only (#199).",
       default: false,
     },
+    "include-errors": {
+      type: "boolean",
+      description: "With --json, output { results, errors } so scripts can read per-file failures without parsing stderr",
+      default: false,
+    },
     verbose: {
       type: "boolean",
       description: "Show language detection details",
@@ -207,6 +213,10 @@ export const mainCommand = defineCommand({
       log.error("--speakers requires --json, --toon, or --format {json,toon}.");
       process.exit(2);
     }
+    if (args["include-errors"] && !wantsJson) {
+      log.error("--include-errors requires --json or --format json.");
+      process.exit(2);
+    }
     const vadMode = vad ? "on" : noVad ? "off" : "auto";
 
     if (files.length === 0) {
@@ -224,6 +234,7 @@ export const mainCommand = defineCommand({
 
     let hasError = false;
     const results: TranscribeResult[] = [];
+    const errors: TranscribeErrorRecord[] = [];
     const stats = createStatsRecorder("transcribe");
 
     const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
@@ -233,6 +244,7 @@ export const mainCommand = defineCommand({
       if (!existsSync(file)) {
         hasError = true;
         stats.recordError("input", new Error("File not found"), "file_not_found");
+        errors.push({ file, code: "file_not_found", message: "File not found" });
         log.error(`${file}: File not found`);
         continue;
       }
@@ -300,12 +312,13 @@ export const mainCommand = defineCommand({
         hasError = true;
         stats.recordError("transcribe", err);
         const message = err instanceof Error ? err.message : String(err);
+        errors.push({ file, code: "transcribe_failed", message });
         log.error(`${file}: ${message}`);
       }
     }
 
     if (wantsJson) {
-      process.stdout.write(formatJsonOutput(results));
+      process.stdout.write(formatJsonOutput(results, args["include-errors"] ? errors : undefined));
     } else if (wantsToon) {
       process.stdout.write(formatToonOutput(results));
     } else if (wantsTranscript) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,4 @@
-import type { TranscribeResult } from "./types";
+import type { TranscribeErrorRecord, TranscribeJsonOutput, TranscribeResult } from "./types";
 
 export function formatTextOutput(results: TranscribeResult[]): string {
   if (results.length === 1) {
@@ -52,6 +52,11 @@ export function formatTranscriptOutput(results: TranscribeResult[]): string {
     .join("\n") + "\n";
 }
 
-export function formatJsonOutput(results: TranscribeResult[]): string {
-  return JSON.stringify(results, null, 2) + "\n";
+export function formatJsonOutput(
+  results: TranscribeResult[],
+  errors?: TranscribeErrorRecord[],
+): string {
+  const payload: TranscribeJsonOutput =
+    errors === undefined ? results : { results, errors };
+  return JSON.stringify(payload, null, 2) + "\n";
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -23,7 +23,11 @@ export { formatToonOutput as toToon } from "./toon";
  * `toToon`. Lives in `./types` (since #179) so the public API stops
  * reaching into the CLI-layer file.
  */
-export type { TranscribeResult } from "./types";
+export type {
+  TranscribeErrorRecord,
+  TranscribeJsonOutput,
+  TranscribeResult,
+} from "./types";
 
 /** Install Kokoro TTS models. Shorthand for `downloadModel({ tts: true })`. */
 export async function downloadTts(noCache = false): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,4 +17,17 @@ export type TranscribeResult = {
   sttTimeMs?: number;
 };
 
+export type TranscribeErrorRecord = {
+  file: string;
+  code: "file_not_found" | "transcribe_failed";
+  message: string;
+};
+
+export type TranscribeJsonOutput =
+  | TranscribeResult[]
+  | {
+      results: TranscribeResult[];
+      errors: TranscribeErrorRecord[];
+    };
+
 export type { LangDetectResult, TranscriptionSegment };

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -221,6 +221,62 @@ describe("e2e-cli", () => {
     expect(stderr).toContain("a.wav");
   });
 
+  test("--json --include-errors reports structured missing-file errors", async () => {
+    const { stdout, stderr, exitCode } = await runCli([
+      "--json",
+      "--include-errors",
+      "a.wav",
+      "b.wav",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("a.wav");
+    expect(JSON.parse(stdout)).toEqual({
+      results: [],
+      errors: [
+        { file: "a.wav", code: "file_not_found", message: "File not found" },
+        { file: "b.wav", code: "file_not_found", message: "File not found" },
+      ],
+    });
+  });
+
+  test("--json --include-errors preserves successes and adds file errors", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-json-errors-cli-"));
+    tempDirs.push(dir);
+    const mediaPath = join(dir, "sample.wav");
+    const enginePath = createFakeEngine(dir);
+    writeFileSync(mediaPath, "fake wav bytes");
+
+    const { stdout, stderr, exitCode } = await runCli([
+      "--json",
+      "--include-errors",
+      mediaPath,
+      "missing.wav",
+    ], {
+      env: {
+        HOME: dir,
+        KESHA_CACHE_DIR: dir,
+        KESHA_ENGINE_BIN: enginePath,
+      },
+    });
+
+    const parsed = JSON.parse(stdout);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("missing.wav");
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].file).toBe(mediaPath);
+    expect(parsed.results[0].text).toContain("Привет с воркшопа");
+    expect(parsed.errors).toEqual([
+      { file: "missing.wav", code: "file_not_found", message: "File not found" },
+    ]);
+  });
+
+  test("--include-errors requires JSON output", async () => {
+    const { stderr, exitCode } = await runCli(["--include-errors", "a.wav"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--include-errors requires");
+  });
+
   test("unknown subcommand suggests closest match", async () => {
     const { stderr, exitCode } = await runCli(["instal"]);
     expect(exitCode).toBe(1);

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -134,6 +134,17 @@ describe("output formatting", () => {
     });
   });
 
+  test("JSON output with --include-errors and no errors still uses envelope shape", () => {
+    const output = formatJsonOutput(
+      [{ file: "ok.ogg", text: "Hello", lang: "en" }],
+      [],
+    );
+    expect(JSON.parse(output)).toEqual({
+      results: [{ file: "ok.ogg", text: "Hello", lang: "en" }],
+      errors: [],
+    });
+  });
+
   test("JSON output preserves timestamped segments", () => {
     const output = formatJsonOutput([
       {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -48,6 +48,11 @@ describe("CLI help", () => {
     expect(usage).toContain("--json");
   });
 
+  test("main help contains --include-errors flag (#324 P1)", async () => {
+    const usage = await renderUsage(mainCommand);
+    expect(usage).toContain("--include-errors");
+  });
+
   test("main help contains --toon flag (#138)", async () => {
     const usage = await renderUsage(mainCommand);
     expect(usage).toContain("--toon");
@@ -116,6 +121,17 @@ describe("output formatting", () => {
   test("JSON output: empty array when no results", () => {
     const output = formatJsonOutput([]);
     expect(JSON.parse(output)).toEqual([]);
+  });
+
+  test("JSON output can opt into structured file errors (#324 P1)", () => {
+    const output = formatJsonOutput(
+      [{ file: "ok.ogg", text: "Hello", lang: "en" }],
+      [{ file: "missing.ogg", code: "file_not_found", message: "File not found" }],
+    );
+    expect(JSON.parse(output)).toEqual({
+      results: [{ file: "ok.ogg", text: "Hello", lang: "en" }],
+      errors: [{ file: "missing.ogg", code: "file_not_found", message: "File not found" }],
+    });
   });
 
   test("JSON output preserves timestamped segments", () => {


### PR DESCRIPTION
## Summary
- Add `--include-errors` for `kesha --json` so machine consumers can opt into `{ results, errors }` instead of parsing stderr for per-file failures.
- Preserve the existing default `--json` array output for backward compatibility.
- Export `TranscribeErrorRecord` / `TranscribeJsonOutput` types alongside `TranscribeResult`.

Refs #324 P1.8.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/unit/cli.test.ts tests/integration/e2e-cli.test.ts`
- `bun test` (221 pass, 4 skip)