### PR TITLE
ci(homebrew): keep tap updater on default branch

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -39,11 +39,11 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout source tag
+      - name: Checkout workflow source
         if: steps.tag.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.tag.outputs.tag }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Node.js
         if: steps.tag.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- checkout the default branch for the Homebrew tap workflow helper script
- keep manual dispatch for existing stable tags usable, even when the tag predates the workflow helper

## Validation
- bun run check:workflows
- bunx tsc --noEmit
- bun test