### PR TITLE
fix(cli): validate say numeric flags

### DIFF
--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -29,6 +29,48 @@ async function resolveText(inline: string | undefined): Promise<string> {
   return new TextDecoder().decode(merged).trim();
 }
 
+function parseFiniteNumberFlag(name: string, value: unknown): number | undefined {
+  if (value === undefined || value === null || value === false) return undefined;
+  const raw = String(value).trim();
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    log.error(`${name} must be a finite number.`);
+    process.exit(2);
+  }
+  return parsed;
+}
+
+function parseRateFlag(value: unknown): number | undefined {
+  const rate = parseFiniteNumberFlag("--rate", value);
+  if (rate === undefined) return undefined;
+  if (rate < 0.5 || rate > 2.0) {
+    log.error("--rate must be between 0.5 and 2.0.");
+    process.exit(2);
+  }
+  return rate;
+}
+
+function parseBitrateFlag(value: unknown): number | undefined {
+  const bitrate = parseFiniteNumberFlag("--bitrate", value);
+  if (bitrate === undefined) return undefined;
+  if (!Number.isInteger(bitrate) || bitrate <= 0) {
+    log.error("--bitrate must be a positive integer.");
+    process.exit(2);
+  }
+  return bitrate;
+}
+
+function parseSampleRateFlag(value: unknown): number | undefined {
+  const sampleRate = parseFiniteNumberFlag("--sample-rate", value);
+  if (sampleRate === undefined) return undefined;
+  const supported = [8000, 12000, 16000, 24000, 48000];
+  if (!Number.isInteger(sampleRate) || !supported.includes(sampleRate)) {
+    log.error("--sample-rate must be one of 8000, 12000, 16000, 24000, 48000.");
+    process.exit(2);
+  }
+  return sampleRate;
+}
+
 export const sayCommand = defineCommand({
   meta: {
     name: "say",
@@ -88,11 +130,6 @@ export const sayCommand = defineCommand({
       process.exit(await proc.exited);
     }
 
-    const inlineText = typeof args.text === "string" ? args.text : undefined;
-    const text = await resolveText(inlineText);
-    const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
-    const voice = explicitVoice ?? (await autoRouteVoice(text));
-
     // Validate --format up front so we surface a clear error before spawning
     // the engine subprocess. The engine repeats the check authoritatively, but
     // catching it here gives the user a faster failure mode in scripts.
@@ -109,8 +146,12 @@ export const sayCommand = defineCommand({
       }
     }
 
+    const rate = parseRateFlag(args.rate);
+    const bitrate = parseBitrateFlag(args.bitrate);
+    const sampleRate = parseSampleRateFlag(args["sample-rate"]);
+
     // Reject --bitrate / --sample-rate with WAV up front to surface the error fast.
-    const hasOpusOnlyFlag = Boolean(args.bitrate) || Boolean(args["sample-rate"]);
+    const hasOpusOnlyFlag = bitrate !== undefined || sampleRate !== undefined;
     if (hasOpusOnlyFlag) {
       const outExt = typeof args.out === "string"
         ? args.out.split(".").pop()?.toLowerCase()
@@ -122,16 +163,21 @@ export const sayCommand = defineCommand({
       }
     }
 
+    const inlineText = typeof args.text === "string" ? args.text : undefined;
+    const text = await resolveText(inlineText);
+    const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
+    const voice = explicitVoice ?? (await autoRouteVoice(text));
+
     const opts = {
       text,
       voice,
       lang: typeof args.lang === "string" ? args.lang : undefined,
       out: typeof args.out === "string" ? args.out : undefined,
-      rate: args.rate ? Number(args.rate) : undefined,
+      rate,
       ssml: Boolean(args.ssml),
       format,
-      bitrate: args.bitrate ? Number(args.bitrate) : undefined,
-      sampleRate: args["sample-rate"] ? Number(args["sample-rate"]) : undefined,
+      bitrate,
+      sampleRate,
       noExpandAbbrev: Boolean(args["no-expand-abbrev"]),
     };
     const stats = createStatsRecorder("say");

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -32,9 +32,8 @@ async function resolveText(inline: string | undefined): Promise<string> {
 function parseFiniteNumberFlag(name: string, value: unknown): number | undefined {
   if (value === undefined || value === null || value === false) return undefined;
   const raw = String(value).trim();
-  if (raw === "") return undefined;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed)) {
+  if (raw === "" || !Number.isFinite(parsed)) {
     log.error(`${name} must be a finite number.`);
     process.exit(2);
   }

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -32,6 +32,7 @@ async function resolveText(inline: string | undefined): Promise<string> {
 function parseFiniteNumberFlag(name: string, value: unknown): number | undefined {
   if (value === undefined || value === null || value === false) return undefined;
   const raw = String(value).trim();
+  if (raw === "") return undefined;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed)) {
     log.error(`${name} must be a finite number.`);

--- a/tests/integration/say.test.ts
+++ b/tests/integration/say.test.ts
@@ -133,6 +133,7 @@ describe("kesha say (CLI)", () => {
   it("rejects invalid numeric flags before spawning the engine", async () => {
     const cases: Array<{ args: string[]; message: string }> = [
       { args: ["--rate", "fast", "Hello"], message: "--rate must be a finite number" },
+      { args: ["--rate", "", "Hello"], message: "--rate must be a finite number" },
       { args: ["--rate", "3", "Hello"], message: "--rate must be between 0.5 and 2.0" },
       { args: ["--format", "ogg-opus", "--bitrate", "wide", "Hello"], message: "--bitrate must be a finite number" },
       { args: ["--format", "ogg-opus", "--bitrate", "-1", "Hello"], message: "--bitrate must be a positive integer" },

--- a/tests/integration/say.test.ts
+++ b/tests/integration/say.test.ts
@@ -36,6 +36,39 @@ process.exit(99);
   return enginePath;
 }
 
+const INVALID_NUMERIC_FLAG_CASES: Array<{ name: string; args: string[]; message: string }> = [
+  {
+    name: "non-numeric rate",
+    args: ["--rate", "fast", "Hello"],
+    message: "--rate must be a finite number",
+  },
+  {
+    name: "empty rate",
+    args: ["--rate", "", "Hello"],
+    message: "--rate must be a finite number",
+  },
+  {
+    name: "out-of-range rate",
+    args: ["--rate", "3", "Hello"],
+    message: "--rate must be between 0.5 and 2.0",
+  },
+  {
+    name: "non-numeric bitrate",
+    args: ["--format", "ogg-opus", "--bitrate", "wide", "Hello"],
+    message: "--bitrate must be a finite number",
+  },
+  {
+    name: "negative bitrate",
+    args: ["--format", "ogg-opus", "--bitrate", "-1", "Hello"],
+    message: "--bitrate must be a positive integer",
+  },
+  {
+    name: "unsupported sample rate",
+    args: ["--format", "ogg-opus", "--sample-rate", "44100", "Hello"],
+    message: "--sample-rate must be one of",
+  },
+];
+
 describe("kesha say (CLI)", () => {
   it("--help exits 0 and mentions --voice", async () => {
     const proc = spawn(["bun", CLI_PATH, "say", "--help"], {
@@ -130,17 +163,8 @@ describe("kesha say (CLI)", () => {
     expect(stderr).not.toContain("TTS time:");
   });
 
-  it("rejects invalid numeric flags before spawning the engine", async () => {
-    const cases: Array<{ args: string[]; message: string }> = [
-      { args: ["--rate", "fast", "Hello"], message: "--rate must be a finite number" },
-      { args: ["--rate", "", "Hello"], message: "--rate must be a finite number" },
-      { args: ["--rate", "3", "Hello"], message: "--rate must be between 0.5 and 2.0" },
-      { args: ["--format", "ogg-opus", "--bitrate", "wide", "Hello"], message: "--bitrate must be a finite number" },
-      { args: ["--format", "ogg-opus", "--bitrate", "-1", "Hello"], message: "--bitrate must be a positive integer" },
-      { args: ["--format", "ogg-opus", "--sample-rate", "44100", "Hello"], message: "--sample-rate must be one of" },
-    ];
-
-    for (const tc of cases) {
+  for (const tc of INVALID_NUMERIC_FLAG_CASES) {
+    it(`rejects ${tc.name} before spawning the engine`, async () => {
       const dir = `/tmp/kesha-fail-engine-${Date.now()}-${Math.random()}`;
       const enginePath = await createFailingEngine(dir);
       const proc = spawn(["bun", CLI_PATH, "say", "--voice", "ru-vosk-m02", ...tc.args], {
@@ -160,6 +184,6 @@ describe("kesha say (CLI)", () => {
       expect(stdout).toBe("");
       expect(stderr).toContain(tc.message);
       expect(stderr).not.toContain("fake engine should not have been invoked");
-    }
-  });
+    });
+  }
 });

--- a/tests/integration/say.test.ts
+++ b/tests/integration/say.test.ts
@@ -25,6 +25,17 @@ if (outIndex >= 0) {
   return enginePath;
 }
 
+async function createFailingEngine(dir: string): Promise<string> {
+  mkdirSync(dir, { recursive: true });
+  const enginePath = `${dir}/kesha-engine-fail-on-use`;
+  await Bun.write(enginePath, `#!/usr/bin/env bun
+console.error("fake engine should not have been invoked: " + JSON.stringify(Bun.argv.slice(2)));
+process.exit(99);
+`);
+  chmodSync(enginePath, 0o755);
+  return enginePath;
+}
+
 describe("kesha say (CLI)", () => {
   it("--help exits 0 and mentions --voice", async () => {
     const proc = spawn(["bun", CLI_PATH, "say", "--help"], {
@@ -117,5 +128,37 @@ describe("kesha say (CLI)", () => {
 
     expect(stderr).toMatch(/Saved .*reply\.wav \(\d+ms\)/);
     expect(stderr).not.toContain("TTS time:");
+  });
+
+  it("rejects invalid numeric flags before spawning the engine", async () => {
+    const cases: Array<{ args: string[]; message: string }> = [
+      { args: ["--rate", "fast", "Hello"], message: "--rate must be a finite number" },
+      { args: ["--rate", "3", "Hello"], message: "--rate must be between 0.5 and 2.0" },
+      { args: ["--format", "ogg-opus", "--bitrate", "wide", "Hello"], message: "--bitrate must be a finite number" },
+      { args: ["--format", "ogg-opus", "--bitrate", "-1", "Hello"], message: "--bitrate must be a positive integer" },
+      { args: ["--format", "ogg-opus", "--sample-rate", "44100", "Hello"], message: "--sample-rate must be one of" },
+    ];
+
+    for (const tc of cases) {
+      const dir = `/tmp/kesha-fail-engine-${Date.now()}-${Math.random()}`;
+      const enginePath = await createFailingEngine(dir);
+      const proc = spawn(["bun", CLI_PATH, "say", "--voice", "ru-vosk-m02", ...tc.args], {
+        env: {
+          ...process.env,
+          KESHA_CACHE_DIR: dir,
+          KESHA_ENGINE_BIN: enginePath,
+          HOME: dir,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      expect(await proc.exited).toBe(2);
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      expect(stdout).toBe("");
+      expect(stderr).toContain(tc.message);
+      expect(stderr).not.toContain("fake engine should not have been invoked");
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Validate `kesha say` numeric flags in the TypeScript wrapper before reading stdin, auto-routing voices, or spawning the engine.
- Reject invalid/out-of-range `--rate`, `--bitrate`, and `--sample-rate` values with exit 2 and stderr-only messages.
- Add integration coverage proving invalid numeric flags do not invoke a configured engine.

Refs #324 P1.15.

## Validation
- `bun test tests/integration/say.test.ts`
- `bunx tsc --noEmit`
- `bun test` (230 pass, 4 skip)