### PR TITLE
ci(docker): setup buildx for GHA cache export

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,10 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: 🧰 Setup Docker Buildx
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        uses: docker/setup-buildx-action@v4
+
       - name: 📦 Build and publish image
         if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
         uses: docker/build-push-action@v7


### PR DESCRIPTION
## Summary
- add docker/setup-buildx-action before the Docker publish step
- keep the existing GHA cache configuration, but run it on a buildx driver that supports cache export

## Failure fixed
- https://github.com/drakulavich/kesha-voice-kit/actions/runs/25991873872/job/76399394954
- error: Cache export is not supported for the docker driver

## Validation
- bun run check:workflows
- bunx tsc --noEmit
- bun test