### PR TITLE
fix(cli): reject tty say without text

### DIFF
--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -29,6 +29,13 @@ async function resolveText(inline: string | undefined): Promise<string> {
   return new TextDecoder().decode(merged).trim();
 }
 
+export function shouldRejectMissingSayText(
+  inlineText: string | undefined,
+  stdinIsTty: boolean | undefined,
+): boolean {
+  return (inlineText === undefined || inlineText.length === 0) && stdinIsTty === true;
+}
+
 function parseFiniteNumberFlag(name: string, value: unknown): number | undefined {
   if (value === undefined || value === null || value === false) return undefined;
   const raw = String(value).trim();
@@ -164,6 +171,11 @@ export const sayCommand = defineCommand({
     }
 
     const inlineText = typeof args.text === "string" ? args.text : undefined;
+    const stdinIsTty = (process.stdin as { isTTY?: boolean }).isTTY;
+    if (shouldRejectMissingSayText(inlineText, stdinIsTty)) {
+      log.error("kesha say requires text or piped stdin. Usage: kesha say <text>");
+      process.exit(2);
+    }
     const text = await resolveText(inlineText);
     const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
     const voice = explicitVoice ?? (await autoRouteVoice(text));

--- a/tests/unit/say-cli.test.ts
+++ b/tests/unit/say-cli.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { shouldRejectMissingSayText } from "../../src/cli/say";
+
+describe("say CLI input guard (#324 P1)", () => {
+  test("rejects missing text only when stdin is a TTY", () => {
+    expect(shouldRejectMissingSayText(undefined, true)).toBe(true);
+    expect(shouldRejectMissingSayText("", true)).toBe(true);
+  });
+
+  test("allows piped stdin when text is omitted", () => {
+    expect(shouldRejectMissingSayText(undefined, false)).toBe(false);
+    expect(shouldRejectMissingSayText(undefined, undefined)).toBe(false);
+  });
+
+  test("allows explicit positional text even from a TTY", () => {
+    expect(shouldRejectMissingSayText("Hello", true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Reject `kesha say` with no positional text when stdin is an interactive TTY, instead of waiting on stdin.
- Preserve piped-stdin behavior for non-TTY input.
- Add a unit guard contract and verify the real pseudo-TTY path.

Refs #324 P1.14.

## Validation
- `bun test tests/unit/say-cli.test.ts tests/integration/say.test.ts`
- `bunx tsc --noEmit`
- `script -q /dev/null bun bin/kesha.js say`
- `bun test` (243 pass, 4 skip, 0 fail)