### PR TITLE
chore: add fast CLI check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,17 @@ full split.
 ## Development
 
 ```bash
+make cli-fast       # typecheck + version drift + deterministic CLI tests
 make test           # bun unit + integration tests
 make lint           # bunx tsc --noEmit
 make smoke-test     # bun link → kesha install → run against fixtures
 make release        # lint + test + smoke-test
 ```
+
+Use `bun run check` or `make cli-fast` for a quick local confidence pass before
+opening small CLI-only PRs. It avoids the engine-backed E2E lanes while still
+covering command routing, stdout/stderr contracts, help goldens, and wrapper
+validation.
 
 Rust engine work happens in `rust/`:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install check test unit integration rust-test lint lint-tsgo versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
+.PHONY: install check cli-fast test unit integration rust-test lint lint-tsgo versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -9,6 +9,9 @@ install: ## Install dependencies
 test: unit integration ## Run all tests
 
 check: lint versions test ## Run local checks that mirror the cheap CI gates
+
+cli-fast: ## Run deterministic CLI checks without engine-backed E2E lanes
+	bun run check
 
 unit: ## Run unit tests
 	bun run test:unit

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
   "scripts": {
     "test": "bun test",
     "test:unit": "bun test tests/unit/",
+    "test:cli-fast": "bun test tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts tests/integration/say.test.ts",
     "test:integration": "bun test tests/integration/",
     "lint": "bunx tsc --noEmit",
     "lint:tsgo": "bunx tsgo --noEmit",
+    "check": "bun run lint && bun run check:versions && bun run test:cli-fast",
     "check:workflows": "bun .github/scripts/check-workflows.ts",
     "check:release-manifest": "bun .github/scripts/release-manifest.mjs --check",
     "check:versions": "bun .github/scripts/check-versions.ts",


### PR DESCRIPTION
## Summary
- Add `bun run test:cli-fast` for deterministic unit/CLI integration coverage without engine-backed E2E lanes.
- Add `bun run check` and `make cli-fast` as the quick contributor confidence gate.
- Document when to use the fast gate in `CONTRIBUTING.md`.

Refs #324 P2.20.

## Validation
- `make cli-fast` (223 pass, 0 fail)
- `bun test` (243 pass, 4 skip, 0 fail)