### PR TITLE
fix(cli): make status disk scan opt-in

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,12 +1,23 @@
 import { defineCommand } from "citty";
 import { showStatus } from "../status";
 
+interface StatusCommandArgs {
+  disk: boolean;
+}
+
 export const statusCommand = defineCommand({
   meta: {
     name: "status",
     description: "Show backend installation status",
   },
-  async run() {
-    await showStatus();
+  args: {
+    disk: {
+      type: "boolean",
+      description: "Include recursive cache disk usage",
+      default: false,
+    },
+  },
+  async run({ args }: { args: StatusCommandArgs }) {
+    await showStatus({ disk: args.disk });
   },
 });

--- a/src/status.ts
+++ b/src/status.ts
@@ -44,7 +44,11 @@ export function formatStatusLine(
   return `  ${label}:${pathStr ? `   ${pathStr}` : ""}${padding}${status}`;
 }
 
-export async function showStatus(): Promise<void> {
+export interface ShowStatusOptions {
+  disk?: boolean;
+}
+
+export async function showStatus(options: ShowStatusOptions = {}): Promise<void> {
   const binPath = getEngineBinPath();
   const installed = isEngineInstalled();
 
@@ -86,7 +90,9 @@ export async function showStatus(): Promise<void> {
       log.info("");
     }
 
-    showDiskUsage(binPath);
+    if (options.disk) {
+      showDiskUsage(binPath);
+    }
   }
 
   if (!installed) {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -156,7 +156,11 @@ OPTIONS
   test("status help matches the normalized golden output", async () => {
     expect(normalizeUsage(await renderUsage(statusCommand))).toBe(`Show backend installation status (status)
 
-USAGE status`);
+USAGE status [OPTIONS]
+
+OPTIONS
+
+  --disk    Include recursive cache disk usage (Default: false)`);
   });
 
   test("say help matches the normalized golden output", async () => {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -104,4 +104,38 @@ describe("showStatus", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("does not scan or print disk usage unless requested", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-test-"));
+    const binDir = join(dir, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFileSync(binPath, "not a real executable");
+    mkdirSync(join(dir, "models", "parakeet-tdt-v3"), { recursive: true });
+    writeFileSync(join(dir, "models", "parakeet-tdt-v3", "model.onnx"), "model");
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = dir;
+    process.env.HOME = dir;
+
+    const originalLog = console.log;
+    const originalError = console.error;
+    const lines: string[] = [];
+    console.log = (msg: string) => {
+      lines.push(msg);
+    };
+    console.error = () => {};
+    try {
+      await showStatus();
+      expect(lines.join("\n")).not.toContain("Disk usage");
+
+      lines.length = 0;
+      await showStatus({ disk: true });
+      expect(lines.join("\n")).toContain("Disk usage");
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add `kesha status --disk` for recursive cache disk usage.
- Keep plain `kesha status` on the fast diagnostic path without walking the cache tree.
- Update status help golden and unit coverage for the opt-in behavior.

Refs #324 P2.17.

## Validation
- `bun test tests/unit/status.test.ts tests/unit/cli.test.ts`
- `make cli-fast` (224 pass, 0 fail)
- `bun test` (244 pass, 4 skip, 0 fail)