### PR TITLE
test(cli): add scenario runner helper

### DIFF
--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -2,77 +2,15 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { runCliScenario, type CliScenarioOptions, type CliScenarioResult } from "./cli-scenario";
 
-const CWD = import.meta.dir + "/../..";
-const CLI_TIMEOUT_MS = 4_000;
 const tempDirs: string[] = [];
-
-interface CliRun {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
 
 async function runCli(
   args: string[],
-  opts: { env?: Record<string, string> } = {},
-): Promise<CliRun> {
-  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
-    cwd: CWD,
-    env: {
-      ...process.env,
-      NO_COLOR: "1",
-      FORCE_COLOR: "0",
-      ...(opts.env ?? {}),
-    },
-  });
-
-  const stdoutPromise = new Response(proc.stdout).text();
-  const stderrPromise = new Response(proc.stderr).text();
-  let timeout: Timer | undefined;
-  let forceKill: Timer | undefined;
-  const timeoutPromise = new Promise<"timeout">((resolve) => {
-    timeout = setTimeout(() => resolve("timeout"), CLI_TIMEOUT_MS);
-  });
-  const exitOrTimeout = await Promise.race([proc.exited, timeoutPromise]);
-  if (timeout) clearTimeout(timeout);
-  if (exitOrTimeout === "timeout") {
-    proc.kill("SIGTERM");
-    forceKill = setTimeout(() => proc.kill("SIGKILL"), 1_000);
-  }
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    stdoutPromise,
-    stderrPromise,
-    proc.exited,
-  ]);
-  if (forceKill) clearTimeout(forceKill);
-
-  if (exitOrTimeout === "timeout") {
-    throw new Error(
-      [
-        `CLI timed out after ${CLI_TIMEOUT_MS}ms: kesha ${args.join(" ")}`,
-        `exitCode=${exitCode}`,
-        `stdout=${stdout.trim()}`,
-        `stderr=${stderr.trim()}`,
-      ].join("\n"),
-    );
-  }
-
-  return {
-    stdout: stripAnsi(stdout.trim()),
-    stderr: stripAnsi(stderr.trim()),
-    exitCode,
-  };
-}
-
-function stripAnsi(value: string): string {
-  return value.replace(
-    /[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g,
-    "",
-  );
+  opts: CliScenarioOptions = {},
+): Promise<CliScenarioResult> {
+  return runCliScenario(args, opts);
 }
 
 function makeTempDir(prefix: string): string {
@@ -150,7 +88,7 @@ process.exit(99);
 }
 
 function expectContract(
-  actual: CliRun,
+  actual: CliScenarioResult,
   expected: {
     exitCode: number;
     stdoutContains?: string[];
@@ -380,13 +318,21 @@ describe("CLI contracts", () => {
     expect(report.env.KESHA_STATS_DB).toBe("~/stats.sqlite");
 
     const bundlePath = join(dir, "bundle.tar.gz");
-    const bundle = await runCli(["support-bundle", "--output", bundlePath], { env });
+    const bundle = await runCli(["support-bundle", "--output", bundlePath], {
+      env,
+      artifacts: [bundlePath],
+    });
     expectContract(bundle, {
       exitCode: 0,
       stdoutContains: [`Created support bundle: ${bundlePath}`, "Entries: 4", "Size:"],
       stderrEmpty: true,
     });
     expect(existsSync(bundlePath)).toBe(true);
+    expect(bundle.artifacts[0]).toMatchObject({
+      path: bundlePath,
+      exists: true,
+    });
+    expect(bundle.artifacts[0]?.sizeBytes).toBeGreaterThan(0);
   });
 
   test("read-only planning and stats commands keep user data on stdout", async () => {
@@ -398,6 +344,7 @@ describe("CLI contracts", () => {
     };
 
     const plan = await runCli(["install", "--plan", "--tts"], { env });
+    expect(plan.envDiff.overrides.KESHA_ENGINE_BIN).toBe(enginePath);
     expectContract(plan, {
       exitCode: 0,
       stdoutContains: ["Kesha install plan", "Expected network for this run:", "Run: kesha install --tts"],

--- a/tests/integration/cli-scenario.ts
+++ b/tests/integration/cli-scenario.ts
@@ -1,0 +1,185 @@
+import { existsSync, readFileSync, statSync } from "fs";
+
+const DEFAULT_CWD = import.meta.dir + "/../..";
+const DEFAULT_TIMEOUT_MS = 4_000;
+const FORCE_KILL_GRACE_MS = 1_000;
+
+export interface CliScenarioArtifactRequest {
+  name?: string;
+  path: string;
+  text?: boolean;
+}
+
+export interface CliScenarioArtifact {
+  name: string;
+  path: string;
+  exists: boolean;
+  sizeBytes?: number;
+  text?: string;
+}
+
+export interface CliScenarioEnvDiff {
+  added: string[];
+  changed: string[];
+  overrides: Record<string, string>;
+}
+
+export interface CliScenarioResult {
+  args: string[];
+  command: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  elapsedMs: number;
+  timedOut: boolean;
+  envDiff: CliScenarioEnvDiff;
+  artifacts: CliScenarioArtifact[];
+}
+
+export interface CliScenarioOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+  stripAnsi?: boolean;
+  trimOutput?: boolean;
+  artifacts?: Array<string | CliScenarioArtifactRequest>;
+  maxArtifactBytes?: number;
+}
+
+export async function runCliScenario(
+  args: string[],
+  opts: CliScenarioOptions = {},
+): Promise<CliScenarioResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const startedAt = performance.now();
+  const envOverrides = {
+    NO_COLOR: "1",
+    FORCE_COLOR: "0",
+    ...(opts.env ?? {}),
+  };
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: opts.cwd ?? DEFAULT_CWD,
+    env: {
+      ...process.env,
+      ...envOverrides,
+    },
+  });
+
+  const stdoutPromise = new Response(proc.stdout).text();
+  const stderrPromise = new Response(proc.stderr).text();
+  let timeout: Timer | undefined;
+  let forceKill: Timer | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeout = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+  const exitOrTimeout = await Promise.race([proc.exited, timeoutPromise]);
+  if (timeout) clearTimeout(timeout);
+
+  if (exitOrTimeout === "timeout") {
+    proc.kill("SIGTERM");
+    forceKill = setTimeout(() => proc.kill("SIGKILL"), FORCE_KILL_GRACE_MS);
+  }
+
+  const [rawStdout, rawStderr, exitCode] = await Promise.all([
+    stdoutPromise,
+    stderrPromise,
+    proc.exited,
+  ]);
+  if (forceKill) clearTimeout(forceKill);
+
+  const elapsedMs = Math.round(performance.now() - startedAt);
+  const result: CliScenarioResult = {
+    args,
+    command: ["kesha", ...args].join(" "),
+    stdout: normalizeOutput(rawStdout, opts),
+    stderr: normalizeOutput(rawStderr, opts),
+    exitCode,
+    elapsedMs,
+    timedOut: exitOrTimeout === "timeout",
+    envDiff: diffEnv(envOverrides),
+    artifacts: captureArtifacts(opts.artifacts ?? [], opts.maxArtifactBytes ?? 64_000),
+  };
+
+  if (result.timedOut) {
+    throw new CliScenarioTimeoutError(result, timeoutMs);
+  }
+
+  return result;
+}
+
+export class CliScenarioTimeoutError extends Error {
+  constructor(
+    readonly result: CliScenarioResult,
+    timeoutMs: number,
+  ) {
+    super(formatTimeout(result, timeoutMs));
+    this.name = "CliScenarioTimeoutError";
+  }
+}
+
+function normalizeOutput(value: string, opts: CliScenarioOptions): string {
+  const stripped = opts.stripAnsi === false ? value : stripAnsi(value);
+  return opts.trimOutput === false ? stripped : stripped.trim();
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(
+    /[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g,
+    "",
+  );
+}
+
+function diffEnv(overrides: Record<string, string>): CliScenarioEnvDiff {
+  const added: string[] = [];
+  const changed: string[] = [];
+  for (const [key, value] of Object.entries(overrides)) {
+    if (!(key in process.env)) {
+      added.push(key);
+    } else if (process.env[key] !== value) {
+      changed.push(key);
+    }
+  }
+  return {
+    added: added.sort(),
+    changed: changed.sort(),
+    overrides,
+  };
+}
+
+function captureArtifacts(
+  artifacts: Array<string | CliScenarioArtifactRequest>,
+  maxArtifactBytes: number,
+): CliScenarioArtifact[] {
+  return artifacts.map((entry) => {
+    const request = typeof entry === "string" ? { path: entry } : entry;
+    const artifact: CliScenarioArtifact = {
+      name: request.name ?? request.path,
+      path: request.path,
+      exists: existsSync(request.path),
+    };
+    if (!artifact.exists) {
+      return artifact;
+    }
+
+    const stats = statSync(request.path);
+    artifact.sizeBytes = stats.size;
+    if (request.text && stats.size <= maxArtifactBytes) {
+      artifact.text = readFileSync(request.path, "utf8");
+    }
+    return artifact;
+  });
+}
+
+function formatTimeout(result: CliScenarioResult, timeoutMs: number): string {
+  return [
+    `CLI timed out after ${timeoutMs}ms: ${result.command}`,
+    `elapsedMs=${result.elapsedMs}`,
+    `exitCode=${result.exitCode}`,
+    `envAdded=${result.envDiff.added.join(",")}`,
+    `envChanged=${result.envDiff.changed.join(",")}`,
+    `stdout=${result.stdout}`,
+    `stderr=${result.stderr}`,
+  ].join("\n");
+}

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -3,55 +3,15 @@ import { Database } from "bun:sqlite";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { runCliScenario, type CliScenarioResult } from "./cli-scenario";
 
-const CWD = import.meta.dir + "/../..";
-const CLI_TIMEOUT_MS = 4_000;
 const tempDirs: string[] = [];
 
 async function runCli(
   args: string[],
   opts: { env?: Record<string, string> } = {},
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const startedAt = performance.now();
-  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
-    cwd: CWD,
-    env: opts.env ? { ...process.env, ...opts.env } : process.env,
-  });
-
-  const stdoutPromise = new Response(proc.stdout).text();
-  const stderrPromise = new Response(proc.stderr).text();
-  let timeout: Timer | undefined;
-  const timeoutPromise = new Promise<"timeout">((resolve) => {
-    timeout = setTimeout(() => resolve("timeout"), CLI_TIMEOUT_MS);
-  });
-  const exitOrTimeout = await Promise.race([proc.exited, timeoutPromise]);
-  if (timeout) clearTimeout(timeout);
-
-  if (exitOrTimeout === "timeout") {
-    proc.kill();
-  }
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    stdoutPromise,
-    stderrPromise,
-    proc.exited,
-  ]);
-
-  if (exitOrTimeout === "timeout") {
-    throw new Error(
-      [
-        `CLI timed out after ${CLI_TIMEOUT_MS}ms: kesha ${args.join(" ")}`,
-        `elapsedMs=${Math.round(performance.now() - startedAt)}`,
-        `exitCode=${exitCode}`,
-        `stdout=${stdout.trim()}`,
-        `stderr=${stderr.trim()}`,
-      ].join("\n"),
-    );
-  }
-
-  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+): Promise<CliScenarioResult> {
+  return runCliScenario(args, opts);
 }
 
 function emptyKeshaEnv(): Record<string, string> {


### PR DESCRIPTION
## Summary
- add a shared CLI scenario runner for integration tests with elapsed time, timeout, env diff, and optional artifact capture
- reuse it in CLI contract and fast e2e CLI tests instead of duplicated subprocess wrappers
- assert artifact/env-diff capture in existing contract coverage

Refs #324

## Validation
- bun test tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts
- bunx tsc --noEmit
- bun run check:workflows
- bun test