### PR TITLE
fix(status): avoid fragile status alignment

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -38,10 +38,9 @@ export function formatStatusLine(
   installed: boolean,
   missingLabel = "not installed",
 ): string {
-  const status = installed ? pc.green("✓") : pc.red(`✗ ${missingLabel}`);
-  const pathStr = path ?? "";
-  const padding = " ".repeat(Math.max(1, 50 - label.length - pathStr.length));
-  return `  ${label}:${pathStr ? `   ${pathStr}` : ""}${padding}${status}`;
+  const status = installed ? pc.green("✓") : pc.red("✗");
+  const value = installed ? path : missingLabel;
+  return `  ${status} ${label}: ${value ?? ""}`;
 }
 
 export interface ShowStatusOptions {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -25,6 +25,14 @@ describe("formatStatusLine", () => {
     const line = formatStatusLine("ffmpeg", null, false, "not found");
     expect(line).toContain("not found");
   });
+
+  test("keeps status before long values instead of padding to a fragile column", () => {
+    const longPath = `/very/long/${"nested/".repeat(20)}kesha-engine`;
+    const line = formatStatusLine("Binary", longPath, true);
+    expect(line.indexOf("✓")).toBeLessThan(line.indexOf("Binary"));
+    expect(line).toContain(`Binary: ${longPath}`);
+    expect(line).not.toMatch(/ {8,}✓/);
+  });
 });
 
 describe("activeModelMirror (#121)", () => {


### PR DESCRIPTION
## Summary
- make status rows render as stable `status label: value` lines instead of padding to a right-side status column
- keep long paths and feature lists readable without raw string-length alignment
- cover the long-value case in unit tests

Refs #324

## Validation
- bun test tests/unit/status.test.ts tests/integration/e2e-cli.test.ts tests/integration/cli-contracts.test.ts
- bunx tsc --noEmit
- bun run check:workflows
- bun test