### PR TITLE
docs(api): update transcribe alias deprecation

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -65,7 +65,7 @@ export async function transcribeWithTimestamps(
 
 /**
  * @deprecated Renamed to {@link transcribeWithTimestamps} (#248). The old
- * name shipped briefly in v1.9.0; this alias keeps existing imports working
- * for one minor-version cycle. Will be removed in v1.12.0.
+ * name shipped briefly in v1.9.0; this alias keeps existing imports working.
+ * No removal is scheduled before the next major version.
  */
 export const transcribeWithSegments = transcribeWithTimestamps;

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -17,6 +17,11 @@ describe("lib API", () => {
     expect(typeof downloadTts).toBe("function");
   });
 
+  it("keeps transcribeWithSegments as a compatibility alias", async () => {
+    const { transcribeWithSegments, transcribeWithTimestamps } = await import("../../src/lib");
+    expect(transcribeWithSegments).toBe(transcribeWithTimestamps);
+  });
+
   it("exports SayError class with code + stderr fields", async () => {
     const { SayError } = await import("../../src/lib");
     const e = new SayError("msg", 1, "stderr");


### PR DESCRIPTION
## Summary
- replace the stale `transcribeWithSegments` removal note that still promised deletion in v1.12.0
- document the alias as a compatibility export with no scheduled removal before the next major version
- add unit coverage that the old name remains wired to `transcribeWithTimestamps`

Refs #324

## Validation
- bun test tests/unit/lib.test.ts
- bunx tsc --noEmit
- bun test