### PR TITLE
chore(release): bump CLI to 1.18.1

### DIFF
--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -214,7 +214,7 @@ function validateSourceConsistency(manifest) {
 }
 
 const pkg = readPackage();
-const defaultTag = `v${pkg.keshaEngine?.version ?? pkg.version}`;
+const defaultTag = `v${pkg.version}`;
 const tag = getArg("--tag") ?? defaultTag;
 if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
   throw new Error(`release manifest tag must look like vX.Y.Z, got: ${tag}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump the npm CLI package version to 1.18.1
- keep `keshaEngine.version` at 1.18.0 because this is a CLI-only release
- prepare the marker release `v1.18.1-cli` after merge

## Release notes draft
- New diagnostics: `kesha doctor` and redacted `kesha support-bundle` for support reports.
- Install planning: `kesha install --plan` previews component size and cache state before downloads.
- Automation-friendly CLI output: structured `--json --include-errors`, stronger stdout/stderr contracts, and deterministic negative-path validation.
- TTS/CLI safety: `kesha say` rejects missing TTY input and invalid numeric flags before engine startup.
- Packaging/ops groundwork: Docker/GHCR, Homebrew tap, Linux package workflows, release manifest, checksums/SBOM/sigstore release plumbing.
- Test/CI hardening: CLI scenario runner, golden help contracts, Linux published-engine smoke, release-branch engine smoke, and clearer skipped-test summaries.

Engine: v1.18.0 (unchanged).

## Validation
- `bun run check:versions`
- `bunx tsc --noEmit`
- `bun run test:cli-fast`
- `bun pm pack --dry-run`
- `bun test`