### PR TITLE
ci: add monthly Cargo maintenance signal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,9 @@ updates:
   # Dependabot runner image ships a libcurl that mishandles the sparse
   # HTTP framing, and no cargo PR has ever merged successfully since we
   # added the ecosystem in PR #160.
-  # Workaround: run `cd rust && cargo update` manually and open a PR.
-  # Revisit once Dependabot ships a fix upstream.
+  # Replacement signal: `.github/workflows/cargo-dependency-maintenance.yml`
+  # opens a monthly checklist issue for the manual `cargo update` pass.
+  # Revisit Dependabot once it ships a fix upstream.
 
   # Workflow action versions across .github/workflows/*.
   - package-ecosystem: github-actions

--- a/.github/workflows/cargo-dependency-maintenance.yml
+++ b/.github/workflows/cargo-dependency-maintenance.yml
@@ -6,6 +6,11 @@ on:
     # remains disabled here because its runner hits sparse-index curl errors.
     - cron: "17 7 1 * *"
   workflow_dispatch:
+    inputs:
+      month:
+        description: "UTC month to open, formatted YYYY-MM. Defaults to the current month."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -23,21 +28,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          REQUESTED_MONTH: ${{ inputs.month }}
         shell: bash
         run: |
           set -euo pipefail
 
-          month="$(date -u +'%Y-%m')"
+          if [[ -n "$REQUESTED_MONTH" ]]; then
+            if [[ ! "$REQUESTED_MONTH" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; then
+              echo "::error::month must use YYYY-MM format, got '$REQUESTED_MONTH'"
+              exit 1
+            fi
+            month="$REQUESTED_MONTH"
+          else
+            month="$(date -u +'%Y-%m')"
+          fi
+
           title="Cargo dependency maintenance - ${month}"
 
           existing="$(
             gh issue list \
               -R "$REPO" \
-              --state open \
+              --state all \
               --search "\"$title\" in:title" \
               --json number,title \
-              --jq ".[] | select(.title == \"$title\") | .number" |
-              head -n 1
+              --jq "map(select(.title == \"$title\")) | first | .number // \"\""
           )"
 
           if [[ -n "$existing" ]]; then
@@ -66,9 +80,15 @@ jobs:
           If `cargo update` produces no diff, close this issue with a short note.
           EOF
 
+          labels=(--label dependencies)
+          if gh label list -R "$REPO" --search rust --json name --jq '.[].name' | grep -Fxq rust; then
+            labels+=(--label rust)
+          else
+            echo "::warning::Label 'rust' does not exist; creating the checklist with only 'dependencies'."
+          fi
+
           gh issue create \
             -R "$REPO" \
             --title "$title" \
             --body-file "$body" \
-            --label dependencies \
-            --label rust
+            "${labels[@]}"

--- a/.github/workflows/cargo-dependency-maintenance.yml
+++ b/.github/workflows/cargo-dependency-maintenance.yml
@@ -1,0 +1,74 @@
+name: "🦀 Cargo Dependency Maintenance"
+
+on:
+  schedule:
+    # Monthly signal for Rust dependency drift. Dependabot's cargo ecosystem
+    # remains disabled here because its runner hits sparse-index curl errors.
+    - cron: "17 7 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  checklist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧾 Open monthly Cargo checklist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          month="$(date -u +'%Y-%m')"
+          title="Cargo dependency maintenance - ${month}"
+
+          existing="$(
+            gh issue list \
+              -R "$REPO" \
+              --state open \
+              --search "\"$title\" in:title" \
+              --json number,title \
+              --jq ".[] | select(.title == \"$title\") | .number" |
+              head -n 1
+          )"
+
+          if [[ -n "$existing" ]]; then
+            echo "Cargo maintenance issue already exists: #$existing"
+            exit 0
+          fi
+
+          body="$RUNNER_TEMP/cargo-maintenance.md"
+          cat > "$body" <<'EOF'
+          Monthly Rust dependency upkeep checklist.
+
+          Dependabot Cargo updates are intentionally disabled in this repo because its runner has repeatedly failed against the crates.io sparse index. This issue keeps the replacement process explicit and visible.
+
+          ## Checklist
+
+          - [ ] Create a branch from current `main`
+          - [ ] Run `cd rust && cargo update`
+          - [ ] Review `rust/Cargo.lock` for major, security-sensitive, or native dependency changes
+          - [ ] Run `cd rust && cargo fmt -- --check`
+          - [ ] Run `cd rust && cargo clippy --all-targets -- -D warnings`
+          - [ ] Run `cd rust && cargo nextest run --features tts`
+          - [ ] If backend or platform crates changed, also run `cd rust && cargo check --features coreml --no-default-features`
+          - [ ] Open a PR titled `chore(deps): refresh Rust dependencies`
+          - [ ] Link this issue from the PR and note any risky transitive changes
+
+          If `cargo update` produces no diff, close this issue with a short note.
+          EOF
+
+          gh issue create \
+            -R "$REPO" \
+            --title "$title" \
+            --body-file "$body" \
+            --label dependencies \
+            --label rust


### PR DESCRIPTION
## Summary

- add a scheduled/manual Cargo dependency maintenance workflow that opens one deduplicated monthly checklist issue
- document that this replaces Dependabot Cargo until its sparse-index runner issue is fixed
- keep the process manual/visible instead of creating GITHUB_TOKEN-authored dependency PRs that would not reliably trigger downstream CI

Part of #344, item 13.

## Validation

- `bun run check:workflows`
- `bun run check:versions`
- `git diff --check`