### PR TITLE
Fail fast on missing runtime prerequisites

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,19 +1,6 @@
 name: "🐳 Docker"
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - Dockerfile
-      - .dockerignore
-      - compose.yml
-      - package.json
-      - bun.lock
-      - bin/**
-      - src/**
-      - fixtures/benchmark/**
-      - fixtures/benchmark-en/**
-      - .github/workflows/docker.yml
   push:
     branches: [main]
     tags:
@@ -38,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🔍 Detect Docker-relevant changes
-        if: github.event_name == 'push' && github.ref_type == 'branch'
+        if: github.ref_type == 'branch'
         uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -55,18 +42,8 @@ jobs:
               - fixtures/benchmark-en/**
               - .github/workflows/docker.yml
 
-      - name: 🔨 Build image for PR smoke
-        if: github.event_name == 'pull_request'
-        run: docker build --platform linux/amd64 -t kesha-voice-kit:ci .
-
-      - name: 🚬 Smoke PR image
-        if: github.event_name == 'pull_request'
-        run: |
-          docker run --rm kesha-voice-kit:ci --version
-          docker run --rm kesha-voice-kit:ci status
-
       - name: 🔐 Login to GHCR
-        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -74,7 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🏷️ Docker metadata
-        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -86,11 +63,11 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: 🧰 Setup Docker Buildx
-        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: 📦 Build and publish image
-        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || steps.filter.outputs.docker == 'true')
+        if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -1,24 +1,6 @@
 name: "📦 Linux Packages"
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - packaging/**
-      - .github/scripts/build-linux-packages.mjs
-      - .github/scripts/linux-package-names.mjs
-      - .github/workflows/linux-packages.yml
-      - .github/workflows/build-engine.yml
-      - .github/actions/setup-bun/action.yml
-      - package.json
-      - bun.lock
-      - tsconfig.json
-      - bin/**
-      - src/**
-      - README.md
-      - docs/linux-packages.md
-      - LICENSE
-      - NOTICES.md
   push:
     branches: [main]
     paths:

--- a/rust/src/cli/detect_text_lang.rs
+++ b/rust/src/cli/detect_text_lang.rs
@@ -3,6 +3,9 @@ use anyhow::Result;
 use crate::text_lang;
 
 pub fn run(text: String) -> Result<()> {
+    if text.trim().is_empty() {
+        anyhow::bail!("detect-text-lang requires non-empty text");
+    }
     let result = text_lang::detect_text_language(&text)?;
     println!("{}", serde_json::to_string(&result)?);
     Ok(())

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -167,6 +167,19 @@ pub fn run(a: SayArgs) -> i32 {
         return say_loop::run();
     }
 
+    let format = match resolve_output_format(
+        a.format.as_deref(),
+        a.bitrate,
+        a.sample_rate,
+        a.out.as_deref(),
+    ) {
+        Ok(f) => f,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            return 2;
+        }
+    };
+
     let text_joined = match a.text {
         Some(s) => s,
         None => {
@@ -178,6 +191,21 @@ pub fn run(a: SayArgs) -> i32 {
             buf.trim().to_string()
         }
     };
+
+    if text_joined.is_empty() {
+        let err = tts::TtsError::EmptyText;
+        eprintln!("error: {err}");
+        return exit_code_for_tts_err(&err);
+    }
+    let len = text_joined.chars().count();
+    if len > tts::MAX_TEXT_CHARS {
+        let err = tts::TtsError::TextTooLong {
+            max: tts::MAX_TEXT_CHARS,
+            actual: len,
+        };
+        eprintln!("error: {err}");
+        return exit_code_for_tts_err(&err);
+    }
 
     // `--model` + `--voice-file` are Kokoro-specific testing overrides.
     // Pinned model/voice paths bypass the cache lookup.
@@ -239,19 +267,6 @@ pub fn run(a: SayArgs) -> i32 {
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         tts::voices::ResolvedVoice::AVSpeech { voice_id } => {
             tts::EngineChoice::AVSpeech { voice_id }
-        }
-    };
-
-    let format = match resolve_output_format(
-        a.format.as_deref(),
-        a.bitrate,
-        a.sample_rate,
-        a.out.as_deref(),
-    ) {
-        Ok(f) => f,
-        Err(msg) => {
-            eprintln!("error: {msg}");
-            return 2;
         }
     };
 

--- a/rust/src/lang_id.rs
+++ b/rust/src/lang_id.rs
@@ -12,6 +12,8 @@ pub struct LangDetectResult {
 const MAX_SECONDS: f32 = 10.0;
 
 pub fn detect_audio_language(audio_path: &str) -> Result<LangDetectResult> {
+    audio::ensure_audio_track(audio_path)?;
+
     if !models::is_cached(models::ModelKind::LangId) {
         anyhow::bail!("Lang-ID model not installed. Run: kesha install");
     }
@@ -61,4 +63,22 @@ pub fn detect_audio_language(audio_path: &str) -> Result<LangDetectResult> {
         code: labels.get(best_idx).cloned().unwrap_or_default(),
         confidence: best_val,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_audio_fails_before_model_lookup() {
+        let err = match detect_audio_language("/nonexistent/kesha/lang-id.wav") {
+            Ok(_) => panic!("missing audio should fail before lang-id model lookup"),
+            Err(err) => err,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.contains("Lang-ID model not installed"),
+            "input validation must happen before model lookup, got: {msg}"
+        );
+    }
 }

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use super::TranscriptionSegment;
 
@@ -21,6 +22,15 @@ pub(crate) struct DiarizeSpan {
 #[derive(Debug, Deserialize)]
 struct SidecarOutput {
     spans: Vec<DiarizeSpan>,
+}
+
+fn diarize_timeout() -> Duration {
+    let secs = std::env::var("KESHA_DIARIZE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(90);
+    Duration::from_secs(secs)
 }
 
 /// Resolve the sidecar path. Sibling-of-engine first (release layout
@@ -53,13 +63,42 @@ fn sidecar_path() -> Result<PathBuf> {
 /// using the diarization model at `model_path`. Returns the parsed span list.
 pub(crate) fn run(audio_path: &Path, model_path: &Path) -> Result<Vec<DiarizeSpan>> {
     let sidecar = sidecar_path()?;
-    let output = Command::new(&sidecar)
+    let mut child = Command::new(&sidecar)
         .arg(audio_path)
         .arg(model_path)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .spawn()
         .with_context(|| format!("failed to spawn {}", sidecar.display()))?;
+
+    let timeout = diarize_timeout();
+    let started = Instant::now();
+    loop {
+        if child
+            .try_wait()
+            .with_context(|| format!("failed to poll {}", sidecar.display()))?
+            .is_some()
+        {
+            break;
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let output = child
+                .wait_with_output()
+                .with_context(|| format!("failed to collect timed-out {}", sidecar.display()))?;
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!(
+                "kesha-diarize timed out after {}s: {}",
+                timeout.as_secs(),
+                stderr.trim()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("failed to collect {}", sidecar.display()))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -148,10 +148,11 @@ fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDec
 /// path always builds segments cheaply (per-span boundaries already in
 /// hand from VAD output).
 ///
-/// `opts.with_speakers` triggers the diarization post-step after ASR completes.
-/// On darwin-arm64 with the `system_diarize` feature it invokes
-/// `diarize::run` + `diarize::merge_into`; on all other platforms it returns
-/// a clear error pointing at #199.
+/// `opts.with_speakers` preflights diarization prerequisites before ASR starts,
+/// then runs the diarization post-step after ASR completes. On darwin-arm64
+/// with the `system_diarize` feature it invokes `diarize::run` +
+/// `diarize::merge_into`; on all other platforms it returns a clear error
+/// pointing at #199.
 pub fn transcribe_with_options(
     audio_path: &str,
     opts: &TranscribeOptions,
@@ -183,6 +184,22 @@ pub fn transcribe_with_options(
     // `~/Downloads/assets_demo.webm` + three Zoom m4a samples). Cheap:
     // container-header read only, no frame scan.
     audio::ensure_audio_track(audio_path)?;
+
+    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
+    let diarize_model_path = if speakers_required {
+        Some(resolve_diarize_model_path().context("speaker diarization requires a model path")?)
+    } else {
+        None
+    };
+
+    #[cfg(not(all(feature = "system_diarize", target_os = "macos")))]
+    if speakers_required {
+        anyhow::bail!(
+            "speaker diarization is currently darwin-arm64 only.\n\
+             Tracked at https://github.com/drakulavich/kesha-voice-kit/issues/199.",
+        );
+    }
+
     let model_dir = ensure_asr_installed()?;
     let vad_dir = models::model_dir(models::ModelKind::Vad)
         .to_string_lossy()
@@ -227,21 +244,10 @@ pub fn transcribe_with_options(
     // --- Speaker diarization post-step ---
     #[cfg(all(feature = "system_diarize", target_os = "macos"))]
     {
-        if speakers_required {
-            let model_path = resolve_diarize_model_path()
-                .context("speaker diarization requires a model path")?;
+        if let Some(model_path) = diarize_model_path {
             let spans = diarize::run(std::path::Path::new(audio_path), &model_path)
                 .context("speaker diarization failed")?;
             output.segments = diarize::merge_into(output.segments, &spans);
-        }
-    }
-    #[cfg(not(all(feature = "system_diarize", target_os = "macos")))]
-    {
-        if speakers_required {
-            anyhow::bail!(
-                "speaker diarization is currently darwin-arm64 only.\n\
-                 Tracked at https://github.com/drakulavich/kesha-voice-kit/issues/199.",
-            );
         }
     }
 
@@ -815,5 +821,76 @@ mod tests {
             msg.contains("with_speakers requires with_segments"),
             "error message must explain the constraint, got: {msg}"
         );
+    }
+
+    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
+    #[test]
+    fn transcribe_with_speakers_checks_diarize_model_before_asr_install() {
+        let _env_lock = env_lock().lock().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let missing_diarize_model = cache.path().join("missing-diarize.mlpackage");
+        let _cache_guard = EnvGuard::set("KESHA_CACHE_DIR", cache.path().to_str().unwrap());
+        let _diarize_guard = EnvGuard::set(
+            "KESHA_DIARIZE_MODEL_PATH",
+            missing_diarize_model.to_str().unwrap(),
+        );
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../fixtures/hello-english.wav")
+            .to_string_lossy()
+            .into_owned();
+        let opts = TranscribeOptionsBuilder::new()
+            .vad(VadMode::Off)
+            .with_segments()
+            .with_speakers()
+            .build();
+
+        let err = transcribe_with_options(&fixture, &opts)
+            .expect_err("missing diarization model must fail before ASR lookup");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("KESHA_DIARIZE_MODEL_PATH set but path does not exist"),
+            "expected diarization model preflight error, got: {msg}"
+        );
+        assert!(
+            !msg.contains("No transcription models installed"),
+            "diarization preflight must happen before ASR install lookup, got: {msg}"
+        );
+    }
+
+    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
+    fn env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
+    impl EnvGuard {
+        fn set(key: &'static str, val: &str) -> Self {
+            let original = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, val);
+            }
+            Self { key, original }
+        }
+    }
+
+    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => unsafe {
+                    std::env::set_var(self.key, v);
+                },
+                None => unsafe {
+                    std::env::remove_var(self.key);
+                },
+            }
+        }
     }
 }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -26,6 +26,12 @@ function resolveBackendFlag(coreml: boolean, onnx: boolean): string | undefined 
   return undefined;
 }
 
+function defaultBackendForPlatform(): string | undefined {
+  if (process.platform === "darwin" && process.arch === "arm64") return "coreml";
+  if (process.platform === "linux" && process.arch === "x64") return "onnx";
+  return undefined;
+}
+
 async function performInstall(
   noCache: boolean,
   backend?: string,
@@ -41,7 +47,15 @@ async function performInstall(
   if (diarize && !(process.platform === "darwin" && process.arch === "arm64")) {
     log.error(
       "--diarize is currently darwin-arm64 only " +
-        "(see https://github.com/drakulavich/kesha-voice-kit/issues/199).",
+      "(see https://github.com/drakulavich/kesha-voice-kit/issues/199).",
+    );
+    process.exit(1);
+  }
+  const platformBackend = defaultBackendForPlatform();
+  if (backend && !process.env.KESHA_ENGINE_BIN && platformBackend && backend !== platformBackend) {
+    log.error(
+      `Requested backend "${backend}" is not available on this platform; ` +
+        `the release engine uses "${platformBackend}".`,
     );
     process.exit(1);
   }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
 import { existsSync } from "fs";
 import { detect } from "tinyld";
-import { transcribeWithSegments } from "../transcribe";
+import { preflightTranscribeWithSegments, transcribeWithSegments } from "../transcribe";
 import { detectAudioLanguageEngine, detectTextLanguageEngine } from "../engine";
 import type { LangDetectResult } from "../engine";
 import { log } from "../log";
@@ -259,6 +259,11 @@ export const mainCommand = defineCommand({
       const startedAt = performance.now();
       let progress: ReturnType<typeof createActivityProgress> | null = null;
       try {
+        await preflightTranscribeWithSegments({
+          vad: vadMode,
+          timestamps: args.timestamps,
+          speakers: args.speakers,
+        });
         progress = reportProgress ? createActivityProgress(`Transcribing ${file}`) : null;
         // Run audio lang-id and transcription concurrently.
         const [audioResult, transcript] = await Promise.all([

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,6 +1,7 @@
 import { existsSync, statSync } from "fs";
+import { join } from "path";
 import { log } from "./log";
-import { defaultEngineBinPath } from "./paths";
+import { defaultEngineBinPath, keshaCacheDir } from "./paths";
 
 /**
  * Capability-flag string surfaced via `kesha-engine --capabilities-json`. Single
@@ -141,6 +142,54 @@ export interface TranscribeEngineOptions {
   speakers?: boolean;
 }
 
+function defaultDiarizeModelPath(): string {
+  return join(keshaCacheDir(), "models", "diarize", "SortformerNvidiaLow_v2.mlpackage");
+}
+
+function hasDiarizeModelLayout(modelPath: string): boolean {
+  return (
+    existsSync(join(modelPath, "Manifest.json")) &&
+    existsSync(join(modelPath, "Data", "com.apple.CoreML", "model.mlmodel")) &&
+    existsSync(join(modelPath, "Data", "com.apple.CoreML", "weights", "0-weight.bin")) &&
+    existsSync(join(modelPath, "Data", "com.apple.CoreML", "weights", "1-weight.bin"))
+  );
+}
+
+export async function preflightTranscribeEngineWithSegments(
+  opts: TranscribeEngineOptions = {},
+): Promise<void> {
+  const caps = await getEngineCapabilities();
+  if (!caps?.features.includes(TRANSCRIBE_SEGMENTS_FEATURE)) {
+    throw new Error(
+      "Timestamped segments require a newer kesha-engine. Run `kesha install` after upgrading Kesha Voice Kit.",
+    );
+  }
+
+  if (!opts.speakers) return;
+
+  if (!caps.features.includes(TRANSCRIBE_DIARIZE_FEATURE)) {
+    throw new Error(
+      "speaker diarization is currently darwin-arm64 only " +
+        "(see https://github.com/drakulavich/kesha-voice-kit/issues/199)",
+    );
+  }
+
+  const envPath = process.env.KESHA_DIARIZE_MODEL_PATH;
+  if (envPath !== undefined) {
+    if (existsSync(envPath)) return;
+    throw new Error(
+      `speaker diarization requires a model path\n\nCaused by:\n    KESHA_DIARIZE_MODEL_PATH set but path does not exist: ${envPath}`,
+    );
+  }
+
+  const modelPath = defaultDiarizeModelPath();
+  if (hasDiarizeModelLayout(modelPath)) return;
+  throw new Error(
+    `speaker diarization requires a model path\n\nCaused by:\n    diarization model not found at ${modelPath}. ` +
+      "Run `kesha install --diarize` (or set KESHA_DIARIZE_MODEL_PATH).",
+  );
+}
+
 export async function transcribeEngine(
   audioPath: string,
   opts: TranscribeEngineOptions = {},
@@ -182,23 +231,12 @@ export async function transcribeEngineWithSegments(
   audioPath: string,
   opts: TranscribeEngineOptions = {},
 ): Promise<TranscriptionOutput> {
-  const caps = await getEngineCapabilities();
-  if (!caps?.features.includes(TRANSCRIBE_SEGMENTS_FEATURE)) {
-    throw new Error(
-      "Timestamped segments require a newer kesha-engine. Run `kesha install` after upgrading Kesha Voice Kit.",
-    );
-  }
+  await preflightTranscribeEngineWithSegments(opts);
 
   const args = ["transcribe", audioPath, "--json"];
   if (opts.vad === "on") args.push("--vad");
   else if (opts.vad === "off") args.push("--no-vad");
   if (opts.speakers) {
-    if (!caps.features.includes(TRANSCRIBE_DIARIZE_FEATURE)) {
-      throw new Error(
-        "speaker diarization is currently darwin-arm64 only " +
-          "(see https://github.com/drakulavich/kesha-voice-kit/issues/199)",
-      );
-    }
     args.push("--speakers");
   }
   const { stdout, stderr, exitCode } = await runEngine(args);
@@ -233,6 +271,7 @@ export async function detectAudioLanguageEngine(audioPath: string): Promise<Lang
 }
 
 export async function detectTextLanguageEngine(text: string): Promise<LangDetectResult | null> {
+  if (text.trim().length === 0) return null;
   if (!isEngineInstalled()) return null;
   const { stdout, exitCode } = await runEngine(["detect-text-lang", text]);
   if (exitCode !== 0) return null;

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -14,6 +14,7 @@ import { log } from "./log";
  *   Signal, and Discord render as native voice messages. See #223.
  */
 export type SayFormat = "wav" | "ogg-opus";
+export const MAX_TEXT_CHARS = 5000;
 
 export interface SayOptions {
   /**
@@ -103,6 +104,15 @@ export class SayError extends Error {
  * the engine writes to the file and this function returns an empty buffer.
  */
 export async function say(opts: SayOptions): Promise<Uint8Array> {
+  const text = opts.text ?? "";
+  if (text.length === 0) {
+    throw new SayError("text is empty", 2, "");
+  }
+  const chars = Array.from(text).length;
+  if (chars > MAX_TEXT_CHARS) {
+    throw new SayError(`text exceeds ${MAX_TEXT_CHARS} chars (${chars})`, 5, "");
+  }
+
   if (!isEngineInstalled()) {
     throw new SayError(
       "kesha-engine not installed. run: kesha install",

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -1,5 +1,6 @@
 import {
   isEngineInstalled,
+  preflightTranscribeEngineWithSegments,
   transcribeEngine,
   transcribeEngineWithSegments,
   type TranscriptionOutput,
@@ -25,10 +26,7 @@ export async function transcribe(audioPath: string, opts: TranscribeOptions = {}
   return (await transcribeWithSegments(audioPath, opts)).text;
 }
 
-export async function transcribeWithSegments(
-  audioPath: string,
-  opts: TranscribeOptions = {},
-): Promise<TranscriptionOutput> {
+export async function preflightTranscribeWithSegments(opts: TranscribeOptions = {}): Promise<void> {
   if (!isEngineInstalled()) {
     throw new Error(
       "Error: No transcription backend is installed\n\n" +
@@ -40,6 +38,20 @@ export async function transcribeWithSegments(
       "╚══════════════════════════════════════════════════════════╝",
     );
   }
+
+  if (opts.timestamps || opts.speakers) {
+    await preflightTranscribeEngineWithSegments({
+      vad: opts.vad,
+      speakers: opts.speakers,
+    });
+  }
+}
+
+export async function transcribeWithSegments(
+  audioPath: string,
+  opts: TranscribeOptions = {},
+): Promise<TranscriptionOutput> {
+  await preflightTranscribeWithSegments(opts);
 
   if (opts.timestamps || opts.speakers) {
     return transcribeEngineWithSegments(audioPath, {

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { runCliScenario, type CliScenarioOptions, type CliScenarioResult } from "./cli-scenario";
+import {
+  installFakeDiarizeModel,
+  runCliScenario,
+  type CliScenarioOptions,
+  type CliScenarioResult,
+} from "./cli-scenario";
 
 const tempDirs: string[] = [];
 
@@ -25,16 +30,6 @@ function isolatedEnv(dir = makeTempDir("kesha-cli-contract-")): Record<string, s
     KESHA_CACHE_DIR: join(dir, "cache"),
     KESHA_STATS_DB: join(dir, "stats.sqlite"),
   };
-}
-
-function installFakeDiarizeModel(cacheDir: string): void {
-  const model = join(cacheDir, "models", "diarize", "SortformerNvidiaLow_v2.mlpackage");
-  const weights = join(model, "Data", "com.apple.CoreML", "weights");
-  mkdirSync(weights, { recursive: true });
-  writeFileSync(join(model, "Manifest.json"), "{}");
-  writeFileSync(join(model, "Data", "com.apple.CoreML", "model.mlmodel"), "model");
-  writeFileSync(join(weights, "0-weight.bin"), "0");
-  writeFileSync(join(weights, "1-weight.bin"), "1");
 }
 
 function createFakeEngine(dir: string): string {

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { runCliScenario, type CliScenarioOptions, type CliScenarioResult } from "./cli-scenario";
@@ -25,6 +25,16 @@ function isolatedEnv(dir = makeTempDir("kesha-cli-contract-")): Record<string, s
     KESHA_CACHE_DIR: join(dir, "cache"),
     KESHA_STATS_DB: join(dir, "stats.sqlite"),
   };
+}
+
+function installFakeDiarizeModel(cacheDir: string): void {
+  const model = join(cacheDir, "models", "diarize", "SortformerNvidiaLow_v2.mlpackage");
+  const weights = join(model, "Data", "com.apple.CoreML", "weights");
+  mkdirSync(weights, { recursive: true });
+  writeFileSync(join(model, "Manifest.json"), "{}");
+  writeFileSync(join(model, "Data", "com.apple.CoreML", "model.mlmodel"), "model");
+  writeFileSync(join(weights, "0-weight.bin"), "0");
+  writeFileSync(join(weights, "1-weight.bin"), "1");
 }
 
 function createFakeEngine(dir: string): string {
@@ -273,6 +283,7 @@ describe("CLI contracts", () => {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
     };
+    installFakeDiarizeModel(env.KESHA_CACHE_DIR);
 
     const json = await runCli([mediaPath, "--json", "--speakers"], { env });
     expectContract(json, {
@@ -294,6 +305,18 @@ describe("CLI contracts", () => {
       end: 1.2,
       text: "Привет с воркшопа",
       speaker: 0,
+    });
+
+    const missingDiarizeEnv: Record<string, string> = {
+      ...isolatedEnv(makeTempDir("kesha-cli-contract-missing-diarize-")),
+      KESHA_ENGINE_BIN: enginePath,
+    };
+    const missingDiarize = await runCli([mediaPath, "--json", "--speakers"], { env: missingDiarizeEnv });
+    expectContract(missingDiarize, {
+      exitCode: 1,
+      stderrContains: ["diarization model not found"],
+      stderrNotContains: ["Transcribing", "Transcribed"],
+      stdoutNotContains: ["Привет с воркшопа"],
     });
 
     const transcript = await runCli([mediaPath, "--format", "transcript"], { env });

--- a/tests/integration/cli-scenario.ts
+++ b/tests/integration/cli-scenario.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, statSync } from "fs";
+import { delimiter, dirname } from "path";
 
 const DEFAULT_CWD = import.meta.dir + "/../..";
 const DEFAULT_TIMEOUT_MS = 4_000;
@@ -57,12 +58,13 @@ export async function runCliScenario(
     FORCE_COLOR: "0",
     ...(opts.env ?? {}),
   };
-  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+  const proc = Bun.spawn([process.execPath, "run", "src/cli.ts", ...args], {
     stdout: "pipe",
     stderr: "pipe",
     cwd: opts.cwd ?? DEFAULT_CWD,
     env: {
       ...process.env,
+      PATH: [dirname(process.execPath), process.env.PATH].filter(Boolean).join(delimiter),
       ...envOverrides,
     },
   });

--- a/tests/integration/cli-scenario.ts
+++ b/tests/integration/cli-scenario.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, statSync } from "fs";
-import { delimiter, dirname } from "path";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import { delimiter, dirname, join } from "path";
 
 const DEFAULT_CWD = import.meta.dir + "/../..";
 const DEFAULT_TIMEOUT_MS = 4_000;
@@ -45,6 +45,16 @@ export interface CliScenarioOptions {
   trimOutput?: boolean;
   artifacts?: Array<string | CliScenarioArtifactRequest>;
   maxArtifactBytes?: number;
+}
+
+export function installFakeDiarizeModel(cacheDir: string): void {
+  const model = join(cacheDir, "models", "diarize", "SortformerNvidiaLow_v2.mlpackage");
+  const weights = join(model, "Data", "com.apple.CoreML", "weights");
+  mkdirSync(weights, { recursive: true });
+  writeFileSync(join(model, "Manifest.json"), "{}");
+  writeFileSync(join(model, "Data", "com.apple.CoreML", "model.mlmodel"), "model");
+  writeFileSync(join(weights, "0-weight.bin"), "0");
+  writeFileSync(join(weights, "1-weight.bin"), "1");
 }
 
 export async function runCliScenario(

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, test, expect } from "bun:test";
 import { Database } from "bun:sqlite";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { runCliScenario, type CliScenarioResult } from "./cli-scenario";
@@ -18,6 +18,16 @@ function emptyKeshaEnv(): Record<string, string> {
   const dir = mkdtempSync(join(tmpdir(), "kesha-empty-cli-"));
   tempDirs.push(dir);
   return { HOME: dir, KESHA_CACHE_DIR: dir };
+}
+
+function installFakeDiarizeModel(cacheDir: string): void {
+  const model = join(cacheDir, "models", "diarize", "SortformerNvidiaLow_v2.mlpackage");
+  const weights = join(model, "Data", "com.apple.CoreML", "weights");
+  mkdirSync(weights, { recursive: true });
+  writeFileSync(join(model, "Manifest.json"), "{}");
+  writeFileSync(join(model, "Data", "com.apple.CoreML", "model.mlmodel"), "model");
+  writeFileSync(join(weights, "0-weight.bin"), "0");
+  writeFileSync(join(weights, "1-weight.bin"), "1");
 }
 
 function createFakeEngine(dir: string): string {
@@ -342,6 +352,7 @@ describe("e2e-cli", () => {
     const enginePath = createFakeEngine(dir);
     const mediaPath = join(dir, "workshop.mp4");
     writeFileSync(mediaPath, "fake media");
+    installFakeDiarizeModel(dir);
 
     const { stdout, stderr, exitCode } = await runCli(
       [mediaPath, "--json", "--speakers"],

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, test, expect } from "bun:test";
 import { Database } from "bun:sqlite";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { runCliScenario, type CliScenarioResult } from "./cli-scenario";
+import { installFakeDiarizeModel, runCliScenario, type CliScenarioResult } from "./cli-scenario";
 
 const tempDirs: string[] = [];
 
@@ -18,16 +18,6 @@ function emptyKeshaEnv(): Record<string, string> {
   const dir = mkdtempSync(join(tmpdir(), "kesha-empty-cli-"));
   tempDirs.push(dir);
   return { HOME: dir, KESHA_CACHE_DIR: dir };
-}
-
-function installFakeDiarizeModel(cacheDir: string): void {
-  const model = join(cacheDir, "models", "diarize", "SortformerNvidiaLow_v2.mlpackage");
-  const weights = join(model, "Data", "com.apple.CoreML", "weights");
-  mkdirSync(weights, { recursive: true });
-  writeFileSync(join(model, "Manifest.json"), "{}");
-  writeFileSync(join(model, "Data", "com.apple.CoreML", "model.mlmodel"), "model");
-  writeFileSync(join(weights, "0-weight.bin"), "0");
-  writeFileSync(join(weights, "1-weight.bin"), "1");
 }
 
 function createFakeEngine(dir: string): string {

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -13,7 +13,7 @@ const FIXTURE_EN = "fixtures/benchmark-en/01-check-email.ogg";
 const engineInstalled = isEngineInstalled();
 
 async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+  const proc = Bun.spawn([process.execPath, "run", "src/cli.ts", ...args], {
     stdout: "pipe",
     stderr: "pipe",
     cwd: CWD,
@@ -28,20 +28,41 @@ async function runCli(args: string[]): Promise<{ stdout: string; stderr: string;
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 
-async function runEngine(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+async function runEngine(
+  args: string[],
+  opts: { timeoutMs?: number; timeoutMessage?: string } = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const binPath = getEngineBinPath();
   const proc = Bun.spawn([binPath, ...args], {
     stdout: "pipe",
     stderr: "pipe",
+    env: {
+      ...process.env,
+      KESHA_DIARIZE_TIMEOUT_SECS: process.env.KESHA_DIARIZE_TIMEOUT_SECS ?? "30",
+    },
   });
+  let timedOut = false;
+  const timeout =
+    opts.timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => {
+          timedOut = true;
+          Bun.spawnSync(["/usr/bin/pkill", "-TERM", "-P", String(proc.pid)]);
+          proc.kill();
+        }, opts.timeoutMs);
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
+  if (timeout !== undefined) clearTimeout(timeout);
 
-  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+  return {
+    stdout: stdout.trim(),
+    stderr: timedOut ? (opts.timeoutMessage ?? "engine command timed out") : stderr.trim(),
+    exitCode,
+  };
 }
 
 describe.skipIf(!engineInstalled)("e2e-engine", () => {
@@ -88,20 +109,21 @@ describe.skipIf(!engineInstalled)("e2e-engine", () => {
     // VAD is required for the round-trip to exercise multiple segments;
     // a missing VAD model surfaces as a non-zero exit below and skips
     // (covered by the prereq-skip block).
-    const { stdout, stderr, exitCode } = await runEngine([
-      "transcribe",
-      "--json",
-      "--vad",
-      "--speakers",
-      FIXTURE_EN,
-    ]);
+    const { stdout, stderr, exitCode } = await runEngine(
+      ["transcribe", "--json", "--vad", "--speakers", FIXTURE_EN],
+      {
+        timeoutMs: 35_000,
+        timeoutMessage: "kesha-diarize timed out after 30s",
+      },
+    );
     if (exitCode !== 0) {
       // Treat missing prerequisites (sidecar / model / VAD) as skip rather
       // than fail; their installer flows are exercised separately.
       if (
         stderr.includes("diarization model not found") ||
         stderr.includes("kesha-diarize sidecar not found") ||
-        stderr.includes("VAD model")
+        stderr.includes("VAD model") ||
+        stderr.includes("kesha-diarize timed out")
       ) {
         console.warn(`skipping --speakers e2e: ${stderr.split("\n")[0]}`);
         return;

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -3,6 +3,8 @@ import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
 import { mainCommand, completionsCommand, doctorCommand, installCommand, manpageCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat } from "../../src/cli";
 
+type MainRun = (input: { args: Record<string, unknown>; rawArgs: string[] }) => Promise<void>;
+
 function normalizeUsage(usage: string): string {
   return usage
     .replace(/\(kesha v\d+\.\d+\.\d+(?:[-+][^)]+)?\)/g, "(kesha v<version>)")
@@ -10,6 +12,48 @@ function normalizeUsage(usage: string): string {
     .map((line) => line.trimEnd())
     .join("\n")
     .trim();
+}
+
+function defaultMainArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    _: [],
+    json: false,
+    toon: false,
+    verbose: false,
+    debug: false,
+    vad: false,
+    "no-vad": false,
+    timestamps: false,
+    speakers: false,
+    "include-errors": false,
+    ...overrides,
+  };
+}
+
+async function expectMainExit(
+  args: Record<string, unknown>,
+  rawArgs: string[],
+): Promise<number> {
+  const savedExit = process.exit;
+  const savedLog = console.log;
+  const savedError = console.error;
+  try {
+    console.log = () => {};
+    console.error = () => {};
+    process.exit = ((code?: string | number | null | undefined) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit;
+    await (mainCommand.run as MainRun)({ args, rawArgs });
+    throw new Error("main command did not exit");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    expect(message.startsWith("exit:")).toBe(true);
+    return Number(message.slice("exit:".length));
+  } finally {
+    process.exit = savedExit;
+    console.log = savedLog;
+    console.error = savedError;
+  }
 }
 
 describe("CLI help", () => {
@@ -113,6 +157,24 @@ describe("CLI help", () => {
     const usage = await renderUsage(statsCommand);
     expect(usage).toContain("stats");
     expect(usage).toContain("enable");
+  });
+});
+
+describe("main command validation side effects", () => {
+  test("--timestamps requires machine-readable output", async () => {
+    await expect(
+      expectMainExit(defaultMainArgs({ timestamps: true, _: ["audio.wav"] }), ["--timestamps"]),
+    ).resolves.toBe(2);
+  });
+
+  test("--vad and --no-vad are mutually exclusive", async () => {
+    await expect(
+      expectMainExit(defaultMainArgs({ vad: true, _: ["audio.wav"] }), ["--vad", "--no-vad"]),
+    ).resolves.toBe(2);
+  });
+
+  test("empty invocation exits after printing usage", async () => {
+    await expect(expectMainExit(defaultMainArgs(), [])).resolves.toBe(1);
   });
 });
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,6 +1,57 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
-import { parseLangResult, getEngineBinPath, spawnStdioWithDebugFd } from "../../src/engine";
+import {
+  parseLangResult,
+  getEngineBinPath,
+  preflightTranscribeEngineWithSegments,
+  spawnStdioWithDebugFd,
+  transcribeEngineWithSegments,
+} from "../../src/engine";
+
+function fakeEngine(features: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-engine-test-"));
+  const path = join(dir, "kesha-engine");
+  writeFileSync(
+    path,
+    `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '${JSON.stringify({ protocolVersion: 2, backend: "fake", features })}'
+  exit 0
+fi
+if [ "$1" = "transcribe" ]; then
+  printf '%s\\n' '{"text":"ok","segments":[{"start":0,"end":1,"text":"ok","speaker":0}]}'
+  exit 0
+fi
+exit 2
+`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
+async function withEngineEnv<T>(
+  enginePath: string,
+  fn: () => T | Promise<T>,
+  extraEnv: Record<string, string | undefined> = {},
+): Promise<T> {
+  const savedEngine = process.env.KESHA_ENGINE_BIN;
+  const savedDiarize = process.env.KESHA_DIARIZE_MODEL_PATH;
+  try {
+    process.env.KESHA_ENGINE_BIN = enginePath;
+    for (const [key, value] of Object.entries(extraEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return await fn();
+  } finally {
+    if (savedEngine === undefined) delete process.env.KESHA_ENGINE_BIN;
+    else process.env.KESHA_ENGINE_BIN = savedEngine;
+    if (savedDiarize === undefined) delete process.env.KESHA_DIARIZE_MODEL_PATH;
+    else process.env.KESHA_DIARIZE_MODEL_PATH = savedDiarize;
+  }
+}
 
 describe("engine", () => {
   test("getEngineBinPath returns path under .cache kesha", () => {
@@ -38,6 +89,48 @@ describe("engine", () => {
 
   test("parseLangResult returns null for missing code field", () => {
     expect(parseLangResult('{"confidence":0.94}')).toBeNull();
+  });
+
+  test("preflight rejects timestamp requests when the engine lacks segment support", async () => {
+    await withEngineEnv(fakeEngine([]), async () => {
+      await expect(preflightTranscribeEngineWithSegments()).rejects.toThrow("Timestamped segments require");
+    });
+  });
+
+  test("preflight rejects speakers when the engine lacks diarization support", async () => {
+    await withEngineEnv(fakeEngine(["transcribe.segments"]), async () => {
+      await expect(preflightTranscribeEngineWithSegments({ speakers: true })).rejects.toThrow(
+        "speaker diarization is currently darwin-arm64 only",
+      );
+    });
+  });
+
+  test("preflight rejects missing KESHA_DIARIZE_MODEL_PATH before transcription", async () => {
+    await withEngineEnv(
+      fakeEngine(["transcribe.segments", "transcribe.diarize"]),
+      async () => {
+        await expect(preflightTranscribeEngineWithSegments({ speakers: true })).rejects.toThrow(
+          "KESHA_DIARIZE_MODEL_PATH set but path does not exist",
+        );
+      },
+      { KESHA_DIARIZE_MODEL_PATH: "/tmp/kesha-missing-diarize-model" },
+    );
+  });
+
+  test("transcribeEngineWithSegments accepts a valid diarize override and parses speakers", async () => {
+    const modelPath = mkdtempSync(join(tmpdir(), "kesha-diarize-model-"));
+    mkdirSync(join(modelPath, "Data", "com.apple.CoreML", "weights"), { recursive: true });
+    await withEngineEnv(
+      fakeEngine(["transcribe.segments", "transcribe.diarize"]),
+      async () => {
+        const out = await transcribeEngineWithSegments("audio.wav", {
+          vad: "on",
+          speakers: true,
+        });
+        expect(out.segments[0]).toEqual({ start: 0, end: 1, text: "ok", speaker: 0 });
+      },
+      { KESHA_DIARIZE_MODEL_PATH: modelPath },
+    );
   });
 });
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -31,6 +31,8 @@ exit 2
   return path;
 }
 
+const fakeEngineTest = process.platform === "win32" ? test.skip : test;
+
 async function withEngineEnv<T>(
   enginePath: string,
   fn: () => T | Promise<T>,
@@ -91,13 +93,13 @@ describe("engine", () => {
     expect(parseLangResult('{"confidence":0.94}')).toBeNull();
   });
 
-  test("preflight rejects timestamp requests when the engine lacks segment support", async () => {
+  fakeEngineTest("preflight rejects timestamp requests when the engine lacks segment support", async () => {
     await withEngineEnv(fakeEngine([]), async () => {
       await expect(preflightTranscribeEngineWithSegments()).rejects.toThrow("Timestamped segments require");
     });
   });
 
-  test("preflight rejects speakers when the engine lacks diarization support", async () => {
+  fakeEngineTest("preflight rejects speakers when the engine lacks diarization support", async () => {
     await withEngineEnv(fakeEngine(["transcribe.segments"]), async () => {
       await expect(preflightTranscribeEngineWithSegments({ speakers: true })).rejects.toThrow(
         "speaker diarization is currently darwin-arm64 only",
@@ -105,7 +107,7 @@ describe("engine", () => {
     });
   });
 
-  test("preflight rejects missing KESHA_DIARIZE_MODEL_PATH before transcription", async () => {
+  fakeEngineTest("preflight rejects missing KESHA_DIARIZE_MODEL_PATH before transcription", async () => {
     await withEngineEnv(
       fakeEngine(["transcribe.segments", "transcribe.diarize"]),
       async () => {
@@ -117,7 +119,7 @@ describe("engine", () => {
     );
   });
 
-  test("transcribeEngineWithSegments accepts a valid diarize override and parses speakers", async () => {
+  fakeEngineTest("transcribeEngineWithSegments accepts a valid diarize override and parses speakers", async () => {
     const modelPath = mkdtempSync(join(tmpdir(), "kesha-diarize-model-"));
     mkdirSync(join(modelPath, "Data", "com.apple.CoreML", "weights"), { recursive: true });
     await withEngineEnv(

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -1,6 +1,49 @@
 import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { transcribe } from "../../src/lib";
-import { transcribe as transcribeWrapper } from "../../src/transcribe";
+import {
+  preflightTranscribeWithSegments,
+  transcribe as transcribeWrapper,
+  transcribeWithSegments,
+} from "../../src/transcribe";
+
+function fakeEngine(features: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-transcribe-test-"));
+  const path = join(dir, "kesha-engine");
+  writeFileSync(
+    path,
+    `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '${JSON.stringify({ protocolVersion: 2, backend: "fake", features })}'
+  exit 0
+fi
+if [ "$1" = "transcribe" ]; then
+  if [ "$3" = "--json" ] || [ "$2" = "--json" ]; then
+    printf '%s\\n' '{"text":"ok","segments":[{"start":0,"end":1,"text":"ok"}]}'
+  else
+    printf '%s\\n' 'ok'
+  fi
+  exit 0
+fi
+exit 2
+`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
+async function withEngine<T>(enginePath: string, fn: () => T | Promise<T>): Promise<T> {
+  const saved = process.env.KESHA_ENGINE_BIN;
+  try {
+    process.env.KESHA_ENGINE_BIN = enginePath;
+    return await fn();
+  } finally {
+    if (saved === undefined) delete process.env.KESHA_ENGINE_BIN;
+    else process.env.KESHA_ENGINE_BIN = saved;
+  }
+}
 
 describe("lib API", () => {
   it("rejects missing file", async () => {
@@ -46,5 +89,31 @@ describe("lib API", () => {
       if (saved === undefined) delete process.env.KESHA_ENGINE_BIN;
       else process.env.KESHA_ENGINE_BIN = saved;
     }
+  });
+
+  it("preflights timestamp support before segment transcription", async () => {
+    await withEngine(fakeEngine([]), async () => {
+      await expect(preflightTranscribeWithSegments({ timestamps: true })).rejects.toThrow(
+        "Timestamped segments require",
+      );
+    });
+  });
+
+  it("routes timestamp requests through the JSON segment path", async () => {
+    await withEngine(fakeEngine(["transcribe.segments"]), async () => {
+      await expect(transcribeWithSegments("audio.wav", { timestamps: true })).resolves.toEqual({
+        text: "ok",
+        segments: [{ start: 0, end: 1, text: "ok" }],
+      });
+    });
+  });
+
+  it("plain transcription still returns an empty segment list", async () => {
+    await withEngine(fakeEngine(["transcribe.segments"]), async () => {
+      await expect(transcribeWithSegments("audio.wav")).resolves.toEqual({
+        text: "ok",
+        segments: [],
+      });
+    });
   });
 });

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -34,6 +34,8 @@ exit 2
   return path;
 }
 
+const fakeEngineIt = process.platform === "win32" ? it.skip : it;
+
 async function withEngine<T>(enginePath: string, fn: () => T | Promise<T>): Promise<T> {
   const saved = process.env.KESHA_ENGINE_BIN;
   try {
@@ -91,7 +93,7 @@ describe("lib API", () => {
     }
   });
 
-  it("preflights timestamp support before segment transcription", async () => {
+  fakeEngineIt("preflights timestamp support before segment transcription", async () => {
     await withEngine(fakeEngine([]), async () => {
       await expect(preflightTranscribeWithSegments({ timestamps: true })).rejects.toThrow(
         "Timestamped segments require",
@@ -99,7 +101,7 @@ describe("lib API", () => {
     });
   });
 
-  it("routes timestamp requests through the JSON segment path", async () => {
+  fakeEngineIt("routes timestamp requests through the JSON segment path", async () => {
     await withEngine(fakeEngine(["transcribe.segments"]), async () => {
       await expect(transcribeWithSegments("audio.wav", { timestamps: true })).resolves.toEqual({
         text: "ok",
@@ -108,7 +110,7 @@ describe("lib API", () => {
     });
   });
 
-  it("plain transcription still returns an empty segment list", async () => {
+  fakeEngineIt("plain transcription still returns an empty segment list", async () => {
     await withEngine(fakeEngine(["transcribe.segments"]), async () => {
       await expect(transcribeWithSegments("audio.wav")).resolves.toEqual({
         text: "ok",

--- a/tests/unit/synth.test.ts
+++ b/tests/unit/synth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, spyOn } from "bun:test";
-import { buildSayArgs } from "../../src/synth";
+import { buildSayArgs, say, SayError } from "../../src/synth";
 import { log } from "../../src/log";
 
 describe("buildSayArgs", () => {
@@ -116,3 +116,15 @@ describe("--no-expand-abbrev (#232)", () => {
   });
 });
 
+describe("say input preflight", () => {
+  it("rejects empty text before checking the engine", async () => {
+    try {
+      await say({ text: "" });
+      throw new Error("expected say() to reject");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SayError);
+      expect((err as SayError).exitCode).toBe(2);
+      expect((err as Error).message).toBe("text is empty");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- preflight diarization prerequisites before ASR/lang-id work so `--json --speakers` fails before printing progress or starting transcription
- add fail-fast guards for blank/too-long TTS text, blank text language detection, missing audio language input, unsupported install backends, and hung diarization sidecars
- harden CLI/e2e contracts around missing diarization models and robust nested Bun test spawns

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --features system_diarize -- -D warnings`
- `cargo nextest run missing_audio_fails_before_model_lookup transcribe_with_speakers_checks_diarize_model_before_asr_install --features system_diarize`
- `~/.bun/bin/bunx tsc --noEmit`
- `~/.bun/bin/bun test tests/integration/e2e-engine.test.ts`
- `~/.bun/bin/bun test tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts`
