### PR TITLE
Fix progress bar redraw around warnings

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -278,7 +278,9 @@ export const mainCommand = defineCommand({
 
         if (audioLanguage && args.lang && audioLanguage.confidence > 0.8) {
           const mismatch = checkLanguageMismatch(args.lang, audioLanguage.code);
-          if (mismatch) log.warn(`${file}: ${mismatch} (from audio)`);
+          if (mismatch) {
+            progress?.interrupt(() => log.warn(`${file}: ${mismatch} (from audio)`));
+          }
         }
 
         const tinyldLang = wantsLangId ? detectLanguage(text) : "";
@@ -294,7 +296,9 @@ export const mainCommand = defineCommand({
         const lang = textLanguage?.code || tinyldLang;
 
         const mismatchWarning = checkLanguageMismatch(args.lang, lang);
-        if (mismatchWarning) log.warn(`${file}: ${mismatchWarning}`);
+        if (mismatchWarning) {
+          progress?.interrupt(() => log.warn(`${file}: ${mismatchWarning}`));
+        }
 
         const sttTimeMs = Math.round(performance.now() - startedAt);
         const result: TranscribeResult = {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -91,6 +91,10 @@ export function createActivityProgress(
       process.stderr.write(`${finalMessage}\n`);
     },
     interrupt(writeLine: () => void) {
+      if (stopped) {
+        writeLine();
+        return;
+      }
       clearLine(false);
       writeLine();
       render();

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -37,6 +37,7 @@ export function createActivityProgress(
   options: { intervalMs?: number } = {},
 ): {
   finish(finalMessage: string): void;
+  interrupt(writeLine: () => void): void;
   stop(): void;
 } {
   const isTTY = process.stderr.isTTY;
@@ -47,6 +48,9 @@ export function createActivityProgress(
       finish(finalMessage: string) {
         process.stderr.write(`${finalMessage}\n`);
       },
+      interrupt(writeLine: () => void) {
+        writeLine();
+      },
       stop() {},
     };
   }
@@ -56,15 +60,18 @@ export function createActivityProgress(
   let frame = 1;
   let lastLineLength = 0;
   let timer: Timer | undefined;
+  let stopped = false;
 
   const render = () => {
+    if (stopped) return;
     const line = formatActivityProgress(label, performance.now() - startedAt, frame);
     frame += 1;
     lastLineLength = line.length;
     process.stderr.write(`\r${line}`);
   };
 
-  const clearLine = () => {
+  const clearLine = (stopTimer: boolean) => {
+    if (stopTimer) stopped = true;
     if (timer) {
       clearInterval(timer);
       timer = undefined;
@@ -80,11 +87,17 @@ export function createActivityProgress(
 
   return {
     finish(finalMessage: string) {
-      clearLine();
+      clearLine(true);
       process.stderr.write(`${finalMessage}\n`);
     },
+    interrupt(writeLine: () => void) {
+      clearLine(false);
+      writeLine();
+      render();
+      timer = setInterval(render, intervalMs);
+    },
     stop() {
-      clearLine();
+      clearLine(true);
     },
   };
 }

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -112,6 +112,32 @@ describe("createActivityProgress", () => {
       process.stderr.write = originalWrite;
     }
   });
+
+  test("TTY mode can interrupt the live bar for side-band output", () => {
+    const originalIsTTY = process.stderr.isTTY;
+    const originalWrite = process.stderr.write;
+    const writes: string[] = [];
+
+    try {
+      Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+      process.stderr.write = ((chunk: string) => {
+        writes.push(chunk);
+        return true;
+      }) as typeof process.stderr.write;
+
+      const progress = createActivityProgress("Transcribing file.wav", { intervalMs: 10_000 });
+      progress.interrupt(() => process.stderr.write("warning: language mismatch\n"));
+      progress.finish("Transcribed file.wav (123ms)");
+
+      const combined = writes.join("");
+      expect(combined).toContain("warning: language mismatch\n");
+      expect(combined).toContain("Transcribing file.wav");
+      expect(combined).toContain("Transcribed file.wav (123ms)\n");
+    } finally {
+      Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+      process.stderr.write = originalWrite;
+    }
+  });
 });
 
 describe("createProgressBar", () => {

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -138,6 +138,31 @@ describe("createActivityProgress", () => {
       process.stderr.write = originalWrite;
     }
   });
+
+  test("TTY interrupt after stop writes without restarting the timer", () => {
+    const originalIsTTY = process.stderr.isTTY;
+    const originalWrite = process.stderr.write;
+    const writes: string[] = [];
+
+    try {
+      Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+      process.stderr.write = ((chunk: string) => {
+        writes.push(chunk);
+        return true;
+      }) as typeof process.stderr.write;
+
+      const progress = createActivityProgress("Transcribing file.wav", { intervalMs: 10_000 });
+      progress.stop();
+      writes.length = 0;
+
+      progress.interrupt(() => process.stderr.write("warning after stop\n"));
+
+      expect(writes).toEqual(["warning after stop\n"]);
+    } finally {
+      Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+      process.stderr.write = originalWrite;
+    }
+  });
 });
 
 describe("createProgressBar", () => {


### PR DESCRIPTION
## Summary
- clear and redraw the live transcription progress bar around warning output
- use the interrupt hook for language mismatch warnings so stderr lines do not collide with the animated bar
- cover the interrupt path in progress unit tests

## Tests
- PATH="/Users/anton/.bun/bin:/opt/homebrew/bin:$PATH" bun test tests/unit/progress.test.ts tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts
- PATH="/Users/anton/.bun/bin:/opt/homebrew/bin:$PATH" bun test && PATH="/Users/anton/.bun/bin:/opt/homebrew/bin:$PATH" bunx tsc --noEmit (passed once after git lfs pull: 256 pass / 4 skip / 0 fail; a later rerun timed out in existing e2e-engine --speakers sidecar path after 120s, before TypeScript ran)

Follow-up to #390 Greptile P2: warning output could collide with the live TTY progress bar.
