### PR TITLE
Skip Nix builds on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,9 +551,8 @@ jobs:
       - name: 🔍 Lint (ray lint includes tsc --noEmit)
         run: npm run lint
 
-  # Supplementary check: verify the Nix flake still evaluates and the
-  # engine derivation builds. Catches regressions in `flake.nix` /
-  # naersk / ort-sys env-var wiring before they reach main. Does NOT
+  # Supplementary post-merge check: verify the Nix flake still evaluates and
+  # the engine derivation builds after relevant changes land on main. Does NOT
   # replace `build-engine.yml` — distributable release artifacts
   # continue to go through Github-runner cargo + Swift toolchain pins.
   #
@@ -573,7 +572,7 @@ jobs:
   # still ships the CoreML backend.
   nix-build:
     needs: changes
-    if: needs.changes.outputs.nix == 'true'
+    if: github.event_name == 'push' && needs.changes.outputs.nix == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- gate the CI `nix-build` job to `push` events only
- keep Nix validation as a post-merge main check for relevant flake/runtime changes
- update the job comment so the workflow documents the new PR-vs-main contract

## Validation
- bun .github/scripts/check-workflows.ts
- git diff --check origin/main..HEAD