### PR TITLE
Bump CLI to 1.18.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,14 +441,17 @@ jobs:
 
   tts-e2e:
     # Runs whenever rust engine code, the TS CLI that drives `kesha say`,
-    # or the say-e2e test itself changes. No `unit-tests` gate: a rust-only
-    # PR has `code == 'false'`, `unit-tests` is skipped, and GitHub Actions
-    # skip-propagation would silently skip a downstream gate even with
-    # `result == 'skipped'` in the `if:` — the latent bug behind #274 that
-    # made rust-only PRs miss tts-e2e coverage for ~a session. Path filter
-    # alone is the contract.
-    needs: changes
-    if: needs.changes.outputs.tts_e2e == 'true'
+    # or the say-e2e test itself changes. Wait for `unit-tests` so a red
+    # typecheck/unit lane fail-fasts this expensive macOS TTS lane. Keep
+    # `always()` because rust-only PRs have `code == 'false'`, so `unit-tests`
+    # is legitimately skipped; those still need the TTS engine coverage that
+    # #274 accidentally dropped when relying on normal skip propagation.
+    needs: [changes, unit-tests]
+    if: |
+      always() &&
+      needs.changes.outputs.tts_e2e == 'true' &&
+      needs.unit-tests.result != 'failure' &&
+      needs.unit-tests.result != 'cancelled'
     runs-on: macos-latest
     timeout-minutes: 20
     permissions:

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.18.1" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.18.2" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump the CLI package version to 1.18.2 for a CLI-only npm release
- keep keshaEngine.version at 1.18.0; no engine rebuild is needed
- publish the updated package description from #394 in the next npm tarball

## Validation
- bun .github/scripts/check-versions.ts
- node -e 'const p=require("./package.json"); console.log(JSON.stringify({version:p.version, keshaEngine:p.keshaEngine.version, description:p.description}, null, 2))'