### PR TITLE
Show percent progress for transcriptions

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,7 +15,7 @@ import {
 import { packageVersion } from "../package-info";
 import { formatToonOutput } from "../toon";
 import { artifactFromFile, createStatsRecorder } from "../stats";
-import { createActivityProgress } from "../progress";
+import { createPercentProgress } from "../progress";
 
 interface MainCommandArgs {
   _: string[];
@@ -257,14 +257,18 @@ export const mainCommand = defineCommand({
       if (inputArtifact) stats.recordArtifact(inputArtifact);
 
       const startedAt = performance.now();
-      let progress: ReturnType<typeof createActivityProgress> | null = null;
+      let progress: ReturnType<typeof createPercentProgress> | null = null;
       try {
         await preflightTranscribeWithSegments({
           vad: vadMode,
           timestamps: args.timestamps,
           speakers: args.speakers,
         });
-        progress = reportProgress ? createActivityProgress(`Transcribing ${file}`) : null;
+        progress = reportProgress
+          ? createPercentProgress(`Transcribing ${file}`, {
+              estimatedTotalMs: args.speakers ? 60 * 60 * 1000 : 30 * 60 * 1000,
+            })
+          : null;
         // Run audio lang-id and transcription concurrently.
         const [audioResult, transcript] = await Promise.all([
           wantsLangId
@@ -318,7 +322,7 @@ export const mainCommand = defineCommand({
           result.segments = segments;
         }
         results.push(result);
-        progress?.finish(`Transcribed ${file} (${sttTimeMs}ms)`);
+        progress?.finish(`Transcribed ${file}`);
       } catch (err: unknown) {
         progress?.stop();
         hasError = true;

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -58,13 +58,13 @@ export function createPercentProgress(
   let lastLineLength = 0;
   let timer: Timer | undefined;
   let stopped = false;
+  let firstRender = true;
 
   const render = () => {
     if (stopped) return;
-    const line = formatPercentProgress(
-      label,
-      estimatePercent(performance.now() - startedAt, estimatedTotalMs),
-    );
+    const percent = firstRender ? 0 : estimatePercent(performance.now() - startedAt, estimatedTotalMs);
+    firstRender = false;
+    const line = formatPercentProgress(label, percent);
     lastLineLength = line.length;
     process.stderr.write(`\r${line}`);
   };

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,7 +1,7 @@
 import { log } from "./log";
 
 const BAR_WIDTH = 20;
-const ACTIVITY_PULSE_WIDTH = 5;
+const DEFAULT_ESTIMATED_PROGRESS_MS = 30 * 60 * 1000;
 
 export function formatBytes(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
@@ -15,38 +15,35 @@ export function formatProgressBar(label: string, downloaded: number, total: numb
   return `${label}  [${bar}] ${pct}%  ${formatBytes(downloaded)}/${formatBytes(total)}`;
 }
 
-export function formatActivityProgress(label: string, elapsedMs: number, frame: number): string {
-  const range = BAR_WIDTH + ACTIVITY_PULSE_WIDTH;
-  const pulseEnd = frame % range;
-  const pulseStart = pulseEnd - ACTIVITY_PULSE_WIDTH;
-  const bar = Array.from({ length: BAR_WIDTH }, (_, i) =>
-    i >= pulseStart && i < pulseEnd ? "█" : "░",
-  ).join("");
-  return `${label}  [${bar}] ${formatElapsed(elapsedMs)}`;
+export function formatPercentProgress(label: string, percent: number): string {
+  const pct = Math.max(0, Math.min(100, Math.floor(percent)));
+  const filled = Math.round((pct / 100) * BAR_WIDTH);
+  const empty = BAR_WIDTH - filled;
+  const bar = "█".repeat(filled) + "░".repeat(empty);
+  return `${label}  [${bar}] ${pct}%`;
 }
 
-function formatElapsed(elapsedMs: number): string {
-  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return minutes > 0 ? `${minutes}m${seconds.toString().padStart(2, "0")}s` : `${seconds}s`;
+function estimatePercent(elapsedMs: number, estimatedTotalMs: number): number {
+  if (elapsedMs <= 0) return 0;
+  const targetMs = Math.max(1, estimatedTotalMs);
+  return Math.max(1, Math.min(99, Math.floor((elapsedMs / targetMs) * 99)));
 }
 
-export function createActivityProgress(
+export function createPercentProgress(
   label: string,
-  options: { intervalMs?: number } = {},
+  options: { estimatedTotalMs?: number; intervalMs?: number } = {},
 ): {
-  finish(finalMessage: string): void;
+  finish(finalLabel: string): void;
   interrupt(writeLine: () => void): void;
   stop(): void;
 } {
   const isTTY = process.stderr.isTTY;
 
   if (!isTTY) {
-    process.stderr.write(`${label}...\n`);
+    process.stderr.write(`${formatPercentProgress(label, 0)}\n`);
     return {
-      finish(finalMessage: string) {
-        process.stderr.write(`${finalMessage}\n`);
+      finish(finalLabel: string) {
+        process.stderr.write(`${formatPercentProgress(finalLabel, 100)}\n`);
       },
       interrupt(writeLine: () => void) {
         writeLine();
@@ -56,16 +53,18 @@ export function createActivityProgress(
   }
 
   const intervalMs = options.intervalMs ?? 250;
+  const estimatedTotalMs = options.estimatedTotalMs ?? DEFAULT_ESTIMATED_PROGRESS_MS;
   const startedAt = performance.now();
-  let frame = 1;
   let lastLineLength = 0;
   let timer: Timer | undefined;
   let stopped = false;
 
   const render = () => {
     if (stopped) return;
-    const line = formatActivityProgress(label, performance.now() - startedAt, frame);
-    frame += 1;
+    const line = formatPercentProgress(
+      label,
+      estimatePercent(performance.now() - startedAt, estimatedTotalMs),
+    );
     lastLineLength = line.length;
     process.stderr.write(`\r${line}`);
   };
@@ -86,9 +85,9 @@ export function createActivityProgress(
   timer = setInterval(render, intervalMs);
 
   return {
-    finish(finalMessage: string) {
+    finish(finalLabel: string) {
       clearLine(true);
-      process.stderr.write(`${finalMessage}\n`);
+      process.stderr.write(`${formatPercentProgress(finalLabel, 100)}\n`);
     },
     interrupt(writeLine: () => void) {
       if (stopped) {

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -254,8 +254,10 @@ describe("CLI contracts", () => {
     expectContract(run, {
       exitCode: 1,
       stderrContains: [
-        `Transcribing ${mediaPath}...`,
+        `Transcribing ${mediaPath}`,
+        "0%",
         `Transcribed ${mediaPath}`,
+        "100%",
         "missing.wav: File not found",
       ],
       stdoutNotContains: ["Transcribing", "Transcribed", "missing.wav: File not found"],
@@ -283,7 +285,7 @@ describe("CLI contracts", () => {
     const json = await runCli([mediaPath, "--json", "--speakers"], { env });
     expectContract(json, {
       exitCode: 0,
-      stderrContains: [`Transcribing ${mediaPath}...`, `Transcribed ${mediaPath}`],
+      stderrContains: [`Transcribing ${mediaPath}`, "0%", `Transcribed ${mediaPath}`, "100%"],
       stdoutNotContains: ["Transcribing", "Transcribed"],
     });
     const parsed = JSON.parse(json.stdout);
@@ -319,14 +321,14 @@ describe("CLI contracts", () => {
       exitCode: 0,
       stdoutContains: ["Привет с воркшопа", "[lang: ru, confidence: 0.98]"],
       stdoutNotContains: ["Transcribing", "Transcribed"],
-      stderrContains: [`Transcribing ${mediaPath}...`, `Transcribed ${mediaPath}`],
+      stderrContains: [`Transcribing ${mediaPath}`, "0%", `Transcribed ${mediaPath}`, "100%"],
     });
 
     const toon = await runCli([mediaPath, "--toon"], { env });
     expectContract(toon, {
       exitCode: 0,
       stdoutNotContains: ["Transcribing", "Transcribed"],
-      stderrContains: [`Transcribing ${mediaPath}...`, `Transcribed ${mediaPath}`],
+      stderrContains: [`Transcribing ${mediaPath}`, "0%", `Transcribed ${mediaPath}`, "100%"],
     });
     const { decode: decodeToon } = await import("@toon-format/toon");
     const decoded = decodeToon(toon.stdout) as Array<Record<string, unknown>>;
@@ -337,7 +339,7 @@ describe("CLI contracts", () => {
     expectContract(noVadJson, {
       exitCode: 0,
       stdoutNotContains: ["Transcribing", "Transcribed"],
-      stderrContains: [`Transcribing ${mediaPath}...`, `Transcribed ${mediaPath}`],
+      stderrContains: [`Transcribing ${mediaPath}`, "0%", `Transcribed ${mediaPath}`, "100%"],
     });
     expect(JSON.parse(noVadJson.stdout)[0].text).toBe("Привет без VAD");
   });

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -356,8 +356,11 @@ describe("e2e-cli", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(stderr).toContain(`Transcribing ${mediaPath}...`);
-    expect(stderr).toMatch(/Transcribed .*workshop\.mp4 \(\d+ms\)/);
+    expect(stderr).toContain(`Transcribing ${mediaPath}`);
+    expect(stderr).toContain("0%");
+    expect(stderr).toContain(`Transcribed ${mediaPath}`);
+    expect(stderr).toContain("100%");
+    expect(stderr).not.toMatch(/Transcribed .*workshop\.mp4 \(\d+ms\)/);
 
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(1);

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -110,6 +110,7 @@ describe("createPercentProgress", () => {
 
       const combined = writes.join("");
       expect(combined).toContain("Transcribing file.wav");
+      expect(combined).toContain("Transcribing file.wav  [░░░░░░░░░░░░░░░░░░░░] 0%");
       expect(combined).toContain("Transcribed file.wav  [████████████████████] 100%\n");
       expect(combined).toContain("\r");
     } finally {

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import {
-  createActivityProgress,
+  createPercentProgress,
   createProgressBar,
-  formatActivityProgress,
+  formatPercentProgress,
   formatProgressBar,
   formatBytes,
 } from "../../src/progress";
@@ -53,18 +53,23 @@ describe("formatProgressBar", () => {
   });
 });
 
-describe("formatActivityProgress", () => {
-  test("renders an indeterminate activity bar with elapsed time", () => {
-    const bar = formatActivityProgress("Transcribing workshop.mp4", 65_000, 7);
+describe("formatPercentProgress", () => {
+  test("renders a determinate percentage bar", () => {
+    const bar = formatPercentProgress("Transcribing workshop.mp4", 42);
     expect(bar).toContain("Transcribing workshop.mp4");
     expect(bar).toContain("[");
-    expect(bar).toContain("1m05s");
+    expect(bar).toContain("42%");
     expect(bar).toContain("█");
     expect(bar).toContain("░");
   });
+
+  test("clamps percentages to the display range", () => {
+    expect(formatPercentProgress("Transcribing file.wav", -10)).toContain("0%");
+    expect(formatPercentProgress("Transcribing file.wav", 120)).toContain("100%");
+  });
 });
 
-describe("createActivityProgress", () => {
+describe("createPercentProgress", () => {
   test("non-TTY mode writes stable log lines", () => {
     const originalIsTTY = process.stderr.isTTY;
     const originalWrite = process.stderr.write;
@@ -77,11 +82,11 @@ describe("createActivityProgress", () => {
         return true;
       }) as typeof process.stderr.write;
 
-      const progress = createActivityProgress("Transcribing file.wav");
-      progress.finish("Transcribed file.wav (123ms)");
+      const progress = createPercentProgress("Transcribing file.wav");
+      progress.finish("Transcribed file.wav");
 
-      expect(writes.join("")).toContain("Transcribing file.wav...\n");
-      expect(writes.join("")).toContain("Transcribed file.wav (123ms)\n");
+      expect(writes.join("")).toContain("Transcribing file.wav  [░░░░░░░░░░░░░░░░░░░░] 0%\n");
+      expect(writes.join("")).toContain("Transcribed file.wav  [████████████████████] 100%\n");
     } finally {
       Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
       process.stderr.write = originalWrite;
@@ -100,12 +105,12 @@ describe("createActivityProgress", () => {
         return true;
       }) as typeof process.stderr.write;
 
-      const progress = createActivityProgress("Transcribing file.wav", { intervalMs: 10_000 });
-      progress.finish("Transcribed file.wav (123ms)");
+      const progress = createPercentProgress("Transcribing file.wav", { intervalMs: 10_000 });
+      progress.finish("Transcribed file.wav");
 
       const combined = writes.join("");
       expect(combined).toContain("Transcribing file.wav");
-      expect(combined).toContain("Transcribed file.wav (123ms)\n");
+      expect(combined).toContain("Transcribed file.wav  [████████████████████] 100%\n");
       expect(combined).toContain("\r");
     } finally {
       Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
@@ -125,14 +130,14 @@ describe("createActivityProgress", () => {
         return true;
       }) as typeof process.stderr.write;
 
-      const progress = createActivityProgress("Transcribing file.wav", { intervalMs: 10_000 });
+      const progress = createPercentProgress("Transcribing file.wav", { intervalMs: 10_000 });
       progress.interrupt(() => process.stderr.write("warning: language mismatch\n"));
-      progress.finish("Transcribed file.wav (123ms)");
+      progress.finish("Transcribed file.wav");
 
       const combined = writes.join("");
       expect(combined).toContain("warning: language mismatch\n");
       expect(combined).toContain("Transcribing file.wav");
-      expect(combined).toContain("Transcribed file.wav (123ms)\n");
+      expect(combined).toContain("Transcribed file.wav  [████████████████████] 100%\n");
     } finally {
       Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
       process.stderr.write = originalWrite;
@@ -151,7 +156,7 @@ describe("createActivityProgress", () => {
         return true;
       }) as typeof process.stderr.write;
 
-      const progress = createActivityProgress("Transcribing file.wav", { intervalMs: 10_000 });
+      const progress = createPercentProgress("Transcribing file.wav", { intervalMs: 10_000 });
       progress.stop();
       writes.length = 0;
 


### PR DESCRIPTION
## Summary
- replace transcription elapsed-time activity output with a percentage progress bar
- finish redirected and TTY progress with a clear 100% line instead of milliseconds
- keep progress on stderr so JSON/stdout output remains machine-readable

## Validation
- bun test
- bunx tsc --noEmit

## Notes
- `sttTimeMs` remains in structured JSON for programmatic consumers; the human progress line no longer prints milliseconds.