### PR TITLE
Fix long --no-vad abort handling

### DIFF
--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -37,6 +37,11 @@ const AUTO_VAD_MIN_SECONDS: f32 = 120.0;
 /// absent — can reach seconds on large CBR files).
 const AUTO_VAD_MIN_FILE_SIZE: u64 = 200_000;
 
+/// Safety ceiling for explicit `--no-vad` on the CoreML backend. FluidAudio's
+/// full-file path can abort the whole process on very long media before Rust
+/// gets a recoverable error, so refuse the hazardous shape before backend load.
+const COREML_NO_VAD_MAX_SECONDS: f32 = 30.0 * 60.0;
+
 /// Caller-requested VAD behaviour.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VadMode {
@@ -206,11 +211,14 @@ pub fn transcribe_with_options(
         .into_owned();
     let vad_installed = models::is_cached(models::ModelKind::Vad);
 
-    // `Auto` needs a duration probe first. `On`/`Off` are deterministic.
+    // `Auto` needs a duration probe for routing. `Off` probes too so we can
+    // reject hazardous very-long CoreML full-file runs before native code can
+    // abort the process.
     let duration = match mode {
-        VadMode::Auto => probe_duration_if_plausible(audio_path),
+        VadMode::Auto | VadMode::Off => probe_duration_if_plausible(audio_path),
         _ => None,
     };
+    validate_plain_transcribe_safety(mode, duration, vad_installed, cfg!(feature = "coreml"))?;
     let decision = decide(mode, duration, vad_installed);
     dtrace!(
         "asr::mode={mode:?} duration={:?} vad_installed={vad_installed} decision={decision:?}",
@@ -476,6 +484,35 @@ fn probe_duration_if_plausible(path: &str) -> Option<f32> {
     }
 }
 
+fn validate_plain_transcribe_safety(
+    mode: VadMode,
+    duration_s: Option<f32>,
+    vad_installed: bool,
+    coreml_backend: bool,
+) -> Result<()> {
+    if !coreml_backend || mode != VadMode::Off {
+        return Ok(());
+    }
+
+    let Some(duration_s) = duration_s else {
+        return Ok(());
+    };
+    if duration_s < COREML_NO_VAD_MAX_SECONDS {
+        return Ok(());
+    }
+
+    let action = if vad_installed {
+        "omit --no-vad so Kesha can segment the file with VAD"
+    } else {
+        "run `kesha install --vad`, then rerun without --no-vad"
+    };
+    anyhow::bail!(
+        "refusing --no-vad for very long audio on the CoreML backend \
+         (detected {duration_s:.0}s; limit is {COREML_NO_VAD_MAX_SECONDS:.0}s). \
+         FluidAudio may abort the process on full-file long audio; {action}."
+    );
+}
+
 /// Resolve the diarization model path. Priority:
 /// 1. `KESHA_DIARIZE_MODEL_PATH` env var (must point to an existing path).
 /// 2. Default cache location populated by `kesha install --diarize`
@@ -638,6 +675,69 @@ mod tests {
             err.to_string()
                 .contains("failed to probe audio duration for timestamped segments"),
             "{err}"
+        );
+    }
+
+    #[test]
+    fn coreml_no_vad_rejects_very_long_plain_runs() {
+        let err = validate_plain_transcribe_safety(
+            VadMode::Off,
+            Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+            true,
+            true,
+        )
+        .expect_err("very long CoreML --no-vad should be rejected before backend load");
+        assert!(err.to_string().contains("refusing --no-vad"), "{err}");
+        assert!(err.to_string().contains("omit --no-vad"), "{err}");
+    }
+
+    #[test]
+    fn coreml_no_vad_rejection_points_at_vad_install_when_missing() {
+        let err = validate_plain_transcribe_safety(
+            VadMode::Off,
+            Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+            false,
+            true,
+        )
+        .expect_err("very long CoreML --no-vad should explain missing VAD");
+        assert!(err.to_string().contains("kesha install --vad"), "{err}");
+    }
+
+    #[test]
+    fn plain_safety_allows_non_coreml_or_short_or_auto_runs() {
+        assert!(
+            validate_plain_transcribe_safety(
+                VadMode::Off,
+                Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+                true,
+                false,
+            )
+            .is_ok(),
+            "non-CoreML backends should keep their existing --no-vad behavior"
+        );
+        assert!(
+            validate_plain_transcribe_safety(
+                VadMode::Off,
+                Some(COREML_NO_VAD_MAX_SECONDS - 1.0),
+                true,
+                true,
+            )
+            .is_ok(),
+            "short CoreML --no-vad runs should still be allowed"
+        );
+        assert!(
+            validate_plain_transcribe_safety(
+                VadMode::Auto,
+                Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+                true,
+                true,
+            )
+            .is_ok(),
+            "Auto mode should route through the existing VAD decision path"
+        );
+        assert!(
+            validate_plain_transcribe_safety(VadMode::Off, None, true, true).is_ok(),
+            "unknown duration should not fail before the backend can report the real error"
         );
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ export {
   detectLanguage,
   checkLanguageMismatch,
   resolveOutputFormat,
+  shouldReportTranscribeProgress,
 } from "./cli/main";
 export type { ResolvedOutputFormat } from "./cli/main";
 export { runCli } from "./cli/dispatch";

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -107,6 +107,14 @@ export function checkLanguageMismatch(expected: string | undefined, detected: st
   return `warning: expected language "${expected}" but detected "${detected}"`;
 }
 
+export function shouldReportTranscribeProgress(input: {
+  stderrIsTty: boolean;
+  stdoutIsTty: boolean;
+  debugEnabled: boolean;
+}): boolean {
+  return !input.debugEnabled && (input.stderrIsTty || !input.stdoutIsTty);
+}
+
 export const mainCommand = defineCommand({
   meta: {
     name: "kesha",
@@ -245,7 +253,11 @@ export const mainCommand = defineCommand({
     const stats = createStatsRecorder("transcribe");
 
     const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
-    const reportProgress = process.stderr.isTTY === true || process.stdout.isTTY !== true;
+    const reportProgress = shouldReportTranscribeProgress({
+      stderrIsTty: process.stderr.isTTY === true,
+      stdoutIsTty: process.stdout.isTTY === true,
+      debugEnabled: log.isDebugEnabled(),
+    });
 
     for (const file of files) {
       if (!existsSync(file)) {
@@ -271,15 +283,31 @@ export const mainCommand = defineCommand({
               estimatedTotalMs: args.speakers ? 60 * 60 * 1000 : 30 * 60 * 1000,
             })
           : null;
-        // Run audio lang-id and transcription concurrently.
-        const [audioResult, transcript] = await Promise.all([
-          wantsLangId
-            ? stats.timeStage("lang_id_audio", () => detectAudioLanguageEngine(file))
-            : Promise.resolve(null),
-          stats.timeStage("transcribe", () =>
-            transcribeWithSegments(file, { vad: vadMode, timestamps: args.timestamps, speakers: args.speakers })
-          ),
-        ]);
+        // Run audio lang-id and transcription concurrently, but do not leave
+        // the sibling engine process alive if one side fails first.
+        const engineAbort = new AbortController();
+        const audioPromise = wantsLangId
+          ? stats.timeStage("lang_id_audio", () =>
+              detectAudioLanguageEngine(file, { signal: engineAbort.signal })
+            )
+          : Promise.resolve(null);
+        const transcriptPromise = stats.timeStage("transcribe", () =>
+          transcribeWithSegments(file, {
+            vad: vadMode,
+            signal: engineAbort.signal,
+            timestamps: args.timestamps,
+            speakers: args.speakers,
+          })
+        );
+        let audioResult: LangDetectResult | null;
+        let transcript: Awaited<ReturnType<typeof transcribeWithSegments>>;
+        try {
+          [audioResult, transcript] = await Promise.all([audioPromise, transcriptPromise]);
+        } catch (err) {
+          engineAbort.abort();
+          await Promise.allSettled([audioPromise, transcriptPromise]);
+          throw err;
+        }
         const { text, segments } = transcript;
 
         let audioLanguage: LangDetectResult | undefined;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -51,6 +51,10 @@ export function isEngineInstalled(): boolean {
 /** A Bun.spawn `stdio` array entry: per-fd action or inherit-by-number. */
 type SpawnStdioEntry = "inherit" | "pipe" | "ignore" | number;
 
+interface RunEngineOptions {
+  signal?: AbortSignal;
+}
+
 /**
  * Upper bound on the fd number we'll forward (#323 Greptile P2).
  *
@@ -96,26 +100,55 @@ export function spawnStdioWithDebugFd(
   return out as [SpawnStdioEntry, SpawnStdioEntry, SpawnStdioEntry, ...SpawnStdioEntry[]];
 }
 
-async function runEngine(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+function engineAbortError(): Error {
+  const err = new Error("kesha-engine process aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+async function runEngine(
+  args: string[],
+  opts: RunEngineOptions = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  if (opts.signal?.aborted) {
+    throw engineAbortError();
+  }
   const binPath = getEngineBinPath();
   const startedAt = performance.now();
   log.debug(`spawn ${binPath} ${args.join(" ")}`);
   const proc = Bun.spawn([binPath, ...args], {
     stdio: spawnStdioWithDebugFd(["ignore", "pipe", "pipe"]),
   });
+  let aborted = false;
+  const abort = () => {
+    aborted = true;
+    proc.kill();
+  };
+  opts.signal?.addEventListener("abort", abort, { once: true });
   // `stdio: [...]` widens stdout/stderr into a union; indices 1/2 are
   // pinned to "pipe" by the helper, so the narrow ReadableStream type
   // is correct. Cast to drop the spurious `number` arm.
   const stdoutStream = proc.stdout as ReadableStream<Uint8Array>;
   const stderrStream = proc.stderr as ReadableStream<Uint8Array>;
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(stdoutStream).text(),
-    new Response(stderrStream).text(),
-    proc.exited,
-  ]);
+  let stdout: string;
+  let stderr: string;
+  let exitCode: number;
+  try {
+    [stdout, stderr, exitCode] = await Promise.all([
+      new Response(stdoutStream).text(),
+      new Response(stderrStream).text(),
+      proc.exited,
+    ]);
+  } finally {
+    opts.signal?.removeEventListener("abort", abort);
+  }
 
   log.debug(`exit=${exitCode} dt=${Math.round(performance.now() - startedAt)}ms args=${JSON.stringify(args)}`);
+  if (aborted) {
+    log.debug(`aborted args=${JSON.stringify(args)}`);
+    throw engineAbortError();
+  }
 
   // #275 D4: surface engine stderr on the success path so warnings like
   // `hint: audio is 180s`, `Model mirror active:`, and the dtrace lines
@@ -137,6 +170,7 @@ export type VadMode = "auto" | "on" | "off";
 
 export interface TranscribeEngineOptions {
   vad?: VadMode;
+  signal?: AbortSignal;
   /** Request speaker labels in transcript segments. Requires the engine to
    * advertise `transcribe.diarize` (darwin-arm64 only — see #199). */
   speakers?: boolean;
@@ -197,7 +231,7 @@ export async function transcribeEngine(
   const args = ["transcribe", audioPath];
   if (opts.vad === "on") args.push("--vad");
   else if (opts.vad === "off") args.push("--no-vad");
-  const { stdout, stderr, exitCode } = await runEngine(args);
+  const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
   }
@@ -239,7 +273,7 @@ export async function transcribeEngineWithSegments(
   if (opts.speakers) {
     args.push("--speakers");
   }
-  const { stdout, stderr, exitCode } = await runEngine(args);
+  const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
   }
@@ -278,17 +312,23 @@ export function parseLangResult(stdout: string): LangDetectResult | null {
   }
 }
 
-export async function detectAudioLanguageEngine(audioPath: string): Promise<LangDetectResult | null> {
+export async function detectAudioLanguageEngine(
+  audioPath: string,
+  opts: RunEngineOptions = {},
+): Promise<LangDetectResult | null> {
   if (!isEngineInstalled()) return null;
-  const { stdout, exitCode } = await runEngine(["detect-lang", audioPath]);
+  const { stdout, exitCode } = await runEngine(["detect-lang", audioPath], opts);
   if (exitCode !== 0) return null;
   return parseLangResult(stdout);
 }
 
-export async function detectTextLanguageEngine(text: string): Promise<LangDetectResult | null> {
+export async function detectTextLanguageEngine(
+  text: string,
+  opts: RunEngineOptions = {},
+): Promise<LangDetectResult | null> {
   if (text.trim().length === 0) return null;
   if (!isEngineInstalled()) return null;
-  const { stdout, exitCode } = await runEngine(["detect-text-lang", text]);
+  const { stdout, exitCode } = await runEngine(["detect-text-lang", text], opts);
   if (exitCode !== 0) return null;
   return parseLangResult(stdout);
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -34,8 +34,11 @@ export const log = {
   error: (msg: string) => console.error(pc.red(msg)),
 
   debugEnabled: false,
+  isDebugEnabled(): boolean {
+    return this.debugEnabled || envDebug();
+  },
   debug(msg: string): void {
-    if (this.debugEnabled || envDebug()) {
+    if (this.isDebugEnabled()) {
       // `[debug +Nms]` prefix sits on the CLI process's own timeline so
       // the reader can see when each line fired. The Rust engine emits
       // the same `+Nms` shape from `rust/src/debug.rs::trace_fmt`, but

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -14,6 +14,8 @@ export interface TranscribeOptions {
   silent?: boolean;
   /** Silero VAD preprocessing selector. Defaults to `"auto"`. */
   vad?: VadMode;
+  /** Cancel any in-flight engine subprocess for this transcription. */
+  signal?: AbortSignal;
   /** Request timestamped transcript segments from the engine. */
   timestamps?: boolean;
   /** Request speaker labels in transcript segments (#199). Implies `timestamps`.
@@ -56,10 +58,11 @@ export async function transcribeWithSegments(
   if (opts.timestamps || opts.speakers) {
     return transcribeEngineWithSegments(audioPath, {
       vad: opts.vad,
+      signal: opts.signal,
       speakers: opts.speakers,
     });
   }
 
-  const text = await transcribeEngine(audioPath, { vad: opts.vad });
+  const text = await transcribeEngine(audioPath, { vad: opts.vad, signal: opts.signal });
   return { text, segments: [] };
 }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
-import { mainCommand, completionsCommand, doctorCommand, installCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat, resolveRecordArgs } from "../../src/cli";
+import { chmodSync, existsSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mainCommand, completionsCommand, doctorCommand, installCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress } from "../../src/cli";
 
 type MainRun = (input: { args: Record<string, unknown>; rawArgs: string[] }) => Promise<void>;
 
@@ -29,6 +32,34 @@ function defaultMainArgs(overrides: Record<string, unknown> = {}): Record<string
     ...overrides,
   };
 }
+
+function fakeFailingTranscribeEngine(killMarker: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-cli-cancel-engine-"));
+  const path = join(dir, "kesha-engine");
+  writeFileSync(
+    path,
+    `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":2,"backend":"fake","features":["transcribe.segments"]}'
+  exit 0
+fi
+if [ "$1" = "detect-lang" ]; then
+  trap 'printf killed > '"'"'${killMarker}'"'"'; exit 143' TERM INT
+  while :; do :; done
+fi
+if [ "$1" = "transcribe" ]; then
+  sleep 0.1
+  printf '%s\\n' 'forced transcribe failure' >&2
+  exit 42
+fi
+exit 2
+`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
+const posixFakeEngineTest = process.platform === "win32" ? test.skip : test;
 
 async function expectMainExit(
   args: Record<string, unknown>,
@@ -183,6 +214,53 @@ describe("main command validation side effects", () => {
 
   test("empty invocation exits after printing usage", async () => {
     await expect(expectMainExit(defaultMainArgs(), [])).resolves.toBe(1);
+  });
+
+  posixFakeEngineTest("cancels parallel audio language detection when transcription fails", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-cli-cancel-"));
+    const input = join(dir, "input.wav");
+    const marker = join(dir, "detect-lang-killed");
+    writeFileSync(input, "placeholder");
+    const savedEngine = process.env.KESHA_ENGINE_BIN;
+    try {
+      process.env.KESHA_ENGINE_BIN = fakeFailingTranscribeEngine(marker);
+      await expect(
+        expectMainExit(defaultMainArgs({ json: true, _: [input] }), ["--json", input]),
+      ).resolves.toBe(1);
+      expect(existsSync(marker)).toBe(true);
+    } finally {
+      if (savedEngine === undefined) delete process.env.KESHA_ENGINE_BIN;
+      else process.env.KESHA_ENGINE_BIN = savedEngine;
+    }
+  });
+});
+
+describe("transcription progress reporting", () => {
+  test("reports progress for redirected stdout or interactive stderr", () => {
+    expect(
+      shouldReportTranscribeProgress({
+        stderrIsTty: false,
+        stdoutIsTty: false,
+        debugEnabled: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReportTranscribeProgress({
+        stderrIsTty: true,
+        stdoutIsTty: true,
+        debugEnabled: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("suppresses progress in debug mode so stderr remains line-oriented", () => {
+    expect(
+      shouldReportTranscribeProgress({
+        stderrIsTty: true,
+        stdoutIsTty: false,
+        debugEnabled: true,
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- refuse very long CoreML `--no-vad` full-file runs before FluidAudio can abort the process
- propagate `AbortSignal` through engine subprocess calls
- cancel the parallel audio language detection subprocess when transcription fails first
- suppress transcription progress bars when `--debug` / `KESHA_DEBUG` is enabled so stderr remains line-oriented

Closes #398

## Validation

- `bun test`
- `bunx tsc --noEmit`
- `cargo fmt -- --check && cargo clippy --all-targets -- -D warnings`
- `cargo nextest run --features tts`

## Note

- `cargo check --features coreml --no-default-features` is currently blocked locally by upstream FluidAudio Swift concurrency diagnostics in `StreamingAsrManager` with the installed Swift toolchain.