### PR TITLE
docs: add Hermes Agent integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Audio decoding via [symphonia](https://github.com/pdeljanov/Symphonia) — WAV, 
 ## Integrations
 
 - **OpenClaw** — give your LLM agent ears. Install & config: [docs/openclaw.md](docs/openclaw.md).
+- **Hermes Agent** — local STT/TTS through Hermes command providers. Setup: [docs/hermes.md](docs/hermes.md).
 - **Raycast** (macOS) — transcribe selected audio & speak clipboard from the launcher. Source + install: [`raycast/`](raycast/).
 
 ## Programmatic API

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -78,6 +78,7 @@ tts:
       output_format: ogg
       timeout: 60
       voice_compatible: true
+      max_text_length: 2000
 ```
 
 ## Verify

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -87,7 +87,8 @@ which kesha
 kesha status
 
 tmp="$(mktemp -d)"
-kesha --format transcript fixtures/benchmark-en/01-check-email.ogg > "$tmp/transcript.txt"
+# Replace /path/to/audio.ogg with your own audio file:
+kesha --format transcript /path/to/audio.ogg > "$tmp/transcript.txt"
 cat "$tmp/transcript.txt"
 
 echo "Hello from Hermes" | kesha say --format ogg-opus --out "$tmp/reply.ogg"

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -1,0 +1,109 @@
+# Hermes Agent Integration
+
+Kesha Voice Kit can run as a local voice backend for
+[Hermes Agent](https://hermes-agent.nousresearch.com/) through Hermes' command
+provider surfaces. No API keys are required; audio stays on the machine where
+Hermes runs.
+
+Hermes exposes two useful integration points:
+
+- **Voice message transcription (STT)** through `HERMES_LOCAL_STT_COMMAND`.
+- **Text-to-speech (TTS)** through `tts.providers.<name>.type: command`.
+
+## Install Kesha
+
+```bash
+bun add -g @drakulavich/kesha-voice-kit
+kesha install
+```
+
+Install TTS models only if you want Hermes replies as audio:
+
+```bash
+kesha install --tts
+```
+
+## Speech-to-text
+
+Hermes writes each incoming voice message to `{input_path}`, runs the command
+template, then reads a `.txt` transcript from `{output_dir}`.
+
+```bash
+export HERMES_LOCAL_STT_COMMAND='sh -c '"'"'kesha --format transcript "$1" > "$2/transcript.txt"'"'"' sh {input_path} {output_dir}'
+```
+
+In `~/.hermes/config.yaml`:
+
+```yaml
+stt:
+  provider: local_command
+```
+
+Use plain text output if you do not want the `[lang: ...]` footer:
+
+```bash
+export HERMES_LOCAL_STT_COMMAND='sh -c '"'"'kesha "$1" > "$2/transcript.txt"'"'"' sh {input_path} {output_dir}'
+```
+
+## Text-to-speech
+
+Hermes command providers write input text to `{input_path}` and expect the
+configured command to create audio at `{output_path}`. Kesha's `say` command
+already reads text from stdin, so no wrapper script is required.
+
+In `~/.hermes/config.yaml`:
+
+```yaml
+tts:
+  provider: kesha
+  providers:
+    kesha:
+      type: command
+      command: "kesha say --format ogg-opus --out {output_path} < {input_path}"
+      output_format: ogg
+      timeout: 60
+      voice_compatible: true
+      max_text_length: 2000
+```
+
+To force a specific Kesha voice, add `--voice`:
+
+```yaml
+tts:
+  provider: kesha-ru
+  providers:
+    kesha-ru:
+      type: command
+      command: "kesha say --voice ru-vosk-m02 --format ogg-opus --out {output_path} < {input_path}"
+      output_format: ogg
+      timeout: 60
+      voice_compatible: true
+```
+
+## Verify
+
+```bash
+which kesha
+kesha status
+
+tmp="$(mktemp -d)"
+kesha --format transcript fixtures/benchmark-en/01-check-email.ogg > "$tmp/transcript.txt"
+cat "$tmp/transcript.txt"
+
+echo "Hello from Hermes" | kesha say --format ogg-opus --out "$tmp/reply.ogg"
+test -s "$tmp/reply.ogg"
+```
+
+## Notes
+
+- `kesha --format transcript` keeps the transcript on stdout and progress or
+  warnings on stderr, which matches Hermes' command contract.
+- `kesha say --format ogg-opus` emits messenger-ready OGG/Opus directly.
+- Hermes command providers run trusted local shell commands with the user's
+  permissions. Keep the command template in your own config or deployment
+  automation.
+
+Hermes reference docs:
+[Voice & TTS](https://hermes-agent.nousresearch.com/docs/user-guide/features/tts/)
+and
+[Build a Hermes Plugin](https://hermes-agent.nousresearch.com/docs/guides/build-a-hermes-plugin/).

--- a/docs/product-positioning.md
+++ b/docs/product-positioning.md
@@ -8,6 +8,7 @@ The product promise is not "one model for every audio problem." The promise is a
 
 - Developers and agent builders who need local speech-to-text for voice messages, meetings, support clips, or batch audio files.
 - OpenClaw users who want private, low-latency voice-message transcription through a CLI model route.
+- Hermes Agent users who want command-provider STT/TTS without cloud audio uploads.
 - macOS users who want the fastest path on Apple Silicon through CoreML, with a CPU/ONNX fallback on Linux and Windows.
 - Automation-heavy users who prefer stdout/stderr contracts, JSON/TOON output, and shell-friendly commands over a hosted dashboard.
 - Projects that can accept explicit model downloads and local cache management in exchange for no API keys and no cloud audio upload.
@@ -24,6 +25,7 @@ The product promise is not "one model for every audio problem." The promise is a
 | Use macOS system voices without model downloads | Stable on macOS | `kesha say --voice macos-*` |
 | Label speakers in meeting transcripts | Preview, darwin-arm64 only | `kesha --json --vad --speakers meeting.m4a` |
 | Integrate with OpenClaw as a local voice model | Stable integration surface, user-configured route | `docs/openclaw.md` |
+| Integrate with Hermes Agent as local STT/TTS commands | Stable CLI surface, user-configured route | `docs/hermes.md` |
 | Use Raycast actions for selected-file transcription or clipboard speech | Beta, macOS only | `raycast/` extension |
 | Install through Nix instead of Bun/npm | Beta, selected systems | `docs/nix-install.md` |
 
@@ -51,6 +53,7 @@ The product promise is not "one model for every audio problem." The promise is a
 | Speaker diarization | Preview | darwin-arm64 only; cluster IDs are stable within one file only. |
 | Raycast extension | Beta | Convenience UI over the CLI; macOS-only. |
 | OpenClaw plugin | Stable integration surface | Discovery is packaged; actual audio route remains explicit user config. |
+| Hermes Agent command provider | Stable CLI surface | Hermes owns the command-provider lifecycle; Kesha supplies the local STT/TTS commands. |
 | Nix flake | Beta | Reproducible alternate install path for selected systems; Bun/npm remains canonical. |
 
 ## Platform matrix
@@ -66,6 +69,7 @@ The product promise is not "one model for every audio problem." The promise is a
 | Speaker diarization | Preview, darwin-arm64 only | Not supported | Not supported | Not supported | Not wired into the Nix build yet |
 | Raycast extension | Supported | Not shipped | Not applicable | Not applicable | Not applicable |
 | OpenClaw integration | Supported through CLI route | Not shipped | Supported through CLI route | Supported through CLI route | Use the installed `kesha` command from the chosen path |
+| Hermes Agent integration | Supported through command providers | Not shipped | Supported through command providers | Supported through command providers | Use the installed `kesha` command from the chosen path |
 
 `macOS x64` means Intel Macs. Kesha does not currently publish a `darwin-x64` engine binary, so Intel Macs are intentionally marked as not shipped rather than implied to use the ONNX fallback.
 


### PR DESCRIPTION
## Summary
- add a Hermes Agent integration guide for local STT and TTS command providers
- link Hermes from the README integrations list
- document Hermes as a supported agent workflow in product positioning

## Validation
- `jj diff --git --color never | rg -n '^\\+.*[ \\t]$' || true`
- `PATH="/Users/anton/.bun/bin:$PATH" sh -c 'kesha --format transcript "$1" > "$2/transcript.txt"' sh fixtures/benchmark-en/01-check-email.ogg "$tmp"`
- `PATH="/Users/anton/.bun/bin:$PATH" echo "Hello from Hermes" | kesha say --format ogg-opus --out "$tmp/reply.ogg"`

Refs:
- Hermes Voice & TTS docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/tts/
