### PR TITLE
Fix process-tree cleanup on interrupt

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -34,6 +34,7 @@ pub mod cli;
 pub mod debug;
 pub mod lang_id;
 pub mod models;
+mod process_tree;
 pub mod record;
 #[cfg(feature = "tts")]
 pub mod say_loop;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod debug;
 mod lang_id;
 mod models;
+mod process_tree;
 mod record;
 #[cfg(feature = "tts")]
 mod say_loop;

--- a/rust/src/process_tree.rs
+++ b/rust/src/process_tree.rs
@@ -1,0 +1,129 @@
+// Used by macOS sidecar feature modules; default `--features tts` builds do
+// not compile those call sites, but the helper still needs to stay shared.
+#![allow(dead_code)]
+
+use std::io;
+use std::process::{Child, ChildStdin, ExitStatus, Output};
+
+pub(crate) struct ChildGuard {
+    child: Option<Child>,
+}
+
+impl ChildGuard {
+    pub(crate) fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    pub(crate) fn stdin_mut(&mut self) -> Option<&mut ChildStdin> {
+        self.child.as_mut()?.stdin.as_mut()
+    }
+
+    pub(crate) fn close_stdin(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            drop(child.stdin.take());
+        }
+    }
+
+    pub(crate) fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.child
+            .as_mut()
+            .expect("ChildGuard missing child")
+            .try_wait()
+    }
+
+    pub(crate) fn wait_with_output(mut self) -> io::Result<Output> {
+        self.child
+            .take()
+            .expect("ChildGuard missing child")
+            .wait_with_output()
+    }
+
+    pub(crate) fn kill_and_wait_with_output(mut self) -> io::Result<Output> {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+        }
+        self.wait_with_output()
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        match child.try_wait() {
+            Ok(Some(_)) => {}
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    #[cfg(unix)]
+    fn pid_is_alive(pid: u32) -> bool {
+        Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(unix)]
+    fn wait_until_dead(pid: u32) -> bool {
+        let started = Instant::now();
+        while started.elapsed() < Duration::from_secs(2) {
+            if !pid_is_alive(pid) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        false
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn drop_kills_unreaped_child() {
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("trap '' TERM; while :; do sleep 1; done")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn helper");
+        let pid = child.id();
+
+        {
+            let _guard = ChildGuard::new(child);
+            assert!(pid_is_alive(pid));
+        }
+
+        assert!(wait_until_dead(pid), "child pid {pid} survived guard drop");
+    }
+
+    #[test]
+    fn wait_with_output_disarms_drop_cleanup() {
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("printf ok")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn helper");
+
+        let output = ChildGuard::new(child).wait_with_output().expect("wait");
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"ok");
+    }
+}

--- a/rust/src/text_lang.rs
+++ b/rust/src/text_lang.rs
@@ -65,19 +65,21 @@ pub(crate) fn detect_with_helper(
     use std::io::Write;
     use std::process::{Command, Stdio};
 
-    let mut child = Command::new(helper)
+    use crate::process_tree::ChildGuard;
+
+    let child = Command::new(helper)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .with_context(|| format!("spawn {} failed", helper.display()))?;
+    let mut child = ChildGuard::new(child);
 
     child
-        .stdin
-        .as_mut()
+        .stdin_mut()
         .context("kesha-textlang: stdin unavailable")?
         .write_all(text.as_bytes())?;
-    drop(child.stdin.take());
+    child.close_stdin();
 
     let output = child.wait_with_output()?;
     if !output.status.success() {

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+use crate::process_tree::ChildGuard;
+
 use super::TranscriptionSegment;
 
 /// One speaker span emitted by the sidecar. Cluster IDs are stable within
@@ -63,13 +65,14 @@ fn sidecar_path() -> Result<PathBuf> {
 /// using the diarization model at `model_path`. Returns the parsed span list.
 pub(crate) fn run(audio_path: &Path, model_path: &Path) -> Result<Vec<DiarizeSpan>> {
     let sidecar = sidecar_path()?;
-    let mut child = Command::new(&sidecar)
+    let child = Command::new(&sidecar)
         .arg(audio_path)
         .arg(model_path)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .with_context(|| format!("failed to spawn {}", sidecar.display()))?;
+    let mut child = ChildGuard::new(child);
 
     let timeout = diarize_timeout();
     let started = Instant::now();
@@ -82,9 +85,8 @@ pub(crate) fn run(audio_path: &Path, model_path: &Path) -> Result<Vec<DiarizeSpa
             break;
         }
         if started.elapsed() >= timeout {
-            let _ = child.kill();
             let output = child
-                .wait_with_output()
+                .kill_and_wait_with_output()
                 .with_context(|| format!("failed to collect timed-out {}", sidecar.display()))?;
             let stderr = String::from_utf8_lossy(&output.stderr);
             bail!(

--- a/rust/src/tts/avspeech.rs
+++ b/rust/src/tts/avspeech.rs
@@ -15,6 +15,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use crate::process_tree::ChildGuard;
+
 /// Path to the sidecar `say-avspeech` binary.
 ///
 /// Resolution order:
@@ -53,20 +55,20 @@ pub fn synthesize(text: &str, voice_id: &str, helper: Option<&Path>) -> anyhow::
     }
     let bin = helper.map(PathBuf::from).unwrap_or_else(helper_path);
 
-    let mut child = Command::new(&bin)
+    let child = Command::new(&bin)
         .arg(voice_id)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| anyhow::anyhow!("spawn {}: {e}", bin.display()))?;
+    let mut child = ChildGuard::new(child);
 
     child
-        .stdin
-        .as_mut()
+        .stdin_mut()
         .ok_or_else(|| anyhow::anyhow!("avspeech: stdin unavailable"))?
         .write_all(text.as_bytes())?;
-    drop(child.stdin.take());
+    child.close_stdin();
 
     let output = child.wait_with_output()?;
     if !output.status.success() {

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -15,6 +15,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use crate::process_tree::ChildGuard;
+
 // FluidAudio 0.14.5 voice snapshot. Keep this list in sync with
 // swift/kesha-kokoro/Package.resolved whenever the FluidAudio pin changes.
 const VOICES: &[&str] = &[
@@ -74,7 +76,7 @@ pub fn synthesize(
     let bin = helper.map(PathBuf::from).unwrap_or_else(helper_path);
     let speed_arg = format!("{speed:.3}");
 
-    let mut child = Command::new(&bin)
+    let child = Command::new(&bin)
         .arg("--voice")
         .arg(voice_id)
         .arg("--speed")
@@ -84,13 +86,13 @@ pub fn synthesize(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| anyhow::anyhow!("spawn {}: {e}", bin.display()))?;
+    let mut child = ChildGuard::new(child);
 
     child
-        .stdin
-        .as_mut()
+        .stdin_mut()
         .ok_or_else(|| anyhow::anyhow!("fluid-kokoro: stdin unavailable"))?
         .write_all(text.as_bytes())?;
-    drop(child.stdin.take());
+    child.close_stdin();
 
     let output = child.wait_with_output()?;
     if !output.status.success() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ export {
   detectLanguage,
   checkLanguageMismatch,
   resolveOutputFormat,
+  shouldReportTranscribeProgress,
 } from "./cli/main";
 export type { ResolvedOutputFormat } from "./cli/main";
 export { runCli } from "./cli/dispatch";

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -16,6 +16,7 @@ import { packageVersion } from "../package-info";
 import { formatToonOutput } from "../toon";
 import { artifactFromFile, createStatsRecorder } from "../stats";
 import { createPercentProgress } from "../progress";
+import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../process-tree";
 
 interface MainCommandArgs {
   _: string[];
@@ -378,6 +379,13 @@ export const mainCommand = defineCommand({
 
     stats.finish(hasError ? "failed" : "success", files.length);
 
-    if (hasError) process.exit(1);
+    if (hasError) {
+      const signalExitCode = getPendingSignalExitCode();
+      if (signalExitCode !== null) {
+        await waitForPendingSignalCleanup();
+        process.exit(signalExitCode);
+      }
+      process.exit(1);
+    }
   },
 });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -107,6 +107,15 @@ export function checkLanguageMismatch(expected: string | undefined, detected: st
   return `warning: expected language "${expected}" but detected "${detected}"`;
 }
 
+export function shouldReportTranscribeProgress(input: {
+  stderrIsTty: boolean;
+  stdoutIsTty: boolean;
+  debugEnabled: boolean;
+}): boolean {
+  if (input.debugEnabled) return false;
+  return input.stderrIsTty || !input.stdoutIsTty;
+}
+
 export const mainCommand = defineCommand({
   meta: {
     name: "kesha",
@@ -245,7 +254,11 @@ export const mainCommand = defineCommand({
     const stats = createStatsRecorder("transcribe");
 
     const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
-    const reportProgress = process.stderr.isTTY === true || process.stdout.isTTY !== true;
+    const reportProgress = shouldReportTranscribeProgress({
+      stderrIsTty: process.stderr.isTTY === true,
+      stdoutIsTty: process.stdout.isTTY === true,
+      debugEnabled: log.isDebugEnabled(),
+    });
 
     for (const file of files) {
       if (!existsSync(file)) {
@@ -271,15 +284,31 @@ export const mainCommand = defineCommand({
               estimatedTotalMs: args.speakers ? 60 * 60 * 1000 : 30 * 60 * 1000,
             })
           : null;
-        // Run audio lang-id and transcription concurrently.
-        const [audioResult, transcript] = await Promise.all([
-          wantsLangId
-            ? stats.timeStage("lang_id_audio", () => detectAudioLanguageEngine(file))
-            : Promise.resolve(null),
-          stats.timeStage("transcribe", () =>
-            transcribeWithSegments(file, { vad: vadMode, timestamps: args.timestamps, speakers: args.speakers })
-          ),
-        ]);
+        // Run audio lang-id and transcription concurrently, but do not leave
+        // the sibling engine process alive if one side fails first.
+        const engineAbort = new AbortController();
+        const audioPromise = wantsLangId
+          ? stats.timeStage("lang_id_audio", () =>
+              detectAudioLanguageEngine(file, { signal: engineAbort.signal })
+            )
+          : Promise.resolve(null);
+        const transcriptPromise = stats.timeStage("transcribe", () =>
+          transcribeWithSegments(file, {
+            vad: vadMode,
+            signal: engineAbort.signal,
+            timestamps: args.timestamps,
+            speakers: args.speakers,
+          })
+        );
+        let audioResult: LangDetectResult | null;
+        let transcript: Awaited<ReturnType<typeof transcribeWithSegments>>;
+        try {
+          [audioResult, transcript] = await Promise.all([audioPromise, transcriptPromise]);
+        } catch (err) {
+          engineAbort.abort();
+          await Promise.allSettled([audioPromise, transcriptPromise]);
+          throw err;
+        }
         const { text, segments } = transcript;
 
         let audioLanguage: LangDetectResult | undefined;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from "fs";
 import { join } from "path";
 import { log } from "./log";
 import { defaultEngineBinPath, keshaCacheDir } from "./paths";
+import { engineAbortError, registerProcessTree } from "./process-tree";
 
 /**
  * Capability-flag string surfaced via `kesha-engine --capabilities-json`. Single
@@ -96,26 +97,57 @@ export function spawnStdioWithDebugFd(
   return out as [SpawnStdioEntry, SpawnStdioEntry, SpawnStdioEntry, ...SpawnStdioEntry[]];
 }
 
-async function runEngine(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+export interface RunEngineOptions {
+  signal?: AbortSignal;
+}
+
+async function runEngine(
+  args: string[],
+  opts: RunEngineOptions = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  if (opts.signal?.aborted) throw engineAbortError();
   const binPath = getEngineBinPath();
   const startedAt = performance.now();
   log.debug(`spawn ${binPath} ${args.join(" ")}`);
   const proc = Bun.spawn([binPath, ...args], {
+    detached: true,
     stdio: spawnStdioWithDebugFd(["ignore", "pipe", "pipe"]),
   });
+  const tree = registerProcessTree(proc);
+  let aborted = false;
+  let forceKillTimer: Timer | undefined;
+  const abort = () => {
+    aborted = true;
+    tree.terminate("SIGTERM");
+    forceKillTimer ??= tree.forceKillAfterGrace();
+  };
+  opts.signal?.addEventListener("abort", abort, { once: true });
   // `stdio: [...]` widens stdout/stderr into a union; indices 1/2 are
   // pinned to "pipe" by the helper, so the narrow ReadableStream type
   // is correct. Cast to drop the spurious `number` arm.
   const stdoutStream = proc.stdout as ReadableStream<Uint8Array>;
   const stderrStream = proc.stderr as ReadableStream<Uint8Array>;
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(stdoutStream).text(),
-    new Response(stderrStream).text(),
-    proc.exited,
-  ]);
+  let stdout: string;
+  let stderr: string;
+  let exitCode: number;
+  try {
+    [stdout, stderr, exitCode] = await Promise.all([
+      new Response(stdoutStream).text(),
+      new Response(stderrStream).text(),
+      proc.exited,
+    ]);
+  } finally {
+    opts.signal?.removeEventListener("abort", abort);
+    tree.dispose();
+    if (!aborted && forceKillTimer) clearTimeout(forceKillTimer);
+  }
 
   log.debug(`exit=${exitCode} dt=${Math.round(performance.now() - startedAt)}ms args=${JSON.stringify(args)}`);
+  if (aborted) {
+    log.debug(`aborted args=${JSON.stringify(args)}`);
+    throw engineAbortError();
+  }
 
   // #275 D4: surface engine stderr on the success path so warnings like
   // `hint: audio is 180s`, `Model mirror active:`, and the dtrace lines
@@ -137,6 +169,7 @@ export type VadMode = "auto" | "on" | "off";
 
 export interface TranscribeEngineOptions {
   vad?: VadMode;
+  signal?: AbortSignal;
   /** Request speaker labels in transcript segments. Requires the engine to
    * advertise `transcribe.diarize` (darwin-arm64 only — see #199). */
   speakers?: boolean;
@@ -197,7 +230,7 @@ export async function transcribeEngine(
   const args = ["transcribe", audioPath];
   if (opts.vad === "on") args.push("--vad");
   else if (opts.vad === "off") args.push("--no-vad");
-  const { stdout, stderr, exitCode } = await runEngine(args);
+  const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
   }
@@ -239,7 +272,7 @@ export async function transcribeEngineWithSegments(
   if (opts.speakers) {
     args.push("--speakers");
   }
-  const { stdout, stderr, exitCode } = await runEngine(args);
+  const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
   }
@@ -257,9 +290,16 @@ export async function recordEngine(outPath: string, maxSeconds: number): Promise
   const startedAt = performance.now();
   log.debug(`spawn ${binPath} ${args.join(" ")}`);
   const proc = Bun.spawn([binPath, ...args], {
+    detached: true,
     stdio: spawnStdioWithDebugFd(["inherit", "inherit", "inherit"]),
   });
-  const exitCode = await proc.exited;
+  const tree = registerProcessTree(proc);
+  let exitCode: number;
+  try {
+    exitCode = await proc.exited;
+  } finally {
+    tree.dispose();
+  }
   log.debug(`exit=${exitCode} dt=${Math.round(performance.now() - startedAt)}ms args=${JSON.stringify(args)}`);
   if (exitCode !== 0) {
     throw new Error(`kesha-engine record exited with code ${exitCode}`);
@@ -278,17 +318,23 @@ export function parseLangResult(stdout: string): LangDetectResult | null {
   }
 }
 
-export async function detectAudioLanguageEngine(audioPath: string): Promise<LangDetectResult | null> {
+export async function detectAudioLanguageEngine(
+  audioPath: string,
+  opts: RunEngineOptions = {},
+): Promise<LangDetectResult | null> {
   if (!isEngineInstalled()) return null;
-  const { stdout, exitCode } = await runEngine(["detect-lang", audioPath]);
+  const { stdout, exitCode } = await runEngine(["detect-lang", audioPath], opts);
   if (exitCode !== 0) return null;
   return parseLangResult(stdout);
 }
 
-export async function detectTextLanguageEngine(text: string): Promise<LangDetectResult | null> {
+export async function detectTextLanguageEngine(
+  text: string,
+  opts: RunEngineOptions = {},
+): Promise<LangDetectResult | null> {
   if (text.trim().length === 0) return null;
   if (!isEngineInstalled()) return null;
-  const { stdout, exitCode } = await runEngine(["detect-text-lang", text]);
+  const { stdout, exitCode } = await runEngine(["detect-text-lang", text], opts);
   if (exitCode !== 0) return null;
   return parseLangResult(stdout);
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -34,8 +34,11 @@ export const log = {
   error: (msg: string) => console.error(pc.red(msg)),
 
   debugEnabled: false,
+  isDebugEnabled(): boolean {
+    return this.debugEnabled || envDebug();
+  },
   debug(msg: string): void {
-    if (this.debugEnabled || envDebug()) {
+    if (this.isDebugEnabled()) {
       // `[debug +Nms]` prefix sits on the CLI process's own timeline so
       // the reader can see when each line fired. The Rust engine emits
       // the same `+Nms` shape from `rust/src/debug.rs::trace_fmt`, but

--- a/src/process-tree.ts
+++ b/src/process-tree.ts
@@ -11,8 +11,15 @@ interface ActiveProcess {
 }
 
 const FORCE_KILL_GRACE_MS = 1_000;
+const SIGNAL_EXIT_BUFFER_MS = 50;
 const activeProcesses = new Set<ActiveProcess>();
 let signalHandlersInstalled = false;
+let pendingSignalCleanup:
+  | {
+      exitCode: number;
+      done: Promise<void>;
+    }
+  | null = null;
 
 export function engineAbortError(): Error {
   const err = new Error("kesha-engine process aborted");
@@ -38,6 +45,16 @@ export function registerProcessTree(proc: KillableProcess): {
     terminate: (signal: ManagedSignal = "SIGTERM") => active.kill(signal),
     forceKillAfterGrace: () => scheduleForceKill(active),
   };
+}
+
+export function getPendingSignalExitCode(): number | null {
+  return pendingSignalCleanup?.exitCode ?? null;
+}
+
+export async function waitForPendingSignalCleanup(): Promise<number | null> {
+  if (!pendingSignalCleanup) return null;
+  await pendingSignalCleanup.done;
+  return pendingSignalCleanup.exitCode;
 }
 
 export function terminateProcessTree(proc: KillableProcess, signal: ManagedSignal = "SIGTERM"): void {
@@ -77,9 +94,9 @@ function safeKillDirect(proc: KillableProcess, signal: ManagedSignal): void {
   }
 }
 
-function scheduleForceKill(proc: ActiveProcess): Timer {
+function scheduleForceKill(proc: ActiveProcess, opts: { ref?: boolean } = {}): Timer {
   const timer = setTimeout(() => proc.kill("SIGKILL"), FORCE_KILL_GRACE_MS);
-  timer.unref?.();
+  if (opts.ref !== true) timer.unref?.();
   return timer;
 }
 
@@ -91,10 +108,26 @@ function ensureSignalHandlers(): void {
 }
 
 function terminateActiveProcessTrees(signal: ManagedSignal, exitCode: number): void {
-  for (const proc of activeProcesses) {
+  const processes = [...activeProcesses];
+  process.exitCode = exitCode;
+
+  for (const proc of processes) {
     proc.kill(signal);
-    scheduleForceKill(proc);
+    scheduleForceKill(proc, { ref: true });
   }
-  const timer = setTimeout(() => process.exit(exitCode), 50);
-  timer.unref?.();
+
+  if (pendingSignalCleanup) {
+    return;
+  }
+
+  const delayMs = processes.length > 0
+    ? FORCE_KILL_GRACE_MS + SIGNAL_EXIT_BUFFER_MS
+    : SIGNAL_EXIT_BUFFER_MS;
+  let resolveDone!: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  pendingSignalCleanup = { exitCode, done };
+  setTimeout(resolveDone, delayMs);
+  done.then(() => process.exit(exitCode));
 }

--- a/src/process-tree.ts
+++ b/src/process-tree.ts
@@ -1,0 +1,100 @@
+type ManagedSignal = "SIGINT" | "SIGTERM" | "SIGKILL";
+
+interface KillableProcess {
+  pid: number;
+  kill(signal?: ManagedSignal): void;
+}
+
+interface ActiveProcess {
+  pid: number;
+  kill(signal?: ManagedSignal): void;
+}
+
+const FORCE_KILL_GRACE_MS = 1_000;
+const activeProcesses = new Set<ActiveProcess>();
+let signalHandlersInstalled = false;
+
+export function engineAbortError(): Error {
+  const err = new Error("kesha-engine process aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+export function registerProcessTree(proc: KillableProcess): {
+  dispose: () => void;
+  terminate: (signal?: ManagedSignal) => void;
+  forceKillAfterGrace: () => Timer;
+} {
+  const active: ActiveProcess = {
+    pid: proc.pid,
+    kill: (signal?: ManagedSignal) => terminateProcessTree(proc, signal),
+  };
+  activeProcesses.add(active);
+  ensureSignalHandlers();
+  return {
+    dispose: () => {
+      activeProcesses.delete(active);
+    },
+    terminate: (signal: ManagedSignal = "SIGTERM") => active.kill(signal),
+    forceKillAfterGrace: () => scheduleForceKill(active),
+  };
+}
+
+export function terminateProcessTree(proc: KillableProcess, signal: ManagedSignal = "SIGTERM"): void {
+  if (!Number.isFinite(proc.pid) || proc.pid <= 0) {
+    safeKillDirect(proc, signal);
+    return;
+  }
+
+  if (process.platform === "win32") {
+    const args = ["/PID", String(proc.pid), "/T"];
+    if (signal === "SIGKILL") args.push("/F");
+    try {
+      Bun.spawn(["taskkill", ...args], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      return;
+    } catch {
+      safeKillDirect(proc, signal);
+      return;
+    }
+  }
+
+  try {
+    process.kill(-proc.pid, signal);
+  } catch {
+    safeKillDirect(proc, signal);
+  }
+}
+
+function safeKillDirect(proc: KillableProcess, signal: ManagedSignal): void {
+  try {
+    proc.kill(signal);
+  } catch {
+    // The process may already have exited between the caller deciding to clean
+    // it up and the signal reaching the kernel.
+  }
+}
+
+function scheduleForceKill(proc: ActiveProcess): Timer {
+  const timer = setTimeout(() => proc.kill("SIGKILL"), FORCE_KILL_GRACE_MS);
+  timer.unref?.();
+  return timer;
+}
+
+function ensureSignalHandlers(): void {
+  if (signalHandlersInstalled) return;
+  signalHandlersInstalled = true;
+  process.on("SIGINT", () => terminateActiveProcessTrees("SIGINT", 130));
+  process.on("SIGTERM", () => terminateActiveProcessTrees("SIGTERM", 143));
+}
+
+function terminateActiveProcessTrees(signal: ManagedSignal, exitCode: number): void {
+  for (const proc of activeProcesses) {
+    proc.kill(signal);
+    scheduleForceKill(proc);
+  }
+  const timer = setTimeout(() => process.exit(exitCode), 50);
+  timer.unref?.();
+}

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -6,6 +6,7 @@ import {
   type EngineCapabilities,
 } from "./engine";
 import { log } from "./log";
+import { registerProcessTree } from "./process-tree";
 
 /**
  * Wire format for the synthesized audio. Matches the engine's `--format` flag.
@@ -125,8 +126,10 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
   const startedAt = performance.now();
   log.debug(`spawn ${getEngineBinPath()} ${args.join(" ")} (text: ${opts.text?.length ?? 0} chars)`);
   const proc = Bun.spawn([getEngineBinPath(), ...args], {
+    detached: true,
     stdio: spawnStdioWithDebugFd(["pipe", "pipe", "pipe"]),
   });
+  const tree = registerProcessTree(proc);
   // The `stdio: [...]` form widens stdin/stdout/stderr into a union
   // (Bun.spawn can't infer that indices 0/1/2 are always "pipe" given
   // the helper's return type). All three are guaranteed `FileSink` /
@@ -143,11 +146,18 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
     await stdin.end();
   }
 
-  const [stdoutBuf, stderrText, exitCode] = await Promise.all([
-    new Response(stdout).arrayBuffer(),
-    new Response(stderr).text(),
-    proc.exited,
-  ]);
+  let stdoutBuf: ArrayBuffer;
+  let stderrText: string;
+  let exitCode: number;
+  try {
+    [stdoutBuf, stderrText, exitCode] = await Promise.all([
+      new Response(stdout).arrayBuffer(),
+      new Response(stderr).text(),
+      proc.exited,
+    ]);
+  } finally {
+    tree.dispose();
+  }
 
   log.debug(`exit=${exitCode} dt=${Math.round(performance.now() - startedAt)}ms bytes=${stdoutBuf.byteLength}`);
 

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -12,6 +12,7 @@ export type { TranscriptionOutput };
 
 export interface TranscribeOptions {
   silent?: boolean;
+  signal?: AbortSignal;
   /** Silero VAD preprocessing selector. Defaults to `"auto"`. */
   vad?: VadMode;
   /** Request timestamped transcript segments from the engine. */
@@ -56,10 +57,11 @@ export async function transcribeWithSegments(
   if (opts.timestamps || opts.speakers) {
     return transcribeEngineWithSegments(audioPath, {
       vad: opts.vad,
+      signal: opts.signal,
       speakers: opts.speakers,
     });
   }
 
-  const text = await transcribeEngine(audioPath, { vad: opts.vad });
+  const text = await transcribeEngine(audioPath, { vad: opts.vad, signal: opts.signal });
   return { text, segments: [] };
 }

--- a/tests/helpers/process.ts
+++ b/tests/helpers/process.ts
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync } from "fs";
+
+const PID_FILE_POLL_INTERVAL_MS = 25;
+const PID_FILE_POLL_ATTEMPTS = 80;
+const PID_EXIT_POLL_ATTEMPTS = 120;
+
+export async function waitForPidFile(path: string): Promise<number> {
+  for (let i = 0; i < PID_FILE_POLL_ATTEMPTS; i++) {
+    if (existsSync(path)) return Number(readFileSync(path, "utf8"));
+    await Bun.sleep(PID_FILE_POLL_INTERVAL_MS);
+  }
+  throw new Error(`timed out waiting for pid file: ${path}`);
+}
+
+export function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function waitForPidExit(pid: number): Promise<boolean> {
+  for (let i = 0; i < PID_EXIT_POLL_ATTEMPTS; i++) {
+    if (!pidIsAlive(pid)) return true;
+    await Bun.sleep(PID_FILE_POLL_INTERVAL_MS);
+  }
+  return false;
+}

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
   installFakeDiarizeModel,
   runCliScenario,
@@ -123,7 +124,7 @@ function createSiblingCancellationEngine(dir: string, langPidPath: string): stri
   const enginePath = join(dir, "kesha-engine-sibling-cancel");
   writeFileSync(
     enginePath,
-    `#!/usr/bin/env bun
+    `#!${process.execPath}
 const args = Bun.argv.slice(2);
 if (args[0] === "--capabilities-json") {
   console.log(JSON.stringify({ protocolVersion: 1, backend: "fake", features: [] }));
@@ -148,31 +149,6 @@ process.exit(2);
   );
   chmodSync(enginePath, 0o755);
   return enginePath;
-}
-
-async function waitForPidFile(path: string): Promise<number> {
-  for (let i = 0; i < 80; i++) {
-    if (existsSync(path)) return Number(readFileSync(path, "utf8"));
-    await Bun.sleep(25);
-  }
-  throw new Error(`timed out waiting for pid file: ${path}`);
-}
-
-function pidIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForPidExit(pid: number): Promise<boolean> {
-  for (let i = 0; i < 120; i++) {
-    if (!pidIsAlive(pid)) return true;
-    await Bun.sleep(25);
-  }
-  return false;
 }
 
 function expectContract(
@@ -454,7 +430,7 @@ describe("CLI contracts", () => {
     proc.kill("SIGINT");
 
     const [stdout, stderr, exitCode] = await Promise.all([stdoutPromise, stderrPromise, proc.exited]);
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(130);
     expect(stdout).not.toContain("fake media");
     expect(stderr).toContain(`Transcribing ${mediaPath}`);
     expect(await waitForPidExit(helperPid)).toBe(true);

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -10,6 +10,7 @@ import {
 } from "./cli-scenario";
 
 const tempDirs: string[] = [];
+const DEFAULT_CWD = import.meta.dir + "/../..";
 
 async function runCli(
   args: string[],
@@ -36,7 +37,7 @@ function createFakeEngine(dir: string): string {
   const enginePath = join(dir, "kesha-engine");
   writeFileSync(
     enginePath,
-    `#!/usr/bin/env bun
+    `#!${process.execPath}
 const args = Bun.argv.slice(2);
 
 if (args[0] === "--capabilities-json") {
@@ -90,6 +91,88 @@ process.exit(99);
   );
   chmodSync(enginePath, 0o755);
   return enginePath;
+}
+
+function createSignalAwareEngine(dir: string, helperPidPath: string): string {
+  const enginePath = join(dir, "kesha-engine-signal-aware");
+  writeFileSync(
+    enginePath,
+    `#!${process.execPath}
+const args = Bun.argv.slice(2);
+if (args[0] === "transcribe") {
+  const child = Bun.spawn(["sh", "-c", "trap '' TERM; while :; do sleep 1; done"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await Bun.write(${JSON.stringify(helperPidPath)}, String(child.pid));
+  await new Promise(() => {});
+}
+if (args[0] === "detect-lang") {
+  await Bun.write(${JSON.stringify(helperPidPath)}, String(process.pid));
+  await new Promise(() => {});
+}
+console.error("unexpected fake engine args: " + JSON.stringify(args));
+process.exit(2);
+`,
+  );
+  chmodSync(enginePath, 0o755);
+  return enginePath;
+}
+
+function createSiblingCancellationEngine(dir: string, langPidPath: string): string {
+  const enginePath = join(dir, "kesha-engine-sibling-cancel");
+  writeFileSync(
+    enginePath,
+    `#!/usr/bin/env bun
+const args = Bun.argv.slice(2);
+if (args[0] === "--capabilities-json") {
+  console.log(JSON.stringify({ protocolVersion: 1, backend: "fake", features: [] }));
+  process.exit(0);
+}
+if (args[0] === "detect-lang") {
+  await Bun.write(${JSON.stringify(langPidPath)}, String(process.pid));
+  await new Promise(() => {});
+}
+if (args[0] === "transcribe") {
+  await Bun.sleep(100);
+  console.error("transcribe failed quickly");
+  process.exit(42);
+}
+if (args[0] === "detect-text-lang") {
+  console.log(JSON.stringify({ code: "en", confidence: 0.95 }));
+  process.exit(0);
+}
+console.error("unexpected fake engine args: " + JSON.stringify(args));
+process.exit(2);
+`,
+  );
+  chmodSync(enginePath, 0o755);
+  return enginePath;
+}
+
+async function waitForPidFile(path: string): Promise<number> {
+  for (let i = 0; i < 80; i++) {
+    if (existsSync(path)) return Number(readFileSync(path, "utf8"));
+    await Bun.sleep(25);
+  }
+  throw new Error(`timed out waiting for pid file: ${path}`);
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPidExit(pid: number): Promise<boolean> {
+  for (let i = 0; i < 120; i++) {
+    if (!pidIsAlive(pid)) return true;
+    await Bun.sleep(25);
+  }
+  return false;
 }
 
 function expectContract(
@@ -342,6 +425,62 @@ describe("CLI contracts", () => {
       stderrContains: [`Transcribing ${mediaPath}`, "0%", `Transcribed ${mediaPath}`, "100%"],
     });
     expect(JSON.parse(noVadJson.stdout)[0].text).toBe("Привет без VAD");
+  });
+
+  test("Ctrl+C terminates helper processes below the engine", async () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir("kesha-cli-contract-sigint-");
+    const helperPidPath = join(dir, "helper.pid");
+    const enginePath = createSignalAwareEngine(dir, helperPidPath);
+    const mediaPath = join(dir, "workshop.mp4");
+    writeFileSync(mediaPath, "fake media");
+
+    const proc = Bun.spawn([process.execPath, "run", "src/cli.ts", mediaPath], {
+      cwd: DEFAULT_CWD,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+        ...isolatedEnv(dir),
+        KESHA_ENGINE_BIN: enginePath,
+      },
+    });
+    const stdoutPromise = new Response(proc.stdout).text();
+    const stderrPromise = new Response(proc.stderr).text();
+    const helperPid = await waitForPidFile(helperPidPath);
+
+    proc.kill("SIGINT");
+
+    const [stdout, stderr, exitCode] = await Promise.all([stdoutPromise, stderrPromise, proc.exited]);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).not.toContain("fake media");
+    expect(stderr).toContain(`Transcribing ${mediaPath}`);
+    expect(await waitForPidExit(helperPid)).toBe(true);
+  });
+
+  test("early transcription failure cancels the concurrent audio language engine", async () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir("kesha-cli-contract-sibling-cancel-");
+    const langPidPath = join(dir, "lang.pid");
+    const enginePath = createSiblingCancellationEngine(dir, langPidPath);
+    const mediaPath = join(dir, "workshop.mp4");
+    writeFileSync(mediaPath, "fake media");
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+    };
+
+    const run = await runCli(["--json", mediaPath], { env, timeoutMs: 4_000 });
+    const langPid = await waitForPidFile(langPidPath);
+
+    expectContract(run, {
+      exitCode: 1,
+      stderrContains: ["transcribe failed quickly"],
+    });
+    expect(JSON.parse(run.stdout)).toEqual([]);
+    expect(await waitForPidExit(langPid)).toBe(true);
   });
 
   test("diagnostic and support commands return parseable/readable contracts without leaking temp home", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
-import { mainCommand, completionsCommand, doctorCommand, installCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat, resolveRecordArgs } from "../../src/cli";
+import { mainCommand, completionsCommand, doctorCommand, installCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress } from "../../src/cli";
 
 type MainRun = (input: { args: Record<string, unknown>; rawArgs: string[] }) => Promise<void>;
 
@@ -183,6 +183,32 @@ describe("main command validation side effects", () => {
 
   test("empty invocation exits after printing usage", async () => {
     await expect(expectMainExit(defaultMainArgs(), [])).resolves.toBe(1);
+  });
+});
+
+describe("transcription progress reporting", () => {
+  test("reports progress on terminals and redirected stdout unless debug is enabled", () => {
+    expect(
+      shouldReportTranscribeProgress({
+        stderrIsTty: true,
+        stdoutIsTty: true,
+        debugEnabled: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReportTranscribeProgress({
+        stderrIsTty: false,
+        stdoutIsTty: false,
+        debugEnabled: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReportTranscribeProgress({
+        stderrIsTty: true,
+        stdoutIsTty: true,
+        debugEnabled: true,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
   parseLangResult,
   getEngineBinPath,
@@ -54,31 +55,6 @@ process.exit(2);
   );
   chmodSync(path, 0o755);
   return path;
-}
-
-async function waitForPidFile(path: string): Promise<number> {
-  for (let i = 0; i < 80; i++) {
-    if (existsSync(path)) return Number(readFileSync(path, "utf8"));
-    await Bun.sleep(25);
-  }
-  throw new Error(`timed out waiting for pid file: ${path}`);
-}
-
-function pidIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForPidExit(pid: number): Promise<boolean> {
-  for (let i = 0; i < 120; i++) {
-    if (!pidIsAlive(pid)) return true;
-    await Bun.sleep(25);
-  }
-  return false;
 }
 
 async function withEngineEnv<T>(

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -7,6 +7,7 @@ import {
   getEngineBinPath,
   preflightTranscribeEngineWithSegments,
   spawnStdioWithDebugFd,
+  transcribeEngine,
   transcribeEngineWithSegments,
 } from "../../src/engine";
 
@@ -32,6 +33,53 @@ exit 2
 }
 
 const fakeEngineTest = process.platform === "win32" ? test.skip : test;
+
+function fakeLongRunningEngine(dir: string, helperPidFile: string): string {
+  const path = join(dir, "kesha-engine-long-running");
+  writeFileSync(
+    path,
+    `#!${process.execPath}
+const args = Bun.argv.slice(2);
+if (args[0] === "transcribe") {
+  const child = Bun.spawn(["sh", "-c", "trap '' TERM INT; while :; do sleep 1; done"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await Bun.write(${JSON.stringify(helperPidFile)}, String(child.pid));
+  await new Promise(() => {});
+}
+console.error("unexpected args: " + JSON.stringify(args));
+process.exit(2);
+`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
+async function waitForPidFile(path: string): Promise<number> {
+  for (let i = 0; i < 80; i++) {
+    if (existsSync(path)) return Number(readFileSync(path, "utf8"));
+    await Bun.sleep(25);
+  }
+  throw new Error(`timed out waiting for pid file: ${path}`);
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPidExit(pid: number): Promise<boolean> {
+  for (let i = 0; i < 120; i++) {
+    if (!pidIsAlive(pid)) return true;
+    await Bun.sleep(25);
+  }
+  return false;
+}
 
 async function withEngineEnv<T>(
   enginePath: string,
@@ -133,6 +181,22 @@ describe("engine", () => {
       },
       { KESHA_DIARIZE_MODEL_PATH: modelPath },
     );
+  });
+
+  fakeEngineTest("abort terminates the spawned engine process tree", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-tree-"));
+    const helperPidFile = join(dir, "helper.pid");
+    const enginePath = fakeLongRunningEngine(dir, helperPidFile);
+    await withEngineEnv(enginePath, async () => {
+      const controller = new AbortController();
+      const run = transcribeEngine("audio.wav", { signal: controller.signal });
+      const helperPid = await waitForPidFile(helperPidFile);
+
+      controller.abort();
+
+      await expect(run).rejects.toThrow("kesha-engine process aborted");
+      expect(await waitForPidExit(helperPid)).toBe(true);
+    });
   });
 });
 

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -58,7 +58,7 @@ describe("stats storage", () => {
     const status = getStatsStatus();
     expect(status.exists).toBe(true);
     expect(status.enabled).toBe(false);
-  });
+  }, 15_000);
 
   test("recorder writes runs, stage timings, artifacts, and errors when enabled", async () => {
     enableStats();


### PR DESCRIPTION
## Summary

- add shared TypeScript process-tree cleanup for Bun-spawned `kesha-engine` calls, including detached process groups, abort handling, Ctrl+C/SIGTERM cleanup, and delayed SIGKILL
- propagate `AbortSignal` through transcription/lang-id engine calls and cancel sibling work when concurrent stages fail
- add a Rust `ChildGuard` so engine-launched helper sidecars are killed on error/drop paths
- cover Ctrl+C, abort, sibling cancellation, and Rust child cleanup with fake-process tests

Closes #401

## Validation

- `bunx tsc --noEmit`
- `cd rust && cargo fmt -- --check`
- `cd rust && cargo clippy --all-targets -- -D warnings`
- `cd rust && cargo nextest run --features tts` — 434/434 passed
- `PATH="/Users/anton/.bun/bin:$PATH" bun test tests/unit tests/integration/cli-contracts.test.ts tests/integration/say.test.ts tests/integration/e2e-cli.test.ts` — 263/263 passed

## Note

Full `bun test` could not be used as the final local gate in this LFS-disabled worktree because `git-lfs` is not installed locally and the Russian E2E media under `fixtures/benchmark/*.ogg` checked out as LFS pointer files. The new cancellation/process-tree coverage and non-LFS TS suites pass.
