### PR TITLE
Add long-audio chunked ASR fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ $ kesha freedom.ogg tahiti.ogg
 
 Stdout: transcript. Stderr: errors. Pipe-friendly.
 
-For long / silence-heavy audio, use `--vad` (auto-on past 120 s). Details: [docs/vad.md](docs/vad.md).
+For long / silence-heavy audio, install VAD (`kesha install --vad`) and run without `--no-vad`. Kesha auto-uses VAD past 120 s when installed; without VAD, very long audio falls back to fixed ASR chunks. Details: [docs/vad.md](docs/vad.md).
 
 **Speaker diarization** (darwin-arm64, post-v1.12.0):
 

--- a/completions/kesha.fish
+++ b/completions/kesha.fish
@@ -23,7 +23,7 @@ complete -c kesha -n '__fish_use_subcommand' -l format -r -d 'Output format: tra
 complete -c kesha -n '__fish_use_subcommand' -l lang -r -d 'Expected language code (ISO 639-1), warn if mismatch'
 complete -c kesha -n '__fish_use_subcommand' -l debug -d 'Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)'
 complete -c kesha -n '__fish_use_subcommand' -l vad -d 'Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.'
-complete -c kesha -n '__fish_use_subcommand' -l no-vad -d 'Disable VAD preprocessing regardless of duration or install state'
+complete -c kesha -n '__fish_use_subcommand' -l no-vad -d 'Force full-file ASR for short/medium files; long audio fails early'
 complete -c kesha -n '__fish_seen_subcommand_from completions' -l help -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from completions' -s h -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from doctor' -l help -d 'Show help'

--- a/completions/kesha.zsh
+++ b/completions/kesha.zsh
@@ -31,7 +31,7 @@ _kesha() {
       '--lang=[Expected language code (ISO 639-1), warn if mismatch]:lang:' \
       '--debug[Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)]' \
       '--vad[Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.]' \
-      '--no-vad[Disable VAD preprocessing regardless of duration or install state]'
+      '--no-vad[Force full-file ASR for short/medium files; long audio fails early]'
     else
       _describe -t commands 'kesha command' commands
     fi
@@ -117,7 +117,7 @@ _kesha() {
       '--lang=[Expected language code (ISO 639-1), warn if mismatch]:lang:' \
       '--debug[Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)]' \
       '--vad[Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.]' \
-      '--no-vad[Disable VAD preprocessing regardless of duration or install state]'
+      '--no-vad[Force full-file ASR for short/medium files; long audio fails early]'
       ;;
   esac
 }

--- a/docs/vad.md
+++ b/docs/vad.md
@@ -6,7 +6,11 @@ For meetings, lectures, and podcasts, enable Silero VAD so Parakeet only sees th
 kesha install --vad                   # one-time, ~2.3MB
 kesha lecture.m4a                     # auto-on when audio ≥ 120s and VAD installed
 kesha --vad short-clip.ogg            # force VAD on any input
-kesha --no-vad meeting.m4a            # force VAD off even on long audio
+kesha --no-vad short-clip.ogg         # force full-file ASR for short/medium inputs
 ```
 
-Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. If you have long audio without VAD installed, Kesha prints a one-time stderr hint. Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues [#128](https://github.com/drakulavich/kesha-voice-kit/issues/128) (base) and [#187](https://github.com/drakulavich/kesha-voice-kit/issues/187) (auto-trigger).
+Auto-triggers at 120 s so voice messages (< 30 s of near-pure speech) stay on the fast path. Parakeet full-file ASR is bounded by decoded duration and backend memory, not by compressed file size. The upstream full-attention guidance is about 24 minutes for one pass; Kesha treats longer `--no-vad` runs as unsafe and fails early with a recovery hint.
+
+If VAD is not installed, very long Auto-mode audio uses fixed 10-minute ASR windows with 5 seconds of overlap and stitched absolute offsets. That fallback is safer than one full-file pass, but VAD boundaries are still better for meetings and silence-heavy recordings.
+
+Defaults: threshold 0.5, min-speech 250 ms, min-silence 100 ms, 30 ms edge padding. See issues [#128](https://github.com/drakulavich/kesha-voice-kit/issues/128) (base), [#187](https://github.com/drakulavich/kesha-voice-kit/issues/187) (auto-trigger), and [#404](https://github.com/drakulavich/kesha-voice-kit/issues/404) (long-audio contract).

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -70,7 +70,7 @@ Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)
 Force Silero VAD preprocessing (kesha install \-\-vad first). Without this, VAD auto\-engages on audio ≥ 120s.
 .TP
 .B \-\-no\-vad
-Disable VAD preprocessing regardless of duration or install state
+Force full\-file ASR for short/medium files; long audio fails early
 .SH SUBCOMMAND OPTIONS
 .SS doctor
 .TP

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -541,7 +541,15 @@ where
                     window.output_end_s,
                     text.chars().count()
                 );
-                let trimmed = trim_repeated_prefix(&accumulated_text, text.trim());
+                // Only pass the tail of accumulated_text that can plausibly
+                // overlap with the next chunk; scanning the full transcript
+                // is both wasteful and increases false-positive risk from
+                // repeated phrases appearing elsewhere in the recording.
+                let overlap_chars =
+                    (FIXED_CHUNK_OVERLAP_SECONDS * 20.0).ceil() as usize;
+                let acc_tail = &accumulated_text
+                    [accumulated_text.len().saturating_sub(overlap_chars * 4)..];
+                let trimmed = trim_repeated_prefix(acc_tail, text.trim());
                 if trimmed.is_empty() {
                     continue;
                 }

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -37,6 +37,11 @@ const AUTO_VAD_MIN_SECONDS: f32 = 120.0;
 /// absent — can reach seconds on large CBR files).
 const AUTO_VAD_MIN_FILE_SIZE: u64 = 200_000;
 
+/// Safety ceiling for explicit `--no-vad` on the CoreML backend. FluidAudio's
+/// full-file path can abort the whole process on very long media before Rust
+/// gets a recoverable error, so refuse the hazardous shape before backend load.
+const COREML_NO_VAD_MAX_SECONDS: f32 = 30.0 * 60.0;
+
 /// Caller-requested VAD behaviour.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VadMode {
@@ -206,11 +211,14 @@ pub fn transcribe_with_options(
         .into_owned();
     let vad_installed = models::is_cached(models::ModelKind::Vad);
 
-    // `Auto` needs a duration probe first. `On`/`Off` are deterministic.
+    // `Auto` needs a duration probe for routing. `Off` probes too so we can
+    // reject hazardous very-long CoreML full-file runs before native code can
+    // abort the process.
     let duration = match mode {
-        VadMode::Auto => probe_duration_if_plausible(audio_path),
+        VadMode::Auto | VadMode::Off => probe_duration_if_plausible(audio_path),
         _ => None,
     };
+    validate_plain_transcribe_safety(mode, duration, vad_installed, cfg!(feature = "coreml"))?;
     let decision = decide(mode, duration, vad_installed);
     dtrace!(
         "asr::mode={mode:?} duration={:?} vad_installed={vad_installed} decision={decision:?}",
@@ -476,6 +484,35 @@ fn probe_duration_if_plausible(path: &str) -> Option<f32> {
     }
 }
 
+fn validate_plain_transcribe_safety(
+    mode: VadMode,
+    duration_s: Option<f32>,
+    vad_installed: bool,
+    coreml_backend: bool,
+) -> Result<()> {
+    if !coreml_backend || mode != VadMode::Off {
+        return Ok(());
+    }
+
+    let Some(duration_s) = duration_s else {
+        return Ok(());
+    };
+    if duration_s < COREML_NO_VAD_MAX_SECONDS {
+        return Ok(());
+    }
+
+    let action = if vad_installed {
+        "omit --no-vad so Kesha can segment the file with VAD"
+    } else {
+        "run `kesha install --vad`, then rerun without --no-vad"
+    };
+    anyhow::bail!(
+        "refusing --no-vad for very long audio on the CoreML backend \
+         (detected {duration_s:.0}s; limit is {COREML_NO_VAD_MAX_SECONDS:.0}s). \
+         FluidAudio may abort the process on full-file long audio; {action}."
+    );
+}
+
 /// Resolve the diarization model path. Priority:
 /// 1. `KESHA_DIARIZE_MODEL_PATH` env var (must point to an existing path).
 /// 2. Default cache location populated by `kesha install --diarize`
@@ -638,6 +675,69 @@ mod tests {
             err.to_string()
                 .contains("failed to probe audio duration for timestamped segments"),
             "{err}"
+        );
+    }
+
+    #[test]
+    fn coreml_no_vad_rejects_very_long_plain_runs() {
+        let err = validate_plain_transcribe_safety(
+            VadMode::Off,
+            Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+            true,
+            true,
+        )
+        .expect_err("very long CoreML --no-vad should be rejected before backend load");
+        assert!(err.to_string().contains("refusing --no-vad"), "{err}");
+        assert!(err.to_string().contains("omit --no-vad"), "{err}");
+    }
+
+    #[test]
+    fn coreml_no_vad_rejection_points_at_vad_install_when_missing() {
+        let err = validate_plain_transcribe_safety(
+            VadMode::Off,
+            Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+            false,
+            true,
+        )
+        .expect_err("very long CoreML --no-vad should explain missing VAD");
+        assert!(err.to_string().contains("kesha install --vad"), "{err}");
+    }
+
+    #[test]
+    fn plain_safety_allows_non_coreml_or_short_or_auto_runs() {
+        assert!(
+            validate_plain_transcribe_safety(
+                VadMode::Off,
+                Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+                true,
+                false,
+            )
+            .is_ok(),
+            "non-CoreML backends should keep their existing --no-vad behavior"
+        );
+        assert!(
+            validate_plain_transcribe_safety(
+                VadMode::Off,
+                Some(COREML_NO_VAD_MAX_SECONDS - 1.0),
+                true,
+                true,
+            )
+            .is_ok(),
+            "short CoreML --no-vad runs should still be allowed"
+        );
+        assert!(
+            validate_plain_transcribe_safety(
+                VadMode::Auto,
+                Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+                true,
+                true,
+            )
+            .is_ok(),
+            "Auto mode should route through the existing VAD decision path"
+        );
+        assert!(
+            validate_plain_transcribe_safety(VadMode::Off, None, true, true).is_ok(),
+            "unknown duration should not fail before the backend can report the real error"
         );
     }
 

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -646,7 +646,7 @@ fn trim_repeated_prefix<'a>(previous: &str, current: &'a str) -> &'a str {
         if !previous.is_char_boundary(prev_start) || !current.is_char_boundary(n) {
             continue;
         }
-        if previous[prev_start..].eq_ignore_ascii_case(&current[..n]) {
+        if previous[prev_start..].to_lowercase() == current[..n].to_lowercase() {
             return current[n..].trim_start();
         }
     }

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -37,10 +37,21 @@ const AUTO_VAD_MIN_SECONDS: f32 = 120.0;
 /// absent — can reach seconds on large CBR files).
 const AUTO_VAD_MIN_FILE_SIZE: u64 = 200_000;
 
-/// Safety ceiling for explicit `--no-vad` on the CoreML backend. FluidAudio's
-/// full-file path can abort the whole process on very long media before Rust
-/// gets a recoverable error, so refuse the hazardous shape before backend load.
-const COREML_NO_VAD_MAX_SECONDS: f32 = 30.0 * 60.0;
+/// Conservative full-file ASR ceiling. NVIDIA's Parakeet model cards describe
+/// full-attention single-pass inference as duration/memory-bound, with ~24
+/// minutes as the upstream guidance before local attention or buffered
+/// inference becomes the safe path. Kesha's local backends do not expose local
+/// attention yet, so explicit `--no-vad` fails above this and Auto mode uses
+/// fixed-window chunking when VAD is unavailable.
+const FULL_FILE_SINGLE_PASS_MAX_SECONDS: f32 = 24.0 * 60.0;
+
+/// Fixed-window fallback used when long audio has no VAD-backed path. Keep
+/// windows comfortably below the single-pass ceiling; overlap gives the model
+/// a little boundary context, and output timestamps are trimmed back to
+/// non-overlapping ranges.
+const FIXED_CHUNK_SECONDS: f32 = 10.0 * 60.0;
+const FIXED_CHUNK_OVERLAP_SECONDS: f32 = 5.0;
+const CHUNK_DEDUP_MIN_CHARS: usize = 8;
 
 /// Caller-requested VAD behaviour.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,6 +138,7 @@ enum VadDecision {
     Vad,
     Plain,
     PlainWithHint,
+    ChunkedWithHint,
 }
 
 fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDecision {
@@ -135,6 +147,7 @@ fn decide(mode: VadMode, duration_s: Option<f32>, vad_installed: bool) -> VadDec
         VadMode::Off => VadDecision::Plain,
         VadMode::Auto => match duration_s {
             Some(d) if d >= AUTO_VAD_MIN_SECONDS && vad_installed => VadDecision::Vad,
+            Some(d) if d >= FULL_FILE_SINGLE_PASS_MAX_SECONDS => VadDecision::ChunkedWithHint,
             Some(d) if d >= AUTO_VAD_MIN_SECONDS => VadDecision::PlainWithHint,
             // Unknown duration or short clip → plain, no hint.
             _ => VadDecision::Plain,
@@ -211,14 +224,14 @@ pub fn transcribe_with_options(
         .into_owned();
     let vad_installed = models::is_cached(models::ModelKind::Vad);
 
-    // `Auto` needs a duration probe for routing. `Off` probes too so we can
-    // reject hazardous very-long CoreML full-file runs before native code can
-    // abort the process.
+    // `Auto` needs a duration probe for routing. `Off` probes too so explicit
+    // full-file ASR can fail before loading a backend for media beyond the
+    // duration/memory-bound single-pass contract.
     let duration = match mode {
         VadMode::Auto | VadMode::Off => probe_duration_if_plausible(audio_path),
         _ => None,
     };
-    validate_plain_transcribe_safety(mode, duration, vad_installed, cfg!(feature = "coreml"))?;
+    validate_plain_transcribe_safety(mode, duration, vad_installed)?;
     let decision = decide(mode, duration, vad_installed);
     dtrace!(
         "asr::mode={mode:?} duration={:?} vad_installed={vad_installed} decision={decision:?}",
@@ -246,6 +259,14 @@ pub fn transcribe_with_options(
                 "hint: audio is {secs:.0}s; `kesha install --vad` would improve long-audio accuracy"
             );
             transcribe_plain(audio_path, &model_dir, duration, timestamps_required)
+        }
+        VadDecision::ChunkedWithHint => {
+            let secs = duration.unwrap_or(0.0);
+            eprintln!(
+                "hint: audio is {secs:.0}s; VAD is not installed, so Kesha is using fixed-window ASR chunks. \
+                 Run `kesha install --vad` for better long-audio boundaries."
+            );
+            transcribe_chunked(audio_path, &model_dir, timestamps_required)
         }
     }?;
 
@@ -294,11 +315,41 @@ fn transcribe_plain(
     Ok(TranscriptionOutput { segments, text })
 }
 
+fn transcribe_chunked(
+    audio_path: &str,
+    model_dir: &str,
+    timestamps_required: bool,
+) -> Result<TranscriptionOutput> {
+    let t_audio = Instant::now();
+    let samples = audio::load_audio(audio_path)?;
+    dtrace!(
+        "chunked::audio_loaded dt={}ms samples={}",
+        t_audio.elapsed().as_millis(),
+        samples.len()
+    );
+
+    let t0 = Instant::now();
+    let mut be = backend::create_backend(model_dir)?;
+    let dt_ms = t0.elapsed().as_millis() as u64;
+    dtrace!("asr::backend_loaded dt={dt_ms}ms");
+    dtrace_json!("asr.backend_loaded", { "dt_ms": dt_ms });
+
+    transcribe_chunked_samples(&samples, &mut |slice| be.transcribe_samples(slice)).map(
+        |mut output| {
+            if !timestamps_required {
+                output.segments.clear();
+            }
+            output
+        },
+    )
+}
+
 /// VAD-preprocessed transcription: segment the audio with Silero VAD,
 /// transcribe each speech span independently, stitch with spaces.
 ///
-/// All-silence inputs fall back to a single full-file pass (with a stderr
-/// warning) so a misconfigured threshold never silently drops input.
+/// All-silence inputs fall back to a single full-file pass for short/medium
+/// clips, or fixed-window chunking for very long audio, so a misconfigured
+/// threshold never silently drops input and never forces unsafe full-file ASR.
 fn transcribe_via_vad(
     audio_path: &str,
     model_dir: &str,
@@ -347,9 +398,18 @@ fn transcribe_via_vad(
             cfg.threshold
         );
         if samples.len() >= min_speech_samples {
-            eprintln!(
-                "warning: VAD produced no speech segments; transcribing full file (consider lowering --vad threshold or skipping --vad)"
-            );
+            if total_secs >= FULL_FILE_SINGLE_PASS_MAX_SECONDS {
+                eprintln!(
+                    "warning: VAD produced no speech segments for very long audio; using fixed-window ASR chunks instead of unsafe full-file ASR"
+                );
+                return transcribe_chunked_samples(&samples, &mut |slice| {
+                    be.transcribe_samples(slice)
+                });
+            } else {
+                eprintln!(
+                    "warning: VAD produced no speech segments; transcribing full file (consider lowering --vad threshold or skipping --vad)"
+                );
+            }
         }
         let text = be.transcribe_samples(&samples)?;
         // Reuse the duration we already computed for the dtrace above
@@ -431,6 +491,160 @@ where
     out
 }
 
+fn transcribe_chunked_samples<F>(
+    samples: &[f32],
+    transcribe_chunk: &mut F,
+) -> Result<TranscriptionOutput>
+where
+    F: FnMut(&[f32]) -> Result<String>,
+{
+    let segments = build_chunked_output_segments(
+        samples,
+        VAD_SAMPLE_RATE as f32,
+        FIXED_CHUNK_SECONDS,
+        FIXED_CHUNK_OVERLAP_SECONDS,
+        transcribe_chunk,
+    )?;
+    let text = segments
+        .iter()
+        .map(|s| s.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    Ok(TranscriptionOutput { text, segments })
+}
+
+fn build_chunked_output_segments<F>(
+    samples: &[f32],
+    sr: f32,
+    chunk_seconds: f32,
+    overlap_seconds: f32,
+    mut transcribe_chunk: F,
+) -> Result<Vec<TranscriptionSegment>>
+where
+    F: FnMut(&[f32]) -> Result<String>,
+{
+    let windows = fixed_chunk_windows(samples.len(), sr, chunk_seconds, overlap_seconds);
+    let mut out = Vec::with_capacity(windows.len());
+    let mut accumulated_text = String::new();
+    let mut failures = 0usize;
+    let mut first_failure: Option<String> = None;
+
+    for window in windows {
+        let slice = &samples[window.input_start..window.input_end];
+        let t = Instant::now();
+        match transcribe_chunk(slice) {
+            Ok(text) => {
+                dtrace!(
+                    "chunked::segment dt={}ms range={:.2}-{:.2}s chars={}",
+                    t.elapsed().as_millis(),
+                    window.output_start_s,
+                    window.output_end_s,
+                    text.chars().count()
+                );
+                let trimmed = trim_repeated_prefix(&accumulated_text, text.trim());
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if !accumulated_text.is_empty() {
+                    accumulated_text.push(' ');
+                }
+                accumulated_text.push_str(trimmed);
+                out.push(TranscriptionSegment {
+                    start: window.output_start_s,
+                    end: window.output_end_s,
+                    text: trimmed.to_string(),
+                    speaker: None,
+                });
+            }
+            Err(e) => {
+                failures += 1;
+                if first_failure.is_none() {
+                    first_failure = Some(e.to_string());
+                }
+                eprintln!(
+                    "warning: fixed-window ASR chunk {:.2}-{:.2}s failed: {e}",
+                    window.output_start_s, window.output_end_s
+                );
+            }
+        }
+    }
+
+    if out.is_empty() && failures > 0 {
+        let first = first_failure.unwrap_or_else(|| "unknown error".to_string());
+        anyhow::bail!("all fixed-window ASR chunks failed; first failure: {first}");
+    }
+
+    Ok(out)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ChunkWindow {
+    input_start: usize,
+    input_end: usize,
+    output_start_s: f32,
+    output_end_s: f32,
+}
+
+fn fixed_chunk_windows(
+    total_samples: usize,
+    sr: f32,
+    chunk_seconds: f32,
+    overlap_seconds: f32,
+) -> Vec<ChunkWindow> {
+    if total_samples == 0 || sr <= 0.0 || chunk_seconds <= 0.0 {
+        return vec![];
+    }
+
+    let chunk_samples = ((chunk_seconds * sr).round() as usize).max(1);
+    let overlap_samples =
+        ((overlap_seconds.max(0.0) * sr).round() as usize).min(chunk_samples.saturating_sub(1));
+    let step = chunk_samples.saturating_sub(overlap_samples).max(1);
+
+    let mut windows = Vec::new();
+    let mut start = 0usize;
+    while start < total_samples {
+        let end = start.saturating_add(chunk_samples).min(total_samples);
+        let output_start = if windows.is_empty() {
+            start
+        } else {
+            start.saturating_add(overlap_samples).min(end)
+        };
+        if output_start < end {
+            windows.push(ChunkWindow {
+                input_start: start,
+                input_end: end,
+                output_start_s: output_start as f32 / sr,
+                output_end_s: end as f32 / sr,
+            });
+        }
+        if end == total_samples {
+            break;
+        }
+        start = start.saturating_add(step);
+    }
+    windows
+}
+
+fn trim_repeated_prefix<'a>(previous: &str, current: &'a str) -> &'a str {
+    let previous = previous.trim_end();
+    let current = current.trim_start();
+    if previous.is_empty() || current.is_empty() {
+        return current;
+    }
+
+    let max = previous.len().min(current.len());
+    for n in (CHUNK_DEDUP_MIN_CHARS..=max).rev() {
+        let prev_start = previous.len() - n;
+        if !previous.is_char_boundary(prev_start) || !current.is_char_boundary(n) {
+            continue;
+        }
+        if previous[prev_start..].eq_ignore_ascii_case(&current[..n]) {
+            return current[n..].trim_start();
+        }
+    }
+    current
+}
+
 /// Honor a caller-supplied audio duration if present; otherwise probe the
 /// file. Re-uses the duration already computed during the `Auto` mode
 /// probe-and-decide step (#248) so the plain path doesn't re-open the file.
@@ -488,16 +702,15 @@ fn validate_plain_transcribe_safety(
     mode: VadMode,
     duration_s: Option<f32>,
     vad_installed: bool,
-    coreml_backend: bool,
 ) -> Result<()> {
-    if !coreml_backend || mode != VadMode::Off {
+    if mode != VadMode::Off {
         return Ok(());
     }
 
     let Some(duration_s) = duration_s else {
         return Ok(());
     };
-    if duration_s < COREML_NO_VAD_MAX_SECONDS {
+    if duration_s < FULL_FILE_SINGLE_PASS_MAX_SECONDS {
         return Ok(());
     }
 
@@ -507,9 +720,9 @@ fn validate_plain_transcribe_safety(
         "run `kesha install --vad`, then rerun without --no-vad"
     };
     anyhow::bail!(
-        "refusing --no-vad for very long audio on the CoreML backend \
-         (detected {duration_s:.0}s; limit is {COREML_NO_VAD_MAX_SECONDS:.0}s). \
-         FluidAudio may abort the process on full-file long audio; {action}."
+        "refusing --no-vad for very long audio \
+         (detected {duration_s:.0}s; single-pass limit is {FULL_FILE_SINGLE_PASS_MAX_SECONDS:.0}s). \
+         Parakeet full-file ASR is duration/memory-bound; {action}."
     );
 }
 
@@ -679,66 +892,146 @@ mod tests {
     }
 
     #[test]
-    fn coreml_no_vad_rejects_very_long_plain_runs() {
+    fn no_vad_rejects_very_long_plain_runs() {
         let err = validate_plain_transcribe_safety(
             VadMode::Off,
-            Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
-            true,
+            Some(FULL_FILE_SINGLE_PASS_MAX_SECONDS + 1.0),
             true,
         )
-        .expect_err("very long CoreML --no-vad should be rejected before backend load");
+        .expect_err("very long --no-vad should be rejected before backend load");
         assert!(err.to_string().contains("refusing --no-vad"), "{err}");
         assert!(err.to_string().contains("omit --no-vad"), "{err}");
+        assert!(err.to_string().contains("duration/memory-bound"), "{err}");
     }
 
     #[test]
-    fn coreml_no_vad_rejection_points_at_vad_install_when_missing() {
+    fn no_vad_rejection_points_at_vad_install_when_missing() {
         let err = validate_plain_transcribe_safety(
             VadMode::Off,
-            Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
+            Some(FULL_FILE_SINGLE_PASS_MAX_SECONDS + 1.0),
             false,
-            true,
         )
-        .expect_err("very long CoreML --no-vad should explain missing VAD");
+        .expect_err("very long --no-vad should explain missing VAD");
         assert!(err.to_string().contains("kesha install --vad"), "{err}");
     }
 
     #[test]
-    fn plain_safety_allows_non_coreml_or_short_or_auto_runs() {
+    fn plain_safety_allows_short_or_auto_or_unknown_duration_runs() {
         assert!(
             validate_plain_transcribe_safety(
                 VadMode::Off,
-                Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
-                true,
-                false,
-            )
-            .is_ok(),
-            "non-CoreML backends should keep their existing --no-vad behavior"
-        );
-        assert!(
-            validate_plain_transcribe_safety(
-                VadMode::Off,
-                Some(COREML_NO_VAD_MAX_SECONDS - 1.0),
-                true,
+                Some(FULL_FILE_SINGLE_PASS_MAX_SECONDS - 1.0),
                 true,
             )
             .is_ok(),
-            "short CoreML --no-vad runs should still be allowed"
+            "short --no-vad runs should still be allowed"
         );
         assert!(
             validate_plain_transcribe_safety(
                 VadMode::Auto,
-                Some(COREML_NO_VAD_MAX_SECONDS + 1.0),
-                true,
+                Some(FULL_FILE_SINGLE_PASS_MAX_SECONDS + 1.0),
                 true,
             )
             .is_ok(),
-            "Auto mode should route through the existing VAD decision path"
+            "Auto mode should route through the VAD/chunked decision path"
         );
         assert!(
-            validate_plain_transcribe_safety(VadMode::Off, None, true, true).is_ok(),
+            validate_plain_transcribe_safety(VadMode::Off, None, true).is_ok(),
             "unknown duration should not fail before the backend can report the real error"
         );
+    }
+
+    #[test]
+    fn fixed_windows_cover_new_audio_once_with_overlap_context() {
+        let windows = fixed_chunk_windows(30, 10.0, 1.0, 0.2);
+        assert_eq!(
+            windows,
+            vec![
+                ChunkWindow {
+                    input_start: 0,
+                    input_end: 10,
+                    output_start_s: 0.0,
+                    output_end_s: 1.0,
+                },
+                ChunkWindow {
+                    input_start: 8,
+                    input_end: 18,
+                    output_start_s: 1.0,
+                    output_end_s: 1.8,
+                },
+                ChunkWindow {
+                    input_start: 16,
+                    input_end: 26,
+                    output_start_s: 1.8,
+                    output_end_s: 2.6,
+                },
+                ChunkWindow {
+                    input_start: 24,
+                    input_end: 30,
+                    output_start_s: 2.6,
+                    output_end_s: 3.0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn chunked_segments_trim_overlap_and_preserve_successful_chunks() {
+        let samples = vec![0.0_f32; 30];
+        let mut call = 0usize;
+        let segs = build_chunked_output_segments(&samples, 10.0, 1.0, 0.2, |_slice| {
+            call += 1;
+            match call {
+                1 => Ok("hello sharedtext".to_string()),
+                2 => Ok("sharedtext world".to_string()),
+                3 => anyhow::bail!("synthetic chunk failure"),
+                4 => Ok("tail".to_string()),
+                _ => unreachable!(),
+            }
+        })
+        .expect("one failed chunk should not discard successful chunks");
+
+        assert_eq!(segs.len(), 3);
+        assert_eq!(segs[0].text, "hello sharedtext");
+        assert_eq!(segs[1].text, "world");
+        assert_eq!(segs[2].text, "tail");
+        assert_eq!(segs[0].start, 0.0);
+        assert_eq!(segs[1].start, 1.0);
+        assert_eq!(segs[2].start, 2.6);
+        for s in &segs {
+            assert!(s.end > s.start, "{s:?} violates end > start");
+        }
+    }
+
+    #[test]
+    fn chunked_segments_error_when_every_chunk_fails() {
+        let samples = vec![0.0_f32; 20];
+        let err = build_chunked_output_segments(&samples, 10.0, 1.0, 0.2, |_slice| {
+            anyhow::bail!("backend unavailable")
+        })
+        .expect_err("all failed chunks should still fail the command");
+        assert!(
+            err.to_string()
+                .contains("all fixed-window ASR chunks failed"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn chunked_segments_skip_empty_transcriptions() {
+        let samples = vec![0.0_f32; 12];
+        let mut call = 0usize;
+        let segs = build_chunked_output_segments(&samples, 10.0, 1.0, 0.2, |_slice| {
+            call += 1;
+            if call == 1 {
+                Ok("   ".to_string())
+            } else {
+                Ok("spoken tail".to_string())
+            }
+        })
+        .unwrap();
+        assert_eq!(segs.len(), 1);
+        assert_eq!(segs[0].text, "spoken tail");
     }
 
     #[test]
@@ -843,6 +1136,18 @@ mod tests {
         assert_eq!(
             decide(VadMode::Auto, Some(300.0), false),
             VadDecision::PlainWithHint
+        );
+    }
+
+    #[test]
+    fn auto_very_long_audio_without_vad_routes_to_chunked_fallback() {
+        assert_eq!(
+            decide(
+                VadMode::Auto,
+                Some(FULL_FILE_SINGLE_PASS_MAX_SECONDS),
+                false
+            ),
+            VadDecision::ChunkedWithHint
         );
     }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -186,7 +186,7 @@ export const mainCommand = defineCommand({
     },
     "no-vad": {
       type: "boolean",
-      description: "Disable VAD preprocessing regardless of duration or install state",
+      description: "Force full-file ASR for short/medium files; long audio fails early",
       default: false,
     },
   },

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -52,6 +52,10 @@ export function isEngineInstalled(): boolean {
 /** A Bun.spawn `stdio` array entry: per-fd action or inherit-by-number. */
 type SpawnStdioEntry = "inherit" | "pipe" | "ignore" | number;
 
+interface RunEngineOptions {
+  signal?: AbortSignal;
+}
+
 /**
  * Upper bound on the fd number we'll forward (#323 Greptile P2).
  *

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -52,10 +52,6 @@ export function isEngineInstalled(): boolean {
 /** A Bun.spawn `stdio` array entry: per-fd action or inherit-by-number. */
 type SpawnStdioEntry = "inherit" | "pipe" | "ignore" | number;
 
-interface RunEngineOptions {
-  signal?: AbortSignal;
-}
-
 /**
  * Upper bound on the fd number we'll forward (#323 Greptile P2).
  *
@@ -167,7 +163,7 @@ async function runEngine(
 /** VAD preprocessing selector.
  *  - `"auto"` (default): engine decides — VAD when audio ≥ 120 s and model installed
  *  - `"on"`: force VAD (requires `kesha install --vad`)
- *  - `"off"`: force full-file pass regardless of duration or install state
+ *  - `"off"`: force full-file ASR for short/medium files; long audio fails early
  */
 export type VadMode = "auto" | "on" | "off";
 

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -15,6 +15,8 @@ export interface TranscribeOptions {
   signal?: AbortSignal;
   /** Silero VAD preprocessing selector. Defaults to `"auto"`. */
   vad?: VadMode;
+  /** Cancel any in-flight engine subprocess for this transcription. */
+  signal?: AbortSignal;
   /** Request timestamped transcript segments from the engine. */
   timestamps?: boolean;
   /** Request speaker labels in transcript segments (#199). Implies `timestamps`.

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -12,7 +12,6 @@ export type { TranscriptionOutput };
 
 export interface TranscribeOptions {
   silent?: boolean;
-  signal?: AbortSignal;
   /** Silero VAD preprocessing selector. Defaults to `"auto"`. */
   vad?: VadMode;
   /** Cancel any in-flight engine subprocess for this transcription. */

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -184,6 +184,7 @@ describe("main command validation side effects", () => {
   test("empty invocation exits after printing usage", async () => {
     await expect(expectMainExit(defaultMainArgs(), [])).resolves.toBe(1);
   });
+
 });
 
 describe("transcription progress reporting", () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -280,7 +280,7 @@ OPTIONS
       --lang=<lang>    Expected language code (ISO 639-1), warn if mismatch
             --debug    Trace engine subprocess calls on stderr (or KESHA_DEBUG=1) (Default: false)
               --vad    Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s. (Default: false)
-           --no-vad    Disable VAD preprocessing regardless of duration or install state (Default: false)`);
+           --no-vad    Force full-file ASR for short/medium files; long audio fails early (Default: false)`);
   });
 
   test("install help matches the normalized golden output", async () => {


### PR DESCRIPTION
## Summary
- define the Parakeet long-audio contract around decoded duration/backend memory instead of compressed file size
- fail explicit `--no-vad` early past the conservative single-pass ceiling with VAD recovery guidance
- route very long Auto-mode audio without VAD through fixed-window chunked ASR, preserving stitched offsets and partial successes
- update README/VAD docs/manpage/CLI help to steer long recordings toward VAD/chunking

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo nextest run --features tts
- bun test tests/unit/cli.test.ts
- bunx tsc --noEmit
- git diff --check

Closes #404
