### PR TITLE
Deduplicate Rust Ubuntu CI tests

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -13,6 +13,26 @@ permissions:
   contents: read
 
 jobs:
+  lint-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Install system audio deps (Opus)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
+
+      - name: Check formatting
+        run: cd rust && cargo fmt -- --check
+
+      - name: Clippy
+        run: bash rust/ci/run-clippy.sh Linux
+
   test:
     permissions:
       contents: read
@@ -24,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-latest, windows-latest]
+        os: [macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
@@ -89,19 +109,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_POLICY_VERSION_MINIMUM=3.5"
-
-      # Fail-fast ladder: cheap-to-fail checks first so a typo in fmt
-      # doesn't burn 30 minutes of cargo test before surfacing. fmt
-      # (~5s) → clippy (~30s on warm cache) → coreml check (~5min) →
-      # Kokoro model download + cargo test (~10-30min).
-
-      - name: Check formatting
-        if: matrix.os == 'ubuntu-latest'
-        run: cd rust && cargo fmt -- --check
-
-      - name: Clippy
-        if: matrix.os == 'ubuntu-latest'
-        run: bash rust/ci/run-clippy.sh "${{ runner.os }}"
 
       # Guard against coreml-backend rot: v1.0.0 shipped with broken
       # coreml code because no PR CI job ever tried to build it.

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -159,10 +159,14 @@ jobs:
           bunx flakiness upload ./flakiness-report
 
   coverage:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
+      NEXTEST_PROFILE: ci
     steps:
       - uses: actions/checkout@v6
 
@@ -213,6 +217,27 @@ jobs:
             echo "KESHA_CACHE_DIR=$KOKORO_CACHE" >> "$GITHUB_ENV"
           fi
           bun run coverage:rust
+
+      - name: 📤 Upload Ubuntu JUnit
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rust-junit-ubuntu-latest
+          path: rust/target/nextest/ci/junit.xml
+          retention-days: 7
+
+      - name: 🪼 Upload Ubuntu tests to Flakiness.io
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          if [[ ! -f rust/target/nextest/ci/junit.xml ]]; then
+            echo "No Ubuntu JUnit report found; skipping Flakiness.io upload."
+            exit 0
+          fi
+          bunx flakiness convert-junit rust/target/nextest/ci/junit.xml \
+            --category rust --project Laputa/kesha-voice-kit
+          bunx flakiness upload ./flakiness-report
 
       - name: 🧯 Enforce Rust coverage gates
         run: bun run coverage:check:rust

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:integration": "bun test tests/integration/",
     "coverage:ts": "bun run test:cli-fast --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage/ts",
     "coverage:check:ts": "bun .github/scripts/check-coverage.ts --preset=ts --lcov=coverage/ts/lcov.info --summary=coverage/ts/summary.md",
-    "coverage:rust": "mkdir -p coverage/rust && cd rust && cargo llvm-cov nextest --features tts --lcov --output-path ../coverage/rust/lcov.info",
+    "coverage:rust": "mkdir -p coverage/rust && cd rust && NEXTEST_PROFILE=ci cargo llvm-cov nextest --features tts --lcov --output-path ../coverage/rust/lcov.info",
     "coverage:check:rust": "bun .github/scripts/check-coverage.ts --preset=rust --lcov=coverage/rust/lcov.info --summary=coverage/rust/summary.md",
     "generate:shell-artifacts": "bun scripts/generate-shell-artifacts.ts",
     "lint": "bunx tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:integration": "bun test tests/integration/",
     "coverage:ts": "bun run test:cli-fast --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage/ts",
     "coverage:check:ts": "bun .github/scripts/check-coverage.ts --preset=ts --lcov=coverage/ts/lcov.info --summary=coverage/ts/summary.md",
-    "coverage:rust": "mkdir -p coverage/rust && cd rust && NEXTEST_PROFILE=ci cargo llvm-cov nextest --features tts --lcov --output-path ../coverage/rust/lcov.info",
+    "coverage:rust": "mkdir -p coverage/rust && cd rust && cargo llvm-cov nextest --features tts --lcov --output-path ../coverage/rust/lcov.info",
     "coverage:check:rust": "bun .github/scripts/check-coverage.ts --preset=rust --lcov=coverage/rust/lcov.info --summary=coverage/rust/summary.md",
     "generate:shell-artifacts": "bun scripts/generate-shell-artifacts.ts",
     "lint": "bunx tsc --noEmit",

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -545,10 +545,9 @@ where
                 // overlap with the next chunk; scanning the full transcript
                 // is both wasteful and increases false-positive risk from
                 // repeated phrases appearing elsewhere in the recording.
-                let overlap_chars =
-                    (FIXED_CHUNK_OVERLAP_SECONDS * 20.0).ceil() as usize;
-                let acc_tail = &accumulated_text
-                    [accumulated_text.len().saturating_sub(overlap_chars * 4)..];
+                let overlap_chars = (FIXED_CHUNK_OVERLAP_SECONDS * 20.0).ceil() as usize;
+                let acc_tail =
+                    &accumulated_text[accumulated_text.len().saturating_sub(overlap_chars * 4)..];
                 let trimmed = trim_repeated_prefix(acc_tail, text.trim());
                 if trimmed.is_empty() {
                     continue;


### PR DESCRIPTION
## Summary
- add a dedicated `lint-ubuntu` job for Rust formatting and clippy
- remove `ubuntu-latest` from the normal Rust test matrix
- make Rust coverage run nextest with the CI profile so coverage is the canonical Ubuntu test execution

## Validation
- `PATH="/Users/anton/.bun/bin:$PATH" bun run check:workflows`
- `PATH="/Users/anton/.bun/bin:$PATH" bun run coverage:rust` (278 tests passed)
- `PATH="/Users/anton/.bun/bin:$PATH" bun run coverage:check:rust`
- `git diff --check`
