### PR TITLE
chore(release): v1.18.3-cli

### DIFF
--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.18.2" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.18.3" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump CLI package version to 1.18.3
- refresh the generated manpage header
- keep engine pinned at v1.18.0 for a CLI-only marker release

## Validation
- bun run check:versions
- bun run check:workflows
- bunx tsc --noEmit
- bun test

Note: first bun test run failed because the new worktree had Git LFS pointer files for Russian fixtures; after \, the full suite passed.