### PR TITLE
devops: switch to open source Flakiness.io JUnit XML converter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,9 +210,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          bunx flakiness convert-junit test-results/unit-${{ matrix.os }}.xml \
-            --category bun --project Laputa/kesha-voice-kit
-          bunx flakiness upload ./flakiness-report
+          bunx @flakiness/junit-xml test-results/unit-${{ matrix.os }}.xml \
+            --category bun --flakiness-project Laputa/kesha-voice-kit
 
   ts-coverage:
     needs: [changes, unit-tests]
@@ -316,9 +315,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          bunx flakiness convert-junit test-results/integration.xml \
-            --category bun --project Laputa/kesha-voice-kit
-          bunx flakiness upload ./flakiness-report
+          bunx @flakiness/junit-xml test-results/integration.xml \
+            --category bun --flakiness-project Laputa/kesha-voice-kit
 
   published-engine-smoke:
     # P1.10: keep at least one non-Darwin lane exercising the published
@@ -525,9 +523,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          bunx flakiness convert-junit test-results/tts-e2e.xml \
-            --category bun --project Laputa/kesha-voice-kit
-          bunx flakiness upload ./flakiness-report
+          bunx @flakiness/junit-xml test-results/tts-e2e.xml \
+            --category bun --flakiness-project Laputa/kesha-voice-kit
 
   raycast-lint:
     needs: changes

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -154,9 +154,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          bunx flakiness convert-junit rust/target/nextest/ci/junit.xml \
-            --category rust --project Laputa/kesha-voice-kit
-          bunx flakiness upload ./flakiness-report
+          bunx @flakiness/junit-xml rust/target/nextest/ci/junit.xml \
+            --category rust --flakiness-project Laputa/kesha-voice-kit
 
   coverage:
     permissions:
@@ -235,9 +234,8 @@ jobs:
             echo "No Ubuntu JUnit report found; skipping Flakiness.io upload."
             exit 0
           fi
-          bunx flakiness convert-junit rust/target/nextest/ci/junit.xml \
-            --category rust --project Laputa/kesha-voice-kit
-          bunx flakiness upload ./flakiness-report
+          bunx @flakiness/junit-xml rust/target/nextest/ci/junit.xml \
+            --category rust --flakiness-project Laputa/kesha-voice-kit
 
       - name: 🧯 Enforce Rust coverage gates
         run: bun run coverage:check:rust


### PR DESCRIPTION
Flakiness.io just open-sourced JUnit XML converter: https://github.com/flakiness/junit-xml, previously distributed as a Flakiness CLI subcommand.

This patch moves to the new `@flakiness/junit-xml` command to convert-and-upload JUnit XML reports. 

Notably, the new tool auto-uploads reports after convertion, so no need to run 2 commands. 