### PR TITLE
chore(release): v1.18.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,8 @@ Version drift gate: `bun .github/scripts/check-versions.ts` (`bun run check:vers
 
 **CLI-only patch** (docs, TS, plugin): bump only `package.json#version`; leave `keshaEngine.version` + `rust/Cargo.toml`; PR CI uses the existing engine; merge; create a marker release:
 
+CLI-only is allowed only when the changed CLI surface works against the already-published engine pinned by `package.json#keshaEngine.version`. If a CLI command delegates to a new engine subcommand, capability flag, feature behavior, or output contract, it is an **engine release**: bump `package.json#keshaEngine.version`, `rust/Cargo.toml`, and `rust/Cargo.lock` together. Before cutting any `v*-cli` marker, smoke-test new/changed CLI commands against the published pinned engine, not only a repo-local engine build. The `v1.18.2-cli` / `v1.18.3-cli` mistake was exposing `kesha record` while the pinned published engine was still `v1.18.0` and did not implement `kesha-engine record`.
+
 ```bash
 gh release create vX.Y.Z-cli --title "vX.Y.Z (CLI-only)" \
   --notes "Engine: v<keshaEngine.version> (unchanged)."

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.18.3" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.18.4" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.18.0"
+    "version": "1.18.4"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.18.0"
+version = "1.18.4"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.18.0"
+version = "1.18.4"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## Summary
- bump CLI package version to 1.18.4
- bump pinned kesha-engine version to 1.18.4
- refresh Cargo.lock for the engine version

## Lessons learned
- CLI-only releases are safe only when the changed CLI surface does not require new engine behavior.
- `kesha record` crossed the TS/Rust boundary: the CLI command existed, but the published pinned engine (`v1.18.0`) did not implement `kesha-engine record`.
- Before cutting any future `v*-cli` marker release, smoke-test new CLI commands against the published pinned engine, not just the repo-local engine or TS unit tests.
- If a CLI command delegates to a new engine subcommand, capability, feature flag, or output contract, ship it as a full engine release with `package.json#keshaEngine.version`, `rust/Cargo.toml`, and `Cargo.lock` bumped together.

## Validation
- cargo check --manifest-path rust/Cargo.toml
- cargo build --manifest-path rust/Cargo.toml
- bun .github/scripts/check-versions.ts
- bun test ./tests/unit/cli.test.ts ./tests/unit/engine.test.ts ./tests/integration/cli-contracts.test.ts
- bunx tsc --noEmit
- cd rust && cargo fmt --check
- KESHA_ENGINE_BIN=rust/target/debug/kesha-engine bun src/cli.ts record --out /tmp/kesha-release-record-test.wav --max-seconds 3
