### PR TITLE
fix: skip audio lang-id for long transcripts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,9 @@ export {
   mainCommand,
   detectLanguage,
   checkLanguageMismatch,
+  estimateTranscriptDurationSeconds,
   resolveOutputFormat,
+  shouldRunAudioLanguageDetection,
   shouldReportTranscribeProgress,
 } from "./cli/main";
 export type { ResolvedOutputFormat } from "./cli/main";

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -17,6 +17,7 @@ import { formatToonOutput } from "../toon";
 import { artifactFromFile, createStatsRecorder } from "../stats";
 import { createPercentProgress } from "../progress";
 import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../process-tree";
+import type { TranscriptionSegment } from "../types";
 
 interface MainCommandArgs {
   _: string[];
@@ -115,6 +116,25 @@ export function shouldReportTranscribeProgress(input: {
 }): boolean {
   if (input.debugEnabled) return false;
   return input.stderrIsTty || !input.stdoutIsTty;
+}
+
+const AUDIO_LANG_ID_LONG_AUDIO_THRESHOLD_SECONDS = 10 * 60;
+
+export function estimateTranscriptDurationSeconds(segments: TranscriptionSegment[]): number | null {
+  const duration = segments.reduce((max, segment) => {
+    const end = Number(segment.end);
+    return Number.isFinite(end) && end > max ? end : max;
+  }, 0);
+  return duration > 0 ? duration : null;
+}
+
+export function shouldRunAudioLanguageDetection(input: {
+  wantsLangId: boolean;
+  transcriptDurationSeconds: number | null;
+}): boolean {
+  if (!input.wantsLangId) return false;
+  if (input.transcriptDurationSeconds === null) return true;
+  return input.transcriptDurationSeconds <= AUDIO_LANG_ID_LONG_AUDIO_THRESHOLD_SECONDS;
 }
 
 export const mainCommand = defineCommand({
@@ -285,15 +305,8 @@ export const mainCommand = defineCommand({
               estimatedTotalMs: args.speakers ? 60 * 60 * 1000 : 30 * 60 * 1000,
             })
           : null;
-        // Run audio lang-id and transcription concurrently, but do not leave
-        // the sibling engine process alive if one side fails first.
         const engineAbort = new AbortController();
-        const audioPromise = wantsLangId
-          ? stats.timeStage("lang_id_audio", () =>
-              detectAudioLanguageEngine(file, { signal: engineAbort.signal })
-            )
-          : Promise.resolve(null);
-        const transcriptPromise = stats.timeStage("transcribe", () =>
+        const transcript = await stats.timeStage("transcribe", () =>
           transcribeWithSegments(file, {
             vad: vadMode,
             signal: engineAbort.signal,
@@ -301,16 +314,20 @@ export const mainCommand = defineCommand({
             speakers: args.speakers,
           })
         );
-        let audioResult: LangDetectResult | null;
-        let transcript: Awaited<ReturnType<typeof transcribeWithSegments>>;
-        try {
-          [audioResult, transcript] = await Promise.all([audioPromise, transcriptPromise]);
-        } catch (err) {
-          engineAbort.abort();
-          await Promise.allSettled([audioPromise, transcriptPromise]);
-          throw err;
-        }
         const { text, segments } = transcript;
+        const transcriptDurationSeconds = estimateTranscriptDurationSeconds(segments);
+
+        let audioResult: LangDetectResult | null = null;
+        if (shouldRunAudioLanguageDetection({ wantsLangId, transcriptDurationSeconds })) {
+          audioResult = await stats.timeStage("lang_id_audio", () =>
+            detectAudioLanguageEngine(file, { signal: engineAbort.signal })
+          );
+        } else if (wantsLangId) {
+          log.debug(
+            `skip lang_id_audio for ${file}: transcript duration ${transcriptDurationSeconds?.toFixed(1)}s exceeds ` +
+              `${AUDIO_LANG_ID_LONG_AUDIO_THRESHOLD_SECONDS}s`,
+          );
+        }
 
         let audioLanguage: LangDetectResult | undefined;
         if (audioResult && audioResult.code) {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -305,11 +305,9 @@ export const mainCommand = defineCommand({
               estimatedTotalMs: args.speakers ? 60 * 60 * 1000 : 30 * 60 * 1000,
             })
           : null;
-        const engineAbort = new AbortController();
         const transcript = await stats.timeStage("transcribe", () =>
           transcribeWithSegments(file, {
             vad: vadMode,
-            signal: engineAbort.signal,
             timestamps: args.timestamps,
             speakers: args.speakers,
           })
@@ -319,9 +317,7 @@ export const mainCommand = defineCommand({
 
         let audioResult: LangDetectResult | null = null;
         if (shouldRunAudioLanguageDetection({ wantsLangId, transcriptDurationSeconds })) {
-          audioResult = await stats.timeStage("lang_id_audio", () =>
-            detectAudioLanguageEngine(file, { signal: engineAbort.signal })
-          );
+          audioResult = await stats.timeStage("lang_id_audio", () => detectAudioLanguageEngine(file));
         } else if (wantsLangId) {
           log.debug(
             `skip lang_id_audio for ${file}: transcript duration ${transcriptDurationSeconds?.toFixed(1)}s exceeds ` +

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -51,6 +51,9 @@ if (args[0] === "--capabilities-json") {
 }
 
 if (args[0] === "detect-lang") {
+  if (process.env.KESHA_FAKE_DETECT_LANG_MARKER) {
+    await Bun.write(process.env.KESHA_FAKE_DETECT_LANG_MARKER, "called");
+  }
   console.log(JSON.stringify({ code: "ru", confidence: 0.99 }));
   process.exit(0);
 }
@@ -63,9 +66,10 @@ if (args[0] === "detect-text-lang") {
 if (args[0] === "transcribe") {
   const text = args.includes("--no-vad") ? "Привет без VAD" : "Привет с воркшопа";
   if (args.includes("--speakers")) {
+    const end = Number(process.env.KESHA_FAKE_SEGMENT_END || "1.2");
     console.log(JSON.stringify({
       text,
-      segments: [{ start: 0, end: 1.2, text, speaker: 0 }],
+      segments: [{ start: 0, end, text, speaker: 0 }],
     }));
   } else {
     console.log(text);
@@ -403,6 +407,35 @@ describe("CLI contracts", () => {
     expect(JSON.parse(noVadJson.stdout)[0].text).toBe("Привет без VAD");
   });
 
+  test("long speaker transcripts skip whole-file audio language detection", async () => {
+    const dir = makeTempDir("kesha-cli-contract-long-speakers-");
+    const enginePath = createFakeEngine(dir);
+    const mediaPath = join(dir, "meeting.mp4");
+    const detectLangMarker = join(dir, "detect-lang-called");
+    writeFileSync(mediaPath, "fake media");
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+      KESHA_FAKE_DETECT_LANG_MARKER: detectLangMarker,
+      KESHA_FAKE_SEGMENT_END: "900",
+      KESHA_DEBUG: "1",
+    };
+    installFakeDiarizeModel(env.KESHA_CACHE_DIR);
+
+    const run = await runCli(["--json", "--speakers", mediaPath], { env });
+
+    expectContract(run, {
+      exitCode: 0,
+      stdoutNotContains: ["audioLanguage"],
+      stderrContains: ["skip lang_id_audio"],
+    });
+    const parsed = JSON.parse(run.stdout);
+    expect(parsed[0].audioLanguage).toBeUndefined();
+    expect(parsed[0].textLanguage).toEqual({ code: "ru", confidence: 0.98 });
+    expect(parsed[0].segments[0].end).toBe(900);
+    expect(existsSync(detectLangMarker)).toBe(false);
+  });
+
   test("Ctrl+C terminates helper processes below the engine", async () => {
     if (process.platform === "win32") return;
     const dir = makeTempDir("kesha-cli-contract-sigint-");
@@ -436,7 +469,7 @@ describe("CLI contracts", () => {
     expect(await waitForPidExit(helperPid)).toBe(true);
   });
 
-  test("early transcription failure cancels the concurrent audio language engine", async () => {
+  test("early transcription failure does not start audio language detection", async () => {
     if (process.platform === "win32") return;
     const dir = makeTempDir("kesha-cli-contract-sibling-cancel-");
     const langPidPath = join(dir, "lang.pid");
@@ -449,14 +482,13 @@ describe("CLI contracts", () => {
     };
 
     const run = await runCli(["--json", mediaPath], { env, timeoutMs: 4_000 });
-    const langPid = await waitForPidFile(langPidPath);
 
     expectContract(run, {
       exitCode: 1,
       stderrContains: ["transcribe failed quickly"],
     });
     expect(JSON.parse(run.stdout)).toEqual([]);
-    expect(await waitForPidExit(langPid)).toBe(true);
+    expect(existsSync(langPidPath)).toBe(false);
   });
 
   test("diagnostic and support commands return parseable/readable contracts without leaking temp home", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
-import { mainCommand, completionsCommand, doctorCommand, installCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress } from "../../src/cli";
+import { mainCommand, completionsCommand, doctorCommand, installCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, estimateTranscriptDurationSeconds, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress, shouldRunAudioLanguageDetection } from "../../src/cli";
 
 type MainRun = (input: { args: Record<string, unknown>; rawArgs: string[] }) => Promise<void>;
 
@@ -210,6 +210,45 @@ describe("transcription progress reporting", () => {
         debugEnabled: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("audio language detection routing", () => {
+  test("estimates transcript duration from segment ends", () => {
+    expect(
+      estimateTranscriptDurationSeconds([
+        { start: 0, end: 2.5, text: "short" },
+        { start: 2.5, end: 601, text: "long" },
+      ]),
+    ).toBe(601);
+    expect(estimateTranscriptDurationSeconds([])).toBeNull();
+  });
+
+  test("skips whole-file audio language detection for long ASR timelines", () => {
+    expect(
+      shouldRunAudioLanguageDetection({
+        wantsLangId: true,
+        transcriptDurationSeconds: 600,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRunAudioLanguageDetection({
+        wantsLangId: true,
+        transcriptDurationSeconds: 601,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRunAudioLanguageDetection({
+        wantsLangId: false,
+        transcriptDurationSeconds: 601,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRunAudioLanguageDetection({
+        wantsLangId: true,
+        transcriptDurationSeconds: null,
+      }),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Run ASR before whole-file audio language detection so long meeting-style transcripts can be classified from the transcript path instead of spending work on one global audio language label.
- Skip `detect-lang` when the ASR segment timeline is longer than 10 minutes; `audioLanguage` remains optional and successful output shape stays compatible.
- Keep short clips unchanged: they still get `audioLanguage` when requested by JSON/TOON/transcript/verbose/`--lang`.
- Add debug-only visibility when `lang_id_audio` is skipped.

Refs #397.

## Validation
- `bun test tests/unit/cli.test.ts`
- `bun test tests/integration/cli-contracts.test.ts`
- `bunx tsc --noEmit`
- `bun test` attempted; fails only on Russian engine e2e because this fresh worktree has Git LFS pointer files instead of hydrated audio fixtures (`tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg` is ASCII text). The new unit and CLI contract tests pass.