### PR TITLE
docs: update agent transcript defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,12 +372,26 @@ macOS equivalent is `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`.
 
 The plugin lives in `openclaw.plugin.json` + `openclaw-plugin.cjs` (+ `package.json#openclaw.extensions`).
 
-**How audio transcription actually works in OpenClaw:** the `type: "cli"` path in `tools.media.audio.models` — NOT `registerMediaUnderstandingProvider` (that path requires API keys via `requireApiKey()` and silently fails for local CLI tools). The plugin registers a `MediaUnderstandingProvider` for discoverability (`openclaw plugins inspect` shows `Shape: plain-capability`), but the actual transcription routes through `runCliEntry`, which spawns `kesha --format transcript {{MediaPath}}` and captures stdout.
+**How audio transcription actually works in OpenClaw:** the `type: "cli"` path in `tools.media.audio.models` — NOT `registerMediaUnderstandingProvider` (that path requires API keys via `requireApiKey()` and silently fails for local CLI tools). The plugin registers a `MediaUnderstandingProvider` for discoverability (`openclaw plugins inspect` shows `Shape: plain-capability`), but the actual transcription routes through `runCliEntry`, which spawns `kesha {{MediaPath}}` and captures bare transcript stdout.
 
 Recommended user config:
-```json
-{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}
+```json5
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [
+          {"type":"cli","command":"kesha","args":["{{MediaPath}}"],"timeoutSeconds":15}
+        ],
+        echoTranscript: true,
+        echoFormat: '🦜 "{transcript}"'
+      }
+    }
+  }
+}
 ```
+This is a documented user-config default, not a plugin manifest patch.
 
 **Scanner rules:**
 - OpenClaw's `dangerous-exec` scanner fires when a file contains BOTH a `spawn(`/`exec(`-style call AND the substring for the forbidden module name. **Comments count** — it's a naive regex, not AST-aware.

--- a/SKILL.md
+++ b/SKILL.md
@@ -34,12 +34,30 @@ Install the plugin, then explicitly route OpenClaw audio understanding through t
 bun add -g @drakulavich/kesha-voice-kit
 kesha install
 openclaw plugins install @drakulavich/kesha-voice-kit
-openclaw config set tools.media.audio.enabled true
-openclaw config set tools.media.audio.models \
-  '[{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}]'
+openclaw config patch --stdin <<'JSON5'
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [
+          {
+            type: "cli",
+            command: "kesha",
+            args: ["{{MediaPath}}"],
+            timeoutSeconds: 15,
+          },
+        ],
+        echoTranscript: true,
+        echoFormat: '🦜 "{transcript}"',
+      },
+    },
+  },
+}
+JSON5
 ```
 
-Use `--format transcript` for OpenClaw's normal voice-message path: stdout is compact text plus language metadata, while progress and errors stay off the transcript payload.
+Use Kesha's default output for OpenClaw's normal voice-message path: stdout is the bare transcript text, while progress and errors stay off the transcript payload. The default setup echoes each transcript back to chat as `🦜 "{transcript}"` before the agent responds.
 
 For agents that need timestamped segments, switch the model entry to JSON output and allow a longer timeout:
 
@@ -55,6 +73,8 @@ which kesha
 kesha status
 openclaw plugins list
 openclaw config get tools.media.audio.models
+openclaw config get tools.media.audio.echoTranscript
+openclaw config get tools.media.audio.echoFormat
 ```
 
 Do not rely on `openclaw.plugin.json` to patch `tools.media.audio.models`; OpenClaw ignores non-schema fields such as `configPatch`. Keep the CLI route in user config.

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -29,7 +29,7 @@ Hermes writes each incoming voice message to `{input_path}`, runs the command
 template, then reads a `.txt` transcript from `{output_dir}`.
 
 ```bash
-export HERMES_LOCAL_STT_COMMAND='sh -c '"'"'kesha --format transcript "$1" > "$2/transcript.txt"'"'"' sh {input_path} {output_dir}'
+export HERMES_LOCAL_STT_COMMAND='sh -c '"'"'kesha "$1" > "$2/transcript.txt"'"'"' sh {input_path} {output_dir}'
 ```
 
 In `~/.hermes/config.yaml`:
@@ -39,10 +39,10 @@ stt:
   provider: local_command
 ```
 
-Use plain text output if you do not want the `[lang: ...]` footer:
+Use transcript metadata output if you want the `[lang: ...]` footer:
 
 ```bash
-export HERMES_LOCAL_STT_COMMAND='sh -c '"'"'kesha "$1" > "$2/transcript.txt"'"'"' sh {input_path} {output_dir}'
+export HERMES_LOCAL_STT_COMMAND='sh -c '"'"'kesha --format transcript "$1" > "$2/transcript.txt"'"'"' sh {input_path} {output_dir}'
 ```
 
 ## Text-to-speech
@@ -89,7 +89,7 @@ kesha status
 
 tmp="$(mktemp -d)"
 # Replace /path/to/audio.ogg with your own audio file:
-kesha --format transcript /path/to/audio.ogg > "$tmp/transcript.txt"
+kesha /path/to/audio.ogg > "$tmp/transcript.txt"
 cat "$tmp/transcript.txt"
 
 echo "Hello from Hermes" | kesha say --format ogg-opus --out "$tmp/reply.ogg"
@@ -98,8 +98,9 @@ test -s "$tmp/reply.ogg"
 
 ## Notes
 
-- `kesha --format transcript` keeps the transcript on stdout and progress or
-  warnings on stderr, which matches Hermes' command contract.
+- `kesha audio.ogg` keeps the bare transcript on stdout and progress or
+  warnings on stderr, which matches Hermes' command contract without adding
+  language metadata to the prompt surface.
 - `kesha say --format ogg-opus` emits messenger-ready OGG/Opus directly.
 - Hermes command providers run trusted local shell commands with the user's
   permissions. Keep the command template in your own config or deployment

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -5,13 +5,32 @@ Kesha Voice Kit ships as a plugin for [OpenClaw](https://github.com/openclaw/ope
 ```bash
 bun add -g @drakulavich/kesha-voice-kit && kesha install
 openclaw plugins install @drakulavich/kesha-voice-kit
-openclaw config set tools.media.audio.models \
-  '[{"type":"cli","command":"kesha","args":["--format","transcript","{{MediaPath}}"],"timeoutSeconds":15}]'
+openclaw config patch --stdin <<'JSON5'
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [
+          {
+            type: "cli",
+            command: "kesha",
+            args: ["{{MediaPath}}"],
+            timeoutSeconds: 15,
+          },
+        ],
+        echoTranscript: true,
+        echoFormat: '🦜 "{transcript}"',
+      },
+    },
+  },
+}
+JSON5
 ```
 
-> If audio transcription is not already enabled: `openclaw config set tools.media.audio.enabled true`
+The default setup echoes each transcript back to the originating chat as `🦜 "{transcript}"` before the agent responds.
 
-For agents that need per-utterance timestamps (chapters, navigation, downstream editing), append `--json --timestamps` instead of `--format transcript` (requires engine v1.9.0+):
+For agents that need per-utterance timestamps (chapters, navigation, downstream editing), use `--json --timestamps` instead of the default bare transcript output (requires engine v1.9.0+):
 ```bash
 openclaw config set tools.media.audio.models \
   '[{"type":"cli","command":"kesha","args":["--json","--timestamps","{{MediaPath}}"],"timeoutSeconds":30}]'
@@ -22,7 +41,6 @@ Your agent receives a voice message in Telegram/WhatsApp/Slack, Kesha transcribe
 
 ```
 Таити, Таити! Не были мы ни в какой Таити! Нас и тут неплохо кормят.
-[lang: ru, confidence: 1.00]
 ```
 
 Manage the plugin with `openclaw plugins list`, `openclaw plugins disable kesha-voice-kit`, or `openclaw plugins uninstall kesha-voice-kit`.

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -37,7 +37,7 @@ openclaw config set tools.media.audio.models \
 ```
 Each segment carries `start`, `end`, and `text`. VAD-preprocessed long files yield one segment per utterance; short non-VAD files return one whole-file segment.
 
-Your agent receives a voice message in Telegram/WhatsApp/Slack, Kesha transcribes it locally, and the agent sees enriched context:
+Your agent receives a voice message in Telegram/WhatsApp/Slack, Kesha transcribes it locally, and the agent sees the bare transcript text:
 
 ```
 Таити, Таити! Не были мы ни в какой Таити! Нас и тут неплохо кормят.


### PR DESCRIPTION
## Summary
- update the OpenClaw setup recipe to configure Kesha with bare transcript output by default
- enable OpenClaw transcript echo with the branded `🦜 "{transcript}"` format
- switch Hermes STT defaults to bare transcript output and leave `--format transcript` as an explicit metadata opt-in

## Validation
- `openclaw --profile kesha-snippet-check config patch --dry-run --stdin`
- `npm pack --dry-run --json`
- `git diff --check`
