### PR TITLE
chore(release): v1.18.6

### DIFF
--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.18.5" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.18.6" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.18.5"
+    "version": "1.18.6"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.18.5"
+version = "1.18.6"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.18.5"
+version = "1.18.6"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## Summary
- bump CLI and engine versions to 1.18.6
- refresh Cargo.lock for kesha-engine 1.18.6
- regenerate the checked-in manpage version string

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo nextest run --features tts
- bun test (rerun clean: 287 pass, 4 skip)
- bunx tsc --noEmit
- bun run check:versions
- bun test tests/unit/shell-artifacts.test.ts