### PR TITLE
chore(deps): cargo dep refresh + fluidaudio-rs 0.14 ASR (native transcribe_samples)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "fluidaudio-rs"
-version = "0.1.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619ee6ec2c3e1e12fbe029850ff019b4a705876d7fc2b28ba696f98acce4be07"
+checksum = "6181071acbec602782db378d0677cccfa48c60bc8d759524c4bfe57188a234dc"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -247,9 +247,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -856,7 +856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -974,7 +974,7 @@ dependencies = [
  "symphonia",
  "symphonia-adapter-libopus",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "ureq",
  "vosk_tts",
 ]
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "opusic-sys"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3280fe5b6f97ac1a35a0ac003e2fb0b92f8e4bdf2b2057e1bf9b87acca5696"
+checksum = "2804e694ef0de3b4cbb254de565053b7cb48d3398df7fd60c6c62bed40c5372a"
 dependencies = [
  "cmake",
 ]
@@ -1893,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-adapter-libopus"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d17450685dda0e87467eddf3e0f9c0b2a1707fc5c3234c111f70d46c6e4494"
+checksum = "2bfc8e95f95c23ed1b5328eb66920ad28d9968c797f9c7aa755d4b45a5f47a41"
 dependencies = [
  "log",
  "opusic-sys",
@@ -2703,9 +2703,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,12 +20,10 @@ test = false
 [features]
 default = ["onnx", "tts"]
 # ASR backend selection. Language detection always uses ONNX regardless.
-# `tempfile` is pulled in by `coreml` because the FluidAudio backend writes
-# a temp WAV per VAD segment (`fluidaudio-rs 0.1.0` lacks transcribe_samples).
 # `libc` is used by the coreml backend to silence FluidAudio's stdout during
-# transcribe_file calls — without it, the Swift-side `print("Transcribe error:
+# transcribe calls — without it, the Swift-side `print("Transcribe error:
 # invalidAudioData")` (see #259) interleaves with kesha-engine's JSON output.
-coreml = ["dep:fluidaudio-rs", "dep:tempfile", "dep:libc"]
+coreml = ["dep:fluidaudio-rs", "dep:libc"]
 onnx = []
 tts = ["dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg"]
 # macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
@@ -70,7 +68,7 @@ ort = { version = "2.0.0-rc.12" }
 ndarray = { version = "0.17" }
 
 # CoreML backend (macOS): FluidAudio/Apple Neural Engine for ASR.
-fluidaudio-rs = { version = "0.1", optional = true }
+fluidaudio-rs = { version = "0.14", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)
@@ -85,7 +83,6 @@ ssml-parser = { version = "0.1", optional = true }
 opus = { version = "0.3", optional = true }
 ogg = { version = "0.9", optional = true }
 
-tempfile = { version = "3", optional = true }
 libc = { version = "0.2", optional = true }
 # Keep G2P dependency changes explicit; intentional bumps should review the
 # source-level routing/shape smoke tests instead of relying on transitive drift.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -75,7 +75,7 @@ audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)
 hound = "3.5"
-thiserror = { version = "1", optional = true }
+thiserror = { version = "2", optional = true }
 sha2 = "0.10"
 ssml-parser = { version = "0.1", optional = true }
 

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -1,4 +1,4 @@
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::os::fd::OwnedFd;
 
 use anyhow::{Context, Result};
@@ -50,30 +50,20 @@ impl TranscribeBackend for FluidAudioBackend {
         Ok(result.text)
     }
 
-    /// `fluidaudio-rs 0.1.0` ships without `transcribe_samples` (available
-    /// on main, not yet published), so this shim writes the slice to a
-    /// temp WAV and calls `transcribe_file`. Temp I/O for a 16 kHz mono f32
-    /// slice is negligible vs the ~50-200 ms ASR cost. Drop this shim and
-    /// delegate to `transcribe_samples` directly once upstream cuts a
-    /// release that exposes it.
+    /// Transcribe a raw 16 kHz mono f32 slice via FluidAudio's native
+    /// `transcribe_samples` (published since `fluidaudio-rs` 0.14 — this
+    /// replaced an earlier temp-WAV + `transcribe_file` shim).
     ///
     /// Sub-second VAD segments are padded to MIN_SAMPLES with trailing
-    /// silence (#259); FluidAudio's transcribe_file otherwise emits
-    /// `Transcribe error: invalidAudioData` to stdout and returns an Err.
-    /// stdout is silenced for the duration of the call as belt-and-braces
-    /// — even with padding, residual upstream prints would corrupt the
-    /// engine's `--json` output by interleaving with our JSON write.
+    /// silence (#259); FluidAudio otherwise emits `Transcribe error:
+    /// invalidAudioData` to stdout and returns an Err. stdout is silenced
+    /// for the duration of the call as belt-and-braces — even with padding,
+    /// residual upstream prints would corrupt the engine's `--json` output
+    /// by interleaving with our JSON write.
     fn transcribe_samples(&mut self, samples: &[f32]) -> Result<String> {
         let padded = pad_to_min(samples, MIN_SAMPLES);
-        let tmp = tempfile::Builder::new()
-            .prefix("kesha-vad-segment-")
-            .suffix(".wav")
-            .tempfile()
-            .context("creating temp WAV for VAD segment")?;
-        write_float_wav(tmp.path(), &padded, 16_000).context("writing temp WAV for VAD segment")?;
-        let path_str = tmp.path().to_str().context("temp WAV path was non-UTF-8")?;
         let result = with_silenced_stdout(self.devnull.as_ref(), || {
-            self.audio.transcribe_file(path_str)
+            self.audio.transcribe_samples(&padded)
         })
         .context("FluidAudio sample transcription failed")?;
         Ok(result.text)
@@ -169,43 +159,6 @@ fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce() -> R) -> 
         }
     }
     f()
-}
-
-/// Write a 16 kHz mono IEEE float32 WAV. FluidAudio loads it via Apple's
-/// `AVAudioFile`, which accepts format tag 3 (IEEE_FLOAT). We can't use
-/// `hound` here because the `coreml` feature must build cleanly without
-/// the `tts` feature that pulls it in.
-fn write_float_wav(path: &std::path::Path, samples: &[f32], sample_rate: u32) -> Result<()> {
-    let file = std::fs::File::create(path)?;
-    let mut w = BufWriter::new(file);
-    let channels: u16 = 1;
-    let bits_per_sample: u16 = 32;
-    let byte_rate = sample_rate * channels as u32 * (bits_per_sample as u32 / 8);
-    let block_align = channels * (bits_per_sample / 8);
-    let data_bytes = (samples.len() * 4) as u32;
-    let fmt_chunk_size: u32 = 16;
-    let riff_size = 4 + (8 + fmt_chunk_size) + (8 + data_bytes);
-
-    w.write_all(b"RIFF")?;
-    w.write_all(&riff_size.to_le_bytes())?;
-    w.write_all(b"WAVE")?;
-
-    w.write_all(b"fmt ")?;
-    w.write_all(&fmt_chunk_size.to_le_bytes())?;
-    w.write_all(&3u16.to_le_bytes())?; // format code 3 = IEEE_FLOAT
-    w.write_all(&channels.to_le_bytes())?;
-    w.write_all(&sample_rate.to_le_bytes())?;
-    w.write_all(&byte_rate.to_le_bytes())?;
-    w.write_all(&block_align.to_le_bytes())?;
-    w.write_all(&bits_per_sample.to_le_bytes())?;
-
-    w.write_all(b"data")?;
-    w.write_all(&data_bytes.to_le_bytes())?;
-    for &s in samples {
-        w.write_all(&s.to_le_bytes())?;
-    }
-    w.flush()?;
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
PR 1 of the FluidAudio native-API effort (see `docs/superpowers/specs/2026-05-20-fluidaudio-sidecar-collapse-design.md`, PR #427). Routine cargo dep hygiene + the ASR-side of the `fluidaudio-rs` bump, kept separate from the larger fork-unify (PR 2).

## Dependency refresh
- **`cargo audit`: clean** — no advisories, no unmaintained/yanked warnings.
- **In-range lockfile refresh** (`cargo update`): `cc`, `hashbrown`, `opusic-sys`, `winnow`, `symphonia-adapter-libopus` 0.2.7→0.2.9.
- **`thiserror` 1 → 2** — usage is plain `#[error("…")]` interpolation (2.0-compatible); `thiserror` 1.0.69 remains as a transitive dep.
- **Deferred** (available majors, not necessary, higher risk → separate effort): `symphonia` 0.5→0.6, `cpal` 0.15→0.17, `sha2` 0.10→0.11, `symphonia-adapter-libopus` 0.2→0.3.

## ASR: `fluidaudio-rs` 0.1 → 0.14
- 0.14 publishes `transcribe_samples(&[f32])`, so the CoreML backend's per-VAD-segment **temp-WAV shim is removed** — `transcribe_samples` now calls the native API directly (`backend/fluidaudio.rs`). `write_float_wav` deleted.
- Drops `dep:tempfile` from the `coreml` feature (it was pulled in only for that shim; tests use the dev-dependency).
- Retains the `MIN_SAMPLES` padding (#259) and stdout silencing.

## Verification
- `cargo audit` clean.
- `cargo fmt` + `cargo clippy --all-targets --features tts -- -D warnings` + `cargo nextest run --features tts` → **282 passed, 0 skipped**.
- `cargo check --features coreml --no-default-features` → **Finished** (Swift bridge built against FluidAudio 0.14; only a pre-existing dead_code warning for the onnx-only `argmax` under a coreml build).

## Note
PR CI exercises the coreml feature via `cargo check` (no final link), as it does today; the full coreml **link** with 0.14's framework set is exercised when a release is cut (`build-engine.yml`). This intentionally de-risks the 0.14 ASR transition before PR 2 switches the dep to the fork.

No version bump (engine-release version bump happens at release-cut, not on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)