### PR TITLE
fix(diarize): restore adaptive timeout + collision-safe speaker ids (#434)

### DIFF
--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -509,7 +509,7 @@ mod tests {
                 _guard: LOCK
                     .get_or_init(|| std::sync::Mutex::new(()))
                     .lock()
-                    .unwrap(),
+                    .unwrap_or_else(|e| e.into_inner()),
             }
         }
     }

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -4,7 +4,10 @@
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::mpsc;
+use std::time::Duration;
 
 use crate::{dtrace, dtrace_json};
 use fluidaudio_rs::FluidAudio;
@@ -13,6 +16,15 @@ use super::TranscriptionSegment;
 
 const MIN_DIARIZE_SEGMENT_COVERAGE: f32 = 0.95;
 const MAX_DIARIZE_TAIL_GAP_SECONDS: f32 = 30.0;
+
+// Adaptive diarization timeout: the in-process `diarize_file_with_models` call is
+// blocking and un-interruptible, so `run_with_timeout` runs it on a worker thread
+// and bails if it overruns. Default 90 s, scaled up by audio length / ASR segment
+// count, capped at 30 min, overridable via `KESHA_DIARIZE_TIMEOUT_SECS`. (#434)
+const DEFAULT_DIARIZE_TIMEOUT_SECS: u64 = 90;
+const MAX_ADAPTIVE_DIARIZE_TIMEOUT_SECS: u64 = 1_800;
+const DIARIZE_TIMEOUT_SECONDS_PER_AUDIO_SECOND: f32 = 0.05;
+const DIARIZE_TIMEOUT_SECONDS_PER_ASR_SEGMENT: f32 = 0.10;
 
 /// One speaker span emitted by the sidecar. Cluster IDs are stable within
 /// one invocation but not across calls.
@@ -36,40 +48,23 @@ pub(crate) fn run(
     let audio_secs = duration
         .or_else(|| max_asr_end(asr_segments))
         .unwrap_or(0.0);
+    let timeout = diarize_timeout(asr_segments, duration);
     dtrace!(
-        "diarize::start audio_secs={:.1} asr_segments={}",
+        "diarize::start timeout={}s audio_secs={:.1} asr_segments={}",
+        timeout.as_secs(),
         audio_secs,
         asr_segments.len()
     );
     dtrace_json!(
         "diarize.start",
         {
+            "timeout_secs": timeout.as_secs(),
             "audio_secs": audio_secs,
             "asr_segments": asr_segments.len()
         }
     );
 
-    // FluidAudio's CoreML diarizer prints noise to stdout. This scoped guard
-    // catches synchronous prints during the call; the *asynchronous* teardown
-    // print (`E5RT encountered an STL exception`, emitted on a background queue
-    // after this returns) is NOT catchable here — it is silenced by
-    // `StdoutShield` at the CLI layer, which keeps fd 1 redirected past process
-    // exit (see `cli::transcribe` + `fluid_stdout::StdoutShield`). (#259/#397)
-    let spans: Vec<DiarizeSpan> =
-        crate::fluid_stdout::with_silenced_stdout_oneshot(|| -> Result<Vec<DiarizeSpan>> {
-            let audio = FluidAudio::new().context("failed to initialize FluidAudio bridge")?;
-            let segments = audio
-                .diarize_file_with_models(audio_path, model_path)
-                .context("FluidAudio diarization failed")?;
-            Ok(segments
-                .into_iter()
-                .map(|seg| DiarizeSpan {
-                    start: seg.start_time,
-                    end: seg.end_time,
-                    speaker: speaker_index(&seg.speaker_id),
-                })
-                .collect())
-        })?;
+    let spans: Vec<DiarizeSpan> = run_with_timeout(audio_path, model_path, timeout, audio_secs)?;
 
     let coverage = validate_coverage(asr_segments, &spans)?;
     dtrace!(
@@ -95,15 +90,95 @@ pub(crate) fn run(
     Ok(spans)
 }
 
-/// Parse FluidAudio's `"SPEAKER_NN"` label into a numeric cluster id. Falls back
-/// to 0 if the suffix isn't numeric — the merge contract only needs ids that are
-/// stable within a single call.
-fn speaker_index(speaker_id: &str) -> u32 {
-    speaker_id
-        .rsplit('_')
-        .next()
-        .and_then(|n| n.parse::<u32>().ok())
-        .unwrap_or(0)
+/// Adaptive deadline for one diarization call. `KESHA_DIARIZE_TIMEOUT_SECS`
+/// overrides everything; otherwise scale up from a 90 s floor by audio length and
+/// ASR-segment count, capped at 30 min.
+fn diarize_timeout(asr_segments: &[TranscriptionSegment], duration: Option<f32>) -> Duration {
+    if let Some(secs) = std::env::var("KESHA_DIARIZE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+    {
+        return Duration::from_secs(secs);
+    }
+
+    let asr_end = max_asr_end(asr_segments);
+    let audio_secs = duration.or(asr_end).unwrap_or(0.0).max(0.0);
+    let by_audio = (audio_secs * DIARIZE_TIMEOUT_SECONDS_PER_AUDIO_SECOND).ceil() as u64;
+    let by_segments =
+        (asr_segments.len() as f32 * DIARIZE_TIMEOUT_SECONDS_PER_ASR_SEGMENT).ceil() as u64;
+    let secs = DEFAULT_DIARIZE_TIMEOUT_SECS
+        .max(by_audio)
+        .max(by_segments)
+        .min(MAX_ADAPTIVE_DIARIZE_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Run the (blocking, un-interruptible) FluidAudio diarization on a worker thread
+/// so the caller can enforce `timeout`. A stalled CoreML call can't be cancelled,
+/// so on timeout we deliberately abandon the worker thread: diarization only runs
+/// in a one-shot CLI invocation, so the process exits right after we bail and the
+/// OS reclaims the thread + the stalled model. (#434)
+fn run_with_timeout(
+    audio_path: &Path,
+    model_path: &Path,
+    timeout: Duration,
+    audio_secs: f32,
+) -> Result<Vec<DiarizeSpan>> {
+    let (tx, rx) = mpsc::channel();
+    let audio_path = audio_path.to_path_buf();
+    let model_path = model_path.to_path_buf();
+    std::thread::spawn(move || {
+        // FluidAudio is created inside the thread (it never crosses the boundary).
+        // The oneshot guard silences synchronous CoreML stdout noise during the
+        // call; the *asynchronous* `E5RT` teardown print (fired on a background
+        // queue after the call returns) is silenced by `StdoutShield` at the CLI
+        // layer, which keeps fd 1 redirected past process exit. (#259/#397/#434)
+        let result =
+            crate::fluid_stdout::with_silenced_stdout_oneshot(|| -> Result<Vec<DiarizeSpan>> {
+                let audio = FluidAudio::new().context("failed to initialize FluidAudio bridge")?;
+                let segments = audio
+                    .diarize_file_with_models(&audio_path, &model_path)
+                    .context("FluidAudio diarization failed")?;
+                let mut seen: HashMap<String, u32> = HashMap::new();
+                Ok(segments
+                    .into_iter()
+                    .map(|seg| DiarizeSpan {
+                        start: seg.start_time,
+                        end: seg.end_time,
+                        speaker: speaker_id_to_index(&mut seen, &seg.speaker_id),
+                    })
+                    .collect())
+            });
+        // The receiver is gone if we already timed out; dropping `result` is fine.
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => bail!(
+            "speaker diarization timed out after {}s for {:.0}s of audio; split the \
+             recording or raise KESHA_DIARIZE_TIMEOUT_SECS (currently {}s)",
+            timeout.as_secs(),
+            audio_secs,
+            timeout.as_secs()
+        ),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            bail!("speaker diarization worker terminated unexpectedly")
+        }
+    }
+}
+
+/// Map FluidAudio's speaker labels to stable numeric ids by first-seen order.
+/// Unlike parsing the `SPEAKER_NN` suffix, distinct labels never collide onto the
+/// same id (#434) — the merge contract only needs ids stable within a single call.
+fn speaker_id_to_index(seen: &mut HashMap<String, u32>, label: &str) -> u32 {
+    if let Some(&idx) = seen.get(label) {
+        return idx;
+    }
+    let idx = seen.len() as u32;
+    seen.insert(label.to_string(), idx);
+    idx
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -342,5 +417,129 @@ mod tests {
         assert_eq!(coverage.total_segments, 0);
         assert_eq!(coverage.labeled_segments, 0);
         assert_eq!(coverage.coverage_ratio, 1.0);
+    }
+
+    #[test]
+    fn speaker_ids_map_by_first_seen_order_without_collision() {
+        let mut seen = HashMap::new();
+        assert_eq!(speaker_id_to_index(&mut seen, "SPEAKER_00"), 0);
+        assert_eq!(speaker_id_to_index(&mut seen, "SPEAKER_01"), 1);
+        // Stable within a call.
+        assert_eq!(speaker_id_to_index(&mut seen, "SPEAKER_00"), 0);
+        // The #433 P2 bug: distinct labels sharing a numeric suffix must NOT
+        // collapse onto the same id (the old `rsplit('_')` parse mapped both to 0).
+        assert_eq!(speaker_id_to_index(&mut seen, "A_0"), 2);
+        assert_eq!(speaker_id_to_index(&mut seen, "B_0"), 3);
+    }
+
+    #[test]
+    fn adaptive_timeout_keeps_short_audio_near_current_default() {
+        let _guard = EnvLockGuard::new();
+        let segs = vec![seg(0.0, 1.0, "a")];
+
+        unsafe {
+            std::env::remove_var("KESHA_DIARIZE_TIMEOUT_SECS");
+        }
+
+        assert_eq!(
+            diarize_timeout(&segs, Some(10.0)),
+            Duration::from_secs(DEFAULT_DIARIZE_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn adaptive_timeout_scales_for_long_audio() {
+        let _guard = EnvLockGuard::new();
+        let segs: Vec<_> = (0..6_000)
+            .map(|i| {
+                let start = i as f32;
+                seg(start, start + 0.5, "a")
+            })
+            .collect();
+
+        unsafe {
+            std::env::remove_var("KESHA_DIARIZE_TIMEOUT_SECS");
+        }
+
+        assert_eq!(
+            diarize_timeout(&segs, Some(12_000.0)),
+            Duration::from_secs(600)
+        );
+    }
+
+    #[test]
+    fn adaptive_timeout_is_capped() {
+        let _guard = EnvLockGuard::new();
+        let segs: Vec<_> = (0..100_000)
+            .map(|i| {
+                let start = i as f32;
+                seg(start, start + 0.5, "a")
+            })
+            .collect();
+
+        unsafe {
+            std::env::remove_var("KESHA_DIARIZE_TIMEOUT_SECS");
+        }
+
+        assert_eq!(
+            diarize_timeout(&segs, Some(100_000.0)),
+            Duration::from_secs(MAX_ADAPTIVE_DIARIZE_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn adaptive_timeout_env_override_wins() {
+        let _guard = EnvLockGuard::new();
+        let segs = vec![seg(0.0, 1.0, "a")];
+        let _env = EnvGuard::set("KESHA_DIARIZE_TIMEOUT_SECS", "3600");
+
+        assert_eq!(
+            diarize_timeout(&segs, Some(1.0)),
+            Duration::from_secs(3_600)
+        );
+    }
+
+    struct EnvLockGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvLockGuard {
+        fn new() -> Self {
+            static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+            Self {
+                _guard: LOCK
+                    .get_or_init(|| std::sync::Mutex::new(()))
+                    .lock()
+                    .unwrap(),
+            }
+        }
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, val: &str) -> Self {
+            let original = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, val);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => unsafe {
+                    std::env::set_var(self.key, v);
+                },
+                None => unsafe {
+                    std::env::remove_var(self.key);
+                },
+            }
+        }
     }
 }

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -157,11 +157,10 @@ fn run_with_timeout(
     match rx.recv_timeout(timeout) {
         Ok(result) => result,
         Err(mpsc::RecvTimeoutError::Timeout) => bail!(
-            "speaker diarization timed out after {}s for {:.0}s of audio; split the \
-             recording or raise KESHA_DIARIZE_TIMEOUT_SECS (currently {}s)",
+            "speaker diarization timed out after {}s for {:.0}s of audio; \
+             set KESHA_DIARIZE_TIMEOUT_SECS to override the adaptive limit",
             timeout.as_secs(),
             audio_secs,
-            timeout.as_secs()
         ),
         Err(mpsc::RecvTimeoutError::Disconnected) => {
             bail!("speaker diarization worker terminated unexpectedly")


### PR DESCRIPTION
## Summary

Hardens the in-process diarization from #433 by addressing the two Greptile findings that were deferred at merge (filed as #434).

### P1 — restore the diarization timeout
`fluidaudio_rs::diarize_file_with_models` is a blocking, un-interruptible FFI call. After #433 there was **no timeout**, so a CoreML stall (model corruption, memory pressure, scheduler hang) would block the engine until `SIGKILL` — worst for automated/pipeline use (OpenClaw), where a hang stalls the pipeline instead of surfacing a clean error.

- Re-introduce the adaptive deadline: 90 s floor, scaled by audio length and ASR-segment count, capped at 30 min, overridable via `KESHA_DIARIZE_TIMEOUT_SECS`.
- Run the FluidAudio call on a worker thread + `mpsc::recv_timeout`. On timeout, `bail!` with a clear message and **deliberately abandon** the worker: a stalled CoreML call can't be cancelled, but diarization only runs in a one-shot CLI invocation, so the process exits right after and the OS reclaims the thread + the stalled model.

### P2 — collision-safe speaker ids
The old `rsplit('_').next().parse().unwrap_or(0)` collapsed any non-`SPEAKER_NN` label — or two ids sharing a numeric suffix (`A_0`/`B_0`) — onto speaker `0`, silently mis-attributing speech in a way coverage validation can't detect. Replaced with a first-seen `HashMap<String, u32>` mapping: distinct labels always get distinct ids, stable within a call (the only contract the merge step needs). Standard `SPEAKER_00`/`SPEAKER_01` still yields `0`/`1`.

## Tests
- Restored the 4 `adaptive_timeout_*` tests + `EnvLockGuard`/`EnvGuard` helpers.
- New `speaker_ids_map_by_first_seen_order_without_collision` proving `A_0`/`B_0` map to distinct ids (the #433 P2 bug).

## Verification (darwin-arm64, full feature set)
`cargo fmt`, `clippy --all-targets --features coreml,tts,system_kokoro,system_diarize -- -D warnings` (clean apart from the pre-existing onnx-only `argmax` dead-code, which CI tolerates via `cargo check`), `nextest` diarize tests pass; default `clippy --features tts` + `nextest --features tts` (282) green.

## Notes
Engine change → version bump/tag/release is a separate post-merge step. Single-file change: `rust/src/transcribe/diarize.rs`.

Closes #434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)