### PR TITLE
fix(diarize): warm compiled diarization model at install to restore --speakers perf

### DIFF
--- a/docs/superpowers/plans/2026-05-21-diarize-compile-cache.md
+++ b/docs/superpowers/plans/2026-05-21-diarize-compile-cache.md
@@ -54,9 +54,10 @@
 
 ### Task B2: warm diarize at install
 
-**File:** `rust/src/cli/install.rs`
+**Files:** `rust/src/cli/install.rs`, `rust/src/models.rs`
 
-- [ ] After the ASR warm-up block, add `#[cfg(feature = "system_diarize")]` block: if `!no_warmup` and the diarize model is cached (`models::*` cache predicate), call `fluidaudio_rs::FluidAudio::new().and_then(|fa| fa.compile_diarization_model(models::model_dir(models::ModelKind::Diarize)))`, with a "Warming up diarization model (one-time, ~1-2 min)…" line; warm-up failure is **non-fatal** (match the ASR pattern). Match diarize.rs's `fluidaudio_rs` import path.
+- [ ] After the ASR warm-up block, add `#[cfg(feature = "system_diarize")]` block: if `diarize && !no_warmup` and the diarize model is cached (`models::*` cache predicate), call `fluidaudio_rs::FluidAudio::new().and_then(|fa| fa.compile_diarization_model(models::model_dir(models::ModelKind::Diarize)))` inside the stdout-silencing helper, with a "Warming up diarization model (one-time compile ~1-2 min on first install, ~4 s after)…" line; warm-up failure is **non-fatal** (match the ASR pattern). Match diarize.rs's `fluidaudio_rs` import path.
+- [ ] After a successful warm-up, remove stale Kesha-owned compiled sidecars (`*.mlpackage.mlmodelc`) next to the active diarize `.mlpackage`, keeping the current warmed sidecar and all source `.mlpackage` directories.
 
 ### Task B3: verify kesha
 

--- a/docs/superpowers/plans/2026-05-21-diarize-compile-cache.md
+++ b/docs/superpowers/plans/2026-05-21-diarize-compile-cache.md
@@ -1,0 +1,69 @@
+# Diarize compile-cache — Implementation Plan
+
+**Goal:** Make `kesha transcribe --speakers` fast (~4s) by loading the Sortformer model from a stable compiled `.mlmodelc` (e5rt ANE cache hits across processes) instead of recompiling a throwaway temp model every call (~100s). Warm the one-time compile at `kesha install`.
+
+**Architecture:** Fix in the fork (`drakulavich/fluidaudio-rs`) bridge — compile-to-stable-sibling + load-from-stable via FluidAudio's public `SortformerModels(config:main:)` init; add a no-audio warm FFI. Bump the kesha fork pin and warm diarize in the existing install warm-up step. Keep #435's adaptive timeout untouched.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-diarize-compile-cache-design.md`
+
+---
+
+## Repo A — `drakulavich/fluidaudio-rs` (branch `fix/diarize-compile-cache`)
+
+### Task A1: bridge — load from stable compiled `.mlmodelc`
+
+**File:** `swift/FluidAudioBridge.swift`
+
+- [ ] Add `private func loadSortformerCached(modelPath: String) async throws -> SortformerModels`:
+  - `stableURL = URL(fileURLWithPath: modelPath + ".mlmodelc")`.
+  - if `!FileManager.default.fileExists(atPath: stableURL.path)`: `let compiled = try await MLModel.compileModel(at: URL(fileURLWithPath: modelPath))`; publish atomically — if stable exists `replaceItemAt`, else `moveItem(at: compiled, to: stableURL)`.
+  - `let cfg = MLModelConfiguration(); cfg.computeUnits = .all`
+  - `let model = try MLModel(contentsOf: stableURL, configuration: cfg)`
+  - `return try SortformerModels(config: SortformerConfig.balancedV2, main: model)`
+- [ ] In `diarizeFileWithModels`, replace the two lines
+  `let diarizer = SortformerDiarizer(config: .balancedV2, timelineConfig: .sortformerDefault)` + `try await diarizer.initialize(mainModelPath: URL(fileURLWithPath: modelPath))`
+  with: build diarizer, `let models = try await loadSortformerCached(modelPath: modelPath)`, `diarizer.initialize(models: models)`.
+
+### Task A2: bridge — warm method + FFI
+
+**Files:** `swift/FluidAudioBridge.swift`, `swift/Diarize_ffi.swift`
+
+- [ ] `FluidAudioBridgeInternal.compileDiarizationModel(modelPath:) throws` — semaphore+Task wrapper that calls `_ = try await loadSortformerCached(modelPath:)` and rethrows.
+- [ ] `Diarize_ffi.swift`: `@_cdecl("fluidaudio_compile_diarization_model") func(ptr, modelPath) -> Int32` → `bridge.compileDiarizationModel(modelPath:)`, return 0 / -1 on throw (mirror existing error print).
+
+### Task A3: Rust binding
+
+**Files:** `src/ffi/bridge.rs`, `src/lib.rs`
+
+- [ ] `bridge.rs`: extern decl `fn fluidaudio_compile_diarization_model(bridge, model_path: *const i8) -> i32;` + `FluidAudioBridge::compile_diarization_model(&self, model_path: &str) -> Result<(), String>`.
+- [ ] `lib.rs` (near 398): `pub fn compile_diarization_model<Q: AsRef<Path>>(&self, model_path: Q) -> Result<(), FluidAudioError>` — exists-check then `self.bridge.compile_diarization_model(...).map_err(FluidAudioError::from)`.
+
+### Task A4: verify fork + push
+
+- [ ] `cargo build --release --example diarize`; run `examples/diarize -- /tmp/kdt/a.wav 0.6 <mlpackage>` **twice**: run1 ~100s cold, run2 **~4s** (stable `.mlmodelc` now beside the `.mlpackage`).
+- [ ] Quick warm-API smoke (tiny Rust example or reuse): `compile_diarization_model(<mlpackage>)` returns Ok, creates `<mlpackage>.mlmodelc`.
+- [ ] `cargo fmt && cargo clippy --all-targets -- -D warnings`. Commit, push branch, open PR in the fork. Record the merge/commit SHA.
+
+## Repo B — kesha `fix/diarize-compile-cache` (this worktree)
+
+### Task B1: bump fork pin
+
+**Files:** `rust/Cargo.toml`, `rust/Cargo.lock`
+
+- [ ] Point the `fluidaudio-rs` git dep `rev`/`branch` at the new fork SHA; `cargo check --features coreml,tts,system_kokoro,system_diarize --no-default-features` to refresh `Cargo.lock`.
+
+### Task B2: warm diarize at install
+
+**File:** `rust/src/cli/install.rs`
+
+- [ ] After the ASR warm-up block, add `#[cfg(feature = "system_diarize")]` block: if `!no_warmup` and the diarize model is cached (`models::*` cache predicate), call `fluidaudio_rs::FluidAudio::new().and_then(|fa| fa.compile_diarization_model(models::model_dir(models::ModelKind::Diarize)))`, with a "Warming up diarization model (one-time, ~1-2 min)…" line; warm-up failure is **non-fatal** (match the ASR pattern). Match diarize.rs's `fluidaudio_rs` import path.
+
+### Task B3: verify kesha
+
+- [ ] Rebuild engine on new pin (features `coreml,tts,system_kokoro,system_diarize`). `cargo fmt` (revert `vendor/vosk-tts/src/tokenizer.rs`), `cargo clippy --all-targets ... -- -D warnings -A dead_code`, `cargo nextest run --features tts`.
+- [ ] `KESHA_CACHE_DIR=/tmp/kdt/cache <engine> install --diarize` → shows diarize warm step, ends warm. (Stable `.mlmodelc` created beside the `.mlpackage`.)
+- [ ] `transcribe /tmp/kdt/a.wav --json --speakers` → **~4s**, valid JSON, speaker labelled, zero E5RT on stdout. `KESHA_DIARIZE_TIMEOUT_SECS=1 …` still fast-fails. `say --voice en-am_michael` unaffected.
+- [ ] PR to kesha `main`, referencing #434/#435; wait for CI + Greptile (≥4/5 on latest SHA) before merge.
+
+## Out of scope
+Engine version bump / release (separate; bundles #433 + #435 + this). Pre-compiled `.mlmodelc` in release. Runtime cold-reload timeout headroom.

--- a/docs/superpowers/specs/2026-05-21-diarize-compile-cache-design.md
+++ b/docs/superpowers/specs/2026-05-21-diarize-compile-cache-design.md
@@ -76,10 +76,14 @@ loadSortformerCached(mlpackagePath:) -> SortformerModels
 - `rust/Cargo.toml` + `Cargo.lock`: bump the `fluidaudio-rs` git pin to the new fork SHA.
 - `rust/src/main.rs` install flow: the existing warm-up step (`--no-warmup`,
   main.rs:101-110) already triggers the ASR ANE compile. Extend it so that **when the
-  diarize model is installed** (`--diarize`, or already cached) and `!no_warmup`, it calls
-  `FluidAudio::compile_diarization_model(diarize_model_dir)` once — paying the ~100s ANE
-  compile at the explicit install step. Print a progress line ("Warming diarization model
-  (one-time ~1-2 min)…"). Skipped on `--no-warmup` and on non-`system_diarize` builds.
+  current install requested the diarize model** (`--diarize`) and `!no_warmup`, it calls
+  `FluidAudio::compile_diarization_model(diarize_model_dir)` once inside the existing
+  stdout-silencing helper — paying the ~100s ANE compile at the explicit install step.
+  Print a progress line ("Warming diarization model (one-time compile ~1-2 min on first
+  install, ~4 s after)…"). Skipped on `--no-warmup` and on non-`system_diarize` builds.
+- After a successful diarize warm-up, remove stale Kesha-owned compiled sidecars
+  (`*.mlpackage.mlmodelc`) next to the active diarize `.mlpackage`. Keep the current warmed
+  sidecar and all source `.mlpackage` directories; never touch Apple's e5rt cache.
 - Runtime `transcribe --speakers` is unchanged (`diarize.rs` keeps #435's adaptive timeout
   + worker thread); after install-warm it loads the stable `.mlmodelc` in ~4s.
 

--- a/docs/superpowers/specs/2026-05-21-diarize-compile-cache-design.md
+++ b/docs/superpowers/specs/2026-05-21-diarize-compile-cache-design.md
@@ -1,0 +1,118 @@
+# Diarize compile-cache — restore `--speakers` performance
+
+**Status:** design approved (direction + warm mechanism), pending spec review
+**Date:** 2026-05-21
+**Branch (kesha):** `fix/diarize-compile-cache` (off `main`@47a824a / #435)
+**Repos:** `drakulavich/fluidaudio-rs` (the fork — primary change) + `drakulavich/kesha-voice-kit`
+
+## Problem
+
+`kesha transcribe --json --speakers` takes ~90-105s **every call** and trips the 90s
+adaptive timeout added in #435 → users get an error instead of speaker labels. Neither
+#433 nor #435 is released yet, so no shipped binary is broken; this gates the engine
+release that would bundle #433 + #435 + this fix.
+
+## Root cause (confirmed by spike, M3 Pro, 2026-05-21)
+
+`FluidAudioBridge.swift::diarizeFileWithModels` → `SortformerModels.load()` runs
+`MLModel.compileModel(at: <.mlpackage>)` to a **throwaway temp `.mlmodelc`** and loads it
+with `computeUnits = .all` on **every process**. The cost is the CoreML **ANE program
+compilation** inside `MLModel(contentsOf:, .all)`, which Apple caches in
+`~/Library/Caches/com.apple.e5rt.e5bundlecache` **keyed to the compiled model's path**.
+A fresh temp path every run ⇒ cache key changes ⇒ miss ⇒ full cold compile every run.
+
+| Step | Time |
+|---|---|
+| `compileModel(.mlpackage → .mlmodelc)` | 0.3s |
+| `MLModel(contentsOf: stable.mlmodelc, .all)` — cold (1st process) | 104.7s |
+| `MLModel(contentsOf: stable.mlmodelc, .all)` — warm (2nd process) | **3.9s** |
+
+It was **not** thread QoS (the merged #435 worker-thread theory was wrong: a main-thread
+build is still 92s) and **not** `compileModel`. The fast auto-download path (`diarize_file`)
+is ~4s only because it loads a stable, pre-compiled `.mlmodelc`. `MLModel(contentsOf:
+.mlpackage)` directly is rejected by this OS ("not a valid .mlmodelc") — we must compile to
+a stable `.mlmodelc` explicitly.
+
+## Design
+
+### 1. Fork: load from a stable compiled `.mlmodelc` (the fix)
+
+`drakulavich/fluidaudio-rs` is pinned to upstream `FluidAudio` exact `0.14.5` (not forkable
+cheaply), so the bridge uses only FluidAudio **public** API. `SortformerModels.init(config:
+main: compilationDuration:)` is public and takes a `main: MLModel`, so the bridge can load
+the model itself and skip `SortformerModels.load()`'s temp recompile.
+
+`swift/FluidAudioBridge.swift` — add a private helper:
+
+```
+loadSortformerCached(mlpackagePath:) -> SortformerModels
+  stable = mlpackagePath + ".mlmodelc"        // sibling, in kesha's writable cache dir
+  if !exists(stable):
+      compiled = MLModel.compileModel(at: mlpackagePath)   // 0.3s
+      atomically move/replace compiled -> stable
+  model = MLModel(contentsOf: stable, configuration: { computeUnits = .all })
+  return try SortformerModels(config: .balancedV2, main: model)
+```
+
+- `diarizeFileWithModels` swaps `diarizer.initialize(mainModelPath:)` →
+  `diarizer.initialize(models: loadSortformerCached(modelPath))`.
+- Stable path derivation lives in the bridge (sibling `<.mlpackage>.mlmodelc`), so the
+  Rust/FFI signatures for diarize stay unchanged.
+- Atomic replace (compile to temp, then `replaceItemAt`) so concurrent/interrupted runs
+  can't leave a half-written `.mlmodelc`.
+
+### 2. Fork: dedicated warm API (no fake audio)
+
+- `swift/Diarize_ffi.swift`: new `@_cdecl fluidaudio_compile_diarization_model(ptr,
+  modelPath) -> Int32` → calls `bridge.loadSortformerCached(modelPath)` and discards the
+  result (the `MLModel(contentsOf:, .all)` load populates the e5rt cache; ANE compile
+  happens here).
+- `src/ffi/bridge.rs`: extern decl + `FluidAudioBridgeInternal::compile_diarization_model`.
+- `src/lib.rs`: `FluidAudio::compile_diarization_model<P: AsRef<Path>>(model_path) ->
+  Result<(), FluidAudioError>` (mirror `diarize_file_with_models`, near lib.rs:398).
+
+### 3. Kesha: warm at install, pin bump
+
+- `rust/Cargo.toml` + `Cargo.lock`: bump the `fluidaudio-rs` git pin to the new fork SHA.
+- `rust/src/main.rs` install flow: the existing warm-up step (`--no-warmup`,
+  main.rs:101-110) already triggers the ASR ANE compile. Extend it so that **when the
+  diarize model is installed** (`--diarize`, or already cached) and `!no_warmup`, it calls
+  `FluidAudio::compile_diarization_model(diarize_model_dir)` once — paying the ~100s ANE
+  compile at the explicit install step. Print a progress line ("Warming diarization model
+  (one-time ~1-2 min)…"). Skipped on `--no-warmup` and on non-`system_diarize` builds.
+- Runtime `transcribe --speakers` is unchanged (`diarize.rs` keeps #435's adaptive timeout
+  + worker thread); after install-warm it loads the stable `.mlmodelc` in ~4s.
+
+### 4. Timeout / edge cases
+
+- Keep #435's adaptive timeout as a safety net. With warm install it never fires (4s ≪ 90s).
+- Edge case: if the OS evicts the e5rt cache, a runtime `--speakers` load is cold (~100s)
+  and would exceed the 90s floor → error. Acceptable for v1 (diarize is opt-in); the error
+  hint should suggest re-running `kesha install`. (Optional follow-up: detect cold reload
+  and extend the budget. Out of scope for this fix.)
+
+## Testing / verification
+
+- **Spike already done** (the premise): cold 104.7s, warm 3.9s across processes.
+- Fork: `cargo run --release --example diarize -- /tmp/kdt/a.wav 0.6 <mlpackage>` twice —
+  expect run 1 ~100s (cold/compile), run 2 ~4s (warm). Plus `compile_diarization_model`
+  smoke (returns 0, creates `<mlpackage>.mlmodelc`).
+- Kesha: rebuild engine on the new pin; `kesha install --diarize` shows the warm step and
+  ends warm; `transcribe a.wav --json --speakers` is ~4s, valid JSON, speaker labelled,
+  zero E5RT on stdout (StdoutShield from #433 still applies). `cargo nextest run
+  --features tts` green; clippy `-D warnings` on the full feature set.
+- `say --voice en-am_michael` unaffected (Kokoro).
+
+## Release
+
+Engine release (separate, after both PRs merge): bump `rust/Cargo.toml`,
+`package.json#keshaEngine.version`, `package.json#version`, `Cargo.lock`; tag →
+build-engine.yml; draft-validate the darwin-arm64 binary with a real `--json --speakers`
+(warm) + Kokoro smoke; un-draft to publish. Bundles #433 + #435 + this fix.
+
+## Out of scope
+
+- Shipping a pre-compiled `.mlmodelc` in the release (portability across macOS/chip
+  unverified; on-device warm is reliable and cheap after first run).
+- Runtime cold-reload timeout headroom / e5rt-eviction recovery.
+- Persisting the e5rt cache ourselves (it's OS-managed and already cross-process).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.1"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?branch=forked-main#d8e521062e2553a96275c1c6988adc6acee6ca25"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?branch=forked-main#3463cbb31c7e161231f5bc2f23da9960fbcfdc2a"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -92,9 +92,11 @@ pub fn run(
             "Warming up diarization model (one-time compile ~1-2 min on first install, ~4 s after)..."
         );
         let t = std::time::Instant::now();
-        match fluidaudio_rs::FluidAudio::new()
-            .and_then(|fa| fa.compile_diarization_model(&diarize_pkg))
-        {
+        let result = crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
+            fluidaudio_rs::FluidAudio::new()
+                .and_then(|fa| fa.compile_diarization_model(&diarize_pkg))
+        });
+        match result {
             Ok(_) => eprintln!(
                 "Diarization model warmed up (dt={}ms).",
                 t.elapsed().as_millis()

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -76,6 +76,33 @@ pub fn run(
             ),
         }
     }
+    // Diarization warm-up (macOS `system_diarize` only). Pre-compile the Sortformer
+    // `.mlpackage` to its stable `.mlmodelc` sibling so CoreML's ANE program-compile
+    // (~100 s, cached in `com.apple.e5rt.e5bundlecache` keyed by the compiled model
+    // path) happens HERE rather than on the first `kesha transcribe --speakers`. The
+    // diarize bridge recompiled a throwaway temp model every call before this, so the
+    // first real diarize paid ~100 s and tripped the adaptive timeout; after warm-up
+    // it loads the stable `.mlmodelc` in ~4 s. Only when the model is on disk; warm-up
+    // failure is NON-FATAL (matches the ASR warm-up above).
+    #[cfg(feature = "system_diarize")]
+    if !no_warmup && models::is_cached(models::ModelKind::Diarize) {
+        let diarize_pkg = models::model_dir(models::ModelKind::Diarize);
+        eprintln!("Warming up diarization model (one-time, ~1-2 min for the ANE compile)...");
+        let t = std::time::Instant::now();
+        match fluidaudio_rs::FluidAudio::new()
+            .and_then(|fa| fa.compile_diarization_model(&diarize_pkg))
+        {
+            Ok(_) => eprintln!(
+                "Diarization model warmed up (dt={}ms).",
+                t.elapsed().as_millis()
+            ),
+            Err(e) => eprintln!(
+                "warning: diarization warm-up failed ({e}); install still \
+                 complete but the first `kesha transcribe --speakers` will \
+                 pay the cold-start compile."
+            ),
+        }
+    }
     eprintln!("Install complete.");
     Ok(())
 }

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -97,10 +97,17 @@ pub fn run(
                 .and_then(|fa| fa.compile_diarization_model(&diarize_pkg))
         });
         match result {
-            Ok(_) => eprintln!(
-                "Diarization model warmed up (dt={}ms).",
-                t.elapsed().as_millis()
-            ),
+            Ok(_) => {
+                eprintln!(
+                    "Diarization model warmed up (dt={}ms).",
+                    t.elapsed().as_millis()
+                );
+                match models::cleanup_diarize_compiled_sidecars(&diarize_pkg) {
+                    Ok(0) => {}
+                    Ok(n) => eprintln!("Removed {n} stale diarization sidecar(s)."),
+                    Err(e) => eprintln!("warning: diarization sidecar cleanup failed ({e})"),
+                }
+            }
             Err(e) => eprintln!(
                 "warning: diarization warm-up failed ({e}); install still \
                  complete but the first `kesha transcribe --speakers` will \

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -82,12 +82,15 @@ pub fn run(
     // path) happens HERE rather than on the first `kesha transcribe --speakers`. The
     // diarize bridge recompiled a throwaway temp model every call before this, so the
     // first real diarize paid ~100 s and tripped the adaptive timeout; after warm-up
-    // it loads the stable `.mlmodelc` in ~4 s. Only when the model is on disk; warm-up
-    // failure is NON-FATAL (matches the ASR warm-up above).
+    // it loads the stable `.mlmodelc` in ~4 s. Only when this install requested the
+    // diarize model and the model is on disk; warm-up failure is NON-FATAL (matches
+    // the ASR warm-up above).
     #[cfg(feature = "system_diarize")]
-    if !no_warmup && models::is_cached(models::ModelKind::Diarize) {
+    if diarize && !no_warmup && models::is_cached(models::ModelKind::Diarize) {
         let diarize_pkg = models::model_dir(models::ModelKind::Diarize);
-        eprintln!("Warming up diarization model (one-time, ~1-2 min for the ANE compile)...");
+        eprintln!(
+            "Warming up diarization model (one-time compile ~1-2 min on first install, ~4 s after)..."
+        );
         let t = std::time::Instant::now();
         match fluidaudio_rs::FluidAudio::new()
             .and_then(|fa| fa.compile_diarization_model(&diarize_pkg))

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -476,6 +476,73 @@ mod manifest_tests {
     }
 }
 
+#[cfg(all(test, feature = "system_diarize"))]
+mod diarize_sidecar_tests {
+    use super::*;
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(name: &str) -> Result<Self> {
+            let path = std::env::temp_dir().join(format!(
+                "kesha-{name}-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)?
+                    .as_nanos()
+            ));
+            fs::create_dir_all(&path)?;
+            Ok(Self { path })
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn cleanup_diarize_sidecars_keeps_current_and_removes_stale() -> Result<()> {
+        let tmp = TempDir::new("diarize-sidecars")?;
+        let current = tmp.path.join("SortformerNvidiaLow_v2.mlpackage");
+        let current_sidecar = tmp.path.join("SortformerNvidiaLow_v2.mlpackage.mlmodelc");
+        let old_sidecar = tmp.path.join("SortformerNvidiaLow_v1.mlpackage.mlmodelc");
+        let old_sidecar_file = tmp.path.join("SortformerNvidiaLow_v0.mlpackage.mlmodelc");
+        let source_package = tmp.path.join("SortformerNvidiaLow_v1.mlpackage");
+        let unrelated = tmp.path.join("README.md");
+
+        fs::create_dir_all(&current)?;
+        fs::create_dir_all(&current_sidecar)?;
+        fs::create_dir_all(&old_sidecar)?;
+        fs::write(&old_sidecar_file, b"compiled")?;
+        fs::create_dir_all(&source_package)?;
+        fs::write(&unrelated, b"leave me")?;
+
+        let removed = cleanup_diarize_compiled_sidecars(&current)?;
+
+        assert_eq!(removed, 2);
+        assert!(current.exists());
+        assert!(current_sidecar.exists());
+        assert!(source_package.exists());
+        assert!(unrelated.exists());
+        assert!(!old_sidecar.exists());
+        assert!(!old_sidecar_file.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn cleanup_diarize_sidecars_ignores_missing_parent() -> Result<()> {
+        let tmp = TempDir::new("diarize-sidecars-missing")?;
+        let missing = tmp.path.join("missing/Current.mlpackage");
+
+        assert_eq!(cleanup_diarize_compiled_sidecars(&missing)?, 0);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod mirror_tests {
     use super::*;
@@ -676,6 +743,55 @@ pub fn download_diarize(no_cache: bool) -> Result<()> {
     let cache = cache_dir();
     let refs: Vec<&ModelFile> = DIARIZE_FILES.iter().collect();
     parallel_download(&cache, &refs, no_cache)
+}
+
+/// Remove stale CoreML-compiled diarization sidecars after the current model
+/// was successfully warmed. Only deletes Kesha-owned siblings next to the
+/// active `.mlpackage`; never touches the source `.mlpackage` or Apple's e5rt
+/// cache.
+#[cfg(feature = "system_diarize")]
+pub fn cleanup_diarize_compiled_sidecars(keep_model_package: &Path) -> Result<usize> {
+    let Some(parent) = keep_model_package.parent() else {
+        return Ok(0);
+    };
+    if !parent.exists() {
+        return Ok(0);
+    }
+
+    let keep_sidecar = compiled_model_sidecar(keep_model_package);
+    let mut removed = 0;
+    for entry in
+        fs::read_dir(parent).with_context(|| format!("read diarize cache {}", parent.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path == keep_sidecar || !is_compiled_mlpackage_sidecar(&path) {
+            continue;
+        }
+        if entry.file_type()?.is_dir() {
+            fs::remove_dir_all(&path)
+                .with_context(|| format!("remove stale diarize sidecar {}", path.display()))?;
+        } else {
+            fs::remove_file(&path)
+                .with_context(|| format!("remove stale diarize sidecar {}", path.display()))?;
+        }
+        removed += 1;
+    }
+    Ok(removed)
+}
+
+#[cfg(feature = "system_diarize")]
+fn compiled_model_sidecar(model_package: &Path) -> PathBuf {
+    let mut sidecar = model_package.as_os_str().to_os_string();
+    sidecar.push(".mlmodelc");
+    PathBuf::from(sidecar)
+}
+
+#[cfg(feature = "system_diarize")]
+fn is_compiled_mlpackage_sidecar(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".mlpackage.mlmodelc"))
 }
 
 /// Download the Silero VAD ONNX. Opt-in via `kesha install --vad` (#128).


### PR DESCRIPTION
## Problem

`kesha transcribe --json --speakers` recompiled the Sortformer `.mlpackage`'s CoreML **ANE program on every process** (~100s) and tripped #435's 90s adaptive timeout — so `--speakers` failed for everyone. This was never released (#433/#435 merged but the engine release is still pending), so no shipped binary is broken; this gates that release.

## Root cause (confirmed by spike, M3 Pro)

The fork's `diarizeFileWithModels` loaded via `SortformerModels.load()`, which runs `MLModel.compileModel(.mlpackage)` to a **throwaway temp `.mlmodelc`** and loads it with `computeUnits = .all` every call. The ~100s is the **ANE program compile** inside `MLModel(contentsOf:, .all)`, cached by Apple in `com.apple.e5rt.e5bundlecache` **keyed by the compiled model's path** — a fresh temp path every run = cache miss every run.

| step | time |
|---|---|
| `compileModel(.mlpackage → .mlmodelc)` | 0.3s |
| `MLModel(contentsOf: stable.mlmodelc, .all)` cold | 104.7s |
| same stable path, 2nd process | **3.9s** |

It was **not** thread QoS and **not** `compileModel`.

## Fix

Two parts:

1. **Fork — drakulavich/fluidaudio-rs#1 (merged to `forked-main`):** load from a **stable** sibling `.mlmodelc` (`<modelPath>.mlmodelc`): compile once if absent, then `MLModel(contentsOf: stable, .all)` via the public `SortformerModels(config:main:)` init → `initialize(models:)`. The e5rt cache then hits across processes. Adds `compile_diarization_model` for install-time warming.
2. **This PR (kesha):**
   - `rust/Cargo.lock`: bump the fork pin `forked-main` `d8e5210 → 3463cbb`.
   - `rust/src/cli/install.rs`: when the diarize model is installed (and not `--no-warmup`), pay the one-time ANE compile during `kesha install` — alongside the existing ASR warm-up — so the first real `--speakers` call is fast.

The `diarize.rs` runtime path (incl. #435's adaptive timeout) is unchanged; with warm install it loads in ~4s and never trips the timeout. Edge case (e5rt eviction → cold runtime reload) accepted for v1 (opt-in feature).

## Verification (local, M3 Pro)

- `install --diarize`: ASR warmed 35s + **diarize warmed 108s** (cold, one-time); stable `.mlmodelc` created.
- `transcribe /tmp/a.wav --json --speakers` steady-state: **5–7s**, valid JSON with `segments[].speaker`, **zero E5RT on stdout**.
- `KESHA_DIARIZE_TIMEOUT_SECS=1 transcribe …`: fast-fails in ~1s with the timeout message.
- `say --voice en-am_michael`: WAV unaffected.
- `cargo nextest run --features tts`: 282/282. `tsc --noEmit`, version-drift gate: clean. (The 4 "CLI help golden" `bun test` failures reproduce on clean `main` in a non-TTY shell — pre-existing/environmental, not from this change.)

Refs #434, #435. Engine version bump + release is a separate follow-up that bundles #433 + #435 + this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)