### PR TITLE
Clean retired sidecar helpers after install

### DIFF
--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -88,6 +88,40 @@ const SIDECARS: SidecarSpec[] = [
   },
 ];
 
+const RETIRED_SIDECAR_FILENAMES = [
+  // Historical installed filenames.
+  "kesha-kokoro",
+  "kesha-diarize",
+  // Historical release-asset filenames. Keep these explicit: AVSpeech and
+  // text-lang helpers are still active and must not be swept up by a glob.
+  "kesha-kokoro-darwin-arm64",
+  "kesha-diarize-darwin-arm64",
+];
+
+export function cleanupRetiredSidecars(engineDir: string): string[] {
+  const removed: string[] = [];
+
+  for (const filename of RETIRED_SIDECAR_FILENAMES) {
+    const path = join(engineDir, filename);
+    if (!existsSync(path)) continue;
+
+    try {
+      rmSync(path);
+      removed.push(filename);
+    } catch (e) {
+      log.warn(
+        `Could not remove retired sidecar ${filename} (${e instanceof Error ? e.message : e}); continuing.`,
+      );
+    }
+  }
+
+  if (removed.length > 0) {
+    log.success(`Removed retired sidecars: ${removed.join(", ")}.`);
+  }
+
+  return removed;
+}
+
 /**
  * Make a freshly-downloaded Mach-O runnable on macOS 15+ Sequoia.
  *
@@ -488,6 +522,10 @@ export async function downloadEngine(
 
   if (options.tts) {
     await warmDarwinKokoro(binPath);
+  }
+
+  if (canWriteEngineDir) {
+    cleanupRetiredSidecars(engineDir);
   }
 
   log.success("Backend installed successfully.");

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -1,10 +1,11 @@
 import { describe, test, expect } from "bun:test";
 import {
+  cleanupRetiredSidecars,
   getVersionMarkerPath,
   readInstalledEngineVersion,
   writeInstalledEngineVersion,
 } from "../../src/engine-install";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -61,5 +62,62 @@ describe("engine-install version marker (#151)", () => {
     writeInstalledEngineVersion(binPath, "1.2.0");
     expect(readInstalledEngineVersion(binPath)).toBe("1.2.0");
     rmSync(binPath + ".version");
+  });
+});
+
+describe("engine-install retired sidecar cleanup (#438)", () => {
+  test("removes old Kokoro and diarize helpers without touching active helpers", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-retired-sidecar-test-"));
+    const engineDir = join(dir, "engine", "bin");
+
+    try {
+      mkdirSync(engineDir, { recursive: true });
+      for (const filename of [
+        "kesha-kokoro",
+        "kesha-kokoro-darwin-arm64",
+        "kesha-diarize",
+        "kesha-diarize-darwin-arm64",
+        "say-avspeech",
+        "say-avspeech-darwin-arm64",
+        "kesha-textlang",
+        "kesha-textlang-darwin-arm64",
+        "kesha-engine",
+      ]) {
+        writeFileSync(join(engineDir, filename), "binary");
+      }
+
+      const removed = cleanupRetiredSidecars(engineDir).sort();
+
+      expect(removed).toEqual([
+        "kesha-diarize",
+        "kesha-diarize-darwin-arm64",
+        "kesha-kokoro",
+        "kesha-kokoro-darwin-arm64",
+      ]);
+      for (const filename of removed) {
+        expect(existsSync(join(engineDir, filename))).toBe(false);
+      }
+      for (const filename of [
+        "say-avspeech",
+        "say-avspeech-darwin-arm64",
+        "kesha-textlang",
+        "kesha-textlang-darwin-arm64",
+        "kesha-engine",
+      ]) {
+        expect(existsSync(join(engineDir, filename))).toBe(true);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("is a no-op when retired helpers are absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-retired-sidecar-empty-test-"));
+
+    try {
+      expect(cleanupRetiredSidecars(dir)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- removes retired Kokoro/diarize helper executables from the engine bin directory after a successful install
- keeps the cleanup explicit so active AVSpeech/text-lang helpers and model/CoreML caches are not touched
- adds unit coverage for both historical installed names and release-asset names

Closes #438.

## Validation
- `PATH=/Users/anton/.bun/bin:/opt/homebrew/bin:$PATH bun test tests/unit/engine-install.test.ts`
- `PATH=/Users/anton/.bun/bin:/opt/homebrew/bin:$PATH bunx tsc --noEmit`
