### PR TITLE
Publish prereleases to npm beta channel

### DIFF
--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -147,10 +147,7 @@ function buildManifest(tag) {
     engineVersion,
     packaging: {
       runtime: "bun",
-      userInstall: isStableTag(tag)
-        ? "bun add -g @drakulavich/kesha-voice-kit"
-        : "bun add -g @drakulavich/kesha-voice-kit@beta",
-      npmDistTag: isStableTag(tag) ? "latest" : "beta",
+      userInstall: "bun add -g @drakulavich/kesha-voice-kit",
       manifestPurpose:
         "Release metadata for package-manager channels; it does not replace the Bun-first user install path.",
     },

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -5,6 +5,8 @@ import { linuxPackageNames } from "./linux-package-names.mjs";
 
 const REPOSITORY = "drakulavich/kesha-voice-kit";
 const MANIFEST_NAME = "kesha-release-manifest.json";
+const RELEASE_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const STABLE_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
 
 const ENGINE_ASSETS = [
   {
@@ -70,9 +72,13 @@ function linuxPackageAssets(version) {
   ];
 }
 
+function isStableTag(tag) {
+  return STABLE_TAG_RE.test(tag);
+}
+
 function usage() {
   console.error(
-    "usage: node .github/scripts/release-manifest.mjs [--tag vX.Y.Z] [--out path] [--check]",
+    "usage: node .github/scripts/release-manifest.mjs [--tag vX.Y.Z[-beta.N]] [--out path] [--check]",
   );
   process.exit(2);
 }
@@ -123,9 +129,11 @@ function buildManifest(tag) {
   const assets = [
     ...ENGINE_ASSETS.map((p) => asset(p.engineAsset, "engine", [p.id], p.install)),
     ...DARWIN_SIDECARS.map((s) => asset(s.name, "sidecar", ["darwin-arm64"], s.install)),
-    ...linuxPackageAssets(packageVersion).map((p) =>
-      asset(p.name, p.kind, p.platforms, p.install),
-    ),
+    ...(isStableTag(tag)
+      ? linuxPackageAssets(packageVersion).map((p) =>
+          asset(p.name, p.kind, p.platforms, p.install),
+        )
+      : []),
     asset(sbomName, "sbom", []),
     asset(MANIFEST_NAME, "manifest", []),
     asset("SHA256SUMS", "checksum", [], undefined, false),
@@ -140,6 +148,7 @@ function buildManifest(tag) {
     packaging: {
       runtime: "bun",
       userInstall: "bun add -g @drakulavich/kesha-voice-kit",
+      npmDistTag: isStableTag(tag) ? "latest" : "beta",
       manifestPurpose:
         "Release metadata for package-manager channels; it does not replace the Bun-first user install path.",
     },
@@ -209,8 +218,8 @@ function validateSourceConsistency(manifest) {
 const pkg = readPackage();
 const defaultTag = `v${pkg.version}`;
 const tag = getArg("--tag") ?? defaultTag;
-if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
-  throw new Error(`release manifest tag must look like vX.Y.Z, got: ${tag}`);
+if (!RELEASE_TAG_RE.test(tag)) {
+  throw new Error(`release manifest tag must look like vX.Y.Z or vX.Y.Z-beta.N, got: ${tag}`);
 }
 
 const manifest = buildManifest(tag);

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -5,7 +5,7 @@ import { linuxPackageNames } from "./linux-package-names.mjs";
 
 const REPOSITORY = "drakulavich/kesha-voice-kit";
 const MANIFEST_NAME = "kesha-release-manifest.json";
-const RELEASE_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const RELEASE_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-beta\.[0-9]+)?$/;
 const STABLE_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
 
 const ENGINE_ASSETS = [
@@ -147,7 +147,9 @@ function buildManifest(tag) {
     engineVersion,
     packaging: {
       runtime: "bun",
-      userInstall: "bun add -g @drakulavich/kesha-voice-kit",
+      userInstall: isStableTag(tag)
+        ? "bun add -g @drakulavich/kesha-voice-kit"
+        : "bun add -g @drakulavich/kesha-voice-kit@beta",
       npmDistTag: isStableTag(tag) ? "latest" : "beta",
       manifestPurpose:
         "Release metadata for package-manager channels; it does not replace the Bun-first user install path.",

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -2,18 +2,19 @@ name: "🔨 Build Engine"
 
 on:
   push:
-    # Match real engine-release tags ("v1.0.2") but skip CLI-only marker
-    # tags ("v1.0.8-cli"). CLI-only patches do not rebuild the Rust
-    # engine — a separate marker release is created manually via
-    # `gh release create v<X.Y.Z>-cli --notes-file ...` without
-    # triggering this workflow. See CLAUDE.md → RELEASE PROCESS.
+    # Match real engine-release tags ("v1.0.2") and prerelease engine tags
+    # ("v1.0.3-beta.1"), but skip CLI-only marker tags ("v1.0.8-cli").
+    # CLI-only patches do not rebuild the Rust engine — a separate marker
+    # release is created manually via `gh release create v<X.Y.Z>-cli
+    # --notes-file ...` without triggering this workflow. See CLAUDE.md →
+    # RELEASE PROCESS.
     tags:
       - "v*"
       - "!v*-cli"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to create + build (e.g. v1.17.0). Leave empty to build-only from `ref`."
+        description: "Tag to create + build (e.g. v1.17.0 or v1.17.1-beta.1). Leave empty to build-only from `ref`."
         required: false
       ref:
         description: "Git ref to tag from (commit SHA, branch). Defaults to main HEAD."
@@ -48,15 +49,16 @@ jobs:
           fetch-depth: 0
 
       # Shape + uniqueness validation BEFORE the tag value reaches any
-      # filesystem / argv site. `^v[0-9]+\.[0-9]+\.[0-9]+$` rejects empty,
-      # CLI-only marker tags (vX.Y.Z-cli), and shell-injection attempts.
+      # filesystem / argv site. Stable `vX.Y.Z` and SemVer prerelease
+      # `vX.Y.Z-beta.N` tags are allowed; CLI-only marker tags (vX.Y.Z-cli)
+      # and shell-injection attempts are rejected.
       # CLAUDE.md → TAG NAMES ARE ONE-USE forbids reusing a tag name.
       - name: Validate tag shape and uniqueness
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if ! [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Tag '$INPUT_TAG' must match ^v[0-9]+.[0-9]+.[0-9]+$ (CLI-only marker tags vX.Y.Z-cli are not supported by this workflow)"
+          if ! [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::Tag '$INPUT_TAG' must match vX.Y.Z or vX.Y.Z-beta.N (CLI-only marker tags vX.Y.Z-cli are not supported by this workflow)"
             exit 1
           fi
           if git rev-parse "refs/tags/$INPUT_TAG" >/dev/null 2>&1; then
@@ -359,6 +361,17 @@ jobs:
       - name: Prepare release asset directory
         run: mkdir -p release-assets
 
+      - name: Classify release tag
+        id: release_kind
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate source SBOM
         uses: anchore/sbom-action@v0.24.0
         with:
@@ -375,14 +388,17 @@ jobs:
           bun-version: "1.3.13"
 
       - name: Setup Go
+        if: steps.release_kind.outputs.prerelease != 'true'
         uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: Install nFPM
+        if: steps.release_kind.outputs.prerelease != 'true'
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
 
       - name: Build Linux deb/rpm packages
+        if: steps.release_kind.outputs.prerelease != 'true'
         run: node .github/scripts/build-linux-packages.mjs
 
       - name: Download all artifacts
@@ -392,6 +408,7 @@ jobs:
           path: release-assets
 
       - name: Stage Linux packages
+        if: steps.release_kind.outputs.prerelease != 'true'
         run: cp dist/linux-packages/*.{deb,rpm} release-assets/
 
       - name: Generate release manifest
@@ -428,3 +445,4 @@ jobs:
           body_path: release-notes.md
           files: release-assets/*
           draft: true
+          prerelease: ${{ steps.release_kind.outputs.prerelease }}

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if ! [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+          if ! [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then
             echo "::error::Tag '$INPUT_TAG' must match vX.Y.Z or vX.Y.Z-beta.N (CLI-only marker tags vX.Y.Z-cli are not supported by this workflow)"
             exit 1
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,11 +1,11 @@
 name: "📦 npm Publish"
 
 # Fires once a GitHub release leaves draft (the manual gate per CLAUDE.md
-# release flow). Both real engine releases (`vX.Y.Z`) and CLI-only marker
-# releases (`vX.Y.Z-cli`) un-draft into the same `published` event — both
-# need `npm publish`. Also exposes `workflow_dispatch` so the maintainer
-# can re-publish a tag manually (e.g. after fixing a publishConfig bug)
-# without re-creating the release.
+# release flow). Stable releases publish to npm's default `latest` dist-tag;
+# SemVer prereleases (`vX.Y.Z-beta.N`) publish to the `beta` dist-tag so
+# normal `bun add -g @drakulavich/kesha-voice-kit@latest` users do not get
+# unstable builds. CLI-only marker releases (`vX.Y.Z-cli`) follow the same
+# dist-tag rule after stripping `-cli`.
 on:
   release:
     types: [published]
@@ -95,8 +95,21 @@ jobs:
             echo "already_published=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve npm dist-tag
+        id: dist_tag
+        run: |
+          version=$(jq -r .version package.json)
+          if [[ "$version" == *-* ]]; then
+            echo "tag=beta" >> "$GITHUB_OUTPUT"
+            echo "$version is a prerelease — publishing to npm dist-tag beta."
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "$version is stable — publishing to npm dist-tag latest."
+          fi
+
       - name: Publish to npm with provenance
         if: steps.registry.outputs.already_published == 'false'
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "$NPM_DIST_TAG"
         env:
+          NPM_DIST_TAG: ${{ steps.dist_tag.outputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,14 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 7. Publish: `gh release edit vX.Y.Z --draft=false`. This fires `📦 npm Publish`; verify `npm view @drakulavich/kesha-voice-kit version` within ~60s. Manual fallback: `npm publish --access public` from the maintainer laptop.
 8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo, and attach Linux x64 `.deb`/`.rpm` packages covered by `SHA256SUMS` + Sigstore. CLI-only marker releases skip Homebrew/packages.
 
+**Beta engine release** (unstable channel):
+
+- Use SemVer prerelease versions in all three places: `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`, for example `1.18.7-beta.1`; tag as `v1.18.7-beta.1`.
+- `build-engine.yml` accepts `vX.Y.Z-beta.N`, creates a **draft prerelease**, and uploads engine binaries, sidecars, `SHA256SUMS`, manifest, SBOM, and Sigstore bundles. It intentionally skips Homebrew and Linux `.deb`/`.rpm` packages for beta tags.
+- After draft asset validation, publish with `gh release edit vX.Y.Z-beta.N --draft=false`. `📦 npm Publish` publishes prerelease package versions with `npm publish --tag beta`, so `@latest` stays on the latest stable release.
+- Verify beta with `npm view @drakulavich/kesha-voice-kit@beta version`; user-facing beta install is `bun add -g @drakulavich/kesha-voice-kit@beta && kesha install`.
+- Promote by cutting a later stable `vX.Y.Z` release; do not reuse the beta tag or try to retag it as stable.
+
 **Alternate tag path:** `workflow_dispatch` validates tag shape and authors notes inline, useful when a sandbox cannot push tags:
 
 ```bash
@@ -173,6 +181,7 @@ Post-#291 happy path: publishing a GitHub release runs `.github/workflows/npm-pu
 - Trigger: `release: published` (engine un-draft or published `v*-cli` marker) plus `workflow_dispatch` re-runs.
 - Provenance: `permissions.id-token: write` gives npm the GHA OIDC chain (`commit SHA` → built tarball) and the npm "verified" badge.
 - Guards: tag must match `package.json#version` after stripping leading `v` and trailing `-cli`; already-published versions skip publish and exit 0.
+- Dist-tags: stable package versions publish to `latest`; SemVer prerelease package versions publish to `beta`.
 - Injection rule: route `inputs.tag` / `github.event.release.tag_name` through `env:`, never directly into `run:` while the job holds `id-token: write`.
 - Required secret: `NPM_TOKEN` (granular publish-only token for `@drakulavich/kesha-voice-kit`), set with `gh secret set NPM_TOKEN -R drakulavich/kesha-voice-kit`. If missing, the release remains published but the publish step fails; fallback is `npm publish --access public` from a laptop.
 - Release implication: un-draft is the commit-to-publish point. Validate draft assets via authenticated `gh release download` before un-drafting; npm publish is effectively permanent (72 h unpublish window, noisy provenance). If validation fails before publish: delete release + tag, bump patch, retry.

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -23,8 +23,7 @@ For stable `vX.Y.Z` releases, the manifest records:
 - checksum and Sigstore bundle naming conventions
 
 For prerelease tags such as `vX.Y.Z-beta.1`, Linux `.deb` and `.rpm` package
-assets are omitted; npm receives the package under the `beta` dist-tag instead
-of `latest`.
+assets are omitted.
 
 `SHA256SUMS` and Sigstore bundles cover the manifest itself, so downstream
 packaging can verify the metadata before consuming it.

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -13,7 +13,7 @@ kesha install
 
 ## Contents
 
-The manifest records:
+For stable `vX.Y.Z` releases, the manifest records:
 
 - the repository, release tag, CLI version, and engine version
 - released engine binaries and macOS sidecars
@@ -21,6 +21,10 @@ The manifest records:
 - the install layout used by `kesha install`
 - supported platform status for package managers
 - checksum and Sigstore bundle naming conventions
+
+For prerelease tags such as `vX.Y.Z-beta.1`, Linux `.deb` and `.rpm` package
+assets are omitted; npm receives the package under the `beta` dist-tag instead
+of `latest`.
 
 `SHA256SUMS` and Sigstore bundles cover the manifest itself, so downstream
 packaging can verify the metadata before consuming it.


### PR DESCRIPTION
## Summary
- allow engine prerelease tags such as `v1.18.7-beta.1` in the build workflow
- create beta engine builds as draft GitHub prereleases and publish npm prerelease versions with `--tag beta`
- keep stable releases unchanged: `latest`, Homebrew, and Linux deb/rpm packages remain stable-only
- update release manifest metadata and release runbook docs for the beta channel

## Validation
- `bun run check:release-manifest`
- `bun run check:workflows`
- `bunx tsc --noEmit`
- `git diff --check`
- beta manifest probe with temp `package.json` version `1.18.7-beta.1`: `npmDistTag=beta`, `packageAssets=0`
