### PR TITLE
chore(release): v1.19.0-beta.1

### DIFF
--- a/.github/scripts/check-versions.ts
+++ b/.github/scripts/check-versions.ts
@@ -34,25 +34,61 @@
  */
 import { readFileSync } from "node:fs";
 
-type SemVer = { major: number; minor: number; patch: number };
+type SemVer = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+};
 
 function parseSemver(raw: string, label: string): SemVer {
-  const m = raw.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  const m = raw.match(
+    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/,
+  );
   if (!m) {
-    console.error(`${label}: not a plain x.y.z semver (got '${raw}')`);
+    console.error(`${label}: not a valid x.y.z semver (got '${raw}')`);
     process.exit(1);
   }
-  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4]?.split(".") ?? [],
+  };
 }
 
 function cmp(a: SemVer, b: SemVer): number {
   if (a.major !== b.major) return a.major - b.major;
   if (a.minor !== b.minor) return a.minor - b.minor;
-  return a.patch - b.patch;
+  if (a.patch !== b.patch) return a.patch - b.patch;
+
+  // SemVer precedence: a stable version outranks its prereleases.
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+
+  const len = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a.prerelease[i];
+    const bi = b.prerelease[i];
+    if (ai === undefined) return -1;
+    if (bi === undefined) return 1;
+    if (ai === bi) continue;
+
+    const an = ai.match(/^(0|[1-9]\d*)$/);
+    const bn = bi.match(/^(0|[1-9]\d*)$/);
+    if (an && bn) return Number(ai) - Number(bi);
+    if (an) return -1;
+    if (bn) return 1;
+    return ai < bi ? -1 : 1;
+  }
+
+  return 0;
 }
 
 function fmt(v: SemVer): string {
-  return `${v.major}.${v.minor}.${v.patch}`;
+  const base = `${v.major}.${v.minor}.${v.patch}`;
+  return v.prerelease.length ? `${base}-${v.prerelease.join(".")}` : base;
 }
 
 const pkgRaw = JSON.parse(readFileSync("package.json", "utf8"));

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.18.6" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.19.0-beta.1" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.18.6",
+  "version": "1.19.0-beta.1",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.18.6"
+    "version": "1.19.0-beta.1"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.18.6"
+version = "1.19.0-beta.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.18.6"
+version = "1.19.0-beta.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -205,7 +205,7 @@ describe("CLI contracts", () => {
 
     const version = await runCli(["--version"]);
     expectContract(version, { exitCode: 0, stderrEmpty: true });
-    expect(version.stdout).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(version.stdout).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
 
     const empty = await runCli([]);
     expectContract(empty, {


### PR DESCRIPTION
## Summary
- Bump CLI and engine versions to `1.19.0-beta.1`.
- Refresh Cargo lock metadata and generated manpage version.
- Allow valid SemVer prereleases in the version drift gate and CLI `--version` contract.

## Validation
- `cargo check`
- `bun run check:versions`
- `bun run check:release-manifest`
- `bun run check:workflows`
- `bunx tsc --noEmit`
- `bun test`
- `git diff --check`
