### PR TITLE
fix(tts): surface FluidAudio Kokoro cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Each segment gets a `speaker` integer (cluster ID, stable within one file). Linu
 
 ## Text-to-speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian) — voice auto-picks from the text's language. On darwin-arm64, Kokoro uses FluidAudio CoreML instead of ONNX:
+Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian) — voice auto-picks from the text's language. On darwin-arm64, Kokoro uses FluidAudio CoreML instead of ONNX; FluidAudio stores that CoreML cache at `~/.cache/fluidaudio/Models/kokoro`, outside Kesha's pinned model cache:
 
 ```bash
-kesha install --tts                      # ~990MB (Kokoro + Vosk-TTS RU, opt-in)
+kesha install --tts                      # TTS, opt-in; Darwin Kokoro uses FluidAudio cache
 kesha say "Hello, world" > hello.wav
 kesha say "Привет, мир" > privet.wav     # auto-routes (Milena on darwin, ru-vosk-m02 elsewhere)
 ```
@@ -288,7 +288,7 @@ are missing.
 | SpeechBrain ECAPA-TDNN | Audio language detection | ~86MB | [HuggingFace](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa) |
 | Apple NLLanguageRecognizer | Text language detection | built-in | macOS system framework |
 | Silero VAD v5 (opt-in) | Voice activity detection | ~2.3MB | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) |
-| Kokoro-82M / Vosk-TTS (opt-in) | Text-to-speech | ~990MB | [FluidAudio Kokoro](https://github.com/FluidInference/FluidAudio) on darwin-arm64; ONNX Kokoro elsewhere · [Vosk-TTS](https://github.com/alphacep/vosk-tts) |
+| Kokoro-82M / Vosk-TTS (opt-in) | Text-to-speech | ~990MB | [FluidAudio Kokoro](https://github.com/FluidInference/FluidAudio) on darwin-arm64 (FluidAudio cache, not Kesha-verified); ONNX Kokoro elsewhere · [Vosk-TTS](https://github.com/alphacep/vosk-tts) |
 
 All models run through `kesha-engine` — a Rust binary using [FluidAudio](https://github.com/FluidInference/FluidAudio) (CoreML) on Apple Silicon and [ort](https://github.com/pykeio/ort) (ONNX Runtime) on other platforms.
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,6 +1,6 @@
 # Text-to-Speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, English Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path.
+Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, English Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path. FluidAudio keeps its CoreML Kokoro cache at `~/.cache/fluidaudio/Models/kokoro`; those files are managed by FluidAudio, not Kesha's pinned model downloader.
 
 ```bash
 kesha install --tts                 # TTS models, opt-in (Darwin Kokoro uses FluidAudio cache)

--- a/src/diagnostic-paths.ts
+++ b/src/diagnostic-paths.ts
@@ -1,0 +1,22 @@
+import { readdirSync, statSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export function diagnosticHomeDir(): string {
+  return process.env.HOME ?? homedir();
+}
+
+export function dirSizeBytes(path: string): number {
+  let total = 0;
+  try {
+    const st = statSync(path);
+    if (st.isFile()) return st.size;
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const p = join(path, entry.name);
+      total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size;
+    }
+  } catch {
+    return total;
+  }
+  return total;
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,6 +1,5 @@
-import { existsSync, readdirSync, statSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { dirname, join, sep } from "path";
-import { homedir } from "os";
 import {
   getEngineBinPath,
   getEngineCapabilities,
@@ -11,7 +10,11 @@ import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
 import { packageName, packageVersion } from "./package-info";
 import { getStatsStatus, type StatsStatus } from "./stats";
-import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
+import {
+  fluidKokoroCacheInfo,
+  type FluidKokoroCacheInfo,
+} from "./fluid-kokoro-cache";
+import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
 
 const KNOWN_ENV_KEYS = [
   "KESHA_ENGINE_BIN",
@@ -71,10 +74,6 @@ export interface DoctorReport {
   env: Record<string, string | null>;
 }
 
-function diagnosticHomeDir(): string {
-  return process.env.HOME ?? homedir();
-}
-
 function humanBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   const units = ["KB", "MB", "GB", "TB"];
@@ -85,21 +84,6 @@ function humanBytes(bytes: number): string {
     i++;
   }
   return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
-}
-
-function dirSizeBytes(path: string): number {
-  let total = 0;
-  try {
-    const st = statSync(path);
-    if (st.isFile()) return st.size;
-    for (const entry of readdirSync(path, { withFileTypes: true })) {
-      const p = join(path, entry.name);
-      total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size;
-    }
-  } catch {
-    return total;
-  }
-  return total;
 }
 
 function pathSummary(path: string): PathSummary {
@@ -215,7 +199,10 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
   };
 }
 
-function collectCache(redact: boolean): DoctorReport["cache"] {
+function collectCache(
+  redact: boolean,
+  fluidKokoro: FluidKokoroCacheInfo,
+): DoctorReport["cache"] {
   const cache = keshaCacheDir();
   const binPath = getEngineBinPath();
   const engineDir = dirname(dirname(binPath));
@@ -227,7 +214,6 @@ function collectCache(redact: boolean): DoctorReport["cache"] {
     { label: "TTS (Kokoro)", ...pathSummary(join(cache, "models/kokoro-82m")) },
     { label: "TTS (Vosk)", ...pathSummary(join(cache, "models/vosk-ru")) },
   ];
-  const fluidKokoro = fluidKokoroCacheInfo();
   if (fluidKokoro.supported) {
     components.push({
       label: "FluidAudio Kokoro cache (external)",
@@ -247,10 +233,12 @@ function collectCache(redact: boolean): DoctorReport["cache"] {
   };
 }
 
-function collectOptionalComponents(redact: boolean): OptionalComponent[] {
+function collectOptionalComponents(
+  redact: boolean,
+  fluidKokoro: FluidKokoroCacheInfo,
+): OptionalComponent[] {
   const cache = keshaCacheDir();
   const sidecarDir = dirname(getEngineBinPath());
-  const fluidKokoro = fluidKokoroCacheInfo();
   const components: OptionalComponent[] = [
     {
       name: "VAD (Silero)",
@@ -326,6 +314,7 @@ export async function collectDoctorReport(
   options: DoctorOptions = {},
 ): Promise<DoctorReport> {
   const redact = options.redact === true;
+  const fluidKokoro = fluidKokoroCacheInfo();
   return {
     generatedAt: new Date().toISOString(),
     redacted: redact,
@@ -336,8 +325,8 @@ export async function collectDoctorReport(
       arch: process.arch,
     },
     engine: await collectEngine(redact),
-    cache: collectCache(redact),
-    optionalComponents: collectOptionalComponents(redact),
+    cache: collectCache(redact, fluidKokoro),
+    optionalComponents: collectOptionalComponents(redact, fluidKokoro),
     stats: collectStats(redact),
     env: collectEnv(redact),
   };

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -11,6 +11,7 @@ import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
 import { packageName, packageVersion } from "./package-info";
 import { getStatsStatus, type StatsStatus } from "./stats";
+import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
 
 const KNOWN_ENV_KEYS = [
   "KESHA_ENGINE_BIN",
@@ -226,6 +227,15 @@ function collectCache(redact: boolean): DoctorReport["cache"] {
     { label: "TTS (Kokoro)", ...pathSummary(join(cache, "models/kokoro-82m")) },
     { label: "TTS (Vosk)", ...pathSummary(join(cache, "models/vosk-ru")) },
   ];
+  const fluidKokoro = fluidKokoroCacheInfo();
+  if (fluidKokoro.supported) {
+    components.push({
+      label: "FluidAudio Kokoro cache (external)",
+      path: fluidKokoro.path,
+      exists: fluidKokoro.exists,
+      sizeBytes: fluidKokoro.sizeBytes,
+    });
+  }
   const engineInsideCache = engineDir === cache || engineDir.startsWith(`${cache}${sep}`);
   const engineOutsideCache = engineInsideCache ? 0 : dirSizeBytes(engineDir);
 
@@ -240,6 +250,7 @@ function collectCache(redact: boolean): DoctorReport["cache"] {
 function collectOptionalComponents(redact: boolean): OptionalComponent[] {
   const cache = keshaCacheDir();
   const sidecarDir = dirname(getEngineBinPath());
+  const fluidKokoro = fluidKokoroCacheInfo();
   const components: OptionalComponent[] = [
     {
       name: "VAD (Silero)",
@@ -256,6 +267,17 @@ function collectOptionalComponents(redact: boolean): OptionalComponent[] {
       note: "enabled with `kesha install --tts`",
       ...pathSummary(join(cache, "models/vosk-ru")),
     },
+    ...(fluidKokoro.supported
+      ? [
+          {
+            name: "FluidAudio Kokoro cache",
+            note: "darwin-arm64; managed by FluidAudio outside Kesha's pinned model cache",
+            path: fluidKokoro.path,
+            exists: fluidKokoro.exists,
+            sizeBytes: fluidKokoro.sizeBytes,
+          },
+        ]
+      : []),
     {
       // Diarization (#199) and Kokoro (#207) run in-engine now (native
       // fluidaudio-rs) — no Swift sidecar binaries. The Sortformer model is

--- a/src/fluid-kokoro-cache.ts
+++ b/src/fluid-kokoro-cache.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync, statSync } from "fs";
-import { homedir } from "os";
+import { existsSync } from "fs";
 import { join } from "path";
+import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
 
 export const FLUID_KOKORO_CACHE_NOTE =
   "FluidAudio CoreML in-engine; first warm-up may download/compile FluidAudio's Kokoro CoreML cache outside Kesha's pinned model cache";
@@ -19,25 +19,6 @@ export function isDarwinArm64(
   arch = process.arch,
 ): boolean {
   return platform === "darwin" && arch === "arm64";
-}
-
-function diagnosticHomeDir(): string {
-  return process.env.HOME ?? homedir();
-}
-
-function dirSizeBytes(path: string): number {
-  let total = 0;
-  try {
-    const st = statSync(path);
-    if (st.isFile()) return st.size;
-    for (const entry of readdirSync(path, { withFileTypes: true })) {
-      const p = join(path, entry.name);
-      total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size;
-    }
-  } catch {
-    return total;
-  }
-  return total;
 }
 
 export function fluidKokoroCachePath(homeDir = diagnosticHomeDir()): string {

--- a/src/fluid-kokoro-cache.ts
+++ b/src/fluid-kokoro-cache.ts
@@ -1,0 +1,66 @@
+import { existsSync, readdirSync, statSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export const FLUID_KOKORO_CACHE_NOTE =
+  "FluidAudio CoreML in-engine; first warm-up may download/compile FluidAudio's Kokoro CoreML cache outside Kesha's pinned model cache";
+
+const KOKORO_COREML_BUNDLES = ["kokoro_21_15s.mlmodelc", "kokoro_21_5s.mlmodelc"];
+
+export interface FluidKokoroCacheInfo {
+  supported: boolean;
+  path: string;
+  exists: boolean;
+  sizeBytes: number;
+}
+
+export function isDarwinArm64(
+  platform = process.platform,
+  arch = process.arch,
+): boolean {
+  return platform === "darwin" && arch === "arm64";
+}
+
+function diagnosticHomeDir(): string {
+  return process.env.HOME ?? homedir();
+}
+
+function dirSizeBytes(path: string): number {
+  let total = 0;
+  try {
+    const st = statSync(path);
+    if (st.isFile()) return st.size;
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const p = join(path, entry.name);
+      total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size;
+    }
+  } catch {
+    return total;
+  }
+  return total;
+}
+
+export function fluidKokoroCachePath(homeDir = diagnosticHomeDir()): string {
+  return join(homeDir, ".cache", "fluidaudio", "Models", "kokoro");
+}
+
+export function fluidKokoroCacheInfo(
+  options: {
+    platform?: typeof process.platform;
+    arch?: typeof process.arch;
+    homeDir?: string;
+  } = {},
+): FluidKokoroCacheInfo {
+  const supported = isDarwinArm64(options.platform, options.arch);
+  const path = fluidKokoroCachePath(options.homeDir);
+  const exists =
+    supported &&
+    KOKORO_COREML_BUNDLES.some((bundle) => existsSync(join(path, bundle)));
+
+  return {
+    supported,
+    path,
+    exists,
+    sizeBytes: supported ? dirSizeBytes(path) : 0,
+  };
+}

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -4,6 +4,11 @@ import { getEngineBinPath } from "./engine";
 import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
 import { engineVersion, packageVersion } from "./package-info";
+import {
+  FLUID_KOKORO_CACHE_NOTE,
+  fluidKokoroCacheInfo,
+  isDarwinArm64,
+} from "./fluid-kokoro-cache";
 
 export interface InstallPlanOptions {
   noCache?: boolean;
@@ -25,6 +30,11 @@ interface PlanComponent {
   cached: boolean;
   refresh: boolean;
   note?: string;
+}
+
+interface PlanWarmup {
+  name: string;
+  note: string;
 }
 
 interface ReleaseAssetSpec {
@@ -87,10 +97,6 @@ const DARWIN_SIDECARS: ReleaseAssetSpec[] = [
   { assetName: "say-avspeech-darwin-arm64", sizeBytes: 63_056 },
   { assetName: "kesha-textlang-darwin-arm64", sizeBytes: 57_648 },
 ];
-
-function isDarwinArm64(): boolean {
-  return process.platform === "darwin" && process.arch === "arm64";
-}
 
 function sumFiles(files: PlanFile[]): number {
   return files.reduce((sum, file) => sum + file.sizeBytes, 0);
@@ -158,6 +164,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
   const engineDir = dirname(binPath);
   const noCache = options.noCache === true;
   const components: PlanComponent[] = [];
+  const warmups: PlanWarmup[] = [];
 
   const engineAsset = engineAssetForPlatform();
   if (engineAsset) {
@@ -230,13 +237,10 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
           "Russian ru-vosk-* voices",
         ),
       );
-      components.push({
+      const fluidKokoro = fluidKokoroCacheInfo();
+      warmups.push({
         name: "TTS Kokoro EN",
-        source: "FluidAudio CoreML (in-engine)",
-        sizeBytes: 0,
-        cached: existsSync(binPath),
-        refresh: false,
-        note: "Kokoro runs in-engine via FluidAudio CoreML; no Kokoro ONNX model is downloaded by Kesha on darwin-arm64; warm-up may compile/update FluidAudio's CoreML cache",
+        note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoro.path})`,
       });
     } else {
       components.push(
@@ -320,11 +324,18 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     if (component.note) lines.push(`    ${component.note}`);
   }
 
+  if (warmups.length > 0) {
+    lines.push("", "Warm-ups:");
+    for (const warmup of warmups) {
+      lines.push(`  - ${warmup.name}: ${warmup.note}`);
+    }
+  }
+
   lines.push(
     "",
     "Totals:",
-    `  Cold-cache download: ${humanBytes(coldBytes)}`,
-    `  Expected network for this run: ${humanBytes(expectedNetworkBytes)}`,
+    `  Cold-cache Kesha-managed download: ${humanBytes(coldBytes)}`,
+    `  Expected Kesha-managed network for this run: ${humanBytes(expectedNetworkBytes)}`,
     "",
     "Install behavior:",
     "  - No files are downloaded or changed by --plan.",
@@ -337,7 +348,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
 
   if (options.tts && isDarwinArm64()) {
     lines.push(
-      "  - --tts also warms FluidAudio Kokoro CoreML; first en-* synthesis may compile/update a system CoreML cache.",
+      "  - --tts also warms FluidAudio Kokoro CoreML; FluidAudio may download/compile its own Kokoro cache on first use.",
     );
   }
 

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -6,7 +6,7 @@ import { keshaCacheDir } from "./paths";
 import { engineVersion, packageVersion } from "./package-info";
 import {
   FLUID_KOKORO_CACHE_NOTE,
-  fluidKokoroCacheInfo,
+  fluidKokoroCachePath,
   isDarwinArm64,
 } from "./fluid-kokoro-cache";
 
@@ -237,10 +237,9 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
           "Russian ru-vosk-* voices",
         ),
       );
-      const fluidKokoro = fluidKokoroCacheInfo();
       warmups.push({
         name: "TTS Kokoro EN",
-        note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoro.path})`,
+        note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoroCachePath()})`,
       });
     } else {
       components.push(

--- a/src/status.ts
+++ b/src/status.ts
@@ -4,6 +4,7 @@ import { isEngineInstalled, getEngineBinPath, getEngineCapabilities } from "./en
 import { log } from "./log";
 import { keshaCacheDir } from "./paths";
 import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
+import { dirSizeBytes } from "./diagnostic-paths";
 import pc from "picocolors";
 
 function humanBytes(bytes: number): string {
@@ -16,21 +17,6 @@ function humanBytes(bytes: number): string {
     i++;
   }
   return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
-}
-
-function dirSizeBytes(path: string): number {
-  let total = 0;
-  try {
-    const st = statSync(path);
-    if (st.isFile()) return st.size;
-    for (const entry of readdirSync(path, { withFileTypes: true })) {
-      const p = join(path, entry.name);
-      total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size;
-    }
-  } catch {
-    /* missing path — component not installed */
-  }
-  return total;
 }
 
 export function formatStatusLine(

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { isEngineInstalled, getEngineBinPath, getEngineCapabilities } from "./engine";
 import { log } from "./log";
 import { keshaCacheDir } from "./paths";
+import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
 import pc from "picocolors";
 
 function humanBytes(bytes: number): string {
@@ -149,6 +150,12 @@ function showDiskUsage(binPath: string): void {
   if (total > componentTotal) {
     const other = total - componentTotal;
     log.info(pc.dim(`  (includes ${humanBytes(other)} of other cache files)`));
+  }
+  const fluidKokoro = fluidKokoroCacheInfo();
+  if (fluidKokoro.exists && fluidKokoro.sizeBytes > 0) {
+    log.info("");
+    log.info(`External caches (not included in Kesha total):`);
+    log.info(`  FluidAudio Kokoro: ${humanBytes(fluidKokoro.sizeBytes)} (${fluidKokoro.path})`);
   }
   log.info("");
   log.info(pc.dim(`  To reset cache: rm -rf ${cache} — next \`kesha install\` re-downloads.`));

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -582,7 +582,11 @@ describe("CLI contracts", () => {
     expect(plan.envDiff.overrides.KESHA_ENGINE_BIN).toBe(enginePath);
     expectContract(plan, {
       exitCode: 0,
-      stdoutContains: ["Kesha install plan", "Expected network for this run:", "Run: kesha install --tts"],
+      stdoutContains: [
+        "Kesha install plan",
+        "Expected Kesha-managed network for this run:",
+        "Run: kesha install --tts",
+      ],
       stderrNotContains: ["fake engine should not have been invoked"],
     });
 

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -129,7 +129,7 @@ describe("e2e-cli", () => {
 
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Kesha install plan");
-    expect(stdout).toContain("Expected network for this run:");
+    expect(stdout).toContain("Expected Kesha-managed network for this run:");
     expect(stdout).toContain("Run: kesha install --tts");
     expect(stderr).not.toContain("fake engine should not have been invoked");
   });

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -87,6 +87,21 @@ describe("collectDoctorReport", () => {
 
       mkdirSync(join(dir, ".cache", "kesha", "models", "silero-vad"), { recursive: true });
       writeFileSync(join(dir, ".cache", "kesha", "models", "silero-vad", "model.onnx"), "vad");
+      mkdirSync(join(dir, ".cache", "fluidaudio", "Models", "kokoro", "kokoro_21_15s.mlmodelc"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(
+          dir,
+          ".cache",
+          "fluidaudio",
+          "Models",
+          "kokoro",
+          "kokoro_21_15s.mlmodelc",
+          "coremldata.bin",
+        ),
+        "coreml",
+      );
 
       const report = await collectDoctorReport({ redact: true });
       expect(report.redacted).toBe(true);
@@ -97,6 +112,68 @@ describe("collectDoctorReport", () => {
       expect(report.env.KESHA_MODEL_MIRROR).toBe("https://example.com/kesha");
       expect(report.env.KESHA_DEBUG).toBe("1");
       expect("runCount" in report.stats).toBe(true);
+
+      const fluidCache = report.cache.components.find(
+        (component) => component.label === "FluidAudio Kokoro cache (external)",
+      );
+      const fluidOptional = report.optionalComponents.find(
+        (component) => component.name === "FluidAudio Kokoro cache",
+      );
+      if (process.platform === "darwin" && process.arch === "arm64") {
+        expect(fluidCache).toMatchObject({
+          path: "~/.cache/fluidaudio/Models/kokoro",
+          exists: true,
+        });
+        expect(fluidCache?.sizeBytes).toBeGreaterThan(0);
+        expect(fluidOptional).toMatchObject({
+          path: "~/.cache/fluidaudio/Models/kokoro",
+          exists: true,
+        });
+      } else {
+        expect(fluidCache).toBeUndefined();
+        expect(fluidOptional).toBeUndefined();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports unredacted FluidAudio Kokoro cache on darwin-arm64", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-doctor-fluid-kokoro-test-"));
+    try {
+      process.env.HOME = dir;
+      process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+      process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+      process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+      mkdirSync(join(dir, ".cache", "fluidaudio", "Models", "kokoro", "kokoro_21_5s.mlmodelc"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(
+          dir,
+          ".cache",
+          "fluidaudio",
+          "Models",
+          "kokoro",
+          "kokoro_21_5s.mlmodelc",
+          "coremldata.bin",
+        ),
+        "coreml",
+      );
+
+      const report = await collectDoctorReport({ redact: false });
+      const fluidCache = report.cache.components.find(
+        (component) => component.label === "FluidAudio Kokoro cache (external)",
+      );
+      if (process.platform === "darwin" && process.arch === "arm64") {
+        expect(fluidCache).toMatchObject({
+          path: join(dir, ".cache", "fluidaudio", "Models", "kokoro"),
+          exists: true,
+        });
+        expect(fluidCache?.sizeBytes).toBeGreaterThan(0);
+      } else {
+        expect(fluidCache).toBeUndefined();
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/fluid-kokoro-cache.test.ts
+++ b/tests/unit/fluid-kokoro-cache.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  fluidKokoroCacheInfo,
+  fluidKokoroCachePath,
+  isDarwinArm64,
+} from "../../src/fluid-kokoro-cache";
+
+describe("fluidKokoroCacheInfo", () => {
+  test("uses the FluidAudio Kokoro cache under HOME", () => {
+    expect(fluidKokoroCachePath("/tmp/home")).toBe(
+      join("/tmp/home", ".cache", "fluidaudio", "Models", "kokoro"),
+    );
+  });
+
+  test("detects CoreML Kokoro bundles on darwin-arm64", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-kokoro-cache-test-"));
+    try {
+      const cache = fluidKokoroCachePath(dir);
+      mkdirSync(join(cache, "kokoro_21_15s.mlmodelc"), { recursive: true });
+      writeFileSync(join(cache, "kokoro_21_15s.mlmodelc", "coremldata.bin"), "coreml");
+
+      const info = fluidKokoroCacheInfo({
+        platform: "darwin",
+        arch: "arm64",
+        homeDir: dir,
+      });
+
+      expect(info.supported).toBe(true);
+      expect(info.path).toBe(cache);
+      expect(info.exists).toBe(true);
+      expect(info.sizeBytes).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not advertise FluidAudio Kokoro on non-darwin-arm64", () => {
+    const info = fluidKokoroCacheInfo({
+      platform: "linux",
+      arch: "x64",
+      homeDir: "/tmp/home",
+    });
+
+    expect(isDarwinArm64("linux", "x64")).toBe(false);
+    expect(info.supported).toBe(false);
+    expect(info.exists).toBe(false);
+    expect(info.sizeBytes).toBe(0);
+  });
+});

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -33,10 +33,17 @@ describe("renderInstallPlan", () => {
       expect(output).toContain("ASR Parakeet TDT v3");
       expect(output).toContain("Audio language ID ECAPA");
       expect(output).toContain("TTS");
-      expect(output).toContain("Cold-cache download:");
-      expect(output).toContain("Expected network for this run:");
+      expect(output).toContain("Cold-cache Kesha-managed download:");
+      expect(output).toContain("Expected Kesha-managed network for this run:");
       expect(output).toContain("No files are downloaded or changed by --plan.");
       expect(output).toContain("Run: kesha install --tts");
+      if (process.platform === "darwin" && process.arch === "arm64") {
+        expect(output).toContain("Warm-ups:");
+        expect(output).toContain("TTS Kokoro EN: FluidAudio CoreML in-engine");
+        expect(output).toContain(".cache/fluidaudio/Models/kokoro");
+        expect(output).toContain("outside Kesha's pinned model cache");
+        expect(output).not.toContain("TTS Kokoro EN: 0 B");
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -121,6 +121,21 @@ describe("showStatus", () => {
     writeFileSync(binPath, "not a real executable");
     mkdirSync(join(dir, "models", "parakeet-tdt-v3"), { recursive: true });
     writeFileSync(join(dir, "models", "parakeet-tdt-v3", "model.onnx"), "model");
+    mkdirSync(join(dir, ".cache", "fluidaudio", "Models", "kokoro", "kokoro_21_15s.mlmodelc"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(
+        dir,
+        ".cache",
+        "fluidaudio",
+        "Models",
+        "kokoro",
+        "kokoro_21_15s.mlmodelc",
+        "coremldata.bin",
+      ),
+      "coreml",
+    );
 
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = dir;
@@ -140,6 +155,13 @@ describe("showStatus", () => {
       lines.length = 0;
       await showStatus({ disk: true });
       expect(lines.join("\n")).toContain("Disk usage");
+      if (process.platform === "darwin" && process.arch === "arm64") {
+        expect(lines.join("\n")).toContain("External caches (not included in Kesha total):");
+        expect(lines.join("\n")).toContain("FluidAudio Kokoro:");
+        expect(lines.join("\n")).toContain(".cache/fluidaudio/Models/kokoro");
+      } else {
+        expect(lines.join("\n")).not.toContain("FluidAudio Kokoro:");
+      }
     } finally {
       console.log = originalLog;
       console.error = originalError;


### PR DESCRIPTION
## Summary
- add a shared FluidAudio Kokoro cache helper for darwin-arm64 visibility
- show Kokoro as a FluidAudio warm-up in install --plan instead of a 0 B Kesha component
- include the external FluidAudio Kokoro cache in doctor/status disk output and docs

## Tests
- bun test tests/unit/fluid-kokoro-cache.test.ts tests/unit/install-plan.test.ts tests/unit/doctor.test.ts tests/unit/status.test.ts
- bun test tests/integration/e2e-cli.test.ts --test-name-pattern "install --plan"
- bun test tests/integration/cli-contracts.test.ts --test-name-pattern "diagnostic|read-only planning"
- bunx tsc --noEmit
- git diff --check