### PR TITLE
feat(cli): add privacy-safe diagnostic command events

### DIFF
--- a/docs/diagnostic-logs.md
+++ b/docs/diagnostic-logs.md
@@ -36,6 +36,12 @@ Diagnostic logs are content-free. Event payloads are built from an allowlist of
 typed fields such as command name, app version, platform, backend, feature flags,
 stage names, exit codes, duration numbers, and stable error codes.
 
+When enabled, `kesha <audio>` and `kesha say` record command lifecycle events
+such as `command.start`, `input.audio`, `input.missing`, `engine.exit`, and
+`command.finish`. These events use only counts, booleans, format extensions,
+duration milliseconds, and bucket labels. In the default `retain-on-failure`
+mode, successful runs still leave no log file behind.
+
 Diagnostic logs must not store:
 
 - audio bytes

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -18,6 +18,8 @@ import { artifactFromFile, createStatsRecorder } from "../stats";
 import { createPercentProgress } from "../progress";
 import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../process-tree";
 import type { TranscriptionSegment } from "../types";
+import { createDiagnosticLogSession } from "../diagnostic-log";
+import { diagnosticSizeBucket } from "../diagnostic-events";
 
 interface MainCommandArgs {
   _: string[];
@@ -254,6 +256,7 @@ export const mainCommand = defineCommand({
       process.exit(2);
     }
     const vadMode = vad ? "on" : noVad ? "off" : "auto";
+    const outputFormat = wantsJson ? "json" : wantsToon ? "toon" : wantsTranscript ? "transcript" : "text";
 
     if (files.length === 0) {
       log.info(
@@ -276,6 +279,17 @@ export const mainCommand = defineCommand({
     const results: TranscribeResult[] = [];
     const errors: TranscribeErrorRecord[] = [];
     const stats = createStatsRecorder("transcribe");
+    const diagnosticLog = createDiagnosticLogSession();
+    diagnosticLog.event("command.start", {
+      command: "transcribe",
+      itemCount: files.length,
+      outputFormat,
+      vadMode,
+      timestamps: args.timestamps,
+      speakers: args.speakers,
+      includeErrors: args["include-errors"],
+      hasExpectedLang: Boolean(args.lang),
+    });
 
     const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
     const reportProgress = shouldReportTranscribeProgress({
@@ -288,12 +302,20 @@ export const mainCommand = defineCommand({
       if (!existsSync(file)) {
         hasError = true;
         stats.recordError("input", new Error("File not found"), "file_not_found");
+        diagnosticLog.event("input.missing", { command: "transcribe" });
         errors.push({ file, code: "file_not_found", message: "File not found" });
         log.error(`${file}: File not found`);
         continue;
       }
       const inputArtifact = artifactFromFile(file, "input_audio");
-      if (inputArtifact) stats.recordArtifact(inputArtifact);
+      if (inputArtifact) {
+        stats.recordArtifact(inputArtifact);
+        diagnosticLog.event("input.audio", {
+          command: "transcribe",
+          format: inputArtifact.format ?? null,
+          sizeBucket: diagnosticSizeBucket(inputArtifact.sizeBytes),
+        });
+      }
 
       const startedAt = performance.now();
       let progress: ReturnType<typeof createPercentProgress> | null = null;
@@ -370,11 +392,24 @@ export const mainCommand = defineCommand({
           result.segments = segments;
         }
         results.push(result);
+        diagnosticLog.event("engine.exit", {
+          command: "transcribe",
+          status: "success",
+          durationMs: sttTimeMs,
+          segmentCount: segments.length,
+          ranAudioLangId: audioResult !== null,
+          ranTextLangId: textLanguage !== undefined,
+        });
         progress?.finish(`Transcribed ${file}`);
       } catch (err: unknown) {
         progress?.stop();
         hasError = true;
         stats.recordError("transcribe", err);
+        diagnosticLog.event("engine.exit", {
+          command: "transcribe",
+          status: "failed",
+          errorKind: "transcribe_failed",
+        });
         const message = err instanceof Error ? err.message : String(err);
         errors.push({ file, code: "transcribe_failed", message });
         log.error(`${file}: ${message}`);
@@ -394,6 +429,14 @@ export const mainCommand = defineCommand({
     }
 
     stats.finish(hasError ? "failed" : "success", files.length);
+    diagnosticLog.event("command.finish", {
+      command: "transcribe",
+      status: hasError ? "failed" : "success",
+      itemCount: files.length,
+      resultCount: results.length,
+      errorCount: errors.length,
+    });
+    diagnosticLog.finish(hasError ? "failed" : "success");
 
     if (hasError) {
       const signalExitCode = getPendingSignalExitCode();

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -312,7 +312,7 @@ export const mainCommand = defineCommand({
         stats.recordArtifact(inputArtifact);
         diagnosticLog.event("input.audio", {
           command: "transcribe",
-          format: inputArtifact.format ?? null,
+          format: inputArtifact.format || null,
           sizeBucket: diagnosticSizeBucket(inputArtifact.sizeBytes),
         });
       }
@@ -398,7 +398,7 @@ export const mainCommand = defineCommand({
           durationMs: sttTimeMs,
           segmentCount: segments.length,
           ranAudioLangId: audioResult !== null,
-          ranTextLangId: textLanguage !== undefined,
+          ranTxtLangId: textLanguage !== undefined,
         });
         progress?.finish(`Transcribed ${file}`);
       } catch (err: unknown) {

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -181,7 +181,6 @@ export const sayCommand = defineCommand({
     const text = await resolveText(inlineText);
     const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
     const voice = explicitVoice ?? (await autoRouteVoice(text));
-    const textChars = Array.from(text).length;
 
     const opts = {
       text,
@@ -199,7 +198,7 @@ export const sayCommand = defineCommand({
     const diagnosticLog = createDiagnosticLogSession();
     diagnosticLog.event("command.start", {
       command: "say",
-      charBucket: diagnosticCharBucket(textChars),
+      charBucket: diagnosticCharBucket(Array.from(text).length),
       hasInlineInput: inlineText !== undefined,
       hasVoice: explicitVoice !== undefined,
       autoVoice: explicitVoice === undefined && voice !== undefined,
@@ -224,28 +223,24 @@ export const sayCommand = defineCommand({
         // stderr — stdout may carry raw audio bytes when --out is omitted.
         console.error(`TTS time: ${ttsTimeMs}ms`);
       }
+      let outputFormat: string = opts.format ?? "wav";
+      let outputSizeBytes: number | null | undefined = audio.byteLength;
       if (opts.out) {
         const outputArtifact = artifactFromFile(opts.out, "output_audio");
         if (outputArtifact) stats.recordArtifact(outputArtifact);
-        diagnosticLog.event("command.finish", {
-          command: "say",
-          status: "success",
-          durationMs: ttsTimeMs,
-          hasOut: true,
-          outputFormat: outputArtifact?.format ?? opts.format ?? "auto",
-          outputSizeBucket: diagnosticSizeBucket(outputArtifact?.sizeBytes),
-        });
+        outputFormat = outputArtifact?.format || opts.format || "auto";
+        outputSizeBytes = outputArtifact?.sizeBytes;
       } else {
         stats.recordArtifact(artifactFromBytes(audio.byteLength, "output_audio", opts.format ?? "wav"));
-        diagnosticLog.event("command.finish", {
-          command: "say",
-          status: "success",
-          durationMs: ttsTimeMs,
-          hasOut: false,
-          outputFormat: opts.format ?? "wav",
-          outputSizeBucket: diagnosticSizeBucket(audio.byteLength),
-        });
       }
+      diagnosticLog.event("command.finish", {
+        command: "say",
+        status: "success",
+        durationMs: ttsTimeMs,
+        hasOut: Boolean(opts.out),
+        outputFormat,
+        outputSizeBucket: diagnosticSizeBucket(outputSizeBytes),
+      });
       if (!opts.out) {
         process.stdout.write(audio);
       }

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -4,6 +4,8 @@ import { log } from "../log";
 import { say, SayError, type SayFormat } from "../synth";
 import { artifactFromBytes, artifactFromFile, createStatsRecorder } from "../stats";
 import { pickVoiceForLang } from "../voice-routing";
+import { createDiagnosticLogSession } from "../diagnostic-log";
+import { diagnosticCharBucket, diagnosticSizeBucket } from "../diagnostic-events";
 
 /** Run NLLanguageRecognizer (via engine) on the text and pick a default voice. */
 async function autoRouteVoice(text: string): Promise<string | undefined> {
@@ -179,6 +181,7 @@ export const sayCommand = defineCommand({
     const text = await resolveText(inlineText);
     const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
     const voice = explicitVoice ?? (await autoRouteVoice(text));
+    const textChars = Array.from(text).length;
 
     const opts = {
       text,
@@ -193,6 +196,18 @@ export const sayCommand = defineCommand({
       noExpandAbbrev: Boolean(args["no-expand-abbrev"]),
     };
     const stats = createStatsRecorder("say");
+    const diagnosticLog = createDiagnosticLogSession();
+    diagnosticLog.event("command.start", {
+      command: "say",
+      charBucket: diagnosticCharBucket(textChars),
+      hasInlineInput: inlineText !== undefined,
+      hasVoice: explicitVoice !== undefined,
+      autoVoice: explicitVoice === undefined && voice !== undefined,
+      hasOut: typeof opts.out === "string",
+      outputFormat: opts.format ?? "auto",
+      ssml: opts.ssml,
+      noExpandAbbrev: opts.noExpandAbbrev,
+    });
 
     try {
       const startedAt = performance.now();
@@ -212,16 +227,40 @@ export const sayCommand = defineCommand({
       if (opts.out) {
         const outputArtifact = artifactFromFile(opts.out, "output_audio");
         if (outputArtifact) stats.recordArtifact(outputArtifact);
+        diagnosticLog.event("command.finish", {
+          command: "say",
+          status: "success",
+          durationMs: ttsTimeMs,
+          hasOut: true,
+          outputFormat: outputArtifact?.format ?? opts.format ?? "auto",
+          outputSizeBucket: diagnosticSizeBucket(outputArtifact?.sizeBytes),
+        });
       } else {
         stats.recordArtifact(artifactFromBytes(audio.byteLength, "output_audio", opts.format ?? "wav"));
+        diagnosticLog.event("command.finish", {
+          command: "say",
+          status: "success",
+          durationMs: ttsTimeMs,
+          hasOut: false,
+          outputFormat: opts.format ?? "wav",
+          outputSizeBucket: diagnosticSizeBucket(audio.byteLength),
+        });
       }
       if (!opts.out) {
         process.stdout.write(audio);
       }
       stats.finish("success", 1);
+      diagnosticLog.finish("success");
     } catch (err) {
       stats.recordError("tts", err);
       stats.finish("failed", 1);
+      diagnosticLog.event("command.finish", {
+        command: "say",
+        status: "failed",
+        errorKind: err instanceof SayError ? "say_error" : "error",
+        exitCode: err instanceof SayError ? err.exitCode : 4,
+      });
+      diagnosticLog.finish("failed");
       if (err instanceof SayError) {
         log.error(err.stderr.trim() || err.message);
         process.exit(err.exitCode);

--- a/src/diagnostic-events.ts
+++ b/src/diagnostic-events.ts
@@ -1,0 +1,14 @@
+export function diagnosticSizeBucket(sizeBytes: number | null | undefined): string {
+  if (typeof sizeBytes !== "number" || !Number.isFinite(sizeBytes)) return "unknown";
+  if (sizeBytes < 1024 * 1024) return "lt1MB";
+  if (sizeBytes < 10 * 1024 * 1024) return "mb1_10";
+  if (sizeBytes < 100 * 1024 * 1024) return "mb10_100";
+  return "mb100_plus";
+}
+
+export function diagnosticCharBucket(chars: number): string {
+  if (chars < 100) return "lt100";
+  if (chars < 1000) return "c100_1000";
+  if (chars < 5000) return "c1000_5000";
+  return "c5000_plus";
+}

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
@@ -32,6 +32,19 @@ function isolatedEnv(dir = makeTempDir("kesha-cli-contract-")): Record<string, s
     KESHA_CACHE_DIR: join(dir, "cache"),
     KESHA_LOG_DIR: join(dir, "logs"),
     KESHA_STATS_DB: join(dir, "stats.sqlite"),
+  };
+}
+
+function enableDiagnosticLogs(logDir: string): void {
+  mkdirSync(logDir, { recursive: true });
+  writeFileSync(join(logDir, "diagnostic-logs.json"), `${JSON.stringify({ mode: "on" })}\n`);
+}
+
+function readDiagnosticLog(logDir: string): { raw: string; events: Array<Record<string, unknown>> } {
+  const raw = readFileSync(join(logDir, "kesha.ndjson"), "utf8");
+  return {
+    raw,
+    events: raw.trim().split("\n").map((line) => JSON.parse(line)),
   };
 }
 
@@ -447,6 +460,46 @@ describe("CLI contracts", () => {
     expect(JSON.parse(noVadJson.stdout)[0].text).toBe("Привет без VAD");
   });
 
+  test("diagnostic logs record successful transcribe events without content", async () => {
+    const dir = makeTempDir("kesha-cli-contract-diagnostic-success-");
+    const enginePath = createFakeEngine(dir);
+    const mediaPath = join(dir, "recording");
+    writeFileSync(mediaPath, "fake media");
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+    };
+    enableDiagnosticLogs(env.KESHA_LOG_DIR);
+
+    const run = await runCli(["--json", mediaPath], { env });
+    expectContract(run, {
+      exitCode: 0,
+      stdoutContains: ["Привет с воркшопа"],
+      stderrContains: [`Transcribing ${mediaPath}`, `Transcribed ${mediaPath}`],
+    });
+
+    const { raw: diagnosticLog, events } = readDiagnosticLog(env.KESHA_LOG_DIR);
+    expect(diagnosticLog).not.toContain(mediaPath);
+    expect(diagnosticLog).not.toContain("Привет");
+    expect(events.map((event) => event.event)).toEqual([
+      "command.start",
+      "input.audio",
+      "engine.exit",
+      "command.finish",
+    ]);
+    expect(events[1]).toMatchObject({
+      command: "transcribe",
+      format: null,
+      sizeBucket: "lt1MB",
+    });
+    expect(events[2]).toMatchObject({
+      command: "transcribe",
+      status: "success",
+      ranAudioLangId: true,
+      ranTxtLangId: true,
+    });
+  });
+
   test("long speaker transcripts skip whole-file audio language detection", async () => {
     const dir = makeTempDir("kesha-cli-contract-long-speakers-");
     const enginePath = createFakeEngine(dir);
@@ -652,9 +705,8 @@ describe("CLI contracts", () => {
 
     const missing = await runCli(["private-recording.wav"], { env });
     expect(missing.exitCode).toBe(1);
-    const diagnosticLog = readFileSync(join(env.KESHA_LOG_DIR, "kesha.ndjson"), "utf8");
+    const { raw: diagnosticLog, events: diagnosticEvents } = readDiagnosticLog(env.KESHA_LOG_DIR);
     expect(diagnosticLog).not.toContain("private-recording.wav");
-    const diagnosticEvents = diagnosticLog.trim().split("\n").map((line) => JSON.parse(line));
     expect(diagnosticEvents.map((event) => event.event)).toEqual([
       "command.start",
       "input.missing",

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
@@ -652,6 +652,24 @@ describe("CLI contracts", () => {
 
     const missing = await runCli(["private-recording.wav"], { env });
     expect(missing.exitCode).toBe(1);
+    const diagnosticLog = readFileSync(join(env.KESHA_LOG_DIR, "kesha.ndjson"), "utf8");
+    expect(diagnosticLog).not.toContain("private-recording.wav");
+    const diagnosticEvents = diagnosticLog.trim().split("\n").map((line) => JSON.parse(line));
+    expect(diagnosticEvents.map((event) => event.event)).toEqual([
+      "command.start",
+      "input.missing",
+      "command.finish",
+    ]);
+    expect(diagnosticEvents[0]).toMatchObject({
+      command: "transcribe",
+      itemCount: 1,
+      outputFormat: "text",
+    });
+    expect(diagnosticEvents[2]).toMatchObject({
+      command: "transcribe",
+      status: "failed",
+      errorCount: 1,
+    });
 
     const week = await runCli(["stats", "week"], { env });
     expectContract(week, {

--- a/tests/integration/say.test.ts
+++ b/tests/integration/say.test.ts
@@ -36,6 +36,19 @@ process.exit(99);
   return enginePath;
 }
 
+async function enableDiagnosticLogs(logDir: string): Promise<void> {
+  mkdirSync(logDir, { recursive: true });
+  await Bun.write(`${logDir}/diagnostic-logs.json`, `${JSON.stringify({ mode: "on" })}\n`);
+}
+
+function readDiagnosticLog(logDir: string): { raw: string; events: Array<Record<string, unknown>> } {
+  const raw = readFileSync(`${logDir}/kesha.ndjson`, "utf8");
+  return {
+    raw,
+    events: raw.trim().split("\n").map((line) => JSON.parse(line)),
+  };
+}
+
 const INVALID_NUMERIC_FLAG_CASES: Array<{ name: string; args: string[]; message: string }> = [
   {
     name: "non-numeric rate",
@@ -69,6 +82,19 @@ const INVALID_NUMERIC_FLAG_CASES: Array<{ name: string; args: string[]; message:
   },
 ];
 
+const SAY_OUT_DIAGNOSTIC_CASES = [
+  {
+    name: "say --out reports stderr progress while keeping stdout empty",
+    outputName: "reply.wav",
+    outputFormat: ".wav",
+  },
+  {
+    name: "keeps diagnostic finish event for extensionless --out paths",
+    outputName: "reply",
+    outputFormat: "auto",
+  },
+];
+
 describe("kesha say (CLI)", () => {
   it("--help exits 0 and mentions --voice", async () => {
     const proc = spawn(["bun", CLI_PATH, "say", "--help"], {
@@ -95,63 +121,63 @@ describe("kesha say (CLI)", () => {
     expect(stderr).toMatch(/install/);
   });
 
-  it("say --out reports stderr progress while keeping stdout empty", async () => {
-    const dir = `/tmp/kesha-fake-engine-${Date.now()}-${Math.random()}`;
-    const enginePath = await createFakeEngine(dir);
-    const outPath = `${dir}/reply.wav`;
-    const logDir = `${dir}/logs`;
-    mkdirSync(logDir, { recursive: true });
-    await Bun.write(`${logDir}/diagnostic-logs.json`, `${JSON.stringify({ mode: "on" })}\n`);
-    const proc = spawn([
-      "bun",
-      CLI_PATH,
-      "say",
-      "--voice",
-      "ru-vosk-m02",
-      "--out",
-      outPath,
-      "Привет",
-    ], {
-      env: {
-        ...process.env,
-        KESHA_CACHE_DIR: dir,
-        KESHA_ENGINE_BIN: enginePath,
-        KESHA_LOG_DIR: logDir,
-        HOME: dir,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  for (const tc of SAY_OUT_DIAGNOSTIC_CASES) {
+    it(tc.name, async () => {
+      const dir = `/tmp/kesha-fake-engine-${Date.now()}-${Math.random()}`;
+      const enginePath = await createFakeEngine(dir);
+      const outPath = `${dir}/${tc.outputName}`;
+      const logDir = `${dir}/logs`;
+      await enableDiagnosticLogs(logDir);
+      const proc = spawn([
+        "bun",
+        CLI_PATH,
+        "say",
+        "--voice",
+        "ru-vosk-m02",
+        "--out",
+        outPath,
+        "Привет",
+      ], {
+        env: {
+          ...process.env,
+          KESHA_CACHE_DIR: dir,
+          KESHA_ENGINE_BIN: enginePath,
+          KESHA_LOG_DIR: logDir,
+          HOME: dir,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    expect(await proc.exited).toBe(0);
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
-    const bytes = new Uint8Array(await Bun.file(outPath).arrayBuffer());
+      expect(await proc.exited).toBe(0);
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const bytes = new Uint8Array(await Bun.file(outPath).arrayBuffer());
 
-    expect(stdout).toBe("");
-    expect(stderr).toContain("Synthesizing ru-vosk-m02 ->");
-    expect(stderr).toContain(outPath);
-    expect(stderr).toMatch(/Saved .*reply\.wav \(\d+ms\)/);
-    expect(new TextDecoder().decode(bytes.slice(0, 4))).toBe("RIFF");
+      expect(stdout).toBe("");
+      expect(stderr).toContain("Synthesizing ru-vosk-m02 ->");
+      expect(stderr).toContain(outPath);
+      expect(stderr).toContain(`Saved ${outPath}`);
+      expect(new TextDecoder().decode(bytes.slice(0, 4))).toBe("RIFF");
 
-    const diagnosticLog = readFileSync(`${logDir}/kesha.ndjson`, "utf8");
-    expect(diagnosticLog).not.toContain("Привет");
-    expect(diagnosticLog).not.toContain(outPath);
-    const events = diagnosticLog.trim().split("\n").map((line) => JSON.parse(line));
-    expect(events.map((event) => event.event)).toEqual(["command.start", "command.finish"]);
-    expect(events[0]).toMatchObject({
-      command: "say",
-      charBucket: "lt100",
-      hasVoice: true,
-      hasOut: true,
+      const { raw: diagnosticLog, events } = readDiagnosticLog(logDir);
+      expect(diagnosticLog).not.toContain("Привет");
+      expect(diagnosticLog).not.toContain(outPath);
+      expect(events.map((event) => event.event)).toEqual(["command.start", "command.finish"]);
+      expect(events[0]).toMatchObject({
+        command: "say",
+        charBucket: "lt100",
+        hasVoice: true,
+        hasOut: true,
+      });
+      expect(events[1]).toMatchObject({
+        command: "say",
+        status: "success",
+        outputFormat: tc.outputFormat,
+        outputSizeBucket: "lt1MB",
+      });
     });
-    expect(events[1]).toMatchObject({
-      command: "say",
-      status: "success",
-      outputFormat: ".wav",
-      outputSizeBucket: "lt1MB",
-    });
-  });
+  }
 
   it("--verbose --out does not duplicate timing output", async () => {
     const dir = `/tmp/kesha-fake-engine-${Date.now()}-${Math.random()}`;

--- a/tests/integration/say.test.ts
+++ b/tests/integration/say.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { spawn } from "bun";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, mkdirSync, readFileSync } from "fs";
 
 const CLI_PATH = new URL("../../bin/kesha.js", import.meta.url).pathname;
 
@@ -99,6 +99,9 @@ describe("kesha say (CLI)", () => {
     const dir = `/tmp/kesha-fake-engine-${Date.now()}-${Math.random()}`;
     const enginePath = await createFakeEngine(dir);
     const outPath = `${dir}/reply.wav`;
+    const logDir = `${dir}/logs`;
+    mkdirSync(logDir, { recursive: true });
+    await Bun.write(`${logDir}/diagnostic-logs.json`, `${JSON.stringify({ mode: "on" })}\n`);
     const proc = spawn([
       "bun",
       CLI_PATH,
@@ -113,6 +116,7 @@ describe("kesha say (CLI)", () => {
         ...process.env,
         KESHA_CACHE_DIR: dir,
         KESHA_ENGINE_BIN: enginePath,
+        KESHA_LOG_DIR: logDir,
         HOME: dir,
       },
       stdout: "pipe",
@@ -129,6 +133,24 @@ describe("kesha say (CLI)", () => {
     expect(stderr).toContain(outPath);
     expect(stderr).toMatch(/Saved .*reply\.wav \(\d+ms\)/);
     expect(new TextDecoder().decode(bytes.slice(0, 4))).toBe("RIFF");
+
+    const diagnosticLog = readFileSync(`${logDir}/kesha.ndjson`, "utf8");
+    expect(diagnosticLog).not.toContain("Привет");
+    expect(diagnosticLog).not.toContain(outPath);
+    const events = diagnosticLog.trim().split("\n").map((line) => JSON.parse(line));
+    expect(events.map((event) => event.event)).toEqual(["command.start", "command.finish"]);
+    expect(events[0]).toMatchObject({
+      command: "say",
+      charBucket: "lt100",
+      hasVoice: true,
+      hasOut: true,
+    });
+    expect(events[1]).toMatchObject({
+      command: "say",
+      status: "success",
+      outputFormat: ".wav",
+      outputSizeBucket: "lt1MB",
+    });
   });
 
   it("--verbose --out does not duplicate timing output", async () => {

--- a/tests/unit/diagnostic-events.test.ts
+++ b/tests/unit/diagnostic-events.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { diagnosticCharBucket, diagnosticSizeBucket } from "../../src/diagnostic-events";
+
+describe("diagnostic event buckets", () => {
+  test("buckets byte sizes into privacy-safe labels", () => {
+    expect(diagnosticSizeBucket(null)).toBe("unknown");
+    expect(diagnosticSizeBucket(512)).toBe("lt1MB");
+    expect(diagnosticSizeBucket(2 * 1024 * 1024)).toBe("mb1_10");
+    expect(diagnosticSizeBucket(20 * 1024 * 1024)).toBe("mb10_100");
+    expect(diagnosticSizeBucket(200 * 1024 * 1024)).toBe("mb100_plus");
+  });
+
+  test("buckets character counts into privacy-safe labels", () => {
+    expect(diagnosticCharBucket(10)).toBe("lt100");
+    expect(diagnosticCharBucket(500)).toBe("c100_1000");
+    expect(diagnosticCharBucket(2000)).toBe("c1000_5000");
+    expect(diagnosticCharBucket(5000)).toBe("c5000_plus");
+  });
+});


### PR DESCRIPTION
## Summary
- stack on #447 and add privacy-safe diagnostic lifecycle events for `kesha <audio>` and `kesha say`
- bucket text/audio/output sizes instead of logging content, file paths, or user-provided text
- document the event shape and add focused integration/unit coverage

## Scope
- TS CLI instrumentation only
- no Rust fd plumbing
- no support-bundle inclusion changes

## Tests
- `bun test tests/integration/cli-contracts.test.ts --test-name-pattern "read-only planning"`
- `bun test tests/integration/say.test.ts --test-name-pattern "say --out"`
- `bun test tests/unit/diagnostic-log.test.ts`
- `bun test tests/unit/diagnostic-events.test.ts tests/unit/diagnostic-log.test.ts tests/integration/cli-contracts.test.ts tests/integration/say.test.ts --test-name-pattern "diagnostic event|diagnostic log|read-only planning|say --out"`
- `bun test tests/unit/diagnostic-log.test.ts tests/unit/cli.test.ts tests/integration/cli-contracts.test.ts tests/integration/say.test.ts --test-name-pattern "diagnostic log|logs help|diagnostic and support|read-only planning|say --out"`
- `bunx tsc --noEmit`
- `git diff --check`
- `bun run coverage:ts && bun run coverage:check:ts`