### PR TITLE
feat(cli): expose diagnostic log status JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ kesha doctor --json --redact
 kesha support-bundle --output kesha-support.tar.gz
 kesha support-bundle --include-logs --output kesha-support-with-logs.tar.gz
 kesha logs status
+kesha logs status --json
 ```
 
 `support-bundle` creates a redacted `.tar.gz` archive for GitHub issues. It includes runtime, engine, cache, optional-component, Stats status, and known Kesha environment settings. It does not include audio, transcripts, model files, or the Stats database.
@@ -331,6 +332,8 @@ bounded tail of Kesha's privacy-safe NDJSON diagnostic log.
 
 `kesha logs` manages local, rotated diagnostic logs for troubleshooting. Logs
 default to `retain-on-failure` and also support explicit `off` and `on` modes.
+Use `kesha logs status --json` for a stable machine-readable status contract
+covering the active path, mode, size, rotation settings, and rotated-file list.
 They use content-free NDJSON events: command/stage names, versions, durations,
 exit codes, and coarse audio metadata only. They must not store audio,
 transcripts, input text, generated speech text, file names, full paths, raw

--- a/completions/kesha.bash
+++ b/completions/kesha.bash
@@ -22,7 +22,7 @@ _kesha_completion() {
     doctor) opts="--help -h --json --redact" ;;
     init) opts="--help -h --coreml --onnx --no-cache --plan --yes --tts --vad --diarize" ;;
     install) opts="--help -h --coreml --onnx --no-cache --plan --tts --vad --diarize" ;;
-    logs) opts="--help -h" ;;
+    logs) opts="--help -h --json" ;;
     manpage) opts="--help -h" ;;
     record) opts="--help -h --out --max-seconds --debug" ;;
     say) opts="--help -h --voice --lang --out --rate --list-voices --ssml --format --bitrate --sample-rate --no-expand-abbrev --verbose --debug" ;;

--- a/completions/kesha.fish
+++ b/completions/kesha.fish
@@ -53,6 +53,7 @@ complete -c kesha -n '__fish_seen_subcommand_from install' -l vad -d 'Also insta
 complete -c kesha -n '__fish_seen_subcommand_from install' -l diarize -d 'Also install the Sortformer streaming-diarization model (~245MB, darwin-arm64 only — #199)'
 complete -c kesha -n '__fish_seen_subcommand_from logs' -l help -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from logs' -s h -d 'Show help'
+complete -c kesha -n '__fish_seen_subcommand_from logs' -l json -d 'Output status as JSON'
 complete -c kesha -n '__fish_seen_subcommand_from manpage' -l help -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from manpage' -s h -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from record' -l help -d 'Show help'

--- a/completions/kesha.zsh
+++ b/completions/kesha.zsh
@@ -76,7 +76,8 @@ _kesha() {
       ;;
     logs)
       _arguments '--help[Show help]' \
-        '-h[Show help]'
+        '-h[Show help]' \
+        '--json[Output status as JSON]'
       ;;
     manpage)
       _arguments '--help[Show help]' \

--- a/docs/diagnostic-logs.md
+++ b/docs/diagnostic-logs.md
@@ -10,6 +10,7 @@ file, while failed commands can preserve a small local trace for debugging.
 
 ```bash
 kesha logs status
+kesha logs status --json
 kesha logs enable
 kesha logs disable
 kesha logs mode retain-on-failure
@@ -29,6 +30,10 @@ Diagnostic logs follow a Playwright-style retention model:
 `kesha logs enable` is shorthand for `kesha logs mode on`; `kesha logs disable`
 is shorthand for `kesha logs mode off`. `retain-on-failure` keeps passing runs
 artifact-free while failed runs keep enough context to debug.
+
+`kesha logs status --json` prints the same local status as a stable JSON object:
+`dir`, `activePath`, `statePath`, `exists`, `activeSizeBytes`, `rotatedFiles`,
+`totalSizeBytes`, `mode`, `maxBytes`, and `retain`.
 
 ## Privacy Contract
 
@@ -78,3 +83,11 @@ reset` deletes Kesha log files but preserves the selected mode.
 `kesha support-bundle` does not include diagnostic log contents by default. Use
 `kesha support-bundle --include-logs` to add a bounded tail of the active
 already-sanitized NDJSON log when a support issue needs recent command events.
+Recommended flow for a bug report:
+
+```bash
+kesha logs status
+kesha logs mode retain-on-failure
+# reproduce the failure
+kesha support-bundle --include-logs --output kesha-support-with-logs.tar.gz
+```

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -132,6 +132,10 @@ Also install Silero VAD (~2.3MB) for long\-audio preprocessing
 .TP
 .B \-\-diarize
 Also install the Sortformer streaming\-diarization model (~245MB, darwin\-arm64 only — #199)
+.SS logs
+.TP
+.B \-\-json
+Output status as JSON
 .SS record
 .TP
 .B \-\-out

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -12,6 +12,7 @@ import { log } from "../log";
 interface LogsCommandArgs {
   action?: string;
   value?: string;
+  json?: boolean;
 }
 
 export const logsCommand = defineCommand({
@@ -30,9 +31,18 @@ export const logsCommand = defineCommand({
       required: false,
       description: "Action value: off | on | retain-on-failure",
     },
+    json: {
+      type: "boolean",
+      description: "Output status as JSON",
+      default: false,
+    },
   },
   run({ args }: { args: LogsCommandArgs }) {
     const action = args.action ?? "status";
+    if (args.json && action !== "status") {
+      log.error("usage: kesha logs status --json");
+      process.exit(2);
+    }
     switch (action) {
       case "enable": {
         const status = setDiagnosticLogMode("on");
@@ -51,6 +61,10 @@ export const logsCommand = defineCommand({
       }
       case "status": {
         const status = getDiagnosticLogStatus();
+        if (args.json) {
+          console.log(JSON.stringify(status, null, 2));
+          return;
+        }
         log.info(`Kesha diagnostic logs: ${status.mode === "off" ? "disabled" : "enabled"}`);
         log.info(`Mode: ${status.mode}`);
         log.info(`Path: ${status.activePath}`);

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -677,6 +677,32 @@ describe("CLI contracts", () => {
       stderrEmpty: true,
     });
 
+    const logsStatusJson = await runCli(["logs", "status", "--json"], { env });
+    expectContract(logsStatusJson, {
+      exitCode: 0,
+      stderrEmpty: true,
+    });
+    const logsStatusReport = JSON.parse(logsStatusJson.stdout);
+    expect(logsStatusReport).toMatchObject({
+      dir: env.KESHA_LOG_DIR,
+      activePath: join(env.KESHA_LOG_DIR, "kesha.ndjson"),
+      statePath: join(env.KESHA_LOG_DIR, "diagnostic-logs.json"),
+      exists: false,
+      activeSizeBytes: 0,
+      rotatedFiles: [],
+      totalSizeBytes: 0,
+      mode: "retain-on-failure",
+      maxBytes: 10 * 1024 * 1024,
+      retain: 5,
+    });
+
+    const logsEnableJson = await runCli(["logs", "enable", "--json"], { env });
+    expectContract(logsEnableJson, {
+      exitCode: 2,
+      stdoutEmpty: true,
+      stderrContains: ["usage: kesha logs status --json"],
+    });
+
     const logsEnable = await runCli(["logs", "enable"], { env });
     expectContract(logsEnable, {
       exitCode: 0,


### PR DESCRIPTION
## Summary
- add `kesha logs status --json` for a stable machine-readable diagnostic log status shape
- reject `--json` on non-status `kesha logs` actions instead of silently ignoring it
- pin the JSON shape and misuse contract in CLI coverage
- regenerate shell completions/manpage for the new flag
- document the diagnostic log status/support-bundle workflow

## Tests
- bun test tests/integration/cli-contracts.test.ts --test-name-pattern "read-only planning and stats"
- bun test tests/unit/cli.test.ts --test-name-pattern "logs help"
- bunx tsc --noEmit
- bun run test:cli-fast
- git diff --check
