### PR TITLE
feat(cli): log install diagnostic events

### DIFF
--- a/docs/diagnostic-logs.md
+++ b/docs/diagnostic-logs.md
@@ -41,11 +41,11 @@ Diagnostic logs are content-free. Event payloads are built from an allowlist of
 typed fields such as command name, app version, platform, backend, feature flags,
 stage names, exit codes, duration numbers, and stable error codes.
 
-When enabled, `kesha <audio>` and `kesha say` record command lifecycle events
-such as `command.start`, `input.audio`, `input.missing`, `engine.exit`, and
-`command.finish`. These events use only counts, booleans, format extensions,
-duration milliseconds, and bucket labels. In the default `retain-on-failure`
-mode, successful runs still leave no log file behind.
+When enabled, `kesha install`, `kesha <audio>`, and `kesha say` record command
+lifecycle events such as `command.start`, `input.audio`, `input.missing`,
+`engine.exit`, and `command.finish`. These events use only counts, booleans,
+format extensions, duration milliseconds, and bucket labels. In the default
+`retain-on-failure` mode, successful runs still leave no log file behind.
 
 Diagnostic logs must not store:
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -5,6 +5,7 @@ import { renderInstallPlan } from "../install-plan";
 import { maybeAskForStar } from "../star";
 import { log } from "../log";
 import { packageVersion } from "../package-info";
+import { createDiagnosticLogSession, type DiagnosticLogSession } from "../diagnostic-log";
 
 export interface InstallCommandArgs {
   coreml: boolean;
@@ -46,6 +47,28 @@ function defaultBackendForPlatform(): string | undefined {
   return undefined;
 }
 
+type InstallDiagnosticErrorKind = "validation_failed" | "install_failed";
+
+function finishInstallDiagnostic(
+  diagnosticLog: DiagnosticLogSession | null,
+  startedAt: number,
+  status: "success" | "failed",
+  errorKind?: InstallDiagnosticErrorKind,
+): void {
+  if (!diagnosticLog) return;
+  try {
+    diagnosticLog.event("command.finish", {
+      command: "install",
+      status,
+      durationMs: Math.round(performance.now() - startedAt),
+      ...(errorKind ? { errorKind } : {}),
+    });
+    diagnosticLog.finish(status);
+  } catch (err) {
+    log.debug(`install diagnostic log finish dropped: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 export async function performInstall(
   noCache: boolean,
   backend?: string,
@@ -58,26 +81,42 @@ export async function performInstall(
     log.info(await renderInstallPlan({ noCache, backend, tts, vad, diarize }));
     return;
   }
-  if (diarize && !(process.platform === "darwin" && process.arch === "arm64")) {
-    log.error(
-      "--diarize is currently darwin-arm64 only " +
-      "(see https://github.com/drakulavich/kesha-voice-kit/issues/199).",
-    );
-    process.exit(1);
-  }
-  const platformBackend = defaultBackendForPlatform();
-  if (backend && !process.env.KESHA_ENGINE_BIN && platformBackend && backend !== platformBackend) {
-    log.error(
-      `Requested backend "${backend}" is not available on this platform; ` +
-        `the release engine uses "${platformBackend}".`,
-    );
-    process.exit(1);
-  }
+
+  let diagnosticLog: DiagnosticLogSession | null = null;
+  let errorKind: InstallDiagnosticErrorKind = "install_failed";
+  const startedAt = performance.now();
   try {
+    diagnosticLog = createDiagnosticLogSession();
+    diagnosticLog.event("command.start", {
+      command: "install",
+      backend: backend ?? "auto",
+      noCache,
+      tts,
+      vad,
+      diarize,
+    });
+
+    if (diarize && !(process.platform === "darwin" && process.arch === "arm64")) {
+      errorKind = "validation_failed";
+      throw new Error(
+        "--diarize is currently darwin-arm64 only " +
+        "(see https://github.com/drakulavich/kesha-voice-kit/issues/199).",
+      );
+    }
+    const platformBackend = defaultBackendForPlatform();
+    if (backend && !process.env.KESHA_ENGINE_BIN && platformBackend && backend !== platformBackend) {
+      errorKind = "validation_failed";
+      throw new Error(
+        `Requested backend "${backend}" is not available on this platform; ` +
+          `the release engine uses "${platformBackend}".`,
+      );
+    }
     await downloadEngine(noCache, backend, { tts, vad, diarize });
     await maybeAskForStar(getEngineBinPath(), packageVersion, log);
+    finishInstallDiagnostic(diagnosticLog, startedAt, "success");
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
+    finishInstallDiagnostic(diagnosticLog, startedAt, "failed", errorKind);
     log.error(message);
     process.exit(1);
   }

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
+import { engineVersion } from "../../src/package-info";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
   installFakeDiarizeModel,
@@ -95,12 +96,34 @@ if (args[0] === "transcribe") {
   process.exit(0);
 }
 
+if (args[0] === "install") {
+  if (process.env.KESHA_FAKE_INSTALL_ERROR) {
+    console.error(process.env.KESHA_FAKE_INSTALL_ERROR);
+    process.exit(42);
+  }
+  if (process.env.KESHA_FAKE_INSTALL_ARGS_PATH) {
+    await Bun.write(process.env.KESHA_FAKE_INSTALL_ARGS_PATH, JSON.stringify(args.slice(1)));
+  }
+  process.exit(0);
+}
+
 console.error("unexpected fake engine args: " + JSON.stringify(args));
 process.exit(2);
 `,
   );
   chmodSync(enginePath, 0o755);
   return enginePath;
+}
+
+function markFakeEngineInstalled(enginePath: string): void {
+  writeFileSync(`${enginePath}.version`, `${engineVersion}\n`);
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    for (const sidecar of ["say-avspeech", "kesha-textlang"]) {
+      const path = join(dirname(enginePath), sidecar);
+      writeFileSync(path, "");
+      chmodSync(path, 0o755);
+    }
+  }
 }
 
 function createFailingEngine(dir: string): string {
@@ -497,6 +520,75 @@ describe("CLI contracts", () => {
       status: "success",
       ranAudioLangId: true,
       ranTxtLangId: true,
+    });
+  });
+
+  test("diagnostic logs record successful install events without content", async () => {
+    const dir = makeTempDir("kesha-cli-contract-install-diagnostic-");
+    const enginePath = createFakeEngine(dir);
+    markFakeEngineInstalled(enginePath);
+    const installArgsPath = join(dir, "install-args.json");
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+      KESHA_FAKE_INSTALL_ARGS_PATH: installArgsPath,
+    };
+    enableDiagnosticLogs(env.KESHA_LOG_DIR);
+
+    const run = await runCli(["install", "--vad"], { env });
+    expectContract(run, {
+      exitCode: 0,
+      stdoutContains: ["Engine binary already installed", "Backend installed successfully"],
+      stdoutNotContains: [dir],
+      stderrEmpty: true,
+    });
+    expect(JSON.parse(readFileSync(installArgsPath, "utf8"))).toEqual(["--vad"]);
+
+    const { raw: diagnosticLog, events } = readDiagnosticLog(env.KESHA_LOG_DIR);
+    expect(diagnosticLog).not.toContain(dir);
+    expect(diagnosticLog).not.toContain(enginePath);
+    expect(events.map((event) => event.event)).toEqual(["command.start", "command.finish"]);
+    expect(events[0]).toMatchObject({
+      command: "install",
+      backend: "auto",
+      noCache: false,
+      tts: false,
+      vad: true,
+      diarize: false,
+    });
+    expect(events[1]).toMatchObject({
+      command: "install",
+      status: "success",
+    });
+    expect(typeof events[1].durationMs).toBe("number");
+  });
+
+  test("diagnostic logs record failed install events without content", async () => {
+    const dir = makeTempDir("kesha-cli-contract-install-diagnostic-failure-");
+    const enginePath = createFakeEngine(dir);
+    markFakeEngineInstalled(enginePath);
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+      KESHA_FAKE_INSTALL_ERROR: `fake model install failed in ${dir}`,
+    };
+
+    const run = await runCli(["install", "--vad"], { env });
+    expectContract(run, {
+      exitCode: 1,
+      stdoutContains: ["Engine binary already installed"],
+      stderrContains: ["Failed to install models:"],
+    });
+
+    const { raw: diagnosticLog, events } = readDiagnosticLog(env.KESHA_LOG_DIR);
+    expect(diagnosticLog).not.toContain(dir);
+    expect(diagnosticLog).not.toContain(enginePath);
+    expect(diagnosticLog).not.toContain("fake model install failed");
+    expect(events.map((event) => event.event)).toEqual(["command.start", "command.finish"]);
+    expect(events[1]).toMatchObject({
+      command: "install",
+      status: "failed",
+      errorKind: "install_failed",
     });
   });
 


### PR DESCRIPTION
## Summary
- record privacy-safe `command.start` / `command.finish` diagnostic events for `kesha install`
- keep `install --plan` read-only by skipping diagnostic log sessions for plan output
- add an offline CLI contract test proving install events do not include temp paths or engine paths
- update diagnostic log docs to mention install lifecycle events

## Tests
- bun test tests/integration/cli-contracts.test.ts --test-name-pattern "install events"
- bunx tsc --noEmit
- bun run test:cli-fast
- git diff --check
