### PR TITLE
fix(diarize): address Greptile review on #453

### DIFF
--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -94,7 +94,7 @@ pub(crate) fn run(
 }
 
 /// Adaptive deadline for one diarization call. `KESHA_DIARIZE_TIMEOUT_SECS`
-/// overrides everything; otherwise scale up from a 90 s floor by audio length and
+/// overrides everything; otherwise scale up from a 150 s floor by audio length and
 /// ASR-segment count, capped at 30 min.
 fn diarize_timeout(asr_segments: &[TranscriptionSegment], duration: Option<f32>) -> Duration {
     if let Some(secs) = std::env::var("KESHA_DIARIZE_TIMEOUT_SECS")
@@ -460,7 +460,10 @@ mod tests {
     fn timeout_error_mentions_rewarming_the_ane_cache() {
         let msg = diarize_timeout_error(Duration::from_secs(DEFAULT_DIARIZE_TIMEOUT_SECS), 4.0);
 
-        assert!(msg.contains("speaker diarization timed out after 150s for 4s of audio"));
+        assert!(msg.contains(&format!(
+            "speaker diarization timed out after {}s for 4s of audio",
+            DEFAULT_DIARIZE_TIMEOUT_SECS
+        )));
         assert!(msg.contains("Apple ANE cache may be cold or evicted"));
         assert!(msg.contains("kesha install --diarize"));
         assert!(msg.contains("KESHA_DIARIZE_TIMEOUT_SECS"));


### PR DESCRIPTION
Follow-up to merged #453 — addresses the two Greptile P2 findings that landed after #453 was already merged.

## Changes

- **`rust/src/transcribe/diarize.rs:97`** — update the `diarize_timeout` doc comment from "90 s floor" to "150 s floor" to match the new constant. The block comment above the constant was updated in #453 but this function-level `///` doc was missed (Greptile P2, comments-outside-diff).
- **`rust/src/transcribe/diarize.rs:463`** — derive the timeout error assertion from `DEFAULT_DIARIZE_TIMEOUT_SECS` instead of hardcoding `"150s"`, so the next floor bump won't break this test (Greptile P2, inline thread).

## Verification

- `cargo fmt --check`
- Greptile re-review: **Confidence 5/5**, "Safe to merge — documentation/test-only, no runtime behavior change."
- Sandbox can't fetch `ort-sys` prebuilts (403 from pyke CDN), so `cargo clippy --all-targets` / `cargo nextest run` run in CI rather than locally.
