### PR TITLE
chore(release): v1.19.0-beta.2

### DIFF
--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.19.0-beta.1" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.19.0-beta.2" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.19.0-beta.1",
+  "version": "1.19.0-beta.2",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.19.0-beta.1"
+    "version": "1.19.0-beta.2"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.19.0-beta.1"
+version = "1.19.0-beta.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.19.0-beta.1"
+version = "1.19.0-beta.2"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## Summary

Second beta in the 1.19 line. Bumps the three coupled version sources from `1.19.0-beta.1` → `1.19.0-beta.2`:

- `package.json#version`
- `package.json#keshaEngine.version`
- `rust/Cargo.toml` (+ `rust/Cargo.lock`)

`bun .github/scripts/check-versions.ts` passes locally.

## Commits since v1.19.0-beta.1

| PR | Summary |
|----|---------|
| #445 | `fix: remove package postinstall lifecycle script` |
| #446 | `fix(tts): surface FluidAudio Kokoro cache` |
| #447 | `feat(cli): add privacy-safe diagnostic logs` |
| #448 | `feat(cli): add privacy-safe diagnostic command events` |
| #449 | `feat(cli): include diagnostic logs in support bundles` |
| #450 | `feat(cli): report diagnostic log status in doctor` |
| #451 | `feat(cli): expose diagnostic log status JSON` |
| #452 | `feat(cli): log install diagnostic events` |
| #453 | `fix(diarize): allow cold ANE timeout headroom` (raises adaptive floor 90 s → 150 s for cold Apple ANE compiles) |
| #454 | `fix(diarize): address greptile review on PR #453` |

Highlights vs. beta.1: privacy-safe diagnostic logging surface (`kesha doctor`, support bundles, install events, JSON status), Kokoro TTS cache fix, and the cold-ANE diarization timeout fix.

## Release runbook

After merge, per CLAUDE.md "Beta engine release":

```bash
git fetch
git tag v1.19.0-beta.2 origin/main
git push origin v1.19.0-beta.2          # fires build-engine.yml
```

`build-engine.yml` creates a **draft prerelease** with engine binaries, sidecars, `SHA256SUMS`, manifest, SBOM, and Sigstore bundles. Homebrew + `.deb`/`.rpm` are intentionally skipped for beta tags.

Validate draft assets with authenticated `gh release download` before un-drafting (curl 404s on drafts). Un-drafting fires `📦 npm Publish`, which publishes to the **`@beta`** dist-tag (so `@latest` stays on the current stable). Verify with `npm view @drakulavich/kesha-voice-kit@beta version`.

User-facing install once published:

```bash
bun add -g @drakulavich/kesha-voice-kit@beta
kesha install
```

## CI note

Branch is `release/1.19.0-beta.2` so `integration-tests` skips per the existing chicken-and-egg guard in `.github/workflows/ci.yml` (the v1.19.0-beta.2 release tag doesn't exist yet, so the engine download would 404).


---
_Generated by [Claude Code](https://claude.ai/code/session_01E9NZSwDPdTSYYxoz4LSmDT)_