### PR TITLE
refactor(diagnostic-logs): inline noop session and collapse parseMode

### DIFF
--- a/src/diagnostic-log.ts
+++ b/src/diagnostic-log.ts
@@ -100,9 +100,8 @@ function readConfig(): DiagnosticLogConfig {
   if (!existsSync(statePath)) return defaultConfig();
   try {
     const parsed = JSON.parse(readFileSync(statePath, "utf8")) as Partial<DiagnosticLogConfig>;
-    const parsedMode = parseMode(parsed.mode);
     return {
-      mode: parsedMode ?? defaultConfig().mode,
+      mode: parseDiagnosticLogMode(parsed.mode) ?? defaultConfig().mode,
       maxBytes: positiveInt(parsed.maxBytes, DEFAULT_MAX_BYTES),
       retain: positiveInt(parsed.retain, DEFAULT_RETAIN),
     };
@@ -111,11 +110,7 @@ function readConfig(): DiagnosticLogConfig {
   }
 }
 
-export function parseDiagnosticLogMode(value: string): DiagnosticLogMode | null {
-  return parseMode(value);
-}
-
-function parseMode(value: unknown): DiagnosticLogMode | null {
+export function parseDiagnosticLogMode(value: unknown): DiagnosticLogMode | null {
   return value === "off" || value === "on" || value === "retain-on-failure" ? value : null;
 }
 
@@ -219,9 +214,11 @@ export function resetDiagnosticLogs(): { deleted: number; bytes: number; dir: st
 
 export function createDiagnosticLogSession(): DiagnosticLogSession {
   const status = getDiagnosticLogStatus();
+  if (status.mode === "off") {
+    return { event: () => false, finish: () => false };
+  }
   const buffered: Uint8Array[] = [];
   let finished = false;
-  if (status.mode === "off") return noopSession();
 
   return {
     event(event: string, fields: DiagnosticLogFields = {}): boolean {
@@ -258,13 +255,6 @@ export function createDiagnosticLogSession(): DiagnosticLogSession {
         buffered.length = 0;
       }
     },
-  };
-}
-
-function noopSession(): DiagnosticLogSession {
-  return {
-    event: () => false,
-    finish: () => false,
   };
 }
 


### PR DESCRIPTION
## Summary

Small simplification pass over the diagnostic-logs feature (#447–#452) — no behavior change.

- Inlined the single-use `noopSession()` helper at its only caller in `createDiagnosticLogSession`.
- Collapsed the private `parseMode(value: unknown)` wrapper into the exported `parseDiagnosticLogMode`, which now accepts `unknown` directly. The two functions were a pure delegate split that pre-dated the export.

Net: `src/diagnostic-log.ts` -10 lines.

## What was considered but rejected

- **`humanBytes` dedupe across `src/doctor.ts` and `src/diagnostic-log.ts`** — the two implementations have different rounding thresholds (doctor: integer above 100; diag-log: integer above 10). Behavior-preserving rule wins.
- **`install.ts` outer try/catch around diagnostic finish** — initial pass removed it on the assumption `finish()` swallowed its own errors. On review, `finish()` uses `try/finally`, not `try/catch`, so exceptions during `appendDiagnosticLogLine` would propagate and break the fail-open invariant of the diagnostic feature. Reverted.

## Test plan

- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun test tests/unit/\` — 254 pass / 4 pre-existing fails (CLI help golden ANSI regressions on origin/main, unrelated)
- [ ] CI green
- [ ] Greptile review references the HEAD SHA