### PR TITLE
refactor(cli): collapse subcommand dispatch and extract vadArg helper

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,4 +1,4 @@
-import { runMain } from "citty";
+import { runMain, type CommandDef } from "citty";
 import { existsSync } from "fs";
 import { log } from "../log";
 import { suggestCommand } from "../suggest-command";
@@ -15,19 +15,23 @@ import { statusCommand } from "./status";
 import { supportBundleCommand } from "./support-bundle";
 import { mainCommand } from "./main";
 
-const SUBCOMMANDS = [
-  "doctor",
-  "init",
-  "install",
-  "logs",
-  "status",
-  "record",
-  "say",
-  "stats",
-  "support-bundle",
-  "completions",
-  "manpage",
-];
+// Single source of truth: keyed lookup also feeds the `did you mean` suggester.
+// `CommandDef<any>` is intentional — citty's generic is invariant in the args
+// shape, and each subcommand has its own arg schema; the value here is only
+// passed back to `runMain`, which re-reads the schema from the def itself.
+const SUBCOMMANDS: Record<string, CommandDef<any>> = {
+  doctor: doctorCommand,
+  init: initCommand,
+  install: installCommand,
+  logs: logsCommand,
+  status: statusCommand,
+  record: recordCommand,
+  say: sayCommand,
+  stats: statsCommand,
+  "support-bundle": supportBundleCommand,
+  completions: completionsCommand,
+  manpage: manpageCommand,
+};
 
 function isPathLike(arg: string): boolean {
   return arg.includes(".") || arg.includes("/") || existsSync(arg);
@@ -36,58 +40,8 @@ function isPathLike(arg: string): boolean {
 export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
   const [firstArg, ...restArgs] = rawArgs;
 
-  if (firstArg === "doctor") {
-    await runMain(doctorCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "init") {
-    await runMain(initCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "completions") {
-    await runMain(completionsCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "install") {
-    await runMain(installCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "logs") {
-    await runMain(logsCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "manpage") {
-    await runMain(manpageCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "status") {
-    await runMain(statusCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "record") {
-    await runMain(recordCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "say") {
-    await runMain(sayCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "stats") {
-    await runMain(statsCommand, { rawArgs: restArgs });
-    return;
-  }
-
-  if (firstArg === "support-bundle") {
-    await runMain(supportBundleCommand, { rawArgs: restArgs });
+  if (firstArg && firstArg in SUBCOMMANDS) {
+    await runMain(SUBCOMMANDS[firstArg], { rawArgs: restArgs });
     return;
   }
 
@@ -95,7 +49,7 @@ export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
   // Extensionless existing files remain valid transcription inputs; missing
   // bare tokens are more likely command typos and should not start the engine.
   if (firstArg && !firstArg.startsWith("-") && !isPathLike(firstArg)) {
-    const suggestion = suggestCommand(firstArg, SUBCOMMANDS);
+    const suggestion = suggestCommand(firstArg, Object.keys(SUBCOMMANDS));
     log.error(`unknown command '${firstArg}'`);
     if (suggestion && suggestion !== firstArg) {
       log.warn(`(Did you mean ${suggestion}?)`);

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -40,7 +40,7 @@ function isPathLike(arg: string): boolean {
 export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
   const [firstArg, ...restArgs] = rawArgs;
 
-  if (firstArg && firstArg in SUBCOMMANDS) {
+  if (firstArg && Object.hasOwn(SUBCOMMANDS, firstArg)) {
     await runMain(SUBCOMMANDS[firstArg], { rawArgs: restArgs });
     return;
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -223,13 +223,17 @@ export async function preflightTranscribeEngineWithSegments(
   );
 }
 
+function vadArg(vad: VadMode | undefined): string[] {
+  if (vad === "on") return ["--vad"];
+  if (vad === "off") return ["--no-vad"];
+  return [];
+}
+
 export async function transcribeEngine(
   audioPath: string,
   opts: TranscribeEngineOptions = {},
 ): Promise<string> {
-  const args = ["transcribe", audioPath];
-  if (opts.vad === "on") args.push("--vad");
-  else if (opts.vad === "off") args.push("--no-vad");
+  const args = ["transcribe", audioPath, ...vadArg(opts.vad)];
   const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
@@ -266,12 +270,8 @@ export async function transcribeEngineWithSegments(
 ): Promise<TranscriptionOutput> {
   await preflightTranscribeEngineWithSegments(opts);
 
-  const args = ["transcribe", audioPath, "--json"];
-  if (opts.vad === "on") args.push("--vad");
-  else if (opts.vad === "off") args.push("--no-vad");
-  if (opts.speakers) {
-    args.push("--speakers");
-  }
+  const args = ["transcribe", audioPath, "--json", ...vadArg(opts.vad)];
+  if (opts.speakers) args.push("--speakers");
   const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);


### PR DESCRIPTION
## Summary

Two small simplifications across the engine/CLI integration surface — no behavior change.

- **`src/cli/dispatch.ts`** — replaced 11 repeated `if (firstArg === "X") { await runMain(...); return; }` blocks plus a parallel hand-maintained `SUBCOMMANDS` string array with a single `Record<string, CommandDef<any>>` keyed lookup. Same array now feeds both `runMain` and `suggestCommand`. Net -46 lines. The `<any>` is intentional — citty's `CommandDef` generic is invariant in the args shape and each subcommand carries its own schema; documented inline.
- **`src/engine.ts`** — extracted `vadArg(opts.vad)` helper. The `"on" → --vad / "off" → --no-vad` mapping was duplicated across `transcribeEngine` and `transcribeEngineWithSegments`.

## What was considered but rejected

- **`src/engine-install.ts` retired-sidecar comments** — Comments like `"Kokoro now runs in-engine"` and `RETIRED_SIDECAR_FILENAMES` are load-bearing WHY documentation. Left intact.
- **`src/cli/install.ts::resolveNoCacheFlag`** — Triple-key handling (`no-cache` / `noCache` / `no_cache`) is tested and guards against citty key-normalization drift.
- **`runEngine` outer try/finally** — Per a sibling agent's near-miss this session: `try/finally` does NOT swallow exceptions, only `try/catch` does. Verified the outer guard is load-bearing and left it.
- **`src/cli.ts`** — pure re-export shim, already minimal.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test tests/unit/` — 254 pass / 4 pre-existing fails (CLI help golden ANSI regressions on origin/main, unrelated)
- [x] `bun test tests/integration/` — 71 pass / 4 skip / 0 fail
- [ ] CI green
- [ ] Greptile review references the HEAD SHA