### PR TITLE
feat(cli): route install hints by TTY + refresh SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,6 +25,7 @@ Local voice toolkit: transcribe voice messages to text, synthesize speech, detec
 - **Need to send a voice note (Telegram, WhatsApp, Signal, Discord)**: synthesize directly into messenger-native OGG/Opus with `kesha say --format ogg-opus --out reply.ogg "<text>"`. Default is mono 24 kHz @ 32 kbps - what Telegram `sendVoice` expects. No WAV redirect and no `ffmpeg` round-trip.
 - **Need local file playback/debug output**: WAV is still available with `kesha say --out reply.wav "<text>"`, but do not use WAV for Telegram voice replies. Auto-routes by detected language (Kokoro-82M for English, Vosk-TTS for Russian). On darwin-arm64, English Kokoro uses FluidAudio CoreML instead of ONNX. For other languages and ~180 more voices use `--voice macos-*` on macOS (zero model download).
 - **Need to detect what language a file is in** before choosing a pipeline: `kesha --json audio.ogg` returns both audio-based and text-based language detection with confidence scores.
+- **Need to capture your own voice** for transcription or as a voice-note source: `kesha record --out clip.wav` records up to 120s (override with `--max-seconds`) of mono 16 kHz WAV from the default microphone. Pipe straight into `kesha --json clip.wav` to close the loop.
 
 ## OpenClaw plugin setup
 
@@ -150,8 +151,11 @@ Each `segment.speaker` is a number (cluster id, stable within one file). On Linu
 - `kesha audio.ogg` — plain transcript on stdout
 - `kesha --format transcript audio.ogg` — transcript + `[lang: ru, confidence: 0.99]` footer
 - `kesha --json --timestamps audio.ogg` — JSON with timestamped `segments`
+- `kesha --toon audio.ogg` — TOON (compact, LLM-friendly JSON encoding); preferred when piping multi-file results to an LLM/agent
 - `kesha --verbose audio.ogg` — human-readable with language info
 - `kesha --lang en audio.ogg` — warn if detected language differs (useful sanity check)
+
+**Long audio:** files ≥ 120 s auto-engage Silero VAD chunking; force on with `--vad` or off with `--no-vad`. Short files use full-file ASR by default.
 
 ## TTS: synthesize speech
 
@@ -192,7 +196,10 @@ Format is also inferred from `--out` extension (`.ogg` / `.opus` / `.oga` → OG
 bun add -g @drakulavich/kesha-voice-kit          # global CLI install
 kesha install                                    # downloads engine (~350 MB)
 kesha install --tts                              # adds Kokoro + Vosk-TTS RU (~990 MB more, for TTS)
+kesha init                                       # optional: interactive setup guide for first-time users
 ```
+
+For pre-release builds: `bun add -g @drakulavich/kesha-voice-kit@beta` (current `beta` channel; `@latest` stays on the last stable release).
 
 No system deps — English G2P is embedded (`misaki-rs`); Russian G2P is bundled inside Vosk-TTS. `macos-*` voices need no install either — they use voices already on the Mac.
 
@@ -206,6 +213,13 @@ No system deps — English G2P is embedded (`misaki-rs`); Russian G2P is bundled
 
 - ASR: ~19× faster than OpenAI Whisper on Apple Silicon (CoreML via FluidAudio), ~2.5× on CPU (ONNX via `ort`).
 - TTS: sub-second latency for short utterances on Apple Silicon.
+
+## Troubleshooting
+
+- `kesha doctor` — collect support diagnostics without changing local state. Add `--json` for machine-readable output, `--redact` to scrub secrets and home paths before sharing.
+- `kesha logs` — manage privacy-safe local diagnostic logs. Default mode is `retain-on-failure` (events buffered in memory, flushed to disk only when a command fails). `kesha logs mode on` captures every run, `kesha logs path` prints the NDJSON file, `kesha logs disable` turns it off entirely.
+- `kesha support-bundle --output bundle.tar.gz` — produce a redacted `.tar.gz` for filing an issue. Add `--include-logs` to bundle a bounded tail of diagnostic logs.
+- `kesha stats` — manage local anonymous performance stats (per-command latency percentiles). Actions: `enable | disable | status | week | errors | export | reset | vacuum | retention`. Stays on the machine.
 
 ## Why local
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -192,12 +192,22 @@ Format is also inferred from `--out` extension (`.ogg` / `.opus` / `.oga` → OG
 
 ## Install
 
+**Humans use `kesha init` (guided). Agents and scripts use `kesha install` (deterministic).**
+
 ```bash
-bun add -g @drakulavich/kesha-voice-kit          # global CLI install
-kesha install                                    # downloads engine (~350 MB)
-kesha install --tts                              # adds Kokoro + Vosk-TTS RU (~990 MB more, for TTS)
-kesha init                                       # optional: interactive setup guide for first-time users
+bun add -g @drakulavich/kesha-voice-kit          # global CLI install (always first)
+
+# For humans: interactive setup that prompts for backend / TTS / VAD / diarize
+kesha init
+
+# For agents and CI: explicit, scriptable install commands
+kesha install                                    # engine only (~350 MB)
+kesha install --tts                              # + Kokoro + Vosk-TTS RU (~990 MB more)
+kesha install --tts --vad                        # + Silero VAD (long-audio chunking)
+kesha install --tts --vad --diarize              # + speaker diarization (darwin-arm64 only)
 ```
+
+Kesha's runtime error/warning messages adapt to the same split: when `kesha` is invoked from a TTY, hints suggest `kesha init`; when stderr is piped (CI logs, OpenClaw, agent subprocess), hints suggest the equivalent `kesha install [...flags]`. Both run the same install code under the hood — pick the one your caller is.
 
 For pre-release builds: `bun add -g @drakulavich/kesha-voice-kit@beta` (current `beta` channel; `@latest` stays on the last stable release).
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from "fs";
 import { join } from "path";
+import { installHint } from "./install-hint";
 import { log } from "./log";
 import { defaultEngineBinPath, keshaCacheDir } from "./paths";
 import { engineAbortError, registerProcessTree } from "./process-tree";
@@ -219,7 +220,7 @@ export async function preflightTranscribeEngineWithSegments(
   if (hasDiarizeModelLayout(modelPath)) return;
   throw new Error(
     `speaker diarization requires a model path\n\nCaused by:\n    diarization model not found at ${modelPath}. ` +
-      "Run `kesha install --diarize` (or set KESHA_DIARIZE_MODEL_PATH).",
+      `Run \`${installHint("--diarize")}\` (or set KESHA_DIARIZE_MODEL_PATH).`,
   );
 }
 

--- a/src/install-hint.ts
+++ b/src/install-hint.ts
@@ -1,0 +1,7 @@
+// Pick the right setup-command hint for error/warning messages. Humans on an
+// interactive TTY get `kesha init` (guided + idempotent), agents and scripts
+// piping stderr get `kesha install [...flags]` (deterministic + scriptable).
+export function installHint(...flags: string[]): string {
+  const verb = process.stderr.isTTY ? "kesha init" : "kesha install";
+  return [verb, ...flags].join(" ");
+}

--- a/src/install-hint.ts
+++ b/src/install-hint.ts
@@ -1,6 +1,11 @@
 // Pick the right setup-command hint for error/warning messages. Humans on an
 // interactive TTY get `kesha init` (guided + idempotent), agents and scripts
 // piping stderr get `kesha install [...flags]` (deterministic + scriptable).
+//
+// Flags forward to BOTH paths. `kesha init` accepts the same module-selection
+// flags as `kesha install` (`--tts`, `--vad`, `--diarize`, `--coreml`, `--onnx`,
+// `--no-cache`) — they preselect modules in the interactive wizard rather than
+// being install-only flags. Source of truth: `src/cli/init.ts::initCommand.args`.
 export function installHint(...flags: string[]): string {
   const verb = process.stderr.isTTY ? "kesha init" : "kesha install";
   return [verb, ...flags].join(" ");

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,6 +1,7 @@
 import { readdirSync, statSync } from "fs";
 import { join } from "path";
 import { isEngineInstalled, getEngineBinPath, getEngineCapabilities } from "./engine";
+import { installHint } from "./install-hint";
 import { log } from "./log";
 import { keshaCacheDir } from "./paths";
 import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
@@ -82,7 +83,7 @@ export async function showStatus(options: ShowStatusOptions = {}): Promise<void>
   }
 
   if (!installed) {
-    log.warn('Run "kesha install" to download the engine and models.');
+    log.warn(`Run \`${installHint()}\` to download the engine and models.`);
     return;
   }
 }

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -5,6 +5,7 @@ import {
   spawnStdioWithDebugFd,
   type EngineCapabilities,
 } from "./engine";
+import { installHint } from "./install-hint";
 import { log } from "./log";
 import { registerProcessTree } from "./process-tree";
 
@@ -116,7 +117,7 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
 
   if (!isEngineInstalled()) {
     throw new SayError(
-      "kesha-engine not installed. run: kesha install",
+      `kesha-engine not installed. run: ${installHint("--tts")}`,
       1,
       "",
     );

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -6,6 +6,7 @@ import {
   type TranscriptionOutput,
   type VadMode,
 } from "./engine";
+import { installHint } from "./install-hint";
 
 export type { VadMode };
 export type { TranscriptionOutput };
@@ -31,13 +32,10 @@ export async function transcribe(audioPath: string, opts: TranscribeOptions = {}
 export async function preflightTranscribeWithSegments(opts: TranscribeOptions = {}): Promise<void> {
   if (!isEngineInstalled()) {
     throw new Error(
-      "Error: No transcription backend is installed\n\n" +
-      "╔══════════════════════════════════════════════════════════╗\n" +
-      "║ Please run the following commands to get started:        ║\n" +
-      "║                                                          ║\n" +
-      "║     bun add -g @drakulavich/kesha-voice-kit              ║\n" +
-      "║     kesha install                                        ║\n" +
-      "╚══════════════════════════════════════════════════════════╝",
+      "Error: No transcription backend is installed.\n\n" +
+      "Run the following to get started:\n\n" +
+      "    bun add -g @drakulavich/kesha-voice-kit\n" +
+      `    ${installHint()}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Two related commits on this branch:

1. **`docs(skill)`** — SKILL.md drifted behind the current `kesha --help` surface. Adds coverage for subcommands and flags that shipped in v1.18.x–v1.19.0 (`record`, `logs`, `doctor`, `support-bundle`, `stats`, `--toon`, long-audio auto-VAD, `kesha init`, beta channel).
2. **`feat(cli)`** — error/warning messages that suggest setup now route by TTY: humans on an interactive shell get `kesha init` (guided), agents/scripts piping stderr get `kesha install [...flags]` (scriptable). SKILL.md's Install section documents the split.

## Code changes

- New `src/install-hint.ts` — single helper that branches on `process.stderr.isTTY`.
- Wired into `src/status.ts`, `src/synth.ts` (`--tts`), `src/transcribe.ts` (engine-missing), `src/engine.ts` (diarize hint).
- `src/transcribe.ts` ASCII box replaced with a plain two-command hint; no width-padding fragility, adapts to the new helper.
- Sites that show literal flag invocations in user-facing docs (e.g. `kesha install --plan` output, `kesha doctor` feature notes) intentionally left as-is.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test tests/unit/` — 254 pass / 4 pre-existing fails (CLI help golden ANSI regressions, unrelated)
- [x] `lib.test.ts` "kesha install" assertion still passes — test env is non-TTY, helper returns the agent string
- [x] Each command + flag verified against live `kesha <cmd> --help` (record, doctor, support-bundle, stats, logs)
- [ ] CI green
- [ ] Greptile review on HEAD SHA `2bdb94c`