### PR TITLE
chore(release): v1.19.0

### DIFF
--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.19.0-beta.2" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.19.0" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.19.0-beta.2",
+  "version": "1.19.0",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.19.0-beta.2"
+    "version": "1.19.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.19.0-beta.2"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.19.0-beta.2"
+version = "1.19.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Promote v1.19.0-beta.2 (out since 2026-05-22) + the simplification and skill-refresh PRs to stable v1.19.0.

## What lands on `latest`

Since the last stable v1.18.6:

### Highlights
- **Privacy-safe diagnostic logging** (#447–#452): opt-in command events recorded locally, surfaced via `kesha doctor`, `kesha logs`, and bundled into support tarballs. Redacts paths/arguments; no PII.
- **Diarization stability** (#453, #454): cold Apple Neural Engine warmup gets timeout headroom; first diarize call on a fresh process no longer fails.
- **FluidAudio Kokoro cache** (#446) now surfaced in `kesha status` for debuggability.
- **Postinstall removed** (#445): `bun add -g` no longer runs anything implicitly; users still drive `kesha install` explicitly.
- **`kesha init`** human-friendly install path (`#456`/`#457`/`#458`): runtime warnings now route by TTY — humans see `kesha init` (guided), agents/CI see `kesha install [...flags]` (scriptable).
- **SKILL.md refresh** (#458): covers `record`, `logs`, `doctor`, `support-bundle`, `stats`, `--toon`, long-audio auto-VAD, beta channel.
- **CLI dispatch + engine integration simplifications** (#456, #457): ~60 LoC removed, no behavior change, Greptile 5/5.

### Version bumps
- `package.json#version`: `1.19.0-beta.2` → `1.19.0`
- `package.json#keshaEngine.version`: same
- `rust/Cargo.toml#version`: same
- `rust/Cargo.lock` refreshed via `cargo check`
- `man/kesha.1` regenerated via `bun run generate:shell-artifacts`

## Test plan

- [x] `bun run check:versions` — exit 0 (drift gate)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test tests/unit/` — 254 pass / 4 known pre-existing fails (CLI help golden ANSI regressions on origin/main, unrelated)
- [x] `cd rust && cargo check` — clean, Cargo.lock refreshed
- [ ] CI green (integration-tests job is filtered to skip on `release/*` per CLAUDE.md "RELEASE CHICKEN-AND-EGG")
- [ ] Tag `v1.19.0` after merge → `build-engine.yml` builds 3 platforms + Linux .deb/.rpm + Homebrew tap
- [ ] Validate draft assets via authenticated `gh release download` before un-drafting