### PR TITLE
ci(security): promote cargo-deny + bun audit to required gates

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,6 @@ jobs:
       contents: read
       # Only the scheduled run needs to upsert the findings issue.
       issues: write
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - id: deny
@@ -65,8 +64,6 @@ jobs:
       contents: read
       # Only the scheduled run needs to upsert the findings issue.
       issues: write
-    # NON-BLOCKING on first landing (see cargo-deny note above).
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Final step of #461. Both audit jobs have run clean since the non-blocking phase landed (cargo-deny exits 0; the fast-xml-builder advisory was patched in #466), so flip them from advisory to blocking.

- Removed the **job-level** `continue-on-error: true` from `cargo-deny` and `bun-audit`.
- Kept the **step-level** `continue-on-error` on the deny/audit steps — that's what lets the scheduled findings-issue upsert and the PR-fail steps run after a failing check. With the job-level flag gone, the PR-path `exit 1` now fails the job and blocks merge.

Net: 3 lines removed (2 job-level flags + 1 stale "NON-BLOCKING" comment).

## Behavior after this

- **PR / push:** a real cargo-deny or bun-audit finding now **blocks merge** (job fails).
- **Scheduled cron:** unchanged — findings upsert the tracking issue (Rust + JS), job does not hard-fail on schedule.

## Heads-up (manual step for the maintainer)

For these to *enforce* on merge, add `cargo-deny` and `bun-audit` to **branch protection → required status checks** for `main`. Until then a failure shows red and marks the PR UNSTABLE but doesn't hard-block. The workflow change is necessary but branch-protection config is the other half.

## Test plan

- [x] `bun run check:workflows` — clean
- [x] `actionlint` — clean
- [x] Verified only the 2 job-level flags removed; 2 step-level flags retained
- [ ] CI green (both audit jobs should pass on this PR — deny clean, audit clean post-#466)

Closes #461