### PR TITLE
docs(diarize): correct e5rt keying + document model-bump recompile cost

### DIFF
--- a/.claude/skills/verify-pin-bump/SKILL.md
+++ b/.claude/skills/verify-pin-bump/SKILL.md
@@ -96,6 +96,13 @@ If the bump represents a model version change (not just a re-export), also:
 - Update the URL/rel_path if needed (e.g. `<old-version>-multi` → `<new-version>-multi`)
 - Bump any related model dir constant
 - Update `docs/tts.md` install size table if size changed materially
+- **Diarize (`SortformerNvidiaLow_v*.mlpackage`) only:** expect a one-time **~98 s cold
+  ANE recompile** at the next `kesha install --diarize`. Apple's e5rt cache is keyed by the
+  compiled bundle's identity, not its path, so the new model version is a guaranteed cache
+  MISS — even a same-path recompile pays full cost (#444). The warm-at-install step (#437)
+  absorbs this, surfaced by the "one-time compile ~1-2 min on first install" message; it is
+  install-time cost, not a `transcribe --speakers` failure. Call it out in the release notes
+  so end users expect the slow `install --diarize` after the bump.
 
 ### Step 6: Verify shape invariants
 

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -78,13 +78,16 @@ pub fn run(
     }
     // Diarization warm-up (macOS `system_diarize` only). Pre-compile the Sortformer
     // `.mlpackage` to its stable `.mlmodelc` sibling so CoreML's ANE program-compile
-    // (~100 s, cached in `com.apple.e5rt.e5bundlecache` keyed by the compiled model
-    // path) happens HERE rather than on the first `kesha transcribe --speakers`. The
-    // diarize bridge recompiled a throwaway temp model every call before this, so the
-    // first real diarize paid ~100 s and tripped the adaptive timeout; after warm-up
-    // it loads the stable `.mlmodelc` in ~4 s. Only when this install requested the
-    // diarize model and the model is on disk; warm-up failure is NON-FATAL (matches
-    // the ASR warm-up above).
+    // (~100 s, cached in `com.apple.e5rt.e5bundlecache`) happens HERE rather than on
+    // the first `kesha transcribe --speakers`. The e5rt cache is keyed by the compiled
+    // bundle's IDENTITY (compile UUID/content), NOT by path — so recreating the
+    // `.mlmodelc` at the same path (model-version bump GC, or a user deleting the
+    // cache) is still a cache MISS and re-pays the full cold compile (#444 measured
+    // 97.7 s on a same-path recompile). The diarize bridge recompiled a throwaway temp
+    // model every call before this, so the first real diarize paid ~100 s and tripped
+    // the adaptive timeout; after warm-up it loads the stable `.mlmodelc` in ~4 s. Only
+    // when this install requested the diarize model and the model is on disk; warm-up
+    // failure is NON-FATAL (matches the ASR warm-up above).
     #[cfg(feature = "system_diarize")]
     if diarize && !no_warmup && models::is_cached(models::ModelKind::Diarize) {
         let diarize_pkg = models::model_dir(models::ModelKind::Diarize);

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -749,6 +749,11 @@ pub fn download_diarize(no_cache: bool) -> Result<()> {
 /// was successfully warmed. Only deletes Kesha-owned siblings next to the
 /// active `.mlpackage`; never touches the source `.mlpackage` or Apple's e5rt
 /// cache.
+///
+/// Keeping the active sidecar is load-bearing, not just tidiness: e5rt is keyed
+/// by the compiled bundle's identity, not its path, so a recompiled `.mlmodelc`
+/// at the same path is a cache MISS that re-pays the ~98 s cold ANE compile
+/// (#444). Deleting only stale siblings preserves the warmed sidecar's cache hit.
 #[cfg(feature = "system_diarize")]
 pub fn cleanup_diarize_compiled_sidecars(keep_model_package: &Path) -> Result<usize> {
     let Some(parent) = keep_model_package.parent() else {


### PR DESCRIPTION
## Summary

Closes #444. Documentation + one factual comment correction; no functional change.

**The bug in the docs:** `rust/src/cli/install.rs` claimed Apple's e5rt cache is "keyed by the compiled model **path**." #444 disproved this empirically — deleting the stable `.mlmodelc` and recompiling at the **identical path** still paid a **97.7 s** cold ANE compile. e5rt is keyed by the compiled bundle's *identity* (compile UUID/content), so a same-path recompile is a cache miss.

## Changes

- **`rust/src/cli/install.rs`** — correct the e5rt keying comment; note that recreating the sidecar at the same path (model-version-bump GC or manual cache delete) is still a miss that re-pays the full cold compile.
- **`rust/src/models.rs`** — reaffirm *why* `cleanup_diarize_compiled_sidecars` keeps the active sidecar (identity-keying makes recreate-at-same-path a miss — load-bearing, not tidiness).
- **`.claude/skills/verify-pin-bump/SKILL.md`** — document that a diarize model-version bump triggers a one-time ~98 s cold ANE recompile at the next `install --diarize`, absorbed by the warm step (#437); call it out in release notes so users expect the slow install.

## Out of scope (per issue)

- **Direction 3** (cleanup never removes the current sidecar) — already true and test-covered (`cleanup_diarize_sidecars_keeps_current_and_removes_stale`).
- **Direction 2** (ship a precompiled `.mlmodelc`) — ANE compile is hardware/OS-specific; likely a dead end, not pursued.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo check --features coreml --no-default-features` — compiles (both edited comments sit in the `system_diarize` path)
- [x] Diff is comment/doc-only (every added Rust line is a `//`/`///` comment)
- [ ] CI green + Greptile

Closes #444