### PR TITLE
docs: use absolute URLs for README images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/logo.png" alt="Kesha Voice Kit" width="200">
+  <img src="https://raw.githubusercontent.com/drakulavich/kesha-voice-kit/main/docs/assets/logo.png" alt="Kesha Voice Kit" width="200">
 </p>
 
 <h1 align="center">Kesha Voice Kit</h1>
@@ -21,7 +21,7 @@
 See [Product positioning](docs/product-positioning.md) for supported workflows, non-goals, maturity labels, and the platform matrix.
 
 <p align="center">
-  <img src="./demo.gif" alt="kesha demo — English + Russian transcription with automatic language detection" width="800">
+  <img src="https://raw.githubusercontent.com/drakulavich/kesha-voice-kit/main/demo.gif" alt="kesha demo — English + Russian transcription with automatic language detection" width="800">
 </p>
 
 ## Quick Start
@@ -232,7 +232,7 @@ mandb ~/.local/share/man 2>/dev/null || true
 
 Compared against Whisper `large-v3-turbo` — all engines auto-detect language.
 
-![Benchmark: openai-whisper vs faster-whisper vs Kesha Voice Kit](docs/assets/benchmark.svg)
+![Benchmark: openai-whisper vs faster-whisper vs Kesha Voice Kit](https://raw.githubusercontent.com/drakulavich/kesha-voice-kit/main/docs/assets/benchmark.svg)
 
 See [BENCHMARK.md](BENCHMARK.md) for the full per-file breakdown (Russian + English).
 


### PR DESCRIPTION
## Summary
- Convert the three relative image paths in `README.md` (logo, demo gif, benchmark) to absolute `raw.githubusercontent.com/.../main/` URLs so they render outside github.com (npm package page, mirrors).
- Badge images (shields.io) were already absolute and are unchanged.
- URLs are pinned to `main`, not this branch, so they survive branch deletion.

## Notes
- `benchmark.svg` is served by `raw.githubusercontent.com` as `text/plain`, so github.com's image proxy may not render it inline (it renders on npm and other markdown viewers). PNG/GIF render everywhere. Happy to revert the SVG to a relative path if GitHub inline rendering matters more than external renderers.

## Test plan
- [ ] Confirm logo, demo gif, and benchmark render on the npm package page after publish
- [ ] Confirm logo + demo gif render on github.com

https://claude.ai/code/session_019FpHJ9hV3KKoDd7DB6FkwG

---
_Generated by [Claude Code](https://claude.ai/code/session_019FpHJ9hV3KKoDd7DB6FkwG)_