### PR TITLE
feat(tts): FLAC output (`--format flac`) — v1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ kesha say "Hello, world" > hello.wav
 kesha say "Привет, мир" > privet.wav     # auto-routes (Milena on darwin, ru-vosk-m02 elsewhere)
 ```
 
+**Output formats** (`--format`, or inferred from `--out` extension):
+
+```bash
+kesha say "Hello" --out hi.wav                       # WAV (default, uncompressed)
+kesha say "Hello" --format ogg-opus --out hi.ogg     # OGG/Opus — messenger voice notes (Telegram/WhatsApp/Signal)
+kesha say "Hello" --format flac --out hi.flac        # FLAC — lossless, royalty-free, plays in every browser incl. Safari/iOS
+```
+
+FLAC is the format for web-embeddable samples: it plays natively in all modern browsers (including Safari/iOS, where OGG/Opus does not), stays royalty-free like Opus, and keeps the engine's native sample rate (no resample). `--bitrate` / `--sample-rate` apply only to `--format ogg-opus`.
+
 **Russian abbreviations** (`ru-vosk-*`): all-uppercase Cyrillic 2-5-char tokens auto-expand letter-by-letter when not pronounceable as a Russian syllable (ФСБ → "эф-эс-бэ", ВОЗ → "воз"). Disable with `--no-expand-abbrev`. See [docs/tts.md#russian-abbreviation-auto-expansion](docs/tts.md#russian-abbreviation-auto-expansion).
 
 **English acronyms** (`en-*`, Kokoro): three-table mechanism (letter-spell rule + STOP_LIST + IPA_LEXICON) auto-expands FBI → "ef bee eye" and gives EPAM/JSON/Anthropic the right IPA. Disable letter-spell with `--no-expand-abbrev`. See [docs/tts.md#english-acronym-auto-expansion](docs/tts.md#english-acronym-auto-expansion).

--- a/SKILL.md
+++ b/SKILL.md
@@ -168,6 +168,12 @@ kesha say --list-voices                            # Kokoro + Vosk-TTS + ~180 ma
 
 Output: WAV mono float32 by default. `--out <path>` writes to a file instead of stdout. For Telegram/OpenClaw replies, prefer `--format ogg-opus --out reply.ogg` or the OpenClaw-provided `{{OutputPath}}`.
 
+**Output formats** (`--format`, or inferred from the `--out` extension): `wav` (default, uncompressed), `ogg-opus` (messenger voice notes), `flac` (lossless, royalty-free, plays in every browser incl. Safari/iOS — the format for web-embeddable samples). FLAC keeps the engine's native rate; `--bitrate` / `--sample-rate` apply only to `ogg-opus`.
+
+```bash
+kesha say --format flac --out sample.flac "Hello"   # web-embeddable, Safari-safe
+```
+
 **Voice notes (Telegram / WhatsApp / Signal / Discord):** add `--format ogg-opus` to emit OGG/Opus directly — the format messenger APIs render as a native voice message:
 
 ```bash

--- a/completions/kesha.fish
+++ b/completions/kesha.fish
@@ -69,7 +69,7 @@ complete -c kesha -n '__fish_seen_subcommand_from say' -l out -r -d 'Write audio
 complete -c kesha -n '__fish_seen_subcommand_from say' -l rate -r -d 'Speaking rate 0.5–2.0'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l list-voices -d 'List installed voices and exit'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l ssml -d 'Parse input as SSML (supports <speak>, <break>; strips unknown tags)'
-complete -c kesha -n '__fish_seen_subcommand_from say' -l format -r -d 'Output format: wav (default) or ogg-opus (Telegram-ready voice note). Inferred from --out extension when omitted.'
+complete -c kesha -n '__fish_seen_subcommand_from say' -l format -r -d 'Output format: wav (default), ogg-opus (Telegram-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from --out extension when omitted.'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l bitrate -r -d 'Opus bitrate in bits/sec (e.g. 32000). Only with --format ogg-opus.'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l sample-rate -r -d 'Opus encoder sample rate (8000/12000/16000/24000/48000). Only with --format ogg-opus.'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l no-expand-abbrev -d 'Disable Russian acronym auto-expansion (ВОЗ → \'вэ о зэ\') for ru-vosk-* voices. <say-as interpret-as=\'characters\'> still works. Applies to Russian (ru-vosk-*) and English (en-*) voices.'

--- a/completions/kesha.zsh
+++ b/completions/kesha.zsh
@@ -99,7 +99,7 @@ _kesha() {
         '--rate=[Speaking rate 0.5–2.0]:rate:' \
         '--list-voices[List installed voices and exit]' \
         '--ssml[Parse input as SSML (supports <speak>, <break>; strips unknown tags)]' \
-        '--format=[Output format: wav (default) or ogg-opus (Telegram-ready voice note). Inferred from --out extension when omitted.]:format:' \
+        '--format=[Output format: wav (default), ogg-opus (Telegram-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from --out extension when omitted.]:format:' \
         '--bitrate=[Opus bitrate in bits/sec (e.g. 32000). Only with --format ogg-opus.]:bitrate:' \
         '--sample-rate=[Opus encoder sample rate (8000/12000/16000/24000/48000). Only with --format ogg-opus.]:sample rate:' \
         '--no-expand-abbrev[Disable Russian acronym auto-expansion (ВОЗ → '\''вэ о зэ'\'') for ru-vosk-* voices. <say-as interpret-as='\''characters'\''> still works. Applies to Russian (ru-vosk-*) and English (en-*) voices.]' \

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.19.0" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.20.0" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS
@@ -167,7 +167,7 @@ List installed voices and exit
 Parse input as SSML (supports <speak>, <break>; strips unknown tags)
 .TP
 .B \-\-format
-Output format: wav (default) or ogg\-opus (Telegram\-ready voice note). Inferred from \-\-out extension when omitted.
+Output format: wav (default), ogg\-opus (Telegram\-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from \-\-out extension when omitted.
 .TP
 .B \-\-bitrate
 Opus bitrate in bits/sec (e.g. 32000). Only with \-\-format ogg\-opus.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.19.0"
+    "version": "1.20.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -222,6 +222,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +427,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -640,6 +661,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flacenc"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c892c2b5fa08f967e8b5ad29121570b4762202f2402033ce08479ec65eccd0"
+dependencies = [
+ "built",
+ "crc",
+ "heapless",
+ "md-5",
+ "num-traits",
+ "rustversion",
+ "seq-macro",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +825,16 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -949,13 +1004,14 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",
  "clap",
  "cpal",
  "dirs",
+ "flacenc",
  "fluidaudio-rs",
  "hound",
  "libc",
@@ -1066,6 +1122,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1720,6 +1786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1895,12 @@ dependencies = [
  "quick-xml",
  "regex",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strength_reduce"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,7 +43,6 @@ system_diarize = ["dep:fluidaudio-rs", "dep:libc"]
 # macOS arm of text_lang.rs falls back to the legacy `swift -e` path, so
 # minimal dev environments without Xcode CLT continue to build.
 system_text_lang = []
-flacenc = ["dep:flacenc"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.19.0"
+version = "1.20.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the
@@ -25,7 +25,7 @@ default = ["onnx", "tts"]
 # invalidAudioData")` (see #259) interleaves with kesha-engine's JSON output.
 coreml = ["dep:fluidaudio-rs", "dep:libc"]
 onnx = []
-tts = ["dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg"]
+tts = ["dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg", "dep:flacenc"]
 # macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
 # Opt-in — builds a Swift sidecar via swiftc in build.rs. Silently no-op on
 # non-macOS targets even when enabled.
@@ -43,6 +43,7 @@ system_diarize = ["dep:fluidaudio-rs", "dep:libc"]
 # macOS arm of text_lang.rs falls back to the legacy `swift -e` path, so
 # minimal dev environments without Xcode CLT continue to build.
 system_text_lang = []
+flacenc = ["dep:flacenc"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -90,6 +91,7 @@ libc = { version = "0.2", optional = true }
 # source-level routing/shape smoke tests instead of relying on transitive drift.
 misaki-rs = { version = "=0.3.0", default-features = false }
 vosk_tts = { path = "vendor/vosk-tts" }
+flacenc = { version = "0.5.1", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cpal = "0.15"

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -72,9 +72,8 @@ pub(crate) fn resolve_output_format(
         if let Some(r) = sample_rate {
             *sr = r;
         }
-    } else if matches!(chosen, tts::OutputFormat::Wav)
-        && (bitrate.is_some() || sample_rate.is_some())
-    {
+    } else if bitrate.is_some() || sample_rate.is_some() {
+        // Non-Opus formats (Wav, Flac) have no encoder bitrate/sample-rate knob.
         return Err("--bitrate / --sample-rate only apply to --format ogg-opus".to_string());
     }
 

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -1,8 +1,9 @@
 //! Output audio encoding: f32 PCM samples → wire bytes.
 //!
-//! Closes #223. Today the engine only spoke WAV; this module adds OGG/Opus
-//! (the format Telegram, WhatsApp, Signal, and Discord render as native voice
-//! messages) and keeps the door open for `mp3` / `flac` / `raw-pcm` later.
+//! Closes #223. Adds OGG/Opus (the format Telegram, WhatsApp, Signal, and
+//! Discord render as native voice messages) and FLAC (lossless, royalty-free,
+//! browser-universal incl. Safari) alongside the original WAV. Keeps the door
+//! open for `mp3` / `raw-pcm` later.
 //!
 //! ## Design
 //! - One enum [`OutputFormat`] selects the wire format.

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -50,6 +50,15 @@ pub enum OutputFormat {
         /// is used — matches Kokoro's native rate so most calls skip resampling.
         sample_rate: u32,
     },
+    /// FLAC, mono, lossless.
+    ///
+    /// Royalty-free (Xiph, same ethos as Opus) and plays in every modern
+    /// browser including Safari/iOS — the format for web-embeddable samples.
+    /// FLAC accepts the engine's native rate, so unlike Opus there is no
+    /// resample round-trip and no bitrate knob (lossless). f32 is quantized to
+    /// 16-bit PCM, transparent for TTS. Encoded via the pure-Rust `flacenc`
+    /// crate (Apache-2.0) — no C dependency.
+    Flac,
 }
 
 impl OutputFormat {
@@ -75,8 +84,9 @@ impl FromStr for OutputFormat {
         match s.to_ascii_lowercase().as_str() {
             "wav" => Ok(Self::Wav),
             "ogg-opus" | "opus" | "ogg" => Ok(Self::ogg_opus_default()),
+            "flac" => Ok(Self::Flac),
             other => Err(format!(
-                "unknown --format '{other}'. supported: wav, ogg-opus"
+                "unknown --format '{other}'. supported: wav, ogg-opus, flac"
             )),
         }
     }
@@ -88,6 +98,7 @@ pub fn format_from_extension(ext: &str) -> Option<OutputFormat> {
     match ext.to_ascii_lowercase().as_str() {
         "wav" => Some(OutputFormat::Wav),
         "ogg" | "opus" | "oga" => Some(OutputFormat::ogg_opus_default()),
+        "flac" => Some(OutputFormat::Flac),
         _ => None,
     }
 }
@@ -105,7 +116,62 @@ pub fn encode(samples: &[f32], src_rate: u32, fmt: OutputFormat) -> anyhow::Resu
             bitrate,
             sample_rate,
         } => encode_ogg_opus(samples, src_rate, sample_rate, bitrate),
+        OutputFormat::Flac => encode_flac(samples, src_rate),
     }
+}
+
+// =============================================================================
+// FLAC encoding (lossless, royalty-free, browser-universal incl. Safari)
+// =============================================================================
+
+/// Encode mono f32 PCM to FLAC bytes via the pure-Rust `flacenc` crate.
+///
+/// No resample (FLAC accepts the engine's native rate) and no bitrate (lossless).
+/// f32 in `[-1.0, 1.0]` is quantized to signed 16-bit PCM — transparent for TTS
+/// output and the most broadly compatible FLAC bit depth.
+#[cfg(feature = "tts")]
+fn encode_flac(samples: &[f32], src_rate: u32) -> anyhow::Result<Vec<u8>> {
+    use flacenc::component::BitRepr;
+    use flacenc::error::Verify;
+
+    const BITS_PER_SAMPLE: usize = 16;
+    const CHANNELS: usize = 1;
+
+    // f32 [-1.0, 1.0] -> signed 16-bit PCM, held in i32 as flacenc expects.
+    let pcm: Vec<i32> = samples
+        .iter()
+        .map(|&s| (s.clamp(-1.0, 1.0) * f32::from(i16::MAX)).round() as i32)
+        .collect();
+
+    let config = flacenc::config::Encoder::default()
+        .into_verified()
+        .map_err(|e| anyhow::anyhow!("flac encoder config invalid: {e:?}"))?;
+
+    let source = flacenc::source::MemSource::from_samples(
+        &pcm,
+        CHANNELS,
+        BITS_PER_SAMPLE,
+        src_rate as usize,
+    );
+
+    let mut stream = flacenc::encode_with_fixed_block_size(&config, source, config.block_size)
+        .map_err(|e| anyhow::anyhow!("flac encode failed: {e:?}"))?;
+
+    // flacenc records STREAMINFO min_block_size as the (shorter) final block,
+    // which flags the stream "variable block size" and trips strict decoders
+    // like Symphonia. For a fixed-block-size encode the conventional header
+    // (libFLAC, ffmpeg) sets min == max == nominal; the short final block is
+    // signaled per-frame, not in STREAMINFO. Normalize for max decoder reach.
+    stream
+        .stream_info_mut()
+        .set_block_sizes(config.block_size, config.block_size)
+        .map_err(|e| anyhow::anyhow!("flac stream_info fixup failed: {e:?}"))?;
+
+    let mut sink = flacenc::bitsink::ByteSink::new();
+    stream
+        .write(&mut sink)
+        .map_err(|e| anyhow::anyhow!("flac serialization failed: {e:?}"))?;
+    Ok(sink.as_slice().to_vec())
 }
 
 // =============================================================================
@@ -434,6 +500,12 @@ mod tests {
             OutputFormat::from_str("ogg").unwrap(),
             OutputFormat::OggOpus { .. }
         ));
+        assert_eq!(OutputFormat::from_str("flac").unwrap(), OutputFormat::Flac);
+        assert_eq!(
+            OutputFormat::from_str("FLAC").unwrap(),
+            OutputFormat::Flac,
+            "case-insensitive"
+        );
         // Bogus values must be rejected with a useful message — clap surfaces it.
         let err = OutputFormat::from_str("mp3").unwrap_err();
         assert!(err.contains("mp3") && err.contains("supported"));
@@ -451,6 +523,8 @@ mod tests {
             format_from_extension("opus"),
             Some(OutputFormat::OggOpus { .. })
         ));
+        assert_eq!(format_from_extension("flac"), Some(OutputFormat::Flac));
+        assert_eq!(format_from_extension("FLAC"), Some(OutputFormat::Flac));
         assert_eq!(format_from_extension("mp3"), None);
         assert_eq!(format_from_extension(""), None);
     }
@@ -581,5 +655,50 @@ mod tests {
             .collect();
         let bytes = encode(&samples, src_sr, OutputFormat::ogg_opus_default()).unwrap();
         assert_eq!(&bytes[..4], b"OggS", "resampled output is still valid Ogg");
+    }
+
+    #[test]
+    fn flac_produces_valid_magic_and_decodes_round_trip() {
+        // 1 second of a 440 Hz tone at 24 kHz mono (Kokoro's native rate).
+        let sr = 24_000u32;
+        let samples: Vec<f32> = (0..sr)
+            .map(|i| (i as f32 * 2.0 * std::f32::consts::PI * 440.0 / sr as f32).sin() * 0.3)
+            .collect();
+        let bytes = encode(&samples, sr, OutputFormat::Flac).unwrap();
+
+        // Native FLAC streams begin with the 4-byte stream marker "fLaC".
+        assert_eq!(&bytes[..4], b"fLaC", "missing FLAC stream marker");
+        // Lossless, but still smaller than the raw 16-bit WAV it came from.
+        let wav_bytes = encode(&samples, sr, OutputFormat::Wav).unwrap();
+        assert!(
+            bytes.len() < wav_bytes.len(),
+            "flac ({}) should be smaller than wav ({})",
+            bytes.len(),
+            wav_bytes.len()
+        );
+
+        // Strongest check: it actually decodes via Symphonia (the same decoder
+        // the STT path uses). Round-trip through a temp file and confirm we get
+        // a non-silent signal of roughly the right duration back.
+        let path = std::env::temp_dir().join(format!("kesha-flac-rt-{}.flac", std::process::id()));
+        std::fs::write(&path, &bytes).unwrap();
+        let decoded = crate::audio::load_audio(path.to_str().unwrap()).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert!(!decoded.is_empty(), "decoded FLAC was empty");
+        let rms = (decoded.iter().map(|s| s * s).sum::<f32>() / decoded.len() as f32).sqrt();
+        assert!(rms > 0.01, "decoded FLAC is silent (rms={rms})");
+    }
+
+    #[test]
+    fn flac_uses_engine_native_rate_without_resample() {
+        // Vosk-RU runs at 22.05 kHz. Unlike Opus (which only accepts a fixed set
+        // of rates and must resample), FLAC takes the native rate directly — so
+        // this must succeed and stay valid with no resample round-trip.
+        let src_sr = 22_050u32;
+        let samples: Vec<f32> = (0..src_sr)
+            .map(|i| (i as f32 * 2.0 * std::f32::consts::PI * 220.0 / src_sr as f32).sin() * 0.25)
+            .collect();
+        let bytes = encode(&samples, src_sr, OutputFormat::Flac).unwrap();
+        assert_eq!(&bytes[..4], b"fLaC");
     }
 }

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -100,7 +100,7 @@ export const sayCommand = defineCommand({
     format: {
       type: "string",
       description:
-        "Output format: wav (default) or ogg-opus (Telegram-ready voice note). Inferred from --out extension when omitted.",
+        "Output format: wav (default), ogg-opus (Telegram-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from --out extension when omitted.",
     },
     bitrate: {
       type: "string",
@@ -145,12 +145,12 @@ export const sayCommand = defineCommand({
     const fmtArg = typeof args.format === "string" ? args.format.toLowerCase() : undefined;
     let format: SayFormat | undefined;
     if (fmtArg) {
-      if (fmtArg === "wav" || fmtArg === "ogg-opus") {
+      if (fmtArg === "wav" || fmtArg === "ogg-opus" || fmtArg === "flac") {
         format = fmtArg;
       } else if (fmtArg === "opus" || fmtArg === "ogg") {
         format = "ogg-opus";
       } else {
-        log.error(`unknown --format '${args.format}'. supported: wav, ogg-opus`);
+        log.error(`unknown --format '${args.format}'. supported: wav, ogg-opus, flac`);
         process.exit(2);
       }
     }
@@ -166,7 +166,10 @@ export const sayCommand = defineCommand({
         ? args.out.split(".").pop()?.toLowerCase()
         : undefined;
       const impliesOpus = outExt && ["ogg", "opus", "oga"].includes(outExt);
-      if (format === "wav" || (format === undefined && !impliesOpus)) {
+      // --bitrate / --sample-rate are Opus-only. Reject for wav and flac
+      // (both lossless / no encoder knobs) and for any non-Opus extension.
+      const resolvesToOpus = format === "ogg-opus" || (format === undefined && impliesOpus);
+      if (!resolvesToOpus) {
         log.error("--bitrate and --sample-rate are only valid with --format ogg-opus");
         process.exit(2);
       }

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -15,7 +15,7 @@ import { registerProcessTree } from "./process-tree";
  * - `ogg-opus`: OGG-encapsulated Opus, mono. The format Telegram, WhatsApp,
  *   Signal, and Discord render as native voice messages. See #223.
  */
-export type SayFormat = "wav" | "ogg-opus";
+export type SayFormat = "wav" | "ogg-opus" | "flac";
 export const MAX_TEXT_CHARS = 5000;
 
 export interface SayOptions {

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -14,6 +14,8 @@ import { registerProcessTree } from "./process-tree";
  * - `wav` (default): RIFF WAV at the engine's native sample rate.
  * - `ogg-opus`: OGG-encapsulated Opus, mono. The format Telegram, WhatsApp,
  *   Signal, and Discord render as native voice messages. See #223.
+ * - `flac`: lossless, royalty-free, plays in every modern browser including
+ *   Safari/iOS. Keeps the engine's native rate; no bitrate knob.
  */
 export type SayFormat = "wav" | "ogg-opus" | "flac";
 export const MAX_TEXT_CHARS = 5000;

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -386,7 +386,7 @@ OPTIONS
                 --rate=<rate>    Speaking rate 0.5–2.0 (Default: 1.0)
                 --list-voices    List installed voices and exit
                        --ssml    Parse input as SSML (supports <speak>, <break>; strips unknown tags)
-            --format=<format>    Output format: wav (default) or ogg-opus (Telegram-ready voice note). Inferred from --out extension when omitted.
+            --format=<format>    Output format: wav (default), ogg-opus (Telegram-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from --out extension when omitted.
           --bitrate=<bitrate>    Opus bitrate in bits/sec (e.g. 32000). Only with --format ogg-opus.
   --sample-rate=<sample_rate>    Opus encoder sample rate (8000/12000/16000/24000/48000). Only with --format ogg-opus.
            --no-expand-abbrev    Disable Russian acronym auto-expansion (ВОЗ → 'вэ о зэ') for ru-vosk-* voices. <say-as interpret-as='characters'> still works. Applies to Russian (ru-vosk-*) and English (en-*) voices.


### PR DESCRIPTION
## Summary

Adds lossless **FLAC** output to `kesha say`. FLAC plays natively in **every modern browser including Safari/iOS** (where OGG/Opus does not), stays **royalty-free** (Xiph, same ethos as Opus), and is the format for web-embeddable TTS samples (e.g. the site's "Hear it" section).

Engine release **v1.20.0**.

## Why FLAC (not AAC or MP3)

This started as "add AAC/m4a"; interrogation ruled both out:
- **AAC** — active patent pool (Via LA/Dolby) on distributed encoders; Opus was chosen precisely to avoid codec royalties. Plus MP4 atom muxing + no pure-Rust encoder.
- **MP3** — patents expired (good), but **every** MP3 encoder (LAME/Shine) is **LGPL copyleft** — it'd be the first copyleft dep in an all-permissive tree.
- **FLAC** — patent-free **and** has a permissive **pure-Rust** encoder (`flacenc`, Apache-2.0). Threads the needle. `cargo deny` passes with zero new license exceptions.

## Implementation

- `OutputFormat::Flac` in `rust/src/tts/encode.rs` via `flacenc` (pure Rust, no C dep). **No resample** (FLAC accepts the native 24 kHz Kokoro / 22.05 kHz Vosk rate), **no bitrate** (lossless); f32 → 16-bit PCM.
- **STREAMINFO normalized to fixed-block-size** (`min == max == nominal`, matching libFLAC/ffmpeg). flacenc's literal `min = shortest final block` flags the stream "variable" and trips strict decoders like Symphonia; normalizing makes the output decode everywhere (Symphonia **and** CoreAudio/browsers — both verified).
- CLI: `--format flac` / `.flac` inference on the Rust engine (`from_str`/`format_from_extension`) and the TS wrapper (`src/synth.ts`, `src/cli/say.ts`). `--bitrate`/`--sample-rate` now rejected for **any** non-Opus format (engine + TS), not just WAV.
- Docs (README TTS, SKILL.md), regenerated shell completions + manpage.

## Tests

- `rust/src/tts/encode.rs`: magic-bytes (`fLaC`), size-vs-WAV, native-rate (22.05 kHz, no resample), and a **Symphonia round-trip decode** reusing the existing decode dep.
- Updated the `say` help golden for the new `--format` description.

## Verification (local)

- [x] `cargo fmt --check`, `cargo clippy --all-targets --features tts -- -D warnings` — clean
- [x] `cargo nextest run --features tts` (encode/say/tts) — 37/37 pass incl. FLAC round-trip
- [x] `cargo deny check` — advisories/bans/licenses/sources **ok** (flacenc Apache-2.0, no new exceptions)
- [x] `afinfo` (CoreAudio) decodes the output as valid 24 kHz mono FLAC
- [x] `bunx tsc --noEmit` clean; `bun test` 254 pass / 4 pre-existing local-only help-golden ANSI fails (pass in CI; say golden content updated)
- [ ] CI green (`integration-tests` skips on `release/*` per the chicken-and-egg guard — pinned v1.20.0 engine doesn't exist yet)
- [ ] Greptile review

## Release

`release/1.20.0`: bumped `rust/Cargo.toml` + `Cargo.lock` + `package.json#version` + `#keshaEngine.version` in lockstep. After merge: tag `v1.20.0` → `build-engine.yml` ships the engine binaries.