### PR TITLE
chore(release): 1.21.0-beta.1

### DIFF
--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.21.0" "User Commands"
+.TH KESHA 1 "May 2026" "kesha 1.21.0-beta.1" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.21.0",
+  "version": "1.21.0-beta.1",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.21.0"
+    "version": "1.21.0-beta.1"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.21.0"
+version = "1.21.0-beta.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.21.0"
+version = "1.21.0-beta.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Beta of the upcoming 1.21.0 stable. Validates the FluidAudio 0.14.7 KokoroAneManager migration (#475 fix shipped in #479) before the stable cut.

## Changes

- \`package.json#version\`: 1.21.0 → 1.21.0-beta.1
- \`package.json#keshaEngine.version\`: 1.21.0 → 1.21.0-beta.1
- \`rust/Cargo.toml\` / \`rust/Cargo.lock\`: 1.21.0 → 1.21.0-beta.1

## Release flow

After merge:
1. \`git tag v1.21.0-beta.1 && git push origin v1.21.0-beta.1\`
2. \`build-engine.yml\` cuts a draft prerelease (no Homebrew, no .deb/.rpm)
3. Validate draft assets via authenticated \`gh release download\`
4. Un-draft → \`npm publish --tag beta\` (auto via npm-publish.yml)

Users opt in: \`bun add -g @drakulavich/kesha-voice-kit@beta && kesha install\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)