### PR TITLE
fix(tts): honor SSML on FluidAudio Kokoro (ANE) path (#481)

### DIFF
--- a/rust/src/capabilities.rs
+++ b/rust/src/capabilities.rs
@@ -39,7 +39,10 @@ pub fn get_capabilities() -> Capabilities {
     #[cfg(feature = "tts")]
     features.push("tts.ru_emphasis_marker");
     // `tts.prosody_rate` applies to the Vosk (`ru-vosk-*`) and Kokoro
-    // (`en-*`) engines. AVSpeech (`macos-*`) is unaffected: it rejects SSML
+    // (`en-*`) engines — including the darwin-arm64 FluidAudio Kokoro path,
+    // which threads `<prosody rate>` into its model-native speed input as of
+    // #481 (earlier builds rejected SSML wholesale and made this flag a lie).
+    // AVSpeech (`macos-*`) is unaffected: it rejects SSML
     // wholesale at `tts::say` before any prosody dispatch runs (see
     // `rust/src/tts/mod.rs:120-124`), so callers sending
     // `<prosody rate>` to a `macos-*` voice get the existing

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -279,9 +279,9 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
             target_arch = "aarch64"
         ))]
         tts::voices::ResolvedVoice::FluidKokoro { voice_id, .. } => {
-            if req.ssml {
-                return Err("SSML is not yet supported with FluidAudio Kokoro voices".into());
-            }
+            // SSML is handled inside `tts::say` for FluidAudio Kokoro post-#481
+            // (prosody rate → model-native speed, break silence stitching). No
+            // in-process session to cache: each `say` re-inits the bridge.
             tts::say(tts::SayOptions {
                 text: &req.text,
                 lang: espeak_lang,
@@ -289,7 +289,7 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
                     voice_id: &voice_id,
                     speed: req.rate,
                 },
-                ssml: false,
+                ssml: req.ssml,
                 format,
                 expand_abbrev: req.expand_abbrev,
             })

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -103,10 +103,11 @@ pub fn synthesize_pcm(text: &str, voice_id: &str, speed: f32) -> Result<Vec<f32>
     wav_to_f32(&wav)
 }
 
-/// Decode a FluidAudio Kokoro WAV buffer (24 kHz mono, 16-bit PCM) into f32
-/// samples normalized to `[-1.0, 1.0]`. Mirrors the i16→f32 conversion in
-/// `tts::say::wav_to_mono_f32` but stays mono-only since FluidAudio always
-/// emits a single channel.
+/// Decode a FluidAudio Kokoro WAV buffer (24 kHz, 16-bit PCM) into f32 samples
+/// normalized to `[-1.0, 1.0]`. FluidAudio emits mono today, but we downmix any
+/// multi-channel buffer to mono rather than trusting that — an interleaved
+/// stereo buffer left as-is would silently double the sample count and corrupt
+/// the SSML walker's duration/`<break>` math. Mirrors `tts::say::wav_to_mono_f32`.
 fn wav_to_f32(wav: &[u8]) -> Result<Vec<f32>> {
     let reader =
         hound::WavReader::new(std::io::Cursor::new(wav)).context("decode FluidAudio Kokoro WAV")?;
@@ -125,7 +126,14 @@ fn wav_to_f32(wav: &[u8]) -> Result<Vec<f32>> {
             .collect::<std::result::Result<Vec<f32>, _>>()
             .context("read FluidAudio Kokoro float samples")?,
     };
-    Ok(samples)
+    let channels = spec.channels as usize;
+    if channels <= 1 {
+        return Ok(samples);
+    }
+    Ok(samples
+        .chunks_exact(channels)
+        .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+        .collect())
 }
 
 #[cfg(test)]

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -13,6 +13,10 @@
 use anyhow::{Context, Result};
 use fluidaudio_rs::FluidAudio;
 
+/// FluidAudio Kokoro native output rate (24 kHz mono, 16-bit PCM). Used to size
+/// SSML `<break>` silence buffers when the segment walker stitches audio.
+pub const SAMPLE_RATE: u32 = 24_000;
+
 // FluidAudio 0.14.5 voice snapshot. Keep this list in sync with the FluidAudio
 // pin in the fluidaudio-rs fork whenever it changes.
 const VOICES: &[&str] = &[
@@ -46,6 +50,21 @@ pub fn supports_voice(name: &str) -> bool {
     VOICES.contains(&name)
 }
 
+/// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
+/// with the process's stdout silenced for the whole bridge lifetime (create →
+/// call → drop). FluidAudio's CoreML pipeline writes diagnostics to stdout that
+/// would corrupt `kesha say`'s WAV byte stream; the oneshot guard restores fd 1
+/// on return (#259, mirrors the diarize/ASR guard).
+fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> Result<R> {
+    crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
+        let audio = FluidAudio::new().context("init FluidAudio bridge")?;
+        audio
+            .init_kokoro(voice_id)
+            .context("init FluidAudio Kokoro (downloads the model on first run)")?;
+        f(&audio)
+    })
+}
+
 /// Synthesize `text` with FluidAudio Kokoro (CoreML/ANE) via the native
 /// `fluidaudio-rs` binding. `voice_id` is the bare FluidAudio voice (e.g.
 /// `am_michael`). Returns a complete WAV byte buffer (24 kHz mono, 16-bit PCM);
@@ -54,18 +73,59 @@ pub fn synthesize(text: &str, voice_id: &str, speed: f32) -> Result<Vec<u8>> {
     if text.is_empty() {
         anyhow::bail!("fluid-kokoro: text is empty");
     }
-    // `kesha say` writes the WAV bytes to stdout; silence FluidAudio's CoreML
-    // stdout noise for the whole FluidAudio lifetime so it can't corrupt the
-    // audio stream (#259, mirrors the diarize/ASR guard).
-    crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
-        let audio = FluidAudio::new().context("init FluidAudio bridge")?;
-        audio
-            .init_kokoro(voice_id)
-            .context("init FluidAudio Kokoro (downloads the model on first run)")?;
+    with_kokoro(voice_id, |audio| {
         audio
             .synthesize_kokoro(text, voice_id, speed)
             .context("FluidAudio Kokoro synthesis")
     })
+}
+
+/// Synthesize one text chunk and return raw PCM f32 samples at [`SAMPLE_RATE`].
+///
+/// Used by the SSML segment walker (`tts::say::synth_segments_fluid_kokoro`),
+/// which decodes/concatenates per-segment audio and interleaves `<break>`
+/// silence before encoding once. Empty/whitespace-only text returns an empty
+/// buffer (the walker skips it) rather than erroring the whole utterance.
+///
+/// Each call re-inits the FluidAudio bridge: the dominant SSML case is a single
+/// `<prosody>`-wrapped utterance (one call), and the `.mlmodelc` is disk-cached
+/// after the first compile so multi-segment re-inits load the compiled model
+/// rather than recompiling.
+pub fn synthesize_pcm(text: &str, voice_id: &str, speed: f32) -> Result<Vec<f32>> {
+    if text.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let wav = with_kokoro(voice_id, |audio| {
+        audio
+            .synthesize_kokoro(text, voice_id, speed)
+            .context("FluidAudio Kokoro synthesis")
+    })?;
+    wav_to_f32(&wav)
+}
+
+/// Decode a FluidAudio Kokoro WAV buffer (24 kHz mono, 16-bit PCM) into f32
+/// samples normalized to `[-1.0, 1.0]`. Mirrors the i16→f32 conversion in
+/// `tts::say::wav_to_mono_f32` but stays mono-only since FluidAudio always
+/// emits a single channel.
+fn wav_to_f32(wav: &[u8]) -> Result<Vec<f32>> {
+    let reader =
+        hound::WavReader::new(std::io::Cursor::new(wav)).context("decode FluidAudio Kokoro WAV")?;
+    let spec = reader.spec();
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Int => {
+            let max = (1i64 << (spec.bits_per_sample - 1)) as f32;
+            reader
+                .into_samples::<i32>()
+                .map(|s| s.map(|v| v as f32 / max))
+                .collect::<std::result::Result<Vec<f32>, _>>()
+                .context("read FluidAudio Kokoro PCM samples")?
+        }
+        hound::SampleFormat::Float => reader
+            .into_samples::<f32>()
+            .collect::<std::result::Result<Vec<f32>, _>>()
+            .context("read FluidAudio Kokoro float samples")?,
+    };
+    Ok(samples)
 }
 
 #[cfg(test)]

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -111,9 +111,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
     ))]
     if let EngineChoice::FluidKokoro { voice_id, speed } = &opts.engine {
         if opts.ssml {
-            return Err(TtsError::SynthesisFailed(
-                "SSML is not yet supported with FluidAudio Kokoro voices".into(),
-            ));
+            return synth_segments_fluid_kokoro(opts.text, voice_id, *speed, opts.format);
         }
         let wav_bytes = super::fluid_kokoro::synthesize(opts.text, voice_id, *speed)
             .map_err(|e| TtsError::SynthesisFailed(format!("fluid-kokoro: {e}")))?;
@@ -366,6 +364,119 @@ pub fn synth_segments_kokoro_with(
         ));
     }
     encode_or_fail(&out, sample_rate, format)
+}
+
+/// SSML path for FluidAudio Kokoro (CoreML/ANE), behind `system_kokoro`.
+///
+/// FluidAudio performs its own internal G2P from raw text, so — unlike the ONNX
+/// Kokoro path — we deliberately do NOT run `en::normalize_segments` (which
+/// would emit `Segment::Ipa` chunks FluidAudio cannot accept). Instead we walk
+/// the parsed segments feeding plain text per chunk, threading `<prosody rate>`
+/// into the model-native `speed` and interleaving `<break>` silence. This
+/// restores the prosody/break parity the pre-#479 ONNX path had on
+/// darwin-arm64 (closes #481).
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn synth_segments_fluid_kokoro(
+    text: &str,
+    voice_id: &str,
+    speed: f32,
+    format: OutputFormat,
+) -> Result<Vec<u8>, TtsError> {
+    let segments =
+        ssml::parse(text).map_err(|e| TtsError::SynthesisFailed(format!("ssml: {e}")))?;
+    if segments.is_empty() {
+        return Err(TtsError::SynthesisFailed(
+            "SSML had no speakable content".into(),
+        ));
+    }
+    let synth = |t: &str, sp: f32| super::fluid_kokoro::synthesize_pcm(t, voice_id, sp);
+    let sample_rate = super::fluid_kokoro::SAMPLE_RATE;
+    let mut out: Vec<f32> = Vec::new();
+    for seg in &segments {
+        synth_one_fluid_kokoro(&synth, seg, speed, sample_rate, &mut out)
+            .map_err(|e| TtsError::SynthesisFailed(format!("fluid-kokoro: {e}")))?;
+    }
+    if out.is_empty() {
+        return Err(TtsError::SynthesisFailed(
+            "no audio produced from SSML input".into(),
+        ));
+    }
+    encode_or_fail(&out, sample_rate, format)
+}
+
+/// Append the PCM for one SSML segment to `out`, mirroring `synth_one_vosk` for
+/// the FluidAudio Kokoro engine. `synth(text, speed)` turns a text chunk into
+/// f32 samples (the real impl calls `fluid_kokoro::synthesize_pcm`; tests inject
+/// a deterministic fake). Behaviour per variant:
+///
+/// - `Text` → synthesize at the current speed.
+/// - `Break` → append `sample_rate`-sized silence.
+/// - `ProsodyRate` → recurse with the CLI×SSML [`compose_rate`] product.
+/// - `Emphasis` → strip `+` stress markers (warn-once unless `suppress`), then
+///   synthesize — FluidAudio has no stress input. Mirrors the ONNX path's
+///   fallback.
+/// - `Spell` → warn-once and read as plain text; FluidAudio can't letter-spell.
+/// - `Ipa` → warn-once and skip; FluidAudio's internal G2P can't accept IPA.
+///
+/// Not cfg-gated narrower than `system_kokoro` so the unit test can exercise the
+/// walker without the FluidAudio model.
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn synth_one_fluid_kokoro(
+    synth: &dyn Fn(&str, f32) -> anyhow::Result<Vec<f32>>,
+    seg: &ssml::Segment,
+    speed: f32,
+    sample_rate: u32,
+    out: &mut Vec<f32>,
+) -> anyhow::Result<()> {
+    match seg {
+        ssml::Segment::Text(t) => out.extend(synth(t, speed)?),
+        ssml::Segment::Break(dur) => out.extend(silence_samples(*dur, sample_rate)),
+        ssml::Segment::Emphasis { content, suppress } => {
+            if !suppress {
+                crate::tts::warn::warn_once(
+                    "emphasis-non-ru-vosk",
+                    "<emphasis> stress markers are honored only on ru-vosk-* voices; \
+                     stripping `+` from content for FluidAudio Kokoro",
+                );
+            }
+            let stripped = if content.contains('+') {
+                content.replace('+', "")
+            } else {
+                content.clone()
+            };
+            out.extend(synth(&stripped, speed)?);
+        }
+        ssml::Segment::ProsodyRate { rate, content } => {
+            let effective = compose_rate(speed, *rate);
+            for inner in content {
+                synth_one_fluid_kokoro(synth, inner, effective, sample_rate, out)?;
+            }
+        }
+        ssml::Segment::Spell(s) => {
+            crate::tts::warn::warn_once(
+                "spell-fluid-kokoro",
+                "SSML <say-as interpret-as=\"characters\"> letter-spelling is not honored on \
+                 FluidAudio Kokoro; reading the content as plain text",
+            );
+            out.extend(synth(s, speed)?);
+        }
+        ssml::Segment::Ipa(_) => {
+            crate::tts::warn::warn_once(
+                "ipa-fluid-kokoro",
+                "SSML <phoneme alphabet=\"ipa\"> is not supported on FluidAudio Kokoro \
+                 (internal G2P only); skipping the phoneme segment",
+            );
+        }
+    }
+    Ok(())
 }
 
 fn say_with_kokoro(
@@ -653,5 +764,103 @@ mod tests {
         assert!((super::compose_rate(0.5, 1.0) - 0.5).abs() < 1e-6);
         assert!((super::compose_rate(2.0, 1.0) - 2.0).abs() < 1e-6);
         assert!((super::compose_rate(1.0, 1.0) - 1.0).abs() < 1e-6);
+    }
+}
+
+/// Walker tests for the FluidAudio Kokoro SSML path (#481). A fake `synth`
+/// callback records `(text, speed)` and returns one sentinel sample per
+/// character, so the whole table runs without the FluidAudio model. Gated on
+/// the same triple as the walker; runs locally on darwin-arm64 and is
+/// compile-checked by CI's macos `system_kokoro` clippy step.
+#[cfg(all(
+    test,
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+mod fluid_kokoro_ssml_tests {
+    use super::*;
+    use crate::tts::ssml::Segment;
+    use std::cell::RefCell;
+    use std::time::Duration;
+
+    /// Build a fake synth recording every call into `log`; returns
+    /// `text.chars().count()` sentinel samples so the caller can assert which
+    /// chunks were synthesized and in what order.
+    fn recording_synth(
+        log: &RefCell<Vec<(String, f32)>>,
+    ) -> impl Fn(&str, f32) -> anyhow::Result<Vec<f32>> + '_ {
+        move |t: &str, sp: f32| {
+            log.borrow_mut().push((t.to_string(), sp));
+            Ok(vec![0.5_f32; t.chars().count()])
+        }
+    }
+
+    #[test]
+    fn text_and_break_concatenate_with_silence() {
+        let log = RefCell::new(Vec::new());
+        let synth = recording_synth(&log);
+        let mut out = Vec::new();
+        // 24 kHz × 0.25 s = 6000 samples of silence between two text chunks.
+        let segs = [
+            Segment::Text("abc".into()),
+            Segment::Break(Duration::from_millis(250)),
+            Segment::Text("de".into()),
+        ];
+        for seg in &segs {
+            synth_one_fluid_kokoro(&synth, seg, 1.0, 24_000, &mut out).unwrap();
+        }
+        assert_eq!(out.len(), 3 + 6000 + 2);
+        let calls = log.borrow();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].0, "abc");
+        assert_eq!(calls[1].0, "de");
+    }
+
+    #[test]
+    fn prosody_rate_threads_composed_speed_to_inner_text() {
+        let log = RefCell::new(Vec::new());
+        let synth = recording_synth(&log);
+        let mut out = Vec::new();
+        // x-fast (1.5) wrapping the whole utterance, CLI rate 1.0 → effective 1.5.
+        let seg = Segment::ProsodyRate {
+            rate: 1.5,
+            content: vec![Segment::Text("hi".into())],
+        };
+        synth_one_fluid_kokoro(&synth, &seg, 1.0, 24_000, &mut out).unwrap();
+        let calls = log.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "hi");
+        assert!(
+            (calls[0].1 - 1.5).abs() < 1e-6,
+            "expected composed speed 1.5, got {}",
+            calls[0].1
+        );
+    }
+
+    #[test]
+    fn emphasis_strips_plus_markers_before_synth() {
+        let log = RefCell::new(Vec::new());
+        let synth = recording_synth(&log);
+        let mut out = Vec::new();
+        let seg = Segment::Emphasis {
+            content: "д+ома".into(),
+            suppress: false,
+        };
+        synth_one_fluid_kokoro(&synth, &seg, 1.0, 24_000, &mut out).unwrap();
+        let calls = log.borrow();
+        assert_eq!(calls[0].0, "дома", "`+` stress markers must be stripped");
+    }
+
+    #[test]
+    fn ipa_segment_is_skipped_without_calling_synth() {
+        let log = RefCell::new(Vec::new());
+        let synth = recording_synth(&log);
+        let mut out = Vec::new();
+        // FluidAudio's internal G2P can't accept IPA; the segment is dropped.
+        let seg = Segment::Ipa("həˈloʊ".into());
+        synth_one_fluid_kokoro(&synth, &seg, 1.0, 24_000, &mut out).unwrap();
+        assert!(out.is_empty(), "Ipa segment must produce no audio");
+        assert!(log.borrow().is_empty(), "synth must not be called for Ipa");
     }
 }

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -853,6 +853,21 @@ mod fluid_kokoro_ssml_tests {
     }
 
     #[test]
+    fn spell_segment_reads_as_plain_text() {
+        // FluidAudio can't letter-spell, so `<say-as interpret-as="characters">`
+        // degrades to synthesizing the raw content (warn-once on the side).
+        let log = RefCell::new(Vec::new());
+        let synth = recording_synth(&log);
+        let mut out = Vec::new();
+        let seg = Segment::Spell("ВОЗ".into());
+        synth_one_fluid_kokoro(&synth, &seg, 1.0, 24_000, &mut out).unwrap();
+        let calls = log.borrow();
+        assert_eq!(calls.len(), 1, "Spell must synthesize its content as text");
+        assert_eq!(calls[0].0, "ВОЗ");
+        assert_eq!(out.len(), 3, "expected one sentinel sample per character");
+    }
+
+    #[test]
     fn ipa_segment_is_skipped_without_calling_synth() {
         let log = RefCell::new(Vec::new());
         let synth = recording_synth(&log);

--- a/rust/tests/kokoro_rate_e2e.rs
+++ b/rust/tests/kokoro_rate_e2e.rs
@@ -199,3 +199,115 @@ fn kokoro_rate_changes_duration() {
         tol * 100.0
     );
 }
+
+/// Synthesize SSML `markup` with `voice` into `out` via the real engine binary
+/// (`--ssml`). Same skip/panic contract as [`say_rate`]: a missing-prerequisite
+/// failure returns `false` (skip), success returns `true`, anything else panics.
+fn say_ssml(exe: &Path, markup: &str, voice: &str, out: &Path) -> bool {
+    let result = Command::new(exe)
+        .args([
+            "say",
+            "--voice",
+            voice,
+            "--ssml",
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .arg(markup)
+        .output()
+        .expect("spawn kesha-engine say --ssml");
+    if result.status.success() {
+        return true;
+    }
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    if stderr.contains("install --tts")
+        || stderr.contains("not installed")
+        || stderr.contains("voice pack")
+    {
+        eprintln!(
+            "skipping: ANE Kokoro prerequisite missing (run `kesha install --tts`):\n{stderr}"
+        );
+        return false;
+    }
+    panic!("kesha-engine say --ssml failed unexpectedly: {stderr}");
+}
+
+#[test]
+fn kokoro_ssml_prosody_rate_changes_duration() {
+    // #481: SSML `<prosody rate="x-fast">` on the FluidAudio ANE Kokoro path
+    // must SPEED UP synthesis (threaded into the model-native speed input), not
+    // error out ("SSML is not yet supported with FluidAudio Kokoro voices") and
+    // not be a silent no-op. x-fast maps to 1.5×, so the prosody-wrapped
+    // utterance should be ~1.5× shorter than the same text synthesized as plain
+    // text at 1.0×. Both are single synth calls, so FluidAudio's fixed
+    // leading/trailing silence padding cancels in the ratio.
+    let exe = PathBuf::from(common::engine_bin());
+    if !exe.exists() {
+        eprintln!("skipping: engine binary not found at {}", exe.display());
+        return;
+    }
+    if !ane_kokoro_ready() {
+        eprintln!(
+            "skipping: FluidAudio ANE Kokoro model + am_michael voice pack not staged \
+             (run `kesha install --tts`)"
+        );
+        return;
+    }
+
+    let tmp = tempfile::Builder::new()
+        .prefix("kesha-kokoro-ssml-")
+        .tempdir()
+        .unwrap();
+    let plain = tmp.path().join("plain-1.0.wav");
+    let xfast = tmp.path().join("ssml-xfast.wav");
+
+    let text = "The quick brown fox jumps over the lazy dog near the riverbank at noon.";
+    let voice = "en-am_michael";
+    let ssml = format!("<speak><prosody rate=\"x-fast\">{text}</prosody></speak>");
+
+    if !say_rate(&exe, text, voice, "1.0", &plain) {
+        return; // prerequisite missing — skip cleanly
+    }
+    if !say_ssml(&exe, &ssml, voice, &xfast) {
+        return;
+    }
+
+    // `samples_plain` is unused — the existing `kokoro_rate_changes_duration`
+    // already guards am_michael non-silence at 1.0×; here we only need the
+    // plain-text duration as the prosody baseline.
+    let (dur_plain, _) = wav_duration_and_samples(&plain);
+    let (dur_xfast, samples_xfast) = wav_duration_and_samples(&xfast);
+    eprintln!(
+        "kokoro_ssml_prosody_rate_changes_duration: plain@1.0 -> {dur_plain:.3}s, \
+         x-fast -> {dur_xfast:.3}s, ratio(plain/xfast)={:.3} (expected ~1.5)",
+        dur_plain / dur_xfast
+    );
+
+    // Prosody output is audible — not an empty/silent buffer from a swallowed
+    // segment.
+    assert!(
+        peak(&samples_xfast) > 0.01,
+        "x-fast prosody produced (near-)silent audio (peak {})",
+        peak(&samples_xfast)
+    );
+
+    // The #481 guard: prosody must shorten the audio, and by ~1.5×. A rejected
+    // or no-op `<prosody rate>` would either fail synthesis (caught above) or
+    // emit plain-duration audio.
+    assert!(
+        dur_xfast < dur_plain,
+        "SSML <prosody rate=\"x-fast\"> did not shorten audio ({dur_xfast:.3}s vs plain \
+         {dur_plain:.3}s) — prosody ignored or rejected (#481)"
+    );
+    let expected = dur_plain / 1.5;
+    let tol = 0.12;
+    let lo = expected * (1.0 - tol);
+    let hi = expected * (1.0 + tol);
+    assert!(
+        (lo..=hi).contains(&dur_xfast),
+        "x-fast duration {dur_xfast:.3}s outside ±{:.0}% of expected {expected:.3}s \
+         (range {lo:.3}..={hi:.3}); plain was {dur_plain:.3}s. <prosody rate> not threaded \
+         into the FluidAudio Kokoro speed input (#481).",
+        tol * 100.0
+    );
+}


### PR DESCRIPTION
## Problem

Post-#479, `kesha say --ssml` errors out on darwin-arm64 `en-*` voices:

```
error: synthesis failed: SSML is not yet supported with FluidAudio Kokoro voices
```

A regression from the ONNX Kokoro path (which supported `<prosody rate>`/`<break>`). The engine kept advertising `tts.prosody_rate` in `--capabilities-json`, so the capability flag lied.

## Fix

FluidAudio runs its own internal G2P (raw text → WAV), so — unlike the ONNX path — we deliberately do **not** run `en::normalize_segments` (which would emit `Segment::Ipa` chunks FluidAudio can't accept; this also matches the existing non-SSML FluidAudio path, which already feeds raw text). Instead we walk the parsed SSML segments feeding plain text per chunk:

| Segment | Handling |
|---|---|
| `<prosody rate>` | `compose_rate(cli, ssml)` → model-native `speed` input |
| `<break>` | `silence_samples` at the 24 kHz native rate |
| `<emphasis>` | strip `+` stress markers (warn-once unless `level="none"`), then synthesize |
| `<say-as interpret-as="characters">` | warn-once + read as plain text (FluidAudio can't letter-spell) |
| `<phoneme alphabet="ipa">` | warn-once + skip (FluidAudio's internal G2P can't accept IPA) |

Per-chunk synth re-inits the bridge; the dominant case (one prosody-wrapped utterance) is a single call, and the `.mlmodelc` is disk-cached after first compile. The streaming `say_loop` path now forwards `ssml: req.ssml` instead of rejecting, and the capability comment is corrected.

## Verification

- **4 deterministic walker unit tests** (`fluid_kokoro_ssml_tests`, fake synth — no model): text+break concatenation, prosody speed threading, `+`-strip, Ipa-skip.
- **Real ANE e2e** (`kokoro_rate_e2e.rs::kokoro_ssml_prosody_rate_changes_duration`, self-skips without the staged model): `<prosody rate="x-fast">` → **3.325s** vs plain 1.0× → **5.175s**, ratio **1.556 ≈ 1.5**.
- Clippy `-D warnings` + tests green on **both** the full darwin feature set (`coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang`) and default `tts`.

## Scope / release

Engine-only change. Branch is `fix/*` (not `release/*`), so `integration-tests` downloads the published `v1.21.0-beta.1` engine and passes; the new behavior ships only when the **next engine release** is cut (the beta.2-vs-1.21.0-stable choice is the release decision, not this PR). Issue closes on that release — hence `Refs`, not `Closes`.

Known non-goals on the ANE path (warned, not errored): acronym expansion, letter-spelling, and IPA `<phoneme>` overrides — all require text/IPA preprocessing FluidAudio's internal G2P bypasses. Parity with those ONNX-path refinements is out of scope for the regression fix.

Refs #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)