### PR TITLE
chore(release): 1.21.0

### DIFF
--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha 1.21.0-beta.1" "User Commands"
+.TH KESHA 1 "May 2026" "kesha" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.21.0-beta.1",
+  "version": "1.21.0",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.21.0-beta.1"
+    "version": "1.21.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.21.0-beta.1"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.21.0-beta.1"
+version = "1.21.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the

--- a/src/shell-artifacts.ts
+++ b/src/shell-artifacts.ts
@@ -12,7 +12,6 @@ import { sayCommand } from "./cli/say";
 import { statsCommand } from "./cli/stats";
 import { statusCommand } from "./cli/status";
 import { supportBundleCommand } from "./cli/support-bundle";
-import { packageVersion } from "./package-info";
 
 type Shell = "bash" | "zsh" | "fish";
 
@@ -280,7 +279,7 @@ function renderManpage(model: ArtifactModel): string {
     })
     .join("\n");
 
-  return `.TH KESHA 1 "${manpageDate()}" "kesha ${packageVersion}" "User Commands"
+  return `.TH KESHA 1 "${manpageDate()}" "kesha" "User Commands"
 .SH NAME
 kesha \\- open-source local voice toolkit
 .SH SYNOPSIS

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -7,6 +7,12 @@ type MainRun = (input: { args: Record<string, unknown>; rawArgs: string[] }) => 
 
 function normalizeUsage(usage: string): string {
   return usage
+    // Strip ANSI SGR escapes (color/bold/underline). citty colorizes usage when
+    // it detects a TTY or a color-forcing env (FORCE_COLOR), so the raw output
+    // differs between CI (NO_COLOR) and a local color terminal. The golden
+    // strings are plain text — normalize both to that.
+    // eslint-disable-next-line no-control-regex
+    .replace(/\u001b\[[0-9;]*m/g, "")
     .replace(/\(kesha v\d+\.\d+\.\d+(?:[-+][^)]+)?\)/g, "(kesha v<version>)")
     .split("\n")
     .map((line) => line.trimEnd())


### PR DESCRIPTION
Promote **1.21.0-beta.1 → 1.21.0 stable**. The beta validated the FluidAudio 0.14.7 ANE migration end-to-end; #481 (the last blocker) is fixed and merged.

## Version bump (lockstep)
- `package.json#version` + `package.json#keshaEngine.version`: → `1.21.0`
- `rust/Cargo.toml` + `rust/Cargo.lock`: → `1.21.0`

## What ships since 1.20.0
- **#479** — `--rate` honored on CoreML Kokoro via FluidAudio 0.14.7 `KokoroAneManager` (model-native speed).
- **#482** — SSML honored on the FluidAudio Kokoro (ANE) path: `<prosody rate>` → model speed, `<break>` → silence stitching, `<emphasis>` `+`-strip, `<phoneme ipa>`/`<say-as characters>` warn-and-degrade. Closes **#481**.

## Also in this PR
- **Drop the CLI version from `man/kesha.1`'s `.TH` line.** It forced a man-page bump every release and added no value; `renderManpage` now emits a version-less `.TH … "kesha" …`. Package version remains the single source of truth.
- **Test hardening:** `normalizeUsage` (CLI golden-help contracts) now strips ANSI SGR codes, so the tests pass under both `NO_COLOR` (CI) and a color-forcing local terminal.

## Verification
- Engine fix validated end-to-end on the locally-built release binary: `--ssml '<speak><prosody rate="x-fast">…'` → 3.75s vs plain 5.75s; `<break>` inserts silence; ASR/lang/text-lang/TTS-en/TTS-ru all green.
- Version drift gate, `tsc`, shell-artifact + golden tests pass (golden verified under both color modes).

## Release flow after merge
Tag `v1.21.0` → `build-engine.yml` (draft) → validate draft assets (`gh release download` + exercise incl. SSML) → un-draft → `npm @latest` + Homebrew tap + Linux `.deb`/`.rpm`.

Branch is `release/*` so `integration-tests` correctly skips (the `v1.21.0` tag doesn't exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)