### PR TITLE
chore: ignore agent tooling dirs and macOS cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,14 @@ benchmark-results.json
 .omc/
 coverage/
 result
+# CocoIndex Code (ccc)
+/.cocoindex_code/
+
+# macOS
+.DS_Store
+
+# Agent tooling
+.agents/
+.codegraph/
+.codex/
+skills-lock.json


### PR DESCRIPTION
## What

Adds `.gitignore` entries for files that show up untracked in local checkouts but aren't part of the product:

- `.DS_Store` (covers root and `rust/.DS_Store`)
- Agent tooling dirs: `.agents/`, `.codegraph/`, `.codex/`
- `skills-lock.json` — skill-manager lockfile (pins the `ccc` codebase-search skill)

## Why

These accumulate from local agent/editor tooling and macOS Finder, and currently clutter `git status`. None are build outputs or product source. Consistent with how `.omc/`, `.worktrees/`, and `.cocoindex_code/` are already ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)