### PR TITLE
docs: fix broken README images (LFS assets served as pointer text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/drakulavich/kesha-voice-kit/main/docs/assets/logo.png" alt="Kesha Voice Kit" width="200">
+  <img src="https://github.com/drakulavich/kesha-voice-kit/raw/main/docs/assets/logo.png" alt="Kesha Voice Kit" width="200">
 </p>
 
 <h1 align="center">Kesha Voice Kit</h1>
@@ -21,7 +21,7 @@
 See [Product positioning](docs/product-positioning.md) for supported workflows, non-goals, maturity labels, and the platform matrix.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/drakulavich/kesha-voice-kit/main/demo.gif" alt="kesha demo — English + Russian transcription with automatic language detection" width="800">
+  <img src="https://github.com/drakulavich/kesha-voice-kit/raw/main/demo.gif" alt="kesha demo — English + Russian transcription with automatic language detection" width="800">
 </p>
 
 ## Quick Start
@@ -269,7 +269,7 @@ mandb ~/.local/share/man 2>/dev/null || true
 
 Compared against Whisper `large-v3-turbo` — all engines auto-detect language.
 
-![Benchmark: openai-whisper vs faster-whisper vs Kesha Voice Kit](https://raw.githubusercontent.com/drakulavich/kesha-voice-kit/main/docs/assets/benchmark.svg)
+![Benchmark: openai-whisper vs faster-whisper vs Kesha Voice Kit](https://github.com/drakulavich/kesha-voice-kit/raw/main/docs/assets/benchmark.svg)
 
 See [BENCHMARK.md](BENCHMARK.md) for the full per-file breakdown (Russian + English).
 


### PR DESCRIPTION
## Problem

The README logo, demo GIF, and benchmark SVG all render **broken** on GitHub and npm.

Root cause: all three assets are **Git LFS-tracked**, but the README referenced them via `raw.githubusercontent.com`, which does **not** resolve LFS pointers — it serves the ~130-byte pointer text instead of the asset:

```
$ curl -sI https://raw.githubusercontent.com/drakulavich/kesha-voice-kit/main/docs/assets/logo.png
content-type: text/plain; charset=utf-8
content-length: 131          # ← LFS pointer, not the 578 KB PNG
```

## Fix

Switch the host to `github.com/<owner>/<repo>/raw/main/<path>`, which 302-redirects to `media.githubusercontent.com` and resolves the LFS object to the real binary:

```
$ curl -sIL https://github.com/drakulavich/kesha-voice-kit/raw/main/docs/assets/logo.png
HTTP/2 302
HTTP/2 200
content-type: image/png
content-length: 578532       # ← the actual PNG
```

Affected references (all 3 LFS assets):
- `docs/assets/logo.png`
- `demo.gif`
- `docs/assets/benchmark.svg`

Docs-only change — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)