### PR TITLE
feat: structured error taxonomy — stable codes at every failure path (#462)

### DIFF
--- a/.github/actions/install-kesha-backend/action.yml
+++ b/.github/actions/install-kesha-backend/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         case "${{ inputs.ffmpeg-provider }}" in
-          apt) sudo apt-get install -y ffmpeg ;;
+          apt) sudo apt-get update -qq && sudo apt-get install -y ffmpeg ;;
           brew) which ffmpeg || brew install ffmpeg ;;
           skip) exit 0 ;;
           *) echo "Unsupported ffmpeg provider: ${{ inputs.ffmpeg-provider }}" >&2; exit 1 ;;

--- a/README.md
+++ b/README.md
@@ -400,6 +400,10 @@ exit codes, and coarse audio metadata only. They must not store audio,
 transcripts, input text, generated speech text, file names, full paths, raw
 stdout/stderr, environment variables, tokens, or URLs. See [Diagnostic logs](docs/diagnostic-logs.md).
 
+Every user-facing failure prints a stable `error [CODE]: …` line on stderr. See
+[Error codes](docs/errors.md) for the full reference; engine codes are also
+available via `kesha-engine --error-codes-json`.
+
 ## Local Stats privacy and lifecycle
 
 Kesha Stats is disabled by default. When you opt in with `kesha stats enable`,

--- a/docs/diagnostic-logs.md
+++ b/docs/diagnostic-logs.md
@@ -91,3 +91,9 @@ kesha logs mode retain-on-failure
 # reproduce the failure
 kesha support-bundle --include-logs --output kesha-support-with-logs.tar.gz
 ```
+
+## Error codes
+
+Failure events record a stable `error_code` field (leak-free by construction).
+The same code is printed to stderr as `error [CODE]: …` and recorded in Stats.
+See [Error codes](errors.md) for the full reference.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -36,14 +36,16 @@ needs sanitizing.
 
 ## Where codes come from
 
-- **Engine codes** (everything except `E_ENGINE_SPAWN` and `E_INVALID_ARG`) are
-  defined in the Rust engine and emitted on its stderr as `error [CODE]: …`.
-  List them with `kesha-engine --error-codes-json`.
-- **`E_ENGINE_SPAWN`** and **`E_INVALID_ARG`** originate in the TypeScript CLI,
-  for failures that happen before or around the engine subprocess (a failed
-  spawn, or CLI argument validation). `E_INPUT_NOT_FOUND` is emitted by both:
-  the CLI checks input existence up front, and the engine emits it too if a
-  missing file reaches it directly.
+- **Engine codes** (everything except `E_ENGINE_SPAWN`) are defined in the Rust
+  engine and emitted on its stderr as `error [CODE]: …`. List them with
+  `kesha-engine --error-codes-json`.
+- **`E_ENGINE_SPAWN`** originates only in the TypeScript CLI, for the failure to
+  spawn the engine subprocess at all.
+- **`E_INVALID_ARG`** and **`E_INPUT_NOT_FOUND`** are emitted by *both* the
+  engine and the TypeScript CLI: the CLI validates arguments and checks input
+  existence up front, and the engine emits the same codes when a bad argument or
+  a missing file reaches it directly (e.g. `kesha-engine say` with conflicting
+  `--model` / `--voice-file`, or a malformed `--format`).
 
 ## Stability
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,52 @@
+# Error Codes
+
+Every user-facing failure prints a stable code on stderr:
+
+```
+error [E_MODEL_MISSING]: voice 'ru-vosk-m02' not installed. run: kesha install --tts
+```
+
+The code is stable across releases — quote it in bug reports. Engine codes are
+introspectable via `kesha-engine --error-codes-json`. Codes are recorded
+(leak-free) in [Stats](#) and [diagnostic logs](diagnostic-logs.md); the human
+message may contain a path and is sanitized before storage, but the code never
+needs sanitizing.
+
+| Code | Category | Retryable | When it fires | How to fix |
+|------|----------|-----------|---------------|------------|
+| `E_INPUT_NOT_FOUND` | input | no | The input audio path doesn't exist (or no stdin was piped). | Check the path; pass a readable file. |
+| `E_BAD_AUDIO` | input | no | The audio container/codec couldn't be decoded (or the file couldn't be opened for a reason other than "missing"). | Re-export to wav/ogg/mp3; verify the file isn't truncated; check permissions. |
+| `E_MODEL_MISSING` | model | no | A required model or voice isn't installed. | `kesha install` / `kesha install --tts`. |
+| `E_MODEL_DOWNLOAD` | model | yes | A model download failed (network or mirror error). | Retry; check connectivity and `KESHA_MODEL_MIRROR`. |
+| `E_CACHE_CORRUPT` | model | no | A cached model file failed SHA-256 verification. | `kesha install --no-cache` to re-fetch. |
+| `E_MODEL_LOAD` | model | no | A model file exists but failed to load. | Reinstall the model; check disk space. |
+| `E_UNSUPPORTED_PLATFORM` | platform | no | The feature isn't supported on this OS/arch (e.g. microphone recording off macOS). | Use a supported platform (see the README platform matrix). |
+| `E_SIDECAR_MISSING` | platform | no | A helper sidecar is missing or exited nonzero (e.g. `say-avspeech`). | Reinstall; ensure the sidecar sits beside the engine (macOS). |
+| `E_NO_BACKEND` | platform | no | The binary was built without an ASR backend. | Use an official release build. |
+| `E_TEXT_EMPTY` | tts | no | Synthesis text was empty. | Pass non-empty text. |
+| `E_TEXT_TOO_LONG` | tts | no | Text exceeded the maximum length. | Split into shorter requests. |
+| `E_VOICE_UNKNOWN` | tts | no | The voice id wasn't recognized. | `kesha say --list-voices`. |
+| `E_SSML_INVALID` | tts | no | SSML was malformed (missing `<speak>` root, DOCTYPE, or unsupported relative rate). | Fix the SSML; see [docs/tts.md](tts.md). |
+| `E_SSML_UNSUPPORTED` | tts | no | SSML isn't supported for this engine/voice. | Use a plain-text request or a supported voice. |
+| `E_TRANSCRIBE_FAILED` | transcribe | no | The ASR pipeline failed. | Re-run; file a bug with a support bundle. |
+| `E_DIARIZE_TIMEOUT` | transcribe | yes | Speaker diarization timed out (cold compile or long audio). | Re-run once warm; shorten the audio. |
+| `E_ENGINE_SPAWN` | internal | no | The CLI couldn't spawn the engine subprocess. | `kesha install`; check the engine binary path (`KESHA_ENGINE_BIN`). |
+| `E_INVALID_ARG` | input | no | A CLI flag or argument was invalid. | See `kesha --help`. |
+| `E_INTERNAL` | internal | no | An unexpected or uncoded failure. | File a bug with `kesha support-bundle`. |
+
+## Where codes come from
+
+- **Engine codes** (everything except `E_ENGINE_SPAWN` and `E_INVALID_ARG`) are
+  defined in the Rust engine and emitted on its stderr as `error [CODE]: …`.
+  List them with `kesha-engine --error-codes-json`.
+- **`E_ENGINE_SPAWN`** and **`E_INVALID_ARG`** originate in the TypeScript CLI,
+  for failures that happen before or around the engine subprocess (a failed
+  spawn, or CLI argument validation). `E_INPUT_NOT_FOUND` is emitted by both:
+  the CLI checks input existence up front, and the engine emits it too if a
+  missing file reaches it directly.
+
+## Stability
+
+Codes are part of the public contract. A code's meaning will not change; new
+codes may be added. The human-readable message after the code is **not**
+contractual and may be reworded — match on the code, not the message.

--- a/docs/superpowers/plans/2026-05-30-structured-error-taxonomy.md
+++ b/docs/superpowers/plans/2026-05-30-structured-error-taxonomy.md
@@ -1,0 +1,1384 @@
+# Structured Error Taxonomy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every user-facing failure path a stable, documented, user-visible error code emitted by the engine and recorded as the leak-free primary signal in Stats and diagnostic logs; unify every error surface (Rust `anyhow`/`TtsError`, the Rust `say` exit path, TS engine errors, `SayError`, and the JSON `errors[].code` union) onto one taxonomy.
+
+**Architecture:** A new `rust/src/errors.rs` defines `ErrorCode` + `CodedError` + a `coded_bail!` macro + a `.coded()` Result extension. Leaf failures attach a code; a top-level `report()` chain-walks for the code and prints `error [CODE]: <message>` to stderr. TS extracts the `[CODE]` token from engine stderr (anchored regex) and threads it into `recordError`, diagnostic `error_code` fields, `SayError.code`, and the `errors[].code` JSON output. A drift test enforces engine-codes ∪ TS-native-codes == documented codes.
+
+**Tech Stack:** Rust (anyhow, thiserror, serde_json, nextest), Bun/TypeScript (bun:test), Markdown docs.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`
+
+**Release:** Engine release — final task bumps `rust/Cargo.toml`, `rust/Cargo.lock`, `package.json#keshaEngine.version`, `package.json#version`.
+
+**Conventions for every Rust task:** verify with `cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts`. Use `cargo nextest run`, never plain `cargo test`.
+
+---
+
+## Task 1: `errors.rs` foundation — `ErrorCode`, `CodedError`, `coded_bail!`, `report()`, `.coded()`
+
+**Files:**
+- Create: `rust/src/errors.rs`
+- Modify: `rust/src/lib.rs:30` (add `pub mod errors;` in the alphabetical mod block)
+- Modify: `rust/src/main.rs:4` (add `mod errors;` in the mod block)
+
+- [ ] **Step 1: Write the failing test** — append to the new `rust/src/errors.rs` (write the whole file including the `#[cfg(test)]` block below in Step 3; this step is the test module):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_strings_are_stable_unique_and_prefixed() {
+        let all = ErrorCode::ALL;
+        let mut seen = std::collections::HashSet::new();
+        for c in all {
+            let s = c.as_str();
+            assert!(s.starts_with("E_"), "{s} must start with E_");
+            assert!(seen.insert(s), "duplicate code string {s}");
+            assert!(!c.title().is_empty(), "{s} missing title");
+        }
+    }
+
+    #[test]
+    fn coded_bail_attaches_code_findable_in_chain() {
+        fn leaf() -> anyhow::Result<()> {
+            coded_bail!(ErrorCode::ModelMissing, "voice '{}' not installed", "ru-vosk-m02");
+        }
+        let err = leaf().unwrap_err().context("while loading voice");
+        assert_eq!(code_of(&err), ErrorCode::ModelMissing);
+    }
+
+    #[test]
+    fn coded_extension_snapshots_message_and_code() {
+        let res: anyhow::Result<()> = Err(anyhow::anyhow!("boom"))
+            .context("decode error in: /Users/alice/secret.wav")
+            .coded(ErrorCode::BadAudio);
+        let err = res.unwrap_err();
+        assert_eq!(code_of(&err), ErrorCode::BadAudio);
+        let coded = err.downcast_ref::<CodedError>().expect("is CodedError");
+        assert!(coded.message.contains("decode error"));
+    }
+
+    #[test]
+    fn code_of_falls_back_to_internal_for_uncoded() {
+        let err = anyhow::anyhow!("plain error");
+        assert_eq!(code_of(&err), ErrorCode::Internal);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts errors:: 2>&1 | tail -20`
+Expected: FAIL — `errors` module / `ErrorCode` not found (compile error).
+
+- [ ] **Step 3: Write minimal implementation** — prepend this above the test module in `rust/src/errors.rs`:
+
+```rust
+//! Stable, user-visible error codes for every user-facing failure path.
+//!
+//! A leaf failure attaches a code via [`coded_bail!`] or [`CodedContext::coded`].
+//! The code rides in the `anyhow` chain inside a [`CodedError`]; the top-level
+//! [`report`] walks the chain, prints `error [CODE]: <message>` to stderr, and
+//! returns the process exit code. See
+//! `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    InputNotFound,
+    BadAudio,
+    ModelMissing,
+    ModelDownload,
+    CacheCorrupt,
+    ModelLoad,
+    UnsupportedPlatform,
+    SidecarMissing,
+    NoBackend,
+    TextEmpty,
+    TextTooLong,
+    VoiceUnknown,
+    SsmlInvalid,
+    SsmlUnsupported,
+    TranscribeFailed,
+    DiarizeTimeout,
+    Internal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Category {
+    Input,
+    Model,
+    Platform,
+    Tts,
+    Transcribe,
+    Internal,
+}
+
+impl ErrorCode {
+    /// Every variant, for tests and `--error-codes-json`.
+    pub const ALL: [ErrorCode; 17] = [
+        ErrorCode::InputNotFound,
+        ErrorCode::BadAudio,
+        ErrorCode::ModelMissing,
+        ErrorCode::ModelDownload,
+        ErrorCode::CacheCorrupt,
+        ErrorCode::ModelLoad,
+        ErrorCode::UnsupportedPlatform,
+        ErrorCode::SidecarMissing,
+        ErrorCode::NoBackend,
+        ErrorCode::TextEmpty,
+        ErrorCode::TextTooLong,
+        ErrorCode::VoiceUnknown,
+        ErrorCode::SsmlInvalid,
+        ErrorCode::SsmlUnsupported,
+        ErrorCode::TranscribeFailed,
+        ErrorCode::DiarizeTimeout,
+        ErrorCode::Internal,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ErrorCode::InputNotFound => "E_INPUT_NOT_FOUND",
+            ErrorCode::BadAudio => "E_BAD_AUDIO",
+            ErrorCode::ModelMissing => "E_MODEL_MISSING",
+            ErrorCode::ModelDownload => "E_MODEL_DOWNLOAD",
+            ErrorCode::CacheCorrupt => "E_CACHE_CORRUPT",
+            ErrorCode::ModelLoad => "E_MODEL_LOAD",
+            ErrorCode::UnsupportedPlatform => "E_UNSUPPORTED_PLATFORM",
+            ErrorCode::SidecarMissing => "E_SIDECAR_MISSING",
+            ErrorCode::NoBackend => "E_NO_BACKEND",
+            ErrorCode::TextEmpty => "E_TEXT_EMPTY",
+            ErrorCode::TextTooLong => "E_TEXT_TOO_LONG",
+            ErrorCode::VoiceUnknown => "E_VOICE_UNKNOWN",
+            ErrorCode::SsmlInvalid => "E_SSML_INVALID",
+            ErrorCode::SsmlUnsupported => "E_SSML_UNSUPPORTED",
+            ErrorCode::TranscribeFailed => "E_TRANSCRIBE_FAILED",
+            ErrorCode::DiarizeTimeout => "E_DIARIZE_TIMEOUT",
+            ErrorCode::Internal => "E_INTERNAL",
+        }
+    }
+
+    pub fn title(self) -> &'static str {
+        match self {
+            ErrorCode::InputNotFound => "Input file not found",
+            ErrorCode::BadAudio => "Unreadable or unsupported audio",
+            ErrorCode::ModelMissing => "Model or voice not installed",
+            ErrorCode::ModelDownload => "Model download failed",
+            ErrorCode::CacheCorrupt => "Cached model failed verification",
+            ErrorCode::ModelLoad => "Model failed to load",
+            ErrorCode::UnsupportedPlatform => "Feature unsupported on this platform",
+            ErrorCode::SidecarMissing => "Helper sidecar missing or failed",
+            ErrorCode::NoBackend => "No ASR backend compiled in",
+            ErrorCode::TextEmpty => "Empty synthesis text",
+            ErrorCode::TextTooLong => "Synthesis text too long",
+            ErrorCode::VoiceUnknown => "Unknown voice id",
+            ErrorCode::SsmlInvalid => "Malformed SSML",
+            ErrorCode::SsmlUnsupported => "SSML not supported for this engine",
+            ErrorCode::TranscribeFailed => "Transcription failed",
+            ErrorCode::DiarizeTimeout => "Speaker diarization timed out",
+            ErrorCode::Internal => "Unexpected internal error",
+        }
+    }
+
+    pub fn category(self) -> Category {
+        match self {
+            ErrorCode::InputNotFound | ErrorCode::BadAudio => Category::Input,
+            ErrorCode::ModelMissing
+            | ErrorCode::ModelDownload
+            | ErrorCode::CacheCorrupt
+            | ErrorCode::ModelLoad => Category::Model,
+            ErrorCode::UnsupportedPlatform
+            | ErrorCode::SidecarMissing
+            | ErrorCode::NoBackend => Category::Platform,
+            ErrorCode::TextEmpty
+            | ErrorCode::TextTooLong
+            | ErrorCode::VoiceUnknown
+            | ErrorCode::SsmlInvalid
+            | ErrorCode::SsmlUnsupported => Category::Tts,
+            ErrorCode::TranscribeFailed | ErrorCode::DiarizeTimeout => Category::Transcribe,
+            ErrorCode::Internal => Category::Internal,
+        }
+    }
+
+    pub fn retryable(self) -> bool {
+        matches!(
+            self,
+            ErrorCode::ModelDownload | ErrorCode::DiarizeTimeout
+        )
+    }
+}
+
+/// An error carrying a stable [`ErrorCode`] plus a human message. Sits as a
+/// leaf in the `anyhow` chain so [`code_of`] can recover the code.
+#[derive(Debug)]
+pub struct CodedError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl std::fmt::Display for CodedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CodedError {}
+
+/// Construct and return a coded error. Drop-in for `anyhow::bail!`.
+#[macro_export]
+macro_rules! coded_bail {
+    ($code:expr, $($arg:tt)*) => {
+        return ::core::result::Result::Err(::anyhow::Error::new($crate::errors::CodedError {
+            code: $code,
+            message: ::std::format!($($arg)*),
+        }))
+    };
+}
+
+/// Attach a code to a `Result`, snapshotting the existing chain message.
+pub trait CodedContext<T> {
+    fn coded(self, code: ErrorCode) -> anyhow::Result<T>;
+}
+
+impl<T, E> CodedContext<T> for Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn coded(self, code: ErrorCode) -> anyhow::Result<T> {
+        self.map_err(|e| {
+            let e: anyhow::Error = e.into();
+            anyhow::Error::new(CodedError {
+                code,
+                message: format!("{e:#}"),
+            })
+        })
+    }
+}
+
+/// Recover the code from anywhere in the chain; `Internal` if none.
+pub fn code_of(err: &anyhow::Error) -> ErrorCode {
+    err.chain()
+        .find_map(|e| e.downcast_ref::<CodedError>().map(|c| c.code))
+        .unwrap_or(ErrorCode::Internal)
+}
+
+/// Print `error [CODE]: <message>` to stderr and return the process exit code.
+/// Exit code stays 1 (runtime failure) — unchanged from prior behavior.
+pub fn report(err: &anyhow::Error) -> i32 {
+    let code = code_of(err);
+    eprintln!("error [{}]: {:#}", code.as_str(), err);
+    1
+}
+```
+
+- [ ] **Step 4: Register the module** — in `rust/src/lib.rs`, add `pub mod errors;` (alphabetical, between `debug` and `fluid_stdout`); in `rust/src/main.rs`, add `mod errors;` in the same position.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd rust && cargo nextest run --features tts errors::`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/src/errors.rs rust/src/lib.rs rust/src/main.rs
+git commit -m "feat(engine): error-code taxonomy foundation (errors.rs)"
+```
+
+---
+
+## Task 2: Top-level reporting — `main.rs` prints `error [CODE]:`
+
+The `say` arm already `process::exit`s with its own code (wired in Task 10). Every other command propagates `anyhow::Result` to `fn main`. Restructure so a propagated error routes through `errors::report`.
+
+**Files:**
+- Modify: `rust/src/main.rs:167-260` (`fn main`)
+- Test: `rust/tests/error_codes_cli.rs` (create)
+
+- [ ] **Step 1: Write the failing test** — create `rust/tests/error_codes_cli.rs`:
+
+```rust
+//! CLI-level assertions that failures print `error [CODE]:` on stderr.
+use std::process::Command;
+
+fn engine_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_kesha-engine")
+        .unwrap_or_else(|_| "target/release/kesha-engine".to_string())
+}
+
+#[test]
+fn transcribe_missing_file_prints_input_not_found_code() {
+    let out = Command::new(engine_bin())
+        .args(["transcribe", "/nonexistent/path/audio.wav"])
+        .output()
+        .expect("spawn engine");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "should exit nonzero");
+    assert!(
+        stderr.contains("error [E_"),
+        "stderr should carry a coded line, got: {stderr}"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts --test error_codes_cli`
+Expected: FAIL — stderr is the old uncoded `Error: ...` Display (no `error [E_`). (The transcribe-missing-file path is coded in Task 6/9; this test passes once main.rs routing + that site land. If it fails only because the path isn't coded yet, it still exercises the `E_INTERNAL` fallback — so it should pass as soon as main.rs routing lands, because `code_of` falls back to `E_INTERNAL` and prints `error [E_INTERNAL]:`.)
+
+- [ ] **Step 3: Write minimal implementation** — change `fn main() -> Result<()>` into a thin wrapper plus `run_command`. Replace the signature and the trailing `Ok(())` so the body becomes:
+
+```rust
+fn main() {
+    debug::init();
+    let cli = Cli::parse();
+
+    if cli.capabilities_json {
+        let caps = capabilities::get_capabilities();
+        match serde_json::to_string(&caps) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                let err = anyhow::Error::new(e);
+                std::process::exit(errors::report(&err));
+            }
+        }
+        return;
+    }
+
+    if let Err(err) = run_command(cli.command) {
+        std::process::exit(errors::report(&err));
+    }
+}
+
+fn run_command(command: Option<Commands>) -> Result<()> {
+    match command {
+        // ... existing match arms moved here verbatim, including the
+        // `Some(Commands::Say { .. }) => { std::process::exit(cli::say::run(..)); }`
+        // arm (it diverges, so it never returns to `run_command`) ...
+        None => {
+            eprintln!("Usage: kesha-engine <command>");
+            eprintln!("Run --help for usage information");
+            std::process::exit(1);
+        }
+    }
+    Ok(())
+}
+```
+
+Move the existing `match cli.command { ... }` arms into `run_command` unchanged. The `Say` arm keeps its `std::process::exit(...)`.
+
+- [ ] **Step 4: Build the release binary the integration test needs, then run**
+
+Run: `cd rust && cargo build --release --features tts && cargo nextest run --features tts --test error_codes_cli`
+Expected: PASS — stderr contains `error [E_INTERNAL]:` (input-not-found becomes `E_INPUT_NOT_FOUND` after Task 9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/main.rs rust/tests/error_codes_cli.rs
+git commit -m "feat(engine): route command failures through coded report()"
+```
+
+---
+
+## Task 3: `kesha-engine --error-codes-json`
+
+**Files:**
+- Modify: `rust/src/main.rs` (add `--error-codes-json` flag to `Cli` struct + handle it next to `capabilities_json`)
+- Modify: `rust/src/errors.rs` (add `error_codes_json()` producing the JSON string)
+- Test: `rust/src/errors.rs` test module
+
+- [ ] **Step 1: Write the failing test** — add to `rust/src/errors.rs` tests:
+
+```rust
+    #[test]
+    fn error_codes_json_covers_all_variants() {
+        let json = error_codes_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), ErrorCode::ALL.len());
+        for c in ErrorCode::ALL {
+            assert!(
+                arr.iter().any(|e| e["code"] == c.as_str()),
+                "{} missing from --error-codes-json",
+                c.as_str()
+            );
+        }
+        // shape check on one entry
+        let model_missing = arr
+            .iter()
+            .find(|e| e["code"] == "E_MODEL_MISSING")
+            .unwrap();
+        assert_eq!(model_missing["category"], "model");
+        assert_eq!(model_missing["retryable"], false);
+        assert!(model_missing["title"].is_string());
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts errors::error_codes_json`
+Expected: FAIL — `error_codes_json` not found.
+
+- [ ] **Step 3: Write minimal implementation** — add to `rust/src/errors.rs` (above the test module):
+
+```rust
+#[derive(Serialize)]
+struct CodeEntry {
+    code: &'static str,
+    title: &'static str,
+    category: Category,
+    retryable: bool,
+}
+
+/// JSON array of every error code, for `--error-codes-json`, docs drift tests,
+/// and `kesha doctor`.
+pub fn error_codes_json() -> String {
+    let entries: Vec<CodeEntry> = ErrorCode::ALL
+        .iter()
+        .map(|&c| CodeEntry {
+            code: c.as_str(),
+            title: c.title(),
+            category: c.category(),
+            retryable: c.retryable(),
+        })
+        .collect();
+    serde_json::to_string(&entries).expect("error-codes serialize")
+}
+```
+
+In `rust/src/main.rs`, add the flag to the `Cli` struct next to `capabilities_json` (match its `#[arg(...)]` style):
+
+```rust
+    /// Print the error-code taxonomy as JSON and exit.
+    #[arg(long = "error-codes-json")]
+    error_codes_json: bool,
+```
+
+And handle it in `fn main`, right after the `capabilities_json` block:
+
+```rust
+    if cli.error_codes_json {
+        println!("{}", errors::error_codes_json());
+        return;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd rust && cargo nextest run --features tts errors:: && cargo build --release --features tts && ./target/release/kesha-engine --error-codes-json | jq 'length'`
+Expected: tests PASS; jq prints `17`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/errors.rs rust/src/main.rs
+git commit -m "feat(engine): kesha-engine --error-codes-json introspection"
+```
+
+---
+
+## Task 4: Wire TTS voice/model-missing sites (`voices.rs`)
+
+**Files:**
+- Modify: `rust/src/tts/voices.rs:151,156,184,186` (the four `anyhow::bail!` sites seen in the resolver)
+
+- [ ] **Step 1: Add the import** at the top of `rust/src/tts/voices.rs` (after existing `use` lines):
+
+```rust
+use crate::coded_bail;
+use crate::errors::ErrorCode;
+```
+
+- [ ] **Step 2: Replace the four bail sites** (exact substitutions):
+
+Kokoro voice missing:
+```rust
+// before:
+anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+// after:
+coded_bail!(ErrorCode::ModelMissing, "voice '{voice_id}' not installed. run: kesha install --tts");
+```
+
+Kokoro model missing:
+```rust
+// before:
+anyhow::bail!(
+    "kokoro model not installed at {}. run: kesha install --tts",
+    model_path.display()
+);
+// after:
+coded_bail!(
+    ErrorCode::ModelMissing,
+    "kokoro model not installed at {}. run: kesha install --tts",
+    model_path.display()
+);
+```
+
+Unknown Russian voice (the `_ =>` arm):
+```rust
+// before:
+_ => anyhow::bail!(
+    "unknown Russian voice '{voice_id}'. valid: ru-vosk-f01, ru-vosk-f02, \
+     ru-vosk-f03, ru-vosk-m01, ru-vosk-m02"
+),
+// after:
+_ => coded_bail!(
+    ErrorCode::VoiceUnknown,
+    "unknown Russian voice '{voice_id}'. valid: ru-vosk-f01, ru-vosk-f02, \
+     ru-vosk-f03, ru-vosk-m01, ru-vosk-m02"
+),
+```
+
+Vosk model missing:
+```rust
+// before:
+anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+// after:
+coded_bail!(ErrorCode::ModelMissing, "voice '{voice_id}' not installed. run: kesha install --tts");
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts voices`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/src/tts/voices.rs
+git commit -m "feat(engine): code voice/model-missing failures (E_MODEL_MISSING/E_VOICE_UNKNOWN)"
+```
+
+---
+
+## Task 5: Wire SSML sites (`ssml/mod.rs`)
+
+**Files:**
+- Modify: `rust/src/tts/ssml/mod.rs:43,46,57,67+` (the `anyhow::bail!` sites in `parse`)
+
+- [ ] **Step 1: Add imports** at the top of `rust/src/tts/ssml/mod.rs`:
+
+```rust
+use crate::coded_bail;
+use crate::errors::ErrorCode;
+```
+
+- [ ] **Step 2: Replace each `anyhow::bail!` in `parse` with `coded_bail!(ErrorCode::SsmlInvalid, ...)`** keeping the message args identical. Sites: empty input, missing `<speak>` root, DOCTYPE rejection, relative-percent rate. Example:
+
+```rust
+// before:
+anyhow::bail!("SSML input is empty");
+// after:
+coded_bail!(ErrorCode::SsmlInvalid, "SSML input is empty");
+```
+
+Apply the same transform to the `<speak>`-root, DOCTYPE, and relative-rate bails (each keeps its existing format string + args).
+
+- [ ] **Step 3: Verify**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts ssml`
+Expected: PASS (existing `rust/tests/ssml_integration.rs` still green; messages unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/src/tts/ssml/mod.rs
+git commit -m "feat(engine): code SSML parse failures (E_SSML_INVALID)"
+```
+
+---
+
+## Task 6: Wire audio decode (`audio.rs`)
+
+**Files:**
+- Modify: `rust/src/audio.rs:105,120` (the two `.with_context(|| format!("decode error in: {path}"))` sites)
+
+- [ ] **Step 1: Add import** at the top of `rust/src/audio.rs`:
+
+```rust
+use crate::errors::{CodedContext, ErrorCode};
+```
+
+- [ ] **Step 2: Append `.coded(ErrorCode::BadAudio)` after each decode-error context** (both the `format.next_packet()` and `decoder.decode()` arms):
+
+```rust
+// before:
+Err(e) => return Err(e).with_context(|| format!("decode error in: {path}")),
+// after:
+Err(e) => {
+    return Err(e)
+        .with_context(|| format!("decode error in: {path}"))
+        .coded(ErrorCode::BadAudio)
+}
+```
+
+Apply identically to both sites (lines ~105 and ~120).
+
+- [ ] **Step 3: Verify**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts audio`
+Expected: PASS (existing `rust/tests/audio_format.rs` still green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/src/audio.rs
+git commit -m "feat(engine): code audio decode failures (E_BAD_AUDIO)"
+```
+
+---
+
+## Task 7: Wire model download + cache-corrupt (`models.rs`)
+
+**Files:**
+- Modify: `rust/src/models.rs:1083` (sha256-mismatch `anyhow::bail!` → `E_CACHE_CORRUPT`)
+- Modify: `rust/src/models.rs` download-request error in `download_verified` (the HTTP GET error path → `E_MODEL_DOWNLOAD`)
+
+- [ ] **Step 1: Add imports** at the top of `rust/src/models.rs`:
+
+```rust
+use crate::coded_bail;
+use crate::errors::{CodedContext, ErrorCode};
+```
+
+- [ ] **Step 2: Code the sha256 mismatch** (cache corrupt):
+
+```rust
+// before:
+anyhow::bail!(
+    "sha256 mismatch for {}: expected {} got {}",
+    f.rel_path,
+    f.sha256.get(..12).unwrap_or(f.sha256),
+    actual.get(..12).unwrap_or(&actual)
+);
+// after:
+coded_bail!(
+    ErrorCode::CacheCorrupt,
+    "sha256 mismatch for {}: expected {} got {}",
+    f.rel_path,
+    f.sha256.get(..12).unwrap_or(f.sha256),
+    actual.get(..12).unwrap_or(&actual)
+);
+```
+
+- [ ] **Step 3: Code the download/GET failure.** In `download_verified`, find the HTTP request/response error handling (grep `Run: grep -n "GET\|ureq\|reqwest\|\.call()\|\.send()\|response\|status()" rust/src/models.rs`). Wherever the network fetch error is `?`-propagated or `.context()`-wrapped, append `.coded(ErrorCode::ModelDownload)`. Example shape (adapt to the actual call):
+
+```rust
+// before:
+let resp = agent.get(url).call().with_context(|| format!("GET {url}"))?;
+// after:
+let resp = agent
+    .get(url)
+    .call()
+    .with_context(|| format!("GET {url}"))
+    .coded(ErrorCode::ModelDownload)?;
+```
+
+If a non-2xx status is turned into an error separately, code that site too with `ErrorCode::ModelDownload`.
+
+- [ ] **Step 4: Verify**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts models`
+Expected: PASS (`models::manifest_tests` still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/models.rs
+git commit -m "feat(engine): code download + cache-corrupt failures (E_MODEL_DOWNLOAD/E_CACHE_CORRUPT)"
+```
+
+---
+
+## Task 8: Wire ONNX cache-load (`backend/onnx.rs`)
+
+**Files:**
+- Modify: `rust/src/backend/onnx.rs:33,38,43,48` (the four `.context("Failed to load ... — run install first")` sites)
+
+- [ ] **Step 1: Add import** at the top of `rust/src/backend/onnx.rs`:
+
+```rust
+use crate::errors::{CodedContext, ErrorCode};
+```
+
+- [ ] **Step 2: Append `.coded(ErrorCode::ModelLoad)` to each model-load context** (the `commit_from_file(...).context("Failed to load ...")` chains and the `load_vocab(...).context(...)`). Example:
+
+```rust
+// before:
+.commit_from_file(model_path.join("nemo128.onnx"))
+.context("Failed to load nemo128.onnx — run `kesha-engine install` first")?;
+// after:
+.commit_from_file(model_path.join("nemo128.onnx"))
+.context("Failed to load nemo128.onnx — run `kesha-engine install` first")
+.coded(ErrorCode::ModelLoad)?;
+```
+
+Apply to nemo128, encoder, decoder_joint, and vocab. The "Failed to create … session builder" `.context()` lines may keep `ErrorCode::ModelLoad` too — append `.coded(ErrorCode::ModelLoad)` for consistency.
+
+- [ ] **Step 3: Verify**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features onnx -- -D warnings && cargo nextest run --features onnx onnx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/src/backend/onnx.rs
+git commit -m "feat(engine): code ONNX model-load failures (E_MODEL_LOAD)"
+```
+
+---
+
+## Task 9: Wire platform / sidecar / backend / lang-id / diarize
+
+**Files:**
+- Modify: `rust/src/record.rs:50` (unsupported platform)
+- Modify: `rust/src/tts/avspeech.rs:75` (sidecar)
+- Modify: `rust/src/backend/mod.rs:28` (no backend)
+- Modify: `rust/src/lang_id.rs:18` (lang-id model missing)
+- Modify: `rust/src/transcribe/diarize.rs:163,166` (diarize timeout + worker death)
+- Modify: `rust/src/cli/transcribe.rs` input-not-found path (see Step 6)
+
+- [ ] **Step 1: record.rs** — add `use crate::coded_bail; use crate::errors::ErrorCode;`, then:
+
+```rust
+// before:
+bail!("microphone recording is currently supported on macOS only");
+// after:
+coded_bail!(ErrorCode::UnsupportedPlatform, "microphone recording is currently supported on macOS only");
+```
+
+(Remove the now-unused `bail` import if clippy flags it.)
+
+- [ ] **Step 2: avspeech.rs** — add imports, then:
+
+```rust
+// before:
+anyhow::bail!(
+    "avspeech helper exited {}: {}",
+    output.status,
+    String::from_utf8_lossy(&output.stderr).trim()
+);
+// after:
+coded_bail!(
+    ErrorCode::SidecarMissing,
+    "avspeech helper exited {}: {}",
+    output.status,
+    String::from_utf8_lossy(&output.stderr).trim()
+);
+```
+
+Also code the sidecar-not-found/spawn error in `avspeech.rs` (grep `Run: grep -n "bail!\|context\|spawn\|helper_path" rust/src/tts/avspeech.rs`) with `ErrorCode::SidecarMissing`.
+
+- [ ] **Step 3: backend/mod.rs** — add imports, then:
+
+```rust
+// before:
+anyhow::bail!("No backend available — build with --features onnx or coreml")
+// after:
+coded_bail!(ErrorCode::NoBackend, "No backend available — build with --features onnx or coreml")
+```
+
+- [ ] **Step 4: lang_id.rs** — add imports, then:
+
+```rust
+// before:
+anyhow::bail!("Lang-ID model not installed. Run: kesha install");
+// after:
+coded_bail!(ErrorCode::ModelMissing, "Lang-ID model not installed. Run: kesha install");
+```
+
+Also append `.coded(ErrorCode::ModelLoad)` to the two `.context("failed to create lang-id session builder")` / `.context("failed to load lang-id model")` sites.
+
+- [ ] **Step 5: diarize.rs** — add imports, then:
+
+```rust
+// before:
+Err(mpsc::RecvTimeoutError::Timeout) => {
+    bail!("{}", diarize_timeout_error(timeout, audio_secs))
+}
+Err(mpsc::RecvTimeoutError::Disconnected) => {
+    bail!("speaker diarization worker terminated unexpectedly")
+}
+// after:
+Err(mpsc::RecvTimeoutError::Timeout) => {
+    coded_bail!(ErrorCode::DiarizeTimeout, "{}", diarize_timeout_error(timeout, audio_secs))
+}
+Err(mpsc::RecvTimeoutError::Disconnected) => {
+    coded_bail!(ErrorCode::Internal, "speaker diarization worker terminated unexpectedly")
+}
+```
+
+- [ ] **Step 6: input-not-found** — in `rust/src/cli/transcribe.rs`, find where a missing input path is rejected (grep `Run: grep -n "exists\|not found\|bail\|context" rust/src/cli/transcribe.rs`). Code it `coded_bail!(ErrorCode::InputNotFound, ...)`. If the engine never checks existence (TS checks first), instead ensure `audio::ensure_audio_track`/decode failure carries `E_BAD_AUDIO` (Task 6) and leave input-existence to TS (`E_INPUT_NOT_FOUND`, Task 13). Document which path owns it in the commit message.
+
+- [ ] **Step 7: Verify (both feature sets — backend module changed)**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo check --features coreml --no-default-features && cargo nextest run --features tts`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add rust/src/record.rs rust/src/tts/avspeech.rs rust/src/backend/mod.rs rust/src/lang_id.rs rust/src/transcribe/diarize.rs rust/src/cli/transcribe.rs
+git commit -m "feat(engine): code platform/sidecar/backend/lang-id/diarize failures"
+```
+
+---
+
+## Task 10: `say` exit path — `TtsError::code()` + `error [CODE]:` formatting
+
+The `say` path (`cli/say.rs`) returns `i32`, prints `error: {msg}`, and maps `TtsError` → exit code via `exit_code_for_tts_err`. Make it print `error [CODE]: {msg}`, keep exit codes unchanged.
+
+**Files:**
+- Modify: `rust/src/tts/mod.rs:42-49` (`TtsError` — add `code()` method)
+- Modify: `rust/src/cli/say.rs` (all `eprintln!("error: ...")` sites → `error [CODE]:`)
+- Test: `rust/src/tts/mod.rs` test module (or `rust/tests/tts_e2e.rs`)
+
+- [ ] **Step 1: Write the failing test** — add to `rust/src/tts/mod.rs` (new `#[cfg(test)]` mod or existing):
+
+```rust
+#[cfg(test)]
+mod code_tests {
+    use super::*;
+    use crate::errors::ErrorCode;
+
+    #[test]
+    fn tts_error_maps_to_codes() {
+        assert_eq!(TtsError::EmptyText.code(), ErrorCode::TextEmpty);
+        assert_eq!(
+            TtsError::TextTooLong { max: 5000, actual: 6000 }.code(),
+            ErrorCode::TextTooLong
+        );
+        assert_eq!(
+            TtsError::SynthesisFailed("x".into()).code(),
+            ErrorCode::Internal
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts code_tests`
+Expected: FAIL — `TtsError::code` not found.
+
+- [ ] **Step 3: Implement `TtsError::code()`** — add to `rust/src/tts/mod.rs` after the enum:
+
+```rust
+impl TtsError {
+    /// Stable taxonomy code for this synthesis failure.
+    pub fn code(&self) -> crate::errors::ErrorCode {
+        use crate::errors::ErrorCode;
+        match self {
+            TtsError::EmptyText => ErrorCode::TextEmpty,
+            TtsError::TextTooLong { .. } => ErrorCode::TextTooLong,
+            TtsError::SynthesisFailed(_) => ErrorCode::Internal,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Update `cli/say.rs` printing.** For each error print, include the code. The two kinds:
+
+  - **Anyhow errors** (resolver / synth that returns `anyhow::Error`): use `crate::errors::code_of(&err)`:
+    ```rust
+    // before:
+    eprintln!("error: {err}");
+    return exit_code_for_tts_err(&err);
+    // after (where `err` is anyhow::Error):
+    eprintln!("error [{}]: {err:#}", crate::errors::code_of(&err).as_str());
+    return exit_code_for_tts_err_anyhow(&err);
+    ```
+    where the resolver path that exits 1 keeps exit 1. If the existing code matches on `TtsError`, use `e.code().as_str()` instead.
+
+  - **`TtsError` directly**: 
+    ```rust
+    // before:
+    eprintln!("error: {err}");
+    return exit_code_for_tts_err(&err);
+    // after:
+    eprintln!("error [{}]: {err}", err.code().as_str());
+    return exit_code_for_tts_err(&err);
+    ```
+
+  - **String validation errors** (`Err(msg: String)` at say.rs:176, stdin-read at 187, write-fail at 293):
+    ```rust
+    // before:
+    eprintln!("error: {msg}");
+    // after:
+    eprintln!("error [{}]: {msg}", crate::errors::ErrorCode::InvalidArg.as_str());
+    ```
+    BUT `InvalidArg` is a TS-native code (not in the engine enum). For the engine's own validation/stdin/write prints, use the closest engine code: validation → reuse `E_INVALID_ARG`? Since the engine enum has no `InvalidArg`, add it is out of scope (it's TS-native by design). Instead the engine prints these as `E_INTERNAL` for stdin/write failures, and for argument validation the engine prints `error [E_INVALID_ARG]: ...` by using a literal string (these engine-side arg errors are rare; the user-facing arg validation happens in TS). Use a literal: `eprintln!("error [E_INVALID_ARG]: {msg}");` for the say arg-validation print, and `eprintln!("error [E_INTERNAL]: ...")` for stdin/write IO failures. Keep exit codes exactly as today.
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts code_tests && cargo build --release --features tts`
+Expected: PASS.
+
+- [ ] **Step 6: Manual smoke** — confirm the coded line:
+
+Run: `cd rust && echo "" | ./target/release/kesha-engine say --voice en-am_michael 2>&1 | head -1`
+Expected: `error [E_TEXT_EMPTY]: text is empty` (or the resolver's `E_MODEL_MISSING` if TTS models aren't installed — either is a coded line).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/src/tts/mod.rs rust/src/cli/say.rs
+git commit -m "feat(engine): emit error [CODE]: on the say exit path"
+```
+
+---
+
+## Task 11: Rust docs-drift gate
+
+**Files:**
+- Test: `rust/tests/error_codes_docs.rs` (create)
+- (Depends on `docs/errors.md` from Task 14 — order Task 14 before this, or let it fail until docs land.)
+
+- [ ] **Step 1: Write the test**:
+
+```rust
+//! Every engine ErrorCode must be documented in docs/errors.md.
+use kesha_engine::errors::ErrorCode;
+
+#[test]
+fn every_code_is_documented() {
+    let doc = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../docs/errors.md"))
+        .expect("read docs/errors.md");
+    for c in ErrorCode::ALL {
+        assert!(
+            doc.contains(c.as_str()),
+            "{} is not documented in docs/errors.md",
+            c.as_str()
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run (after Task 14)**
+
+Run: `cd rust && cargo nextest run --features tts --test error_codes_docs`
+Expected: PASS once `docs/errors.md` lists every code.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tests/error_codes_docs.rs
+git commit -m "test(engine): drift gate — every ErrorCode documented"
+```
+
+---
+
+## Task 12: TS `error-codes.ts` — extraction + TS-native constants
+
+**Files:**
+- Create: `src/error-codes.ts`
+- Test: `src/__tests__/error-codes.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test** — create `src/__tests__/error-codes.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { extractEngineErrorCode, TS_NATIVE_CODES, KNOWN_TS_CODES } from "../error-codes";
+
+describe("extractEngineErrorCode", () => {
+  test("extracts the code from a coded engine stderr line", () => {
+    const stderr = "error [E_MODEL_MISSING]: voice 'ru-vosk-m02' not installed. run: kesha install --tts";
+    expect(extractEngineErrorCode(stderr)).toBe("E_MODEL_MISSING");
+  });
+
+  test("extracts even when the message embeds a path or token", () => {
+    const stderr = "warning: foo\nerror [E_BAD_AUDIO]: decode error in: /Users/alice/secret-token-abc.wav";
+    expect(extractEngineErrorCode(stderr)).toBe("E_BAD_AUDIO");
+  });
+
+  test("returns undefined for an uncoded stderr so caller can fall back", () => {
+    expect(extractEngineErrorCode("Error: something went wrong")).toBeUndefined();
+  });
+
+  test("TS-native codes are exposed and included in KNOWN_TS_CODES", () => {
+    expect(TS_NATIVE_CODES.INPUT_NOT_FOUND).toBe("E_INPUT_NOT_FOUND");
+    expect(TS_NATIVE_CODES.ENGINE_SPAWN).toBe("E_ENGINE_SPAWN");
+    expect(TS_NATIVE_CODES.INVALID_ARG).toBe("E_INVALID_ARG");
+    expect(KNOWN_TS_CODES.has("E_INTERNAL")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/__tests__/error-codes.test.ts`
+Expected: FAIL — module `../error-codes` not found.
+
+- [ ] **Step 3: Write implementation** — create `src/error-codes.ts`:
+
+```typescript
+/**
+ * Error-code taxonomy bridge. The engine is the source of truth for engine
+ * codes (see `kesha-engine --error-codes-json`); these are the codes that
+ * originate in TS, before/around the engine. See
+ * `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`.
+ */
+
+/** Matches the engine's `error [CODE]:` line; CODE charset is constrained. */
+const ENGINE_CODE_RE = /^error \[([A-Z0-9_]+)\]:/m;
+
+/** Extract the engine error code from captured stderr, if present. */
+export function extractEngineErrorCode(stderr: string): string | undefined {
+  const m = stderr.match(ENGINE_CODE_RE);
+  return m ? m[1] : undefined;
+}
+
+/** Codes that originate in TS (engine never ran, or isn't the failing party). */
+export const TS_NATIVE_CODES = {
+  INPUT_NOT_FOUND: "E_INPUT_NOT_FOUND",
+  ENGINE_SPAWN: "E_ENGINE_SPAWN",
+  INVALID_ARG: "E_INVALID_ARG",
+  INTERNAL: "E_INTERNAL",
+} as const;
+
+export type TsNativeCode = (typeof TS_NATIVE_CODES)[keyof typeof TS_NATIVE_CODES];
+
+/** The full set of TS-native codes, for the drift test. */
+export const KNOWN_TS_CODES: ReadonlySet<string> = new Set(Object.values(TS_NATIVE_CODES));
+
+/** Resolve a code from engine stderr, falling back to E_INTERNAL. */
+export function engineErrorCode(stderr: string): string {
+  return extractEngineErrorCode(stderr) ?? TS_NATIVE_CODES.INTERNAL;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/__tests__/error-codes.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/error-codes.ts src/__tests__/error-codes.test.ts
+git commit -m "feat(cli): error-code extraction + TS-native code constants"
+```
+
+---
+
+## Task 13: Unify TS error surfaces — `recordError`, diagnostic `error_code`, `SayError`, `errors[].code`
+
+**Files:**
+- Modify: `src/types.ts:22` (`errors[].code` union)
+- Modify: `src/synth.ts:95-121` (`SayError` carries `code`)
+- Modify: `src/cli/main.ts:304,306,407,414` (transcribe recordError + diagnostic + errors[].code)
+- Modify: `src/cli/say.ts:253-262` (tts recordError + diagnostic)
+- Test: `src/__tests__/stats-error-codes.test.ts` (create)
+
+- [ ] **Step 1: Widen the `errors[].code` union** in `src/types.ts:22`:
+
+```typescript
+// before:
+  code: "file_not_found" | "transcribe_failed";
+// after:
+  code: "E_INPUT_NOT_FOUND" | "E_TRANSCRIBE_FAILED" | "E_BAD_AUDIO" | "E_INTERNAL";
+```
+
+- [ ] **Step 2: Add `code` to `SayError`** in `src/synth.ts:95`. Update the constructor and the three throw sites:
+
+```typescript
+// constructor — add a code field:
+export class SayError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+    readonly stderr: string,
+    readonly code: string = "E_INTERNAL",
+  ) {
+    super(message);
+    this.name = "SayError";
+  }
+}
+
+// throw sites:
+//   text empty  -> new SayError("text is empty", 2, "", "E_TEXT_EMPTY")
+//   too long    -> new SayError(`text exceeds ${MAX_TEXT_CHARS} chars (${chars})`, 5, "", "E_TEXT_TOO_LONG")
+//   engine fail -> new SayError(msg, exitCode, stderr, engineErrorCode(stderr))
+```
+
+Import at the top of `src/synth.ts`: `import { engineErrorCode, TS_NATIVE_CODES } from "./error-codes";` and use `engineErrorCode(stderr)` for the engine-failure throw (the one that carries real engine stderr).
+
+- [ ] **Step 3: Wire transcribe in `src/cli/main.ts`.** Imports: `import { extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";`
+
+File-not-found site (main.ts:304-306):
+```typescript
+// before:
+stats.recordError("input", new Error("File not found"), "file_not_found");
+diagnosticLog.event("input.missing", { command: "transcribe" });
+errors.push({ file, code: "file_not_found", message: "File not found" });
+// after:
+stats.recordError("input", new Error("File not found"), TS_NATIVE_CODES.INPUT_NOT_FOUND);
+diagnosticLog.event("input.missing", { command: "transcribe", error_code: TS_NATIVE_CODES.INPUT_NOT_FOUND });
+errors.push({ file, code: TS_NATIVE_CODES.INPUT_NOT_FOUND, message: "File not found" });
+```
+
+Transcribe-failure catch (main.ts:407-414):
+```typescript
+// before:
+stats.recordError("transcribe", err);
+diagnosticLog.event("engine.exit", {
+  command: "transcribe",
+  status: "failed",
+  errorKind: "transcribe_failed",
+});
+const message = err instanceof Error ? err.message : String(err);
+errors.push({ file, code: "transcribe_failed", message });
+// after:
+const stderrText = err instanceof Error ? err.message : String(err);
+const code = extractEngineErrorCode(stderrText) ?? "E_TRANSCRIBE_FAILED";
+stats.recordError("transcribe", err, code);
+diagnosticLog.event("engine.exit", {
+  command: "transcribe",
+  status: "failed",
+  errorKind: "transcribe_failed",
+  error_code: code,
+});
+const message = stderrText;
+errors.push({ file, code: code as ImportedErrorCodeType, message });
+```
+
+(Use the `code` value directly; the `errors[].code` type now includes these. If TS complains about the union, cast through the widened `code` field type or set the union to `string` if simpler — keep it the explicit union above for safety.)
+
+- [ ] **Step 4: Wire say in `src/cli/say.ts:253-262`:**
+
+```typescript
+// before:
+stats.recordError("tts", err);
+stats.finish("failed", 1);
+diagnosticLog.event("command.finish", {
+  command: "say",
+  status: "failed",
+  errorKind: err instanceof SayError ? "say_error" : "error",
+  exitCode: err instanceof SayError ? err.exitCode : 4,
+});
+// after:
+const code = err instanceof SayError ? err.code : "E_INTERNAL";
+stats.recordError("tts", err, code);
+stats.finish("failed", 1);
+diagnosticLog.event("command.finish", {
+  command: "say",
+  status: "failed",
+  errorKind: err instanceof SayError ? "say_error" : "error",
+  exitCode: err instanceof SayError ? err.exitCode : 4,
+  error_code: code,
+});
+```
+
+- [ ] **Step 5: Write the stats-code test** — create `src/__tests__/stats-error-codes.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { SayError } from "../synth";
+
+describe("SayError carries a taxonomy code", () => {
+  test("pre-check throws carry text codes", () => {
+    const e = new SayError("text is empty", 2, "", "E_TEXT_EMPTY");
+    expect(e.code).toBe("E_TEXT_EMPTY");
+    expect(e.exitCode).toBe(2);
+  });
+
+  test("defaults to E_INTERNAL when unspecified", () => {
+    const e = new SayError("boom", 4, "");
+    expect(e.code).toBe("E_INTERNAL");
+  });
+});
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `bun test src/__tests__/error-codes.test.ts src/__tests__/stats-error-codes.test.ts && bunx tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types.ts src/synth.ts src/cli/main.ts src/cli/say.ts src/__tests__/stats-error-codes.test.ts
+git commit -m "feat(cli): unify TS error surfaces onto the taxonomy"
+```
+
+---
+
+## Task 14: `docs/errors.md` + cross-links
+
+**Files:**
+- Create: `docs/errors.md`
+- Modify: `README.md` (add a link under diagnostics/troubleshooting)
+- Modify: `docs/diagnostic-logs.md` (link the error-codes page)
+
+- [ ] **Step 1: Write `docs/errors.md`** — one row per code (all 19: 17 engine + `E_ENGINE_SPAWN`, `E_INVALID_ARG`). Header + table:
+
+```markdown
+# Error Codes
+
+Every user-facing failure prints a stable code on stderr:
+
+```
+error [E_MODEL_MISSING]: voice 'ru-vosk-m02' not installed. run: kesha install --tts
+```
+
+The code is stable across releases; quote it in bug reports. Engine codes are
+introspectable via `kesha-engine --error-codes-json`. Codes are recorded
+(leak-free) in Stats and diagnostic logs; the human message may contain a path
+and is sanitized before storage.
+
+| Code | Category | Retryable | When it fires | How to fix |
+|------|----------|-----------|---------------|------------|
+| `E_INPUT_NOT_FOUND` | input | no | The input audio path doesn't exist (or no stdin). | Check the path; pass a readable file. |
+| `E_BAD_AUDIO` | input | no | The audio container/codec couldn't be decoded. | Re-export to wav/ogg/mp3; verify the file isn't truncated. |
+| `E_MODEL_MISSING` | model | no | A required model or voice isn't installed. | `kesha install` / `kesha install --tts`. |
+| `E_MODEL_DOWNLOAD` | model | yes | A model download failed (network/mirror). | Retry; check connectivity / `KESHA_MODEL_MIRROR`. |
+| `E_CACHE_CORRUPT` | model | no | A cached model failed SHA-256 verification. | `kesha install --no-cache` to re-fetch. |
+| `E_MODEL_LOAD` | model | no | A model file exists but failed to load. | Reinstall the model; check disk space. |
+| `E_UNSUPPORTED_PLATFORM` | platform | no | The feature isn't supported on this OS/arch. | Use a supported platform (see README matrix). |
+| `E_SIDECAR_MISSING` | platform | no | A helper sidecar is missing or exited nonzero. | Reinstall; ensure `say-avspeech` is beside the engine (macOS). |
+| `E_NO_BACKEND` | platform | no | The binary was built without an ASR backend. | Use an official release build. |
+| `E_TEXT_EMPTY` | tts | no | Synthesis text was empty. | Pass non-empty text. |
+| `E_TEXT_TOO_LONG` | tts | no | Text exceeded the max length. | Split into shorter requests. |
+| `E_VOICE_UNKNOWN` | tts | no | The voice id wasn't recognized. | `kesha say --list-voices`. |
+| `E_SSML_INVALID` | tts | no | SSML was malformed (no `<speak>`, DOCTYPE, bad rate). | Fix the SSML; see `docs/tts.md`. |
+| `E_SSML_UNSUPPORTED` | tts | no | SSML isn't supported for this engine/voice. | Use a plain-text request or a supported voice. |
+| `E_TRANSCRIBE_FAILED` | transcribe | no | The ASR pipeline failed. | Re-run; file a bug with a support bundle. |
+| `E_DIARIZE_TIMEOUT` | transcribe | yes | Diarization timed out (cold compile/long audio). | Re-run (warm); shorten audio. |
+| `E_ENGINE_SPAWN` | internal | no | The CLI couldn't spawn the engine subprocess. | `kesha install`; check the engine binary path. |
+| `E_INVALID_ARG` | input | no | A CLI flag/argument was invalid. | See `kesha --help`. |
+| `E_INTERNAL` | internal | no | An unexpected/uncoded failure. | File a bug with `kesha support-bundle`. |
+```
+
+(Keep the table exactly these 19 rows so the drift gates pass.)
+
+- [ ] **Step 2: Cross-link** — add to `README.md` (diagnostics/troubleshooting area): `See [Error codes](docs/errors.md) for stable failure codes.` Add the same link to `docs/diagnostic-logs.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/errors.md README.md docs/diagnostic-logs.md
+git commit -m "docs: error-code reference (docs/errors.md)"
+```
+
+---
+
+## Task 15: TS drift gate — engine ∪ TS-native == documented
+
+**Files:**
+- Test: `src/__tests__/error-codes-drift.test.ts` (create)
+
+- [ ] **Step 1: Write the test** — create `src/__tests__/error-codes-drift.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { KNOWN_TS_CODES } from "../error-codes";
+
+const ENGINE_BIN =
+  process.env.KESHA_ENGINE_BIN ?? join(import.meta.dir, "../../rust/target/release/kesha-engine");
+
+const describeOrSkip = existsSync(ENGINE_BIN) ? describe : describe.skip;
+
+describeOrSkip("error-code drift", () => {
+  test("engine codes ∪ TS-native codes == codes documented in docs/errors.md", () => {
+    const res = spawnSync(ENGINE_BIN, ["--error-codes-json"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    const engineCodes: string[] = JSON.parse(res.stdout).map((e: { code: string }) => e.code);
+
+    const known = new Set<string>([...engineCodes, ...KNOWN_TS_CODES]);
+
+    const doc = readFileSync(join(import.meta.dir, "../../docs/errors.md"), "utf8");
+    const documented = new Set(doc.match(/E_[A-Z0-9_]+/g) ?? []);
+
+    // every known code is documented
+    for (const c of known) {
+      expect(documented.has(c)).toBe(true);
+    }
+    // every documented code is known (no stale doc rows)
+    for (const c of documented) {
+      expect(known.has(c)).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Build the engine, run the test**
+
+Run: `cd rust && cargo build --release --features tts && cd .. && bun test src/__tests__/error-codes-drift.test.ts`
+Expected: PASS (skips if the engine binary is absent).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/error-codes-drift.test.ts
+git commit -m "test(cli): drift gate — engine ∪ TS codes == documented codes"
+```
+
+---
+
+## Task 16: Engine release — version bumps
+
+**Files:**
+- Modify: `rust/Cargo.toml` (`version`)
+- Modify: `rust/Cargo.lock` (via `cargo check`)
+- Modify: `package.json` (`version` and `keshaEngine.version`)
+
+- [ ] **Step 1: Pick the next version.** Read current values:
+
+Run: `node -p "require('./package.json').version + ' / ' + require('./package.json').keshaEngine.version"` and `grep '^version' rust/Cargo.toml`
+Choose the next patch/minor (e.g. if engine is `1.21.0`, use `1.22.0` — a feature). Set all three to the SAME value.
+
+- [ ] **Step 2: Apply the bumps** — set `rust/Cargo.toml#version`, `package.json#version`, and `package.json#keshaEngine.version` to the chosen version, then refresh the lock:
+
+Run: `cd rust && cargo check --features tts && cd ..`
+Expected: `rust/Cargo.lock` updates the `kesha-engine` entry.
+
+- [ ] **Step 3: Verify drift gate**
+
+Run: `bun .github/scripts/check-versions.ts`
+Expected: passes (`keshaEngine.version === rust/Cargo.toml#version`, `package.json#version >= keshaEngine.version`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/Cargo.toml rust/Cargo.lock package.json
+git commit -m "chore(release): bump engine + CLI for error taxonomy"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] `cd rust && cargo fmt --check && cargo clippy --all-targets --features tts -- -D warnings`
+- [ ] `cd rust && cargo check --features coreml --no-default-features` (backend module changed)
+- [ ] `cd rust && cargo build --release --features tts && cargo nextest run --features tts`
+- [ ] `bun test && bunx tsc --noEmit`
+- [ ] Manual: `./rust/target/release/kesha-engine --error-codes-json | jq length` → `17`
+- [ ] Manual: trigger a coded failure, confirm `error [E_...]:` on stderr
+- [ ] Open PR with `Closes #462` (and `Refs #344, #345`), wait for CI + Greptile per CLAUDE.md.
+
+---
+
+## Self-review notes (coverage check vs spec)
+
+- **Emit mechanism (`error [CODE]:`):** Task 2 (report) + Task 10 (say path). ✓
+- **`CodedError`/`ErrorCode`/`coded_bail!`/`.coded()`:** Task 1. ✓
+- **`--error-codes-json`:** Task 3. ✓
+- **Catalogue (19 codes):** enum Task 1; engine wiring Tasks 4-10; TS-native in Task 12; documented Task 14. ✓
+- **`file_not_found` → `E_INPUT_NOT_FOUND` migration:** Task 13 Step 3. ✓
+- **TS hybrid wiring + diagnostic `error_code` field:** Task 13. ✓
+- **Docs:** Task 14. ✓
+- **Drift gates (Rust + TS):** Tasks 11, 15. ✓
+- **Engine release:** Task 16. ✓
+- **Exit codes unchanged:** asserted in Tasks 2/10 (report returns 1; say keeps `exit_code_for_tts_err`). ✓
+- **Open item flagged in Task 9 Step 6:** whether input-existence is checked engine-side or TS-side — resolved as TS-owned (`E_INPUT_NOT_FOUND`) with engine decode failures as `E_BAD_AUDIO`. Implementer confirms via grep.

--- a/docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md
+++ b/docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md
@@ -1,0 +1,171 @@
+# Structured Error Taxonomy
+
+Give every user-facing failure path a stable error code, emitted by the engine, surfaced to the user, recorded in Stats and diagnostic logs as the leak-free primary signal, and documented one row per code. Closes the audit items #345 item 17 (stable codes + docs) and #344 item 9 (wire codes into Stats/log sanitization so arbitrary CLI args / model URLs / sidecar stderr can't leak). Tracked by epic #462.
+
+This is an **engine release**: it changes `rust/` and adds an engine capability (`--error-codes-json`).
+
+## Goals
+
+- A stable, documented code at every user-facing failure path (download, cache corrupt, unsupported platform, sidecar missing, model load, bad audio, unsupported SSML, model-not-installed, etc.).
+- Codes are the **structured backstop** for sanitization: support and Stats key off the code, not a regex-redacted free-form string.
+- Codes are user-visible so a user/support can quote a stable token and look it up.
+- Engine is the single source of truth for engine codes; TS owns codes for failures that happen before/around the engine.
+
+## Non-goals
+
+- **Exit-code normalization.** Exit codes stay as-is today (0 success, 2 usage/validation, 1 runtime, 4 say-synthesis). Codes are orthogonal to exit codes and carry the granularity; remapping exit codes is a separate behavior-contract change, out of scope.
+- Changing stdout output contracts (`--json`/`--toon`/plain transcript). The code travels on **stderr**.
+- Localizing or rewording the human-readable messages. Wording can stay; the code is the new stable part.
+- Retry/backoff behavior. `retryable` is metadata only in this iteration.
+
+## Design
+
+### Emit mechanism: one `error [CODE]:` line serves human + machine
+
+On any user-facing failure, the engine prints its final stderr line as:
+
+```
+error [E_MODEL_MISSING]: voice 'ru-vosk-m02' not installed. run: kesha install --tts
+```
+
+- The **user** reads it directly (user-visible decision).
+- **TS** extracts the code with an anchored regex `^error \[([A-Z0-9_]+)\]:` (multiline). The `[CODE]` token has a constrained charset (`[A-Z0-9_]+`), so extraction is unambiguous **even when the message contains a path or token**. That message is still sanitized before it reaches Stats/logs; the code never needs sanitizing.
+
+This one line is both the human surface and the machine contract. No separate marker line, no stdout change, identical for `transcribe` / `say` / `install`.
+
+### Rust: `CodedError` carrying a stable `ErrorCode`
+
+New `rust/src/errors.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    InputNotFound, BadAudio,
+    ModelMissing, ModelDownload, CacheCorrupt, ModelLoad,
+    UnsupportedPlatform, SidecarMissing, NoBackend,
+    TextEmpty, TextTooLong, VoiceUnknown, SsmlInvalid, SsmlUnsupported,
+    TranscribeFailed, DiarizeTimeout,
+    Internal,
+}
+
+impl ErrorCode {
+    pub fn as_str(self) -> &'static str { /* "E_MODEL_MISSING", ... */ }
+    pub fn title(self) -> &'static str { /* short human title for --error-codes-json */ }
+    pub fn category(self) -> Category { /* Input | Model | Platform | Tts | Transcribe | Internal */ }
+    pub fn retryable(self) -> bool { /* download/timeout = true, rest = false */ }
+}
+
+/// Carries a code alongside the human message. Sits in the anyhow chain.
+#[derive(Debug)]
+pub struct CodedError { pub code: ErrorCode, pub message: String }
+impl std::fmt::Display for CodedError { /* writes message only */ }
+impl std::error::Error for CodedError {}
+```
+
+A macro replaces the relevant `anyhow::bail!` sites:
+
+```rust
+// before: anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+coded_bail!(ErrorCode::ModelMissing, "voice '{voice_id}' not installed. run: kesha install --tts");
+```
+
+`coded_bail!` constructs `CodedError` and returns `Err(anyhow::Error::new(CodedError {..}))`. Existing `.context()` chains are left in place — the `CodedError` sits in the chain and is found by downcast at the top.
+
+Top-level handler (`main.rs`, and the `say` direct-exit path in `cli/say.rs`):
+
+```rust
+fn report(err: &anyhow::Error) -> i32 {
+    let code = err.chain()
+        .find_map(|e| e.downcast_ref::<CodedError>().map(|c| c.code))
+        .unwrap_or(ErrorCode::Internal);
+    eprintln!("error [{}]: {:#}", code.as_str(), err);  // {:#} = full chain message
+    /* existing exit code logic unchanged */
+}
+```
+
+Uncoded `anyhow` errors that bubble up unwrapped fall back to `E_INTERNAL` — so the contract holds even for paths not yet individually coded.
+
+### Engine introspection: `kesha-engine --error-codes-json`
+
+```json
+[
+  {"code":"E_MODEL_MISSING","title":"Model not installed","category":"model","retryable":false},
+  {"code":"E_MODEL_DOWNLOAD","title":"Model download failed","category":"model","retryable":true},
+  ...
+]
+```
+
+Lists every engine code. Powers `kesha doctor`, makes the taxonomy introspectable, and is the cross-language source the drift test consumes.
+
+### Code catalogue
+
+| Code | Category | Fires when | Origin |
+|------|----------|-----------|--------|
+| `E_INPUT_NOT_FOUND` | input | input audio path doesn't exist / no stdin | TS + engine |
+| `E_BAD_AUDIO` | input | container/decode failure (symphonia) | engine |
+| `E_MODEL_MISSING` | model | required model/voice not installed | engine |
+| `E_MODEL_DOWNLOAD` | model | download from HF/mirror failed | engine |
+| `E_CACHE_CORRUPT` | model | cached file fails hash verify / won't load | engine |
+| `E_MODEL_LOAD` | model | ONNX/session build or model load failed | engine |
+| `E_UNSUPPORTED_PLATFORM` | platform | feature unsupported on this OS/arch (e.g. record off-macOS) | engine |
+| `E_SIDECAR_MISSING` | platform | `say-avspeech` sidecar not found/spawnable | engine |
+| `E_NO_BACKEND` | platform | binary built without onnx/coreml | engine |
+| `E_TEXT_EMPTY` | tts | empty synth text | engine |
+| `E_TEXT_TOO_LONG` | tts | text exceeds max chars | engine |
+| `E_VOICE_UNKNOWN` | tts | unrecognized voice id | engine |
+| `E_SSML_INVALID` | tts | malformed SSML / DOCTYPE / no `<speak>` root | engine |
+| `E_SSML_UNSUPPORTED` | tts | SSML used where engine rejects it (e.g. AVSpeech) | engine |
+| `E_TRANSCRIBE_FAILED` | transcribe | ASR pipeline failure | engine |
+| `E_DIARIZE_TIMEOUT` | transcribe | diarization cold-compile/run timeout | engine |
+| `E_ENGINE_SPAWN` | internal | TS failed to spawn the engine subprocess | TS |
+| `E_INVALID_ARG` | input | CLI flag validation failure (exit 2 paths) | TS |
+| `E_INTERNAL` | internal | uncoded/unexpected failure (catch-all) | TS + engine |
+
+`E_INVALID_ARG` and `E_ENGINE_SPAWN` are TS-native (the engine never runs, or isn't the failing party). The existing lone Stats code `file_not_found` migrates to `E_INPUT_NOT_FOUND`.
+
+### TS: hybrid wiring + sanitization (epic checkbox 2)
+
+- `src/cli/main.ts:407` (`transcribe`) and `src/cli/say.ts:253` (`tts`) currently call `stats.recordError(stage, err)` with **no code**. Extract the code from engine stderr and pass it: `stats.recordError(stage, err, codeFromEngine(stderr) ?? "E_INTERNAL")`.
+- New helper `src/error-codes.ts`: `extractEngineErrorCode(stderr): string | undefined` (the anchored regex) + the TS-native code constants + `KNOWN_TS_CODES` set.
+- Diagnostic logs: add `error_code` to failure events (`*_failed`). Verified leak-free — `error_code` matches none of `DISALLOWED_FIELD_NAME` and the value charset `[A-Z0-9_]+` passes `SAFE_STRING_VALUE` / fails `UNSAFE_STRING_VALUE`. The code becomes the **primary** failure signal in logs; the sanitized message stays as secondary context.
+- TS-native failures (`E_INVALID_ARG`, `E_ENGINE_SPAWN`, `E_INPUT_NOT_FOUND`) print `error [CODE]: <message>` in the same format so the user-facing surface is uniform across TS and engine origins.
+
+The point of the code (per audit #344 item 9): Stats/support no longer depend on regex redaction being complete — the structured code is stable and leak-free by construction.
+
+### Docs (epic checkbox 3)
+
+New `docs/errors.md`: one row per code — code, category, when it fires, likely cause, how to fix, retryable. Linked from `README.md` and `docs/diagnostic-logs.md`. The page is the human registry; the drift tests keep it honest.
+
+## Data flow
+
+```
+[leaf failure, Rust]  coded_bail!(ErrorCode::ModelMissing, "...")
+   -> anyhow::Error carrying CodedError in its chain
+   -> propagates up through existing .context() wrappers
+   -> report(): chain-downcast -> code; eprintln "error [E_MODEL_MISSING]: <chain msg>"; exit nonzero
+[TS]  spawn engine, capture stderr
+   -> on nonzero exit: extractEngineErrorCode(stderr) -> "E_MODEL_MISSING" (fallback E_INTERNAL)
+   -> stats.recordError(stage, err, code)              // message sanitized, code stored verbatim
+   -> diagnosticSession.event("say_failed", { error_code: code })   // leak-free field
+   -> user already saw the human stderr line with [E_MODEL_MISSING]
+[TS-native failure]  (file not found, spawn fail, bad flag)
+   -> TS owns the code -> print "error [CODE]: ..." + same recordError + diagnostic event
+```
+
+## Testing
+
+- **Rust** (`rust/src/errors.rs` tests): `as_str()` mapping is stable and unique; `coded_bail!` produces an error whose chain-downcast yields the expected code; `report()` formats `error [CODE]:`; `--error-codes-json` emits valid JSON covering every variant.
+- **Rust drift gate**: a test asserts every `ErrorCode` variant string appears in `../docs/errors.md` (reads the markdown).
+- **TS** (`src/__tests__/error-codes.test.ts`): `extractEngineErrorCode` returns the code for representative engine stderr — **including messages that embed a path or token** (proves the code extracts while the message is what gets sanitized); returns `undefined` for un-coded stderr so the caller falls back to `E_INTERNAL`.
+- **TS Stats test**: `recordError(stage, err, code)` persists `error_code`; sanitized message still redacts paths/URLs/JSON fields.
+- **TS drift gate**: `(codes from kesha-engine --error-codes-json) ∪ KNOWN_TS_CODES == (E_ codes documented in docs/errors.md)`. Catches a code added without docs and a doc row with no code. Uses a repo-local engine build (`KESHA_ENGINE_BIN` / `rust/target/release/kesha-engine`), guarded to skip if the engine binary isn't built (like other engine-dependent TS tests).
+
+## Release
+
+Engine release. Bump together: `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version`, `package.json#version`. No new cargo feature, so the `build-engine.yml` feature matrix is unaffected.
+
+## Out of scope / follow-ups
+
+- Exit-code normalization (codes are sufficient granularity now).
+- `retryable` driving actual retry behavior.
+- Coding internal/non-user-facing failures that never reach a CLI boundary.

--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -51,7 +51,17 @@ fn build_hint(path: &str) -> Hint {
 /// Shared by `decode_audio` and `probe_duration_seconds` so container
 /// detection + error messages live in one place.
 fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameters)> {
-    let src = std::fs::File::open(path).with_context(|| format!("file not found: {path}"))?;
+    let src = std::fs::File::open(path).map_err(|e| {
+        let code = if e.kind() == std::io::ErrorKind::NotFound {
+            ErrorCode::InputNotFound
+        } else {
+            ErrorCode::BadAudio
+        };
+        anyhow::Error::new(crate::errors::CodedError {
+            code,
+            message: format!("file not found: {path}"),
+        })
+    })?;
     let mss = MediaSourceStream::new(Box::new(src), Default::default());
 
     let hint = build_hint(path);

--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -12,6 +12,8 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::{Hint, Probe};
 
+use crate::errors::{CodedContext, ErrorCode};
+
 const TARGET_SAMPLE_RATE: u32 = 16000;
 
 /// Build a codec registry that includes the default codecs plus libopus.
@@ -102,7 +104,11 @@ fn decode_audio(path: &str) -> Result<(Vec<f32>, u32, usize)> {
             Ok(p) => p,
             Err(SymphoniaError::IoError(_)) => break,
             Err(SymphoniaError::ResetRequired) => break,
-            Err(e) => return Err(e).with_context(|| format!("decode error in: {path}")),
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("decode error in: {path}"))
+                    .coded(ErrorCode::BadAudio)
+            }
         };
 
         // Drain stale metadata
@@ -117,7 +123,11 @@ fn decode_audio(path: &str) -> Result<(Vec<f32>, u32, usize)> {
         let decoded = match decoder.decode(&packet) {
             Ok(d) => d,
             Err(SymphoniaError::IoError(_)) | Err(SymphoniaError::DecodeError(_)) => continue,
-            Err(e) => return Err(e).with_context(|| format!("decode error in: {path}")),
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("decode error in: {path}"))
+                    .coded(ErrorCode::BadAudio)
+            }
         };
 
         // Initialise the sample buffer on first decoded frame

--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -57,10 +57,12 @@ fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameter
         } else {
             ErrorCode::BadAudio
         };
-        anyhow::Error::new(crate::errors::CodedError {
-            code,
-            message: format!("file not found: {path}"),
-        })
+        let message = if code == ErrorCode::InputNotFound {
+            format!("file not found: {path}")
+        } else {
+            format!("could not open audio file: {path}: {e}")
+        };
+        anyhow::Error::new(crate::errors::CodedError { code, message })
     })?;
     let mss = MediaSourceStream::new(Box::new(src), Default::default());
 

--- a/rust/src/backend/mod.rs
+++ b/rust/src/backend/mod.rs
@@ -24,7 +24,12 @@ pub fn create_backend(model_dir: &str) -> Result<Box<dyn TranscribeBackend>> {
     }
     #[cfg(not(any(feature = "onnx", feature = "coreml")))]
     {
+        use crate::coded_bail;
+        use crate::errors::ErrorCode;
         let _ = model_dir;
-        anyhow::bail!("No backend available — build with --features onnx or coreml")
+        coded_bail!(
+            ErrorCode::NoBackend,
+            "No backend available — build with --features onnx or coreml"
+        )
     }
 }

--- a/rust/src/backend/onnx.rs
+++ b/rust/src/backend/onnx.rs
@@ -6,6 +6,7 @@ use ort::session::Session;
 use ort::value::Value;
 
 use crate::audio;
+use crate::errors::{CodedContext, ErrorCode};
 use crate::util::argmax;
 
 use super::TranscribeBackend;
@@ -28,24 +29,29 @@ impl OnnxBackend {
         let model_path = Path::new(model_dir);
 
         let preprocessor = Session::builder()
-            .context("Failed to create preprocessor session builder")?
+            .context("Failed to create preprocessor session builder")
+            .coded(ErrorCode::ModelLoad)?
             .commit_from_file(model_path.join("nemo128.onnx"))
-            .context("Failed to load nemo128.onnx — run `kesha-engine install` first")?;
+            .context("Failed to load nemo128.onnx — run `kesha-engine install` first")
+            .coded(ErrorCode::ModelLoad)?;
 
         let encoder = Session::builder()
-            .context("Failed to create encoder session builder")?
+            .context("Failed to create encoder session builder")
+            .coded(ErrorCode::ModelLoad)?
             .commit_from_file(model_path.join("encoder-model.onnx"))
-            .context("Failed to load encoder-model.onnx — run `kesha-engine install` first")?;
+            .context("Failed to load encoder-model.onnx — run `kesha-engine install` first")
+            .coded(ErrorCode::ModelLoad)?;
 
         let decoder = Session::builder()
-            .context("Failed to create decoder session builder")?
+            .context("Failed to create decoder session builder")
+            .coded(ErrorCode::ModelLoad)?
             .commit_from_file(model_path.join("decoder_joint-model.onnx"))
-            .context(
-                "Failed to load decoder_joint-model.onnx — run `kesha-engine install` first",
-            )?;
+            .context("Failed to load decoder_joint-model.onnx — run `kesha-engine install` first")
+            .coded(ErrorCode::ModelLoad)?;
 
         let vocab = load_vocab(model_path.join("vocab.txt"))
-            .context("Failed to load vocab.txt — run `kesha-engine install` first")?;
+            .context("Failed to load vocab.txt — run `kesha-engine install` first")
+            .coded(ErrorCode::ModelLoad)?;
 
         let blank_id = vocab.len() - 1;
 

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -174,7 +174,7 @@ pub fn run(a: SayArgs) -> i32 {
     ) {
         Ok(f) => f,
         Err(msg) => {
-            eprintln!("error: {msg}");
+            eprintln!("error [E_INVALID_ARG]: {msg}");
             return 2;
         }
     };
@@ -184,7 +184,7 @@ pub fn run(a: SayArgs) -> i32 {
         None => {
             let mut buf = String::new();
             if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
-                eprintln!("error: failed to read stdin: {e}");
+                eprintln!("error [E_INTERNAL]: failed to read stdin: {e}");
                 return 4;
             }
             buf.trim().to_string()
@@ -193,7 +193,7 @@ pub fn run(a: SayArgs) -> i32 {
 
     if text_joined.is_empty() {
         let err = tts::TtsError::EmptyText;
-        eprintln!("error: {err}");
+        eprintln!("error [{}]: {err}", err.code().as_str());
         return exit_code_for_tts_err(&err);
     }
     let len = text_joined.chars().count();
@@ -202,7 +202,7 @@ pub fn run(a: SayArgs) -> i32 {
             max: tts::MAX_TEXT_CHARS,
             actual: len,
         };
-        eprintln!("error: {err}");
+        eprintln!("error [{}]: {err}", err.code().as_str());
         return exit_code_for_tts_err(&err);
     }
 
@@ -215,15 +215,15 @@ pub fn run(a: SayArgs) -> i32 {
             espeak_lang: "en-us",
         },
         (Some(_), None) | (None, Some(_)) => {
-            eprintln!("error: pass both --model and --voice-file or neither");
+            eprintln!("error [E_INVALID_ARG]: pass both --model and --voice-file or neither");
             return 2;
         }
         (None, None) => {
             let id = a.voice.as_deref().unwrap_or(tts::voices::DEFAULT_VOICE_ID);
             match tts::voices::resolve_voice(&models::cache_dir(), id) {
                 Ok(r) => r,
-                Err(e) => {
-                    eprintln!("error: {e}");
+                Err(err) => {
+                    eprintln!("error [{}]: {err:#}", crate::errors::code_of(&err).as_str());
                     return 1;
                 }
             }
@@ -279,7 +279,7 @@ pub fn run(a: SayArgs) -> i32 {
     }) {
         Ok(w) => w,
         Err(e) => {
-            eprintln!("error: {e}");
+            eprintln!("error [{}]: {e}", e.code().as_str());
             return exit_code_for_tts_err(&e);
         }
     };
@@ -291,7 +291,7 @@ pub fn run(a: SayArgs) -> i32 {
             .map_err(|e| e.to_string()),
     };
     if let Err(msg) = write_result {
-        eprintln!("error: write failed: {msg}");
+        eprintln!("error [E_INTERNAL]: write failed: {msg}");
         return 4;
     }
     0

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -133,7 +133,7 @@ fn exit_code_for_tts_err(e: &tts::TtsError) -> i32 {
     match e {
         tts::TtsError::EmptyText => 2,
         tts::TtsError::TextTooLong { .. } => 5,
-        tts::TtsError::SynthesisFailed(_) => 4,
+        tts::TtsError::SynthesisFailed(_) | tts::TtsError::Coded { .. } => 4,
     }
 }
 
@@ -174,7 +174,10 @@ pub fn run(a: SayArgs) -> i32 {
     ) {
         Ok(f) => f,
         Err(msg) => {
-            eprintln!("error [E_INVALID_ARG]: {msg}");
+            eprintln!(
+                "error [{}]: {msg}",
+                crate::errors::ErrorCode::InvalidArg.as_str()
+            );
             return 2;
         }
     };
@@ -215,7 +218,10 @@ pub fn run(a: SayArgs) -> i32 {
             espeak_lang: "en-us",
         },
         (Some(_), None) | (None, Some(_)) => {
-            eprintln!("error [E_INVALID_ARG]: pass both --model and --voice-file or neither");
+            eprintln!(
+                "error [{}]: pass both --model and --voice-file or neither",
+                crate::errors::ErrorCode::InvalidArg.as_str()
+            );
             return 2;
         }
         (None, None) => {

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -6,13 +6,6 @@
 //! returns the process exit code. See
 //! `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`.
 
-// Foundation module: this task lands the taxonomy + helpers with no call sites
-// wired in (the bin compiles `errors.rs` separately from the lib, so every item
-// reads as dead until later tasks call them). Subsequent tasks wire `report` in
-// main.rs and the `coded_bail!`/`.coded()` helpers into voices/ssml/audio/models/
-// backend call sites. Lib-target coverage lives in the `tests` module below.
-#![allow(dead_code)]
-
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,6 +26,7 @@ pub enum ErrorCode {
     SsmlUnsupported,
     TranscribeFailed,
     DiarizeTimeout,
+    InvalidArg,
     Internal,
 }
 
@@ -48,7 +42,7 @@ pub enum Category {
 }
 
 impl ErrorCode {
-    pub const ALL: [ErrorCode; 17] = [
+    pub const ALL: [ErrorCode; 18] = [
         ErrorCode::InputNotFound,
         ErrorCode::BadAudio,
         ErrorCode::ModelMissing,
@@ -65,6 +59,7 @@ impl ErrorCode {
         ErrorCode::SsmlUnsupported,
         ErrorCode::TranscribeFailed,
         ErrorCode::DiarizeTimeout,
+        ErrorCode::InvalidArg,
         ErrorCode::Internal,
     ];
 
@@ -86,6 +81,7 @@ impl ErrorCode {
             ErrorCode::SsmlUnsupported => "E_SSML_UNSUPPORTED",
             ErrorCode::TranscribeFailed => "E_TRANSCRIBE_FAILED",
             ErrorCode::DiarizeTimeout => "E_DIARIZE_TIMEOUT",
+            ErrorCode::InvalidArg => "E_INVALID_ARG",
             ErrorCode::Internal => "E_INTERNAL",
         }
     }
@@ -108,13 +104,16 @@ impl ErrorCode {
             ErrorCode::SsmlUnsupported => "SSML not supported for this engine",
             ErrorCode::TranscribeFailed => "Transcription failed",
             ErrorCode::DiarizeTimeout => "Speaker diarization timed out",
+            ErrorCode::InvalidArg => "Invalid command-line argument",
             ErrorCode::Internal => "Unexpected internal error",
         }
     }
 
     pub fn category(self) -> Category {
         match self {
-            ErrorCode::InputNotFound | ErrorCode::BadAudio => Category::Input,
+            ErrorCode::InputNotFound | ErrorCode::BadAudio | ErrorCode::InvalidArg => {
+                Category::Input
+            }
             ErrorCode::ModelMissing
             | ErrorCode::ModelDownload
             | ErrorCode::CacheCorrupt

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -199,6 +199,29 @@ pub fn report(err: &anyhow::Error) -> i32 {
     1
 }
 
+#[derive(Serialize)]
+struct CodeEntry {
+    code: &'static str,
+    title: &'static str,
+    category: Category,
+    retryable: bool,
+}
+
+/// JSON array of every error code, for `--error-codes-json`, docs drift tests,
+/// and `kesha doctor`.
+pub fn error_codes_json() -> String {
+    let entries: Vec<CodeEntry> = ErrorCode::ALL
+        .iter()
+        .map(|&c| CodeEntry {
+            code: c.as_str(),
+            title: c.title(),
+            category: c.category(),
+            retryable: c.retryable(),
+        })
+        .collect();
+    serde_json::to_string(&entries).expect("error-codes serialize")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,5 +299,24 @@ mod tests {
         assert_eq!(report(&coded.unwrap_err()), 1);
         let plain = anyhow::anyhow!("plain");
         assert_eq!(report(&plain), 1);
+    }
+
+    #[test]
+    fn error_codes_json_covers_all_variants() {
+        let json = error_codes_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), ErrorCode::ALL.len());
+        for c in ErrorCode::ALL {
+            assert!(
+                arr.iter().any(|e| e["code"] == c.as_str()),
+                "{} missing from --error-codes-json",
+                c.as_str()
+            );
+        }
+        let model_missing = arr.iter().find(|e| e["code"] == "E_MODEL_MISSING").unwrap();
+        assert_eq!(model_missing["category"], "model");
+        assert_eq!(model_missing["retryable"], false);
+        assert!(model_missing["title"].is_string());
     }
 }

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,0 +1,280 @@
+//! Stable, user-visible error codes for every user-facing failure path.
+//!
+//! A leaf failure attaches a code via [`coded_bail!`] or [`CodedContext::coded`].
+//! The code rides in the `anyhow` chain inside a [`CodedError`]; the top-level
+//! [`report`] walks the chain, prints `error [CODE]: <message>` to stderr, and
+//! returns the process exit code. See
+//! `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`.
+
+// Foundation module: this task lands the taxonomy + helpers with no call sites
+// wired in (the bin compiles `errors.rs` separately from the lib, so every item
+// reads as dead until later tasks call them). Subsequent tasks wire `report` in
+// main.rs and the `coded_bail!`/`.coded()` helpers into voices/ssml/audio/models/
+// backend call sites. Lib-target coverage lives in the `tests` module below.
+#![allow(dead_code)]
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    InputNotFound,
+    BadAudio,
+    ModelMissing,
+    ModelDownload,
+    CacheCorrupt,
+    ModelLoad,
+    UnsupportedPlatform,
+    SidecarMissing,
+    NoBackend,
+    TextEmpty,
+    TextTooLong,
+    VoiceUnknown,
+    SsmlInvalid,
+    SsmlUnsupported,
+    TranscribeFailed,
+    DiarizeTimeout,
+    Internal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Category {
+    Input,
+    Model,
+    Platform,
+    Tts,
+    Transcribe,
+    Internal,
+}
+
+impl ErrorCode {
+    pub const ALL: [ErrorCode; 17] = [
+        ErrorCode::InputNotFound,
+        ErrorCode::BadAudio,
+        ErrorCode::ModelMissing,
+        ErrorCode::ModelDownload,
+        ErrorCode::CacheCorrupt,
+        ErrorCode::ModelLoad,
+        ErrorCode::UnsupportedPlatform,
+        ErrorCode::SidecarMissing,
+        ErrorCode::NoBackend,
+        ErrorCode::TextEmpty,
+        ErrorCode::TextTooLong,
+        ErrorCode::VoiceUnknown,
+        ErrorCode::SsmlInvalid,
+        ErrorCode::SsmlUnsupported,
+        ErrorCode::TranscribeFailed,
+        ErrorCode::DiarizeTimeout,
+        ErrorCode::Internal,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ErrorCode::InputNotFound => "E_INPUT_NOT_FOUND",
+            ErrorCode::BadAudio => "E_BAD_AUDIO",
+            ErrorCode::ModelMissing => "E_MODEL_MISSING",
+            ErrorCode::ModelDownload => "E_MODEL_DOWNLOAD",
+            ErrorCode::CacheCorrupt => "E_CACHE_CORRUPT",
+            ErrorCode::ModelLoad => "E_MODEL_LOAD",
+            ErrorCode::UnsupportedPlatform => "E_UNSUPPORTED_PLATFORM",
+            ErrorCode::SidecarMissing => "E_SIDECAR_MISSING",
+            ErrorCode::NoBackend => "E_NO_BACKEND",
+            ErrorCode::TextEmpty => "E_TEXT_EMPTY",
+            ErrorCode::TextTooLong => "E_TEXT_TOO_LONG",
+            ErrorCode::VoiceUnknown => "E_VOICE_UNKNOWN",
+            ErrorCode::SsmlInvalid => "E_SSML_INVALID",
+            ErrorCode::SsmlUnsupported => "E_SSML_UNSUPPORTED",
+            ErrorCode::TranscribeFailed => "E_TRANSCRIBE_FAILED",
+            ErrorCode::DiarizeTimeout => "E_DIARIZE_TIMEOUT",
+            ErrorCode::Internal => "E_INTERNAL",
+        }
+    }
+
+    pub fn title(self) -> &'static str {
+        match self {
+            ErrorCode::InputNotFound => "Input file not found",
+            ErrorCode::BadAudio => "Unreadable or unsupported audio",
+            ErrorCode::ModelMissing => "Model or voice not installed",
+            ErrorCode::ModelDownload => "Model download failed",
+            ErrorCode::CacheCorrupt => "Cached model failed verification",
+            ErrorCode::ModelLoad => "Model failed to load",
+            ErrorCode::UnsupportedPlatform => "Feature unsupported on this platform",
+            ErrorCode::SidecarMissing => "Helper sidecar missing or failed",
+            ErrorCode::NoBackend => "No ASR backend compiled in",
+            ErrorCode::TextEmpty => "Empty synthesis text",
+            ErrorCode::TextTooLong => "Synthesis text too long",
+            ErrorCode::VoiceUnknown => "Unknown voice id",
+            ErrorCode::SsmlInvalid => "Malformed SSML",
+            ErrorCode::SsmlUnsupported => "SSML not supported for this engine",
+            ErrorCode::TranscribeFailed => "Transcription failed",
+            ErrorCode::DiarizeTimeout => "Speaker diarization timed out",
+            ErrorCode::Internal => "Unexpected internal error",
+        }
+    }
+
+    pub fn category(self) -> Category {
+        match self {
+            ErrorCode::InputNotFound | ErrorCode::BadAudio => Category::Input,
+            ErrorCode::ModelMissing
+            | ErrorCode::ModelDownload
+            | ErrorCode::CacheCorrupt
+            | ErrorCode::ModelLoad => Category::Model,
+            ErrorCode::UnsupportedPlatform | ErrorCode::SidecarMissing | ErrorCode::NoBackend => {
+                Category::Platform
+            }
+            ErrorCode::TextEmpty
+            | ErrorCode::TextTooLong
+            | ErrorCode::VoiceUnknown
+            | ErrorCode::SsmlInvalid
+            | ErrorCode::SsmlUnsupported => Category::Tts,
+            ErrorCode::TranscribeFailed | ErrorCode::DiarizeTimeout => Category::Transcribe,
+            ErrorCode::Internal => Category::Internal,
+        }
+    }
+
+    pub fn retryable(self) -> bool {
+        matches!(self, ErrorCode::ModelDownload | ErrorCode::DiarizeTimeout)
+    }
+}
+
+/// An error carrying a stable [`ErrorCode`] plus a human message. Sits as a
+/// leaf in the `anyhow` chain so [`code_of`] can recover the code.
+#[derive(Debug)]
+pub struct CodedError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl std::fmt::Display for CodedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CodedError {}
+
+/// Construct and return a coded error. Drop-in for `anyhow::bail!`.
+#[macro_export]
+macro_rules! coded_bail {
+    ($code:expr, $($arg:tt)*) => {
+        return ::core::result::Result::Err(::anyhow::Error::new($crate::errors::CodedError {
+            code: $code,
+            message: ::std::format!($($arg)*),
+        }))
+    };
+}
+
+/// Attach a code to a `Result`, snapshotting the existing chain message.
+pub trait CodedContext<T> {
+    fn coded(self, code: ErrorCode) -> anyhow::Result<T>;
+}
+
+impl<T, E> CodedContext<T> for Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn coded(self, code: ErrorCode) -> anyhow::Result<T> {
+        self.map_err(|e| {
+            let e: anyhow::Error = e.into();
+            anyhow::Error::new(CodedError {
+                code,
+                message: format!("{e:#}"),
+            })
+        })
+    }
+}
+
+/// Recover the code from anywhere in the chain; `Internal` if none.
+pub fn code_of(err: &anyhow::Error) -> ErrorCode {
+    err.chain()
+        .find_map(|e| e.downcast_ref::<CodedError>().map(|c| c.code))
+        .unwrap_or(ErrorCode::Internal)
+}
+
+/// Print `error [CODE]: <message>` to stderr and return the process exit code.
+/// Exit code stays 1 (runtime failure) — unchanged from prior behavior.
+pub fn report(err: &anyhow::Error) -> i32 {
+    let code = code_of(err);
+    eprintln!("error [{}]: {:#}", code.as_str(), err);
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Context as _;
+
+    #[test]
+    fn code_strings_are_stable_unique_and_prefixed() {
+        let all = ErrorCode::ALL;
+        let mut seen = std::collections::HashSet::new();
+        for c in all {
+            let s = c.as_str();
+            assert!(s.starts_with("E_"), "{s} must start with E_");
+            assert!(seen.insert(s), "duplicate code string {s}");
+            assert!(!c.title().is_empty(), "{s} missing title");
+        }
+    }
+
+    #[test]
+    fn category_and_retryable_are_total_and_consistent() {
+        // Exercises category() / retryable() (and the Category enum) for every
+        // code so the metadata surface stays total. Only download/timeout codes
+        // are retryable.
+        for c in ErrorCode::ALL {
+            // category() is total — a missing arm would not compile, but assert
+            // the serde rename round-trips to a non-empty lowercase tag.
+            let tag = serde_json::to_string(&c.category()).expect("category serializes");
+            assert!(tag.len() > 2, "{} category serialized empty", c.as_str());
+            let expected_retryable =
+                matches!(c, ErrorCode::ModelDownload | ErrorCode::DiarizeTimeout);
+            assert_eq!(
+                c.retryable(),
+                expected_retryable,
+                "{} retryable mismatch",
+                c.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn coded_bail_attaches_code_findable_in_chain() {
+        fn leaf() -> anyhow::Result<()> {
+            coded_bail!(
+                ErrorCode::ModelMissing,
+                "voice '{}' not installed",
+                "ru-vosk-m02"
+            );
+        }
+        let err = leaf().unwrap_err().context("while loading voice");
+        assert_eq!(code_of(&err), ErrorCode::ModelMissing);
+    }
+
+    #[test]
+    fn coded_extension_snapshots_message_and_code() {
+        let res: anyhow::Result<()> = Err(anyhow::anyhow!("boom"))
+            .context("decode error in: /Users/alice/secret.wav")
+            .coded(ErrorCode::BadAudio);
+        let err = res.unwrap_err();
+        assert_eq!(code_of(&err), ErrorCode::BadAudio);
+        let coded = err.downcast_ref::<CodedError>().expect("is CodedError");
+        assert!(coded.message.contains("decode error"));
+    }
+
+    #[test]
+    fn code_of_falls_back_to_internal_for_uncoded() {
+        let err = anyhow::anyhow!("plain error");
+        assert_eq!(code_of(&err), ErrorCode::Internal);
+    }
+
+    #[test]
+    fn report_returns_runtime_exit_code() {
+        // report() prints `error [CODE]: <msg>` to stderr and returns the
+        // process exit code, which stays 1 for any runtime failure.
+        let coded: anyhow::Result<()> =
+            Err(anyhow::anyhow!("boom")).coded(ErrorCode::TranscribeFailed);
+        assert_eq!(report(&coded.unwrap_err()), 1);
+        let plain = anyhow::anyhow!("plain");
+        assert_eq!(report(&plain), 1);
+    }
+}

--- a/rust/src/lang_id.rs
+++ b/rust/src/lang_id.rs
@@ -1,4 +1,6 @@
 use crate::audio;
+use crate::coded_bail;
+use crate::errors::{CodedContext, ErrorCode};
 use crate::models;
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -15,16 +17,21 @@ pub fn detect_audio_language(audio_path: &str) -> Result<LangDetectResult> {
     audio::ensure_audio_track(audio_path)?;
 
     if !models::is_cached(models::ModelKind::LangId) {
-        anyhow::bail!("Lang-ID model not installed. Run: kesha install");
+        coded_bail!(
+            ErrorCode::ModelMissing,
+            "Lang-ID model not installed. Run: kesha install"
+        );
     }
 
     let dir = models::model_dir(models::ModelKind::LangId);
 
     // Load ONNX session
     let mut session = ort::session::Session::builder()
-        .context("failed to create lang-id session builder")?
+        .context("failed to create lang-id session builder")
+        .coded(ErrorCode::ModelLoad)?
         .commit_from_file(dir.join("lang-id-ecapa.onnx"))
-        .context("failed to load lang-id model")?;
+        .context("failed to load lang-id model")
+        .coded(ErrorCode::ModelLoad)?;
 
     // Load labels
     let labels: Vec<String> = {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,6 +32,7 @@ pub mod backend;
 pub mod capabilities;
 pub mod cli;
 pub mod debug;
+pub mod errors;
 #[cfg(all(
     target_os = "macos",
     any(

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -6,6 +6,7 @@ mod backend;
 mod capabilities;
 mod cli;
 mod debug;
+mod errors;
 #[cfg(all(
     target_os = "macos",
     any(

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -38,6 +38,10 @@ struct Cli {
     /// Print capabilities as JSON
     #[arg(long = "capabilities-json")]
     capabilities_json: bool,
+
+    /// Print the error-code taxonomy as JSON and exit.
+    #[arg(long = "error-codes-json")]
+    error_codes_json: bool,
 }
 
 #[derive(Subcommand)]
@@ -178,6 +182,11 @@ fn main() {
             Ok(s) => println!("{s}"),
             Err(e) => std::process::exit(errors::report(&anyhow::Error::new(e))),
         }
+        return;
+    }
+
+    if cli.error_codes_json {
+        println!("{}", errors::error_codes_json());
         return;
     }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -165,7 +165,7 @@ enum Commands {
     },
 }
 
-fn main() -> Result<()> {
+fn main() {
     // Anchor the `KESHA_DEBUG=1` `+Nms` timeline before `Cli::parse()` so
     // clap parsing + env probes are counted toward the first `dtrace!`'s
     // prefix (Greptile P2 on #293). No-op when debug is off.
@@ -174,11 +174,20 @@ fn main() -> Result<()> {
 
     if cli.capabilities_json {
         let caps = capabilities::get_capabilities();
-        println!("{}", serde_json::to_string(&caps)?);
-        return Ok(());
+        match serde_json::to_string(&caps) {
+            Ok(s) => println!("{s}"),
+            Err(e) => std::process::exit(errors::report(&anyhow::Error::new(e))),
+        }
+        return;
     }
 
-    match cli.command {
+    if let Err(err) = run_command(cli.command) {
+        std::process::exit(errors::report(&err));
+    }
+}
+
+fn run_command(command: Option<Commands>) -> Result<()> {
+    match command {
         Some(Commands::Transcribe {
             audio_path,
             json,

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -3,6 +3,9 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use crate::coded_bail;
+use crate::errors::{CodedContext, ErrorCode};
+
 /// A file in a model manifest. `rel_path` is relative to `cache_dir()`,
 /// uniform across ASR / lang-id / TTS. Every entry carries a pinned
 /// SHA-256 so an upstream rehost or a compromised `KESHA_MODEL_MIRROR`
@@ -1064,7 +1067,8 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
     // fails — anyhow's context surfaces the URL through the bail.
     let response = ureq::get(&url)
         .call()
-        .with_context(|| format!("GET {url} ({})", f.rel_path))?;
+        .with_context(|| format!("GET {url} ({})", f.rel_path))
+        .coded(ErrorCode::ModelDownload)?;
     let mut reader = response.into_body().into_reader();
     let mut out =
         fs::File::create(&target).with_context(|| format!("create {}", target.display()))?;
@@ -1080,7 +1084,8 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
         // unverified weights (#174). Best-effort — errors here are masked
         // by the bail below which surfaces the real problem.
         let _ = fs::remove_file(&target);
-        anyhow::bail!(
+        coded_bail!(
+            ErrorCode::CacheCorrupt,
             "sha256 mismatch for {}: expected {} got {}",
             f.rel_path,
             f.sha256.get(..12).unwrap_or(f.sha256),

--- a/rust/src/record.rs
+++ b/rust/src/record.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 #[cfg(any(target_os = "macos", test))]
 use anyhow::Context;
-use anyhow::{bail, Result};
+use anyhow::Result;
 #[cfg(target_os = "macos")]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 #[cfg(target_os = "macos")]
@@ -58,7 +58,7 @@ pub fn record_default_input_to_wav(_path: &Path, _max_duration: Duration) -> Res
 #[cfg(target_os = "macos")]
 pub fn record_default_input_to_wav(path: &Path, max_duration: Duration) -> Result<RecordSummary> {
     if max_duration.is_zero() {
-        bail!("--max-seconds must be greater than 0");
+        anyhow::bail!("--max-seconds must be greater than 0");
     }
 
     let host = cpal::default_host();
@@ -83,7 +83,7 @@ pub fn record_default_input_to_wav(path: &Path, max_duration: Duration) -> Resul
         SampleFormat::F32 => build_input_stream::<f32>(&device, &config, sample_tx, err_fn)?,
         SampleFormat::I16 => build_input_stream::<i16>(&device, &config, sample_tx, err_fn)?,
         SampleFormat::U16 => build_input_stream::<u16>(&device, &config, sample_tx, err_fn)?,
-        other => bail!("unsupported microphone sample format: {other:?}"),
+        other => anyhow::bail!("unsupported microphone sample format: {other:?}"),
     };
 
     stream
@@ -198,7 +198,7 @@ impl FromInputSample<u16> for f32 {
 #[cfg(target_os = "macos")]
 fn ensure_input_channels(channels: u16) -> Result<()> {
     if channels == 0 {
-        bail!("microphone reported zero channels");
+        anyhow::bail!("microphone reported zero channels");
     }
     Ok(())
 }

--- a/rust/src/record.rs
+++ b/rust/src/record.rs
@@ -47,7 +47,12 @@ pub struct RecordSummary {
 
 #[cfg(not(target_os = "macos"))]
 pub fn record_default_input_to_wav(_path: &Path, _max_duration: Duration) -> Result<RecordSummary> {
-    bail!("microphone recording is currently supported on macOS only");
+    use crate::coded_bail;
+    use crate::errors::ErrorCode;
+    coded_bail!(
+        ErrorCode::UnsupportedPlatform,
+        "microphone recording is currently supported on macOS only"
+    );
 }
 
 #[cfg(target_os = "macos")]

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -4,6 +4,9 @@
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+
+use crate::coded_bail;
+use crate::errors::ErrorCode;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::mpsc;
@@ -160,10 +163,17 @@ fn run_with_timeout(
     match rx.recv_timeout(timeout) {
         Ok(result) => result,
         Err(mpsc::RecvTimeoutError::Timeout) => {
-            bail!("{}", diarize_timeout_error(timeout, audio_secs))
+            coded_bail!(
+                ErrorCode::DiarizeTimeout,
+                "{}",
+                diarize_timeout_error(timeout, audio_secs)
+            )
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
-            bail!("speaker diarization worker terminated unexpectedly")
+            coded_bail!(
+                ErrorCode::Internal,
+                "speaker diarization worker terminated unexpectedly"
+            )
         }
     }
 }

--- a/rust/src/tts/avspeech.rs
+++ b/rust/src/tts/avspeech.rs
@@ -15,6 +15,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use crate::coded_bail;
+use crate::errors::{CodedContext, ErrorCode};
 use crate::process_tree::ChildGuard;
 
 /// Path to the sidecar `say-avspeech` binary.
@@ -61,7 +63,8 @@ pub fn synthesize(text: &str, voice_id: &str, helper: Option<&Path>) -> anyhow::
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| anyhow::anyhow!("spawn {}: {e}", bin.display()))?;
+        .map_err(|e| anyhow::anyhow!("spawn {}: {e}", bin.display()))
+        .coded(ErrorCode::SidecarMissing)?;
     let mut child = ChildGuard::new(child);
 
     child
@@ -72,7 +75,8 @@ pub fn synthesize(text: &str, voice_id: &str, helper: Option<&Path>) -> anyhow::
 
     let output = child.wait_with_output()?;
     if !output.status.success() {
-        anyhow::bail!(
+        coded_bail!(
+            ErrorCode::SidecarMissing,
             "avspeech helper exited {}: {}",
             output.status,
             String::from_utf8_lossy(&output.stderr).trim()

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -48,6 +48,18 @@ pub enum TtsError {
     SynthesisFailed(String),
 }
 
+impl TtsError {
+    /// Stable taxonomy code for this synthesis failure.
+    pub fn code(&self) -> crate::errors::ErrorCode {
+        use crate::errors::ErrorCode;
+        match self {
+            TtsError::EmptyText => ErrorCode::TextEmpty,
+            TtsError::TextTooLong { .. } => ErrorCode::TextTooLong,
+            TtsError::SynthesisFailed(_) => ErrorCode::Internal,
+        }
+    }
+}
+
 /// Which TTS engine to run. Voice ids determine this via `voices::resolve_voice`.
 pub enum EngineChoice<'a> {
     /// Kokoro-82M: separate model + per-voice style embedding + rate.
@@ -92,4 +104,27 @@ pub struct SayOptions<'a> {
     /// (#232), Latin on `en-*` (#244). Default `true`. `<say-as interpret-as="characters">`
     /// is always honored regardless of this flag. No effect for `macos-*` voices.
     pub expand_abbrev: bool,
+}
+
+#[cfg(test)]
+mod code_tests {
+    use super::*;
+    use crate::errors::ErrorCode;
+
+    #[test]
+    fn tts_error_maps_to_codes() {
+        assert_eq!(TtsError::EmptyText.code(), ErrorCode::TextEmpty);
+        assert_eq!(
+            TtsError::TextTooLong {
+                max: 5000,
+                actual: 6000
+            }
+            .code(),
+            ErrorCode::TextTooLong
+        );
+        assert_eq!(
+            TtsError::SynthesisFailed("x".into()).code(),
+            ErrorCode::Internal
+        );
+    }
 }

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -46,6 +46,14 @@ pub enum TtsError {
     TextTooLong { max: usize, actual: usize },
     #[error("synthesis failed: {0}")]
     SynthesisFailed(String),
+    /// A synthesis failure that carries a precise taxonomy code recovered from
+    /// the underlying engine error (e.g. SSML parse failures preserve their
+    /// `SsmlInvalid` code instead of collapsing to `Internal`).
+    #[error("{message}")]
+    Coded {
+        code: crate::errors::ErrorCode,
+        message: String,
+    },
 }
 
 impl TtsError {
@@ -56,6 +64,7 @@ impl TtsError {
             TtsError::EmptyText => ErrorCode::TextEmpty,
             TtsError::TextTooLong { .. } => ErrorCode::TextTooLong,
             TtsError::SynthesisFailed(_) => ErrorCode::Internal,
+            TtsError::Coded { code, .. } => *code,
         }
     }
 }
@@ -125,6 +134,14 @@ mod code_tests {
         assert_eq!(
             TtsError::SynthesisFailed("x".into()).code(),
             ErrorCode::Internal
+        );
+        assert_eq!(
+            TtsError::Coded {
+                code: ErrorCode::SsmlInvalid,
+                message: "ssml: bad".into()
+            }
+            .code(),
+            ErrorCode::SsmlInvalid
         );
     }
 }

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -122,9 +122,10 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
     #[cfg(all(feature = "system_tts", target_os = "macos"))]
     if let EngineChoice::AVSpeech { voice_id } = &opts.engine {
         if opts.ssml {
-            return Err(TtsError::SynthesisFailed(
-                "SSML is not yet supported with macos-* voices (#141 follow-up)".into(),
-            ));
+            return Err(TtsError::Coded {
+                code: crate::errors::ErrorCode::SsmlUnsupported,
+                message: "SSML is not yet supported with macos-* voices (#141 follow-up)".into(),
+            });
         }
         let wav_bytes = avspeech::synthesize(opts.text, voice_id, None)
             .map_err(|e| TtsError::SynthesisFailed(format!("avspeech: {e}")))?;
@@ -220,8 +221,10 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
 /// SSML path: parse, then synthesize each text segment through the engine (loaded once),
 /// interleaving silence for `<break>` segments. Concatenate the f32 samples and wrap as WAV.
 fn say_ssml(opts: &SayOptions) -> Result<Vec<u8>, TtsError> {
-    let segments =
-        ssml::parse(opts.text).map_err(|e| TtsError::SynthesisFailed(format!("ssml: {e}")))?;
+    let segments = ssml::parse(opts.text).map_err(|e| TtsError::Coded {
+        code: crate::errors::code_of(&e),
+        message: format!("ssml: {e:#}"),
+    })?;
     if segments.is_empty() {
         return Err(TtsError::SynthesisFailed(
             "SSML had no speakable content".into(),
@@ -386,8 +389,10 @@ fn synth_segments_fluid_kokoro(
     speed: f32,
     format: OutputFormat,
 ) -> Result<Vec<u8>, TtsError> {
-    let segments =
-        ssml::parse(text).map_err(|e| TtsError::SynthesisFailed(format!("ssml: {e}")))?;
+    let segments = ssml::parse(text).map_err(|e| TtsError::Coded {
+        code: crate::errors::code_of(&e),
+        message: format!("ssml: {e:#}"),
+    })?;
     if segments.is_empty() {
         return Err(TtsError::SynthesisFailed(
             "SSML had no speakable content".into(),
@@ -545,8 +550,10 @@ fn synth_segments_vosk(
     format: OutputFormat,
     expand_abbrev: bool,
 ) -> Result<Vec<u8>, TtsError> {
-    let segments =
-        ssml::parse(text).map_err(|e| TtsError::SynthesisFailed(format!("ssml: {e}")))?;
+    let segments = ssml::parse(text).map_err(|e| TtsError::Coded {
+        code: crate::errors::code_of(&e),
+        message: format!("ssml: {e:#}"),
+    })?;
     if segments.is_empty() {
         return Err(TtsError::SynthesisFailed(
             "SSML had no speakable content".into(),

--- a/rust/src/tts/ssml/mod.rs
+++ b/rust/src/tts/ssml/mod.rs
@@ -23,6 +23,9 @@ mod warnings;
 use ssml_parser::elements::{EmphasisLevel, ParsedElement, PhonemeAlphabet};
 use ssml_parser::parse_ssml;
 
+use crate::coded_bail;
+use crate::errors::ErrorCode;
+
 pub use segment::Segment;
 
 use super::warn::warn_once;
@@ -40,10 +43,11 @@ use warnings::{WARN_PROSODY_MID_UTTERANCE, WARN_PROSODY_NO_SUPPORTED_ATTR};
 pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
     let trimmed = input.trim_start();
     if trimmed.is_empty() {
-        anyhow::bail!("SSML input is empty");
+        coded_bail!(ErrorCode::SsmlInvalid, "SSML input is empty");
     }
     if !trimmed.starts_with("<speak") {
-        anyhow::bail!(
+        coded_bail!(
+            ErrorCode::SsmlInvalid,
             "SSML must start with a <speak> element (got '{}...')",
             &trimmed.chars().take(20).collect::<String>()
         );
@@ -53,7 +57,10 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
     // expand external entities. Input length is already bounded upstream
     // (`MAX_TEXT_CHARS`), so a full scan is cheap.
     if contains_doctype(trimmed) {
-        anyhow::bail!("SSML DOCTYPE declarations are not supported");
+        coded_bail!(
+            ErrorCode::SsmlInvalid,
+            "SSML DOCTYPE declarations are not supported"
+        );
     }
     // Reject relative-percent rate values (`+N%` / `-N%`) before handing off
     // to `ssml-parser`. The upstream crate strips the `+` sign during parse
@@ -64,7 +71,8 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
     // percentage not allowed for rate" message. Tracked as a v2 follow-up
     // on #236.
     if let Some(rel) = find_relative_rate(trimmed) {
-        anyhow::bail!(
+        coded_bail!(
+            ErrorCode::SsmlInvalid,
             "SSML <prosody rate=\"{rel}\"> uses a relative percentage; \
              this is not yet supported. Use an absolute percentage (e.g. \
              \"125%\") or a named value (\"x-slow\"/\"slow\"/\"medium\"/\

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -5,6 +5,9 @@
 
 use std::path::Path;
 
+use crate::coded_bail;
+use crate::errors::ErrorCode;
+
 pub const VOICE_ROWS: usize = 510;
 /// Dimensions per row (voice embedding width).
 pub const VOICE_COLS: usize = 256;
@@ -148,10 +151,14 @@ fn resolve_kokoro(_cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Resu
             .join("models/kokoro-82m/voices")
             .join(format!("{name}.bin"));
         if !voice_path.exists() {
-            anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+            coded_bail!(
+                ErrorCode::ModelMissing,
+                "voice '{voice_id}' not installed. run: kesha install --tts"
+            );
         }
         if !model_path.exists() {
-            anyhow::bail!(
+            coded_bail!(
+                ErrorCode::ModelMissing,
                 "kokoro model not installed at {}. run: kesha install --tts",
                 model_path.display()
             );
@@ -175,14 +182,18 @@ fn resolve_vosk_ru(
         "f03" => 2,
         "m01" => 3,
         "m02" => 4,
-        _ => anyhow::bail!(
+        _ => coded_bail!(
+            ErrorCode::VoiceUnknown,
             "unknown Russian voice '{voice_id}'. valid: ru-vosk-f01, ru-vosk-f02, \
              ru-vosk-f03, ru-vosk-m01, ru-vosk-m02"
         ),
     };
     let model_dir = crate::models::model_dir_at(crate::models::ModelKind::VoskRu, cache_dir);
     if !crate::models::is_cached_in(crate::models::ModelKind::VoskRu, &model_dir) {
-        anyhow::bail!("voice '{voice_id}' not installed. run: kesha install --tts");
+        coded_bail!(
+            ErrorCode::ModelMissing,
+            "voice '{voice_id}' not installed. run: kesha install --tts"
+        );
     }
     Ok(ResolvedVoice::Vosk {
         model_dir,

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -97,9 +97,12 @@ impl ResolvedVoice {
 /// Voice id is `<lang>-<name>`; lang picks the engine and espeak language code.
 /// The special `macos-*` prefix routes to AVSpeechSynthesizer on supported builds.
 pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<ResolvedVoice> {
-    let (lang, name) = voice_id.split_once('-').ok_or_else(|| {
-        anyhow::anyhow!("voice id must be in 'lang-name' form (got '{voice_id}')")
-    })?;
+    let Some((lang, name)) = voice_id.split_once('-') else {
+        coded_bail!(
+            ErrorCode::VoiceUnknown,
+            "voice id must be in 'lang-name' form (got '{voice_id}')"
+        );
+    };
     match lang {
         "en" => resolve_kokoro(cache_dir, voice_id, name),
         "ru" => {
@@ -109,7 +112,8 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         "macos" => {
             if name.is_empty() {
-                anyhow::bail!(
+                coded_bail!(
+                    ErrorCode::VoiceUnknown,
                     "'macos-' voice id requires a suffix (identifier or language code, e.g. macos-en-US)"
                 );
             }
@@ -118,11 +122,15 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
             })
         }
         #[cfg(not(all(feature = "system_tts", target_os = "macos")))]
-        "macos" => anyhow::bail!(
+        "macos" => coded_bail!(
+            ErrorCode::UnsupportedPlatform,
             "'macos-*' voices require a macOS build with --features system_tts (got '{voice_id}')"
         ),
         other => {
-            anyhow::bail!("language '{other}' not supported (use 'en-*', 'ru-*', or 'macos-*')")
+            coded_bail!(
+                ErrorCode::VoiceUnknown,
+                "language '{other}' not supported (use 'en-*', 'ru-*', or 'macos-*')"
+            )
         }
     }
 }
@@ -135,7 +143,8 @@ fn resolve_kokoro(_cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Resu
     ))]
     {
         if !crate::tts::fluid_kokoro::supports_voice(name) {
-            anyhow::bail!(
+            coded_bail!(
+                ErrorCode::VoiceUnknown,
                 "unknown FluidAudio Kokoro voice '{voice_id}'. run: kesha say --list-voices"
             );
         }
@@ -351,10 +360,10 @@ mod tests {
     #[test]
     fn resolve_macos_voice_errors_without_feature() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = resolve_voice(tmp.path(), "macos-en-US")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("system_tts"), "msg: {err}");
+        let err = resolve_voice(tmp.path(), "macos-en-US").unwrap_err();
+        assert!(err.to_string().contains("system_tts"), "msg: {err}");
+        // Missing the macOS feature is a platform failure, not an unknown voice.
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::UnsupportedPlatform);
     }
 
     fn populate_vosk_ru(cache: &Path) {
@@ -447,6 +456,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let err = resolve_voice(tmp.path(), "gibberish").unwrap_err();
         assert!(err.to_string().contains("lang-name"));
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::VoiceUnknown);
     }
 
     #[test]
@@ -454,5 +464,6 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let err = resolve_voice(tmp.path(), "fr-something").unwrap_err();
         assert!(err.to_string().contains("not supported"), "msg: {err}");
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::VoiceUnknown);
     }
 }

--- a/rust/tests/error_codes_cli.rs
+++ b/rust/tests/error_codes_cli.rs
@@ -1,0 +1,21 @@
+//! CLI-level assertions that failures print `error [CODE]:` on stderr.
+use std::process::Command;
+
+fn engine_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_kesha-engine")
+        .unwrap_or_else(|_| "target/release/kesha-engine".to_string())
+}
+
+#[test]
+fn transcribe_missing_file_prints_coded_error() {
+    let out = Command::new(engine_bin())
+        .args(["transcribe", "/nonexistent/path/audio.wav"])
+        .output()
+        .expect("spawn engine");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "should exit nonzero");
+    assert!(
+        stderr.contains("error [E_"),
+        "stderr should carry a coded line, got: {stderr}"
+    );
+}

--- a/rust/tests/error_codes_docs.rs
+++ b/rust/tests/error_codes_docs.rs
@@ -1,0 +1,15 @@
+//! Every engine ErrorCode must be documented in docs/errors.md.
+use kesha_engine::errors::ErrorCode;
+
+#[test]
+fn every_code_is_documented() {
+    let doc = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../docs/errors.md"))
+        .expect("read docs/errors.md");
+    for c in ErrorCode::ALL {
+        assert!(
+            doc.contains(c.as_str()),
+            "{} is not documented in docs/errors.md",
+            c.as_str()
+        );
+    }
+}

--- a/rust/tests/tts_e2e.rs
+++ b/rust/tests/tts_e2e.rs
@@ -7,6 +7,7 @@ mod common;
 
 use std::path::Path;
 
+use kesha_engine::errors::ErrorCode;
 use kesha_engine::tts::{self, EngineChoice, OutputFormat, SayOptions, TtsError};
 
 #[test]
@@ -114,5 +115,13 @@ fn ssml_input_without_speak_root_errors() {
         format: OutputFormat::Wav,
         expand_abbrev: true,
     });
-    assert!(matches!(res, Err(TtsError::SynthesisFailed(_))));
+    // A malformed SSML body now preserves the engine's SsmlInvalid code via
+    // TtsError::Coded instead of collapsing into the generic SynthesisFailed.
+    assert!(matches!(
+        res,
+        Err(TtsError::Coded {
+            code: ErrorCode::SsmlInvalid,
+            ..
+        })
+    ));
 }

--- a/src/__tests__/error-codes-drift.test.ts
+++ b/src/__tests__/error-codes-drift.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { KNOWN_TS_CODES } from "../error-codes";
+
+const ENGINE_BIN =
+  process.env.KESHA_ENGINE_BIN ?? join(import.meta.dir, "../../rust/target/release/kesha-engine");
+
+const describeOrSkip = existsSync(ENGINE_BIN) ? describe : describe.skip;
+
+describeOrSkip("error-code drift", () => {
+  test("engine codes ∪ TS-native codes == codes documented in docs/errors.md", () => {
+    const res = spawnSync(ENGINE_BIN, ["--error-codes-json"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    const engineCodes: string[] = JSON.parse(res.stdout).map((e: { code: string }) => e.code);
+
+    const known = new Set<string>([...engineCodes, ...KNOWN_TS_CODES]);
+
+    const doc = readFileSync(join(import.meta.dir, "../../docs/errors.md"), "utf8");
+    const documented = new Set<string>();
+    for (const m of doc.matchAll(/`(E_[A-Z0-9_]+)`/g)) documented.add(m[1]);
+
+    // every known code is documented
+    for (const c of known) expect(documented.has(c)).toBe(true);
+    // every documented code is known (no stale doc rows)
+    for (const c of documented) expect(known.has(c)).toBe(true);
+  });
+});

--- a/src/__tests__/error-codes.test.ts
+++ b/src/__tests__/error-codes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { extractEngineErrorCode, TS_NATIVE_CODES, KNOWN_TS_CODES } from "../error-codes";
+
+describe("extractEngineErrorCode", () => {
+  test("extracts the code from a coded engine stderr line", () => {
+    const stderr = "error [E_MODEL_MISSING]: voice 'ru-vosk-m02' not installed. run: kesha install --tts";
+    expect(extractEngineErrorCode(stderr)).toBe("E_MODEL_MISSING");
+  });
+
+  test("extracts even when the message embeds a path or token", () => {
+    const stderr = "warning: foo\nerror [E_BAD_AUDIO]: decode error in: /Users/alice/secret-token-abc.wav";
+    expect(extractEngineErrorCode(stderr)).toBe("E_BAD_AUDIO");
+  });
+
+  test("returns undefined for an uncoded stderr so caller can fall back", () => {
+    expect(extractEngineErrorCode("Error: something went wrong")).toBeUndefined();
+  });
+
+  test("TS-native codes are exposed and included in KNOWN_TS_CODES", () => {
+    expect(TS_NATIVE_CODES.INPUT_NOT_FOUND).toBe("E_INPUT_NOT_FOUND");
+    expect(TS_NATIVE_CODES.ENGINE_SPAWN).toBe("E_ENGINE_SPAWN");
+    expect(TS_NATIVE_CODES.INVALID_ARG).toBe("E_INVALID_ARG");
+    expect(KNOWN_TS_CODES.has("E_INTERNAL")).toBe(true);
+  });
+});

--- a/src/__tests__/stats-error-codes.test.ts
+++ b/src/__tests__/stats-error-codes.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { SayError } from "../synth";
+
+describe("SayError carries a taxonomy code", () => {
+  test("pre-check throws carry text codes", () => {
+    const e = new SayError("text is empty", 2, "", "E_TEXT_EMPTY");
+    expect(e.code).toBe("E_TEXT_EMPTY");
+    expect(e.exitCode).toBe(2);
+  });
+  test("defaults to E_INTERNAL when unspecified", () => {
+    const e = new SayError("boom", 4, "");
+    expect(e.code).toBe("E_INTERNAL");
+  });
+});

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -20,7 +20,7 @@ import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../proces
 import type { TranscriptionSegment } from "../types";
 import { createDiagnosticLogSession } from "../diagnostic-log";
 import { diagnosticSizeBucket } from "../diagnostic-events";
-import { extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";
+import { ENGINE_CODES, extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";
 
 interface MainCommandArgs {
   _: string[];
@@ -409,7 +409,7 @@ export const mainCommand = defineCommand({
         progress?.stop();
         hasError = true;
         const stderrText = err instanceof Error ? err.message : String(err);
-        const code = extractEngineErrorCode(stderrText) ?? "E_TRANSCRIBE_FAILED";
+        const code = extractEngineErrorCode(stderrText) ?? ENGINE_CODES.TRANSCRIBE_FAILED;
         stats.recordError("transcribe", err, code);
         diagnosticLog.event("engine.exit", {
           command: "transcribe",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -20,6 +20,28 @@ import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../proces
 import type { TranscriptionSegment } from "../types";
 import { createDiagnosticLogSession } from "../diagnostic-log";
 import { diagnosticSizeBucket } from "../diagnostic-events";
+import { extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";
+
+/**
+ * The taxonomy codes the transcribe path can surface in `errors[].code`.
+ * Mirrors the widened union in `TranscribeErrorRecord` (src/types.ts). Any
+ * other engine code extracted from stderr collapses to E_TRANSCRIBE_FAILED
+ * so the pushed value is always a valid union member (no `any` cast).
+ */
+const TRANSCRIBE_ERROR_CODES = [
+  "E_INPUT_NOT_FOUND",
+  "E_TRANSCRIBE_FAILED",
+  "E_BAD_AUDIO",
+  "E_INTERNAL",
+] as const;
+
+type TranscribeErrorCode = (typeof TRANSCRIBE_ERROR_CODES)[number];
+
+function toTranscribeErrorCode(code: string): TranscribeErrorCode {
+  return (TRANSCRIBE_ERROR_CODES as readonly string[]).includes(code)
+    ? (code as TranscribeErrorCode)
+    : "E_TRANSCRIBE_FAILED";
+}
 
 interface MainCommandArgs {
   _: string[];
@@ -301,9 +323,12 @@ export const mainCommand = defineCommand({
     for (const file of files) {
       if (!existsSync(file)) {
         hasError = true;
-        stats.recordError("input", new Error("File not found"), "file_not_found");
-        diagnosticLog.event("input.missing", { command: "transcribe" });
-        errors.push({ file, code: "file_not_found", message: "File not found" });
+        stats.recordError("input", new Error("File not found"), TS_NATIVE_CODES.INPUT_NOT_FOUND);
+        diagnosticLog.event("input.missing", {
+          command: "transcribe",
+          error_code: TS_NATIVE_CODES.INPUT_NOT_FOUND,
+        });
+        errors.push({ file, code: TS_NATIVE_CODES.INPUT_NOT_FOUND, message: "File not found" });
         log.error(`${file}: File not found`);
         continue;
       }
@@ -404,14 +429,17 @@ export const mainCommand = defineCommand({
       } catch (err: unknown) {
         progress?.stop();
         hasError = true;
-        stats.recordError("transcribe", err);
+        const stderrText = err instanceof Error ? err.message : String(err);
+        const code = extractEngineErrorCode(stderrText) ?? "E_TRANSCRIBE_FAILED";
+        stats.recordError("transcribe", err, code);
         diagnosticLog.event("engine.exit", {
           command: "transcribe",
           status: "failed",
           errorKind: "transcribe_failed",
+          error_code: code,
         });
-        const message = err instanceof Error ? err.message : String(err);
-        errors.push({ file, code: "transcribe_failed", message });
+        const message = stderrText;
+        errors.push({ file, code: toTranscribeErrorCode(code), message });
         log.error(`${file}: ${message}`);
       }
     }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -22,27 +22,6 @@ import { createDiagnosticLogSession } from "../diagnostic-log";
 import { diagnosticSizeBucket } from "../diagnostic-events";
 import { extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";
 
-/**
- * The taxonomy codes the transcribe path can surface in `errors[].code`.
- * Mirrors the widened union in `TranscribeErrorRecord` (src/types.ts). Any
- * other engine code extracted from stderr collapses to E_TRANSCRIBE_FAILED
- * so the pushed value is always a valid union member (no `any` cast).
- */
-const TRANSCRIBE_ERROR_CODES = [
-  "E_INPUT_NOT_FOUND",
-  "E_TRANSCRIBE_FAILED",
-  "E_BAD_AUDIO",
-  "E_INTERNAL",
-] as const;
-
-type TranscribeErrorCode = (typeof TRANSCRIBE_ERROR_CODES)[number];
-
-function toTranscribeErrorCode(code: string): TranscribeErrorCode {
-  return (TRANSCRIBE_ERROR_CODES as readonly string[]).includes(code)
-    ? (code as TranscribeErrorCode)
-    : "E_TRANSCRIBE_FAILED";
-}
-
 interface MainCommandArgs {
   _: string[];
   json: boolean;
@@ -439,7 +418,7 @@ export const mainCommand = defineCommand({
           error_code: code,
         });
         const message = stderrText;
-        errors.push({ file, code: toTranscribeErrorCode(code), message });
+        errors.push({ file, code, message });
         log.error(`${file}: ${message}`);
       }
     }

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -250,13 +250,15 @@ export const sayCommand = defineCommand({
       stats.finish("success", 1);
       diagnosticLog.finish("success");
     } catch (err) {
-      stats.recordError("tts", err);
+      const code = err instanceof SayError ? err.code : "E_INTERNAL";
+      stats.recordError("tts", err, code);
       stats.finish("failed", 1);
       diagnosticLog.event("command.finish", {
         command: "say",
         status: "failed",
         errorKind: err instanceof SayError ? "say_error" : "error",
         exitCode: err instanceof SayError ? err.exitCode : 4,
+        error_code: code,
       });
       diagnosticLog.finish("failed");
       if (err instanceof SayError) {

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -1,0 +1,33 @@
+/**
+ * Error-code taxonomy bridge. The engine is the source of truth for engine
+ * codes (see `kesha-engine --error-codes-json`); these are the codes that
+ * originate in TS, before/around the engine. See
+ * `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`.
+ */
+
+/** Matches the engine's `error [CODE]:` line; CODE charset is constrained. */
+const ENGINE_CODE_RE = /^error \[([A-Z0-9_]+)\]:/m;
+
+/** Extract the engine error code from captured stderr, if present. */
+export function extractEngineErrorCode(stderr: string): string | undefined {
+  const m = stderr.match(ENGINE_CODE_RE);
+  return m ? m[1] : undefined;
+}
+
+/** Codes that originate in TS (engine never ran, or isn't the failing party). */
+export const TS_NATIVE_CODES = {
+  INPUT_NOT_FOUND: "E_INPUT_NOT_FOUND",
+  ENGINE_SPAWN: "E_ENGINE_SPAWN",
+  INVALID_ARG: "E_INVALID_ARG",
+  INTERNAL: "E_INTERNAL",
+} as const;
+
+export type TsNativeCode = (typeof TS_NATIVE_CODES)[keyof typeof TS_NATIVE_CODES];
+
+/** The full set of TS-native codes, for the drift test. */
+export const KNOWN_TS_CODES: ReadonlySet<string> = new Set(Object.values(TS_NATIVE_CODES));
+
+/** Resolve a code from engine stderr, falling back to E_INTERNAL. */
+export function engineErrorCode(stderr: string): string {
+  return extractEngineErrorCode(stderr) ?? TS_NATIVE_CODES.INTERNAL;
+}

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -24,6 +24,17 @@ export const TS_NATIVE_CODES = {
 
 export type TsNativeCode = (typeof TS_NATIVE_CODES)[keyof typeof TS_NATIVE_CODES];
 
+/**
+ * Engine-owned codes the TS CLI also references by name (e.g. as a fallback
+ * when the engine died without printing an `error [CODE]:` line). These are NOT
+ * TS-native — the engine is the source of truth — so they stay out of
+ * {@link KNOWN_TS_CODES} and the drift test. Named here to avoid bare string
+ * literals scattered through the CLI.
+ */
+export const ENGINE_CODES = {
+  TRANSCRIBE_FAILED: "E_TRANSCRIBE_FAILED",
+} as const;
+
 /** The full set of TS-native codes, for the drift test. */
 export const KNOWN_TS_CODES: ReadonlySet<string> = new Set(Object.values(TS_NATIVE_CODES));
 

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -129,7 +129,7 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
       `kesha-engine not installed. run: ${installHint("--tts")}`,
       1,
       "",
-      TS_NATIVE_CODES.INVALID_ARG,
+      TS_NATIVE_CODES.ENGINE_SPAWN,
     );
   }
   const capabilities = opts.noExpandAbbrev ? await getEngineCapabilities() : null;

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -5,6 +5,7 @@ import {
   spawnStdioWithDebugFd,
   type EngineCapabilities,
 } from "./engine";
+import { engineErrorCode, TS_NATIVE_CODES } from "./error-codes";
 import { installHint } from "./install-hint";
 import { log } from "./log";
 import { registerProcessTree } from "./process-tree";
@@ -97,6 +98,7 @@ export class SayError extends Error {
     message: string,
     public readonly exitCode: number,
     public readonly stderr: string,
+    public readonly code: string = "E_INTERNAL",
   ) {
     super(message);
     this.name = "SayError";
@@ -110,11 +112,16 @@ export class SayError extends Error {
 export async function say(opts: SayOptions): Promise<Uint8Array> {
   const text = opts.text ?? "";
   if (text.length === 0) {
-    throw new SayError("text is empty", 2, "");
+    throw new SayError("text is empty", 2, "", "E_TEXT_EMPTY");
   }
   const chars = Array.from(text).length;
   if (chars > MAX_TEXT_CHARS) {
-    throw new SayError(`text exceeds ${MAX_TEXT_CHARS} chars (${chars})`, 5, "");
+    throw new SayError(
+      `text exceeds ${MAX_TEXT_CHARS} chars (${chars})`,
+      5,
+      "",
+      "E_TEXT_TOO_LONG",
+    );
   }
 
   if (!isEngineInstalled()) {
@@ -122,6 +129,7 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
       `kesha-engine not installed. run: ${installHint("--tts")}`,
       1,
       "",
+      TS_NATIVE_CODES.INVALID_ARG,
     );
   }
   const capabilities = opts.noExpandAbbrev ? await getEngineCapabilities() : null;
@@ -176,6 +184,7 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
       stderrText.trim() || `kesha-engine say exited ${exitCode}`,
       exitCode,
       stderrText,
+      engineErrorCode(stderrText),
     );
   }
   return new Uint8Array(stdoutBuf);

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export type TranscribeResult = {
 
 export type TranscribeErrorRecord = {
   file: string;
-  code: "file_not_found" | "transcribe_failed";
+  code: "E_INPUT_NOT_FOUND" | "E_TRANSCRIBE_FAILED" | "E_BAD_AUDIO" | "E_INTERNAL";
   message: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,13 @@ export type TranscribeResult = {
 
 export type TranscribeErrorRecord = {
   file: string;
-  code: "E_INPUT_NOT_FOUND" | "E_TRANSCRIBE_FAILED" | "E_BAD_AUDIO" | "E_INTERNAL";
+  /**
+   * Taxonomy error code. The canonical set lives in Rust and is documented in
+   * `docs/errors.md`; we type it as `string` so the precise engine code (e.g.
+   * `E_DIARIZE_TIMEOUT`, `E_MODEL_MISSING`) flows through to `--include-errors`
+   * output instead of being collapsed to a narrow union.
+   */
+  code: string;
   message: string;
 };
 

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -761,7 +761,21 @@ describe("CLI contracts", () => {
       KESHA_ENGINE_BIN: enginePath,
     };
 
-    const plan = await runCli(["install", "--plan", "--tts"], { env });
+    // These six commands are read-only and observe the pristine initial state
+    // (no stats run recorded yet; diagnostic logs at defaults). They don't
+    // mutate state or depend on each other, so run them concurrently to keep
+    // this spawn-heavy contract test well under its timeout even when the
+    // sibling model-download e2e tests saturate the runner. Everything from
+    // `logs enable` onward mutates state and stays sequential.
+    const [plan, initPlan, status, logsStatus, logsStatusJson, logsEnableJson] = await Promise.all([
+      runCli(["install", "--plan", "--tts"], { env }),
+      runCli(["init", "--plan", "--tts", "--vad"], { env }),
+      runCli(["stats", "status"], { env }),
+      runCli(["logs", "status"], { env }),
+      runCli(["logs", "status", "--json"], { env }),
+      runCli(["logs", "enable", "--json"], { env }),
+    ]);
+
     expect(plan.envDiff.overrides.KESHA_ENGINE_BIN).toBe(enginePath);
     expectContract(plan, {
       exitCode: 0,
@@ -773,7 +787,6 @@ describe("CLI contracts", () => {
       stderrNotContains: ["fake engine should not have been invoked"],
     });
 
-    const initPlan = await runCli(["init", "--plan", "--tts", "--vad"], { env });
     expectContract(initPlan, {
       exitCode: 0,
       stdoutContains: [
@@ -785,14 +798,12 @@ describe("CLI contracts", () => {
       stderrNotContains: ["fake engine should not have been invoked"],
     });
 
-    const status = await runCli(["stats", "status"], { env });
     expectContract(status, {
       exitCode: 0,
       stdoutContains: ["Kesha Stats: disabled", `Database: ${env.KESHA_STATS_DB}`, "Runs: 0", "Retention: 90 day(s)"],
       stderrEmpty: true,
     });
 
-    const logsStatus = await runCli(["logs", "status"], { env });
     expectContract(logsStatus, {
       exitCode: 0,
       stdoutContains: [
@@ -804,7 +815,6 @@ describe("CLI contracts", () => {
       stderrEmpty: true,
     });
 
-    const logsStatusJson = await runCli(["logs", "status", "--json"], { env });
     expectContract(logsStatusJson, {
       exitCode: 0,
       stderrEmpty: true,
@@ -823,7 +833,6 @@ describe("CLI contracts", () => {
       retain: 5,
     });
 
-    const logsEnableJson = await runCli(["logs", "enable", "--json"], { env });
     expectContract(logsEnableJson, {
       exitCode: 2,
       stdoutEmpty: true,
@@ -929,5 +938,7 @@ describe("CLI contracts", () => {
       stdoutContains: ["Kesha Stats reset:", "run(s)"],
       stderrEmpty: true,
     });
-  });
+    // ~20 sequential CLI spawns; the default 5s bun timeout is too tight when
+    // this runs alongside the model-download e2e tests in the same job.
+  }, 30000);
 });

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -410,6 +410,41 @@ describe("CLI contracts", () => {
     ]);
   });
 
+  test("--json --include-errors preserves the engine's precise coded error (no collapse)", async () => {
+    const dir = makeTempDir("kesha-cli-contract-coded-error-");
+    const enginePath = createFakeEngine(dir);
+    const mediaPath = join(dir, "workshop.mp4");
+    writeFileSync(mediaPath, "fake media");
+    // Engine stderr carries a real `error [CODE]:` line; the CLI must surface
+    // that exact code in errors[].code rather than flattening it to
+    // E_TRANSCRIBE_FAILED. E_DIARIZE_TIMEOUT is retryable — losing it would
+    // discard real signal from the one user-facing structured output.
+    const codedError =
+      "error [E_DIARIZE_TIMEOUT]: speaker diarization timed out after 30s for 4s of audio";
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+      KESHA_FAKE_TRANSCRIBE_ERROR: codedError,
+    };
+    installFakeDiarizeModel(env.KESHA_CACHE_DIR);
+
+    const run = await runCli(["--json", "--include-errors", "--speakers", mediaPath], { env });
+
+    expectContract(run, {
+      exitCode: 1,
+      stdoutNotContains: ["Transcribing"],
+    });
+    const parsed = JSON.parse(run.stdout);
+    expect(parsed.results).toEqual([]);
+    expect(parsed.errors).toEqual([
+      {
+        file: mediaPath,
+        code: "E_DIARIZE_TIMEOUT",
+        message: codedError,
+      },
+    ]);
+  });
+
   test("successful machine-readable output keeps progress off stdout", async () => {
     const dir = makeTempDir("kesha-cli-contract-success-");
     const enginePath = createFakeEngine(dir);

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -371,7 +371,7 @@ describe("CLI contracts", () => {
     expect(parsed.results).toHaveLength(1);
     expect(parsed.results[0].file).toBe(mediaPath);
     expect(parsed.errors).toEqual([
-      { file: "missing.wav", code: "file_not_found", message: "File not found" },
+      { file: "missing.wav", code: "E_INPUT_NOT_FOUND", message: "File not found" },
     ]);
   });
 
@@ -404,7 +404,7 @@ describe("CLI contracts", () => {
     expect(parsed.errors).toEqual([
       {
         file: mediaPath,
-        code: "transcribe_failed",
+        code: "E_TRANSCRIBE_FAILED",
         message: diarizeError,
       },
     ]);
@@ -853,7 +853,7 @@ describe("CLI contracts", () => {
     const errors = await runCli(["stats", "errors"], { env });
     expectContract(errors, {
       exitCode: 0,
-      stdoutContains: ["file_not_found"],
+      stdoutContains: ["E_INPUT_NOT_FOUND"],
       stdoutNotContains: ["private-recording.wav"],
       stderrEmpty: true,
     });

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -274,8 +274,8 @@ describe("e2e-cli", () => {
     expect(JSON.parse(stdout)).toEqual({
       results: [],
       errors: [
-        { file: "a.wav", code: "file_not_found", message: "File not found" },
-        { file: "b.wav", code: "file_not_found", message: "File not found" },
+        { file: "a.wav", code: "E_INPUT_NOT_FOUND", message: "File not found" },
+        { file: "b.wav", code: "E_INPUT_NOT_FOUND", message: "File not found" },
       ],
     });
   });
@@ -307,7 +307,7 @@ describe("e2e-cli", () => {
     expect(parsed.results[0].file).toBe(mediaPath);
     expect(parsed.results[0].text).toContain("Привет с воркшопа");
     expect(parsed.errors).toEqual([
-      { file: "missing.wav", code: "file_not_found", message: "File not found" },
+      { file: "missing.wav", code: "E_INPUT_NOT_FOUND", message: "File not found" },
     ]);
   });
 
@@ -403,7 +403,7 @@ describe("e2e-cli", () => {
 
     const errors = await runCli(["stats", "errors"], { env });
     expect(errors.exitCode).toBe(0);
-    expect(errors.stdout).toContain("file_not_found");
+    expect(errors.stdout).toContain("E_INPUT_NOT_FOUND");
     expect(errors.stdout).not.toContain("missing-private-name.wav");
 
     const db = new Database(dbPath, { readonly: true });

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -434,11 +434,11 @@ describe("output formatting", () => {
   test("JSON output can opt into structured file errors (#324 P1)", () => {
     const output = formatJsonOutput(
       [{ file: "ok.ogg", text: "Hello", lang: "en" }],
-      [{ file: "missing.ogg", code: "file_not_found", message: "File not found" }],
+      [{ file: "missing.ogg", code: "E_INPUT_NOT_FOUND", message: "File not found" }],
     );
     expect(JSON.parse(output)).toEqual({
       results: [{ file: "ok.ogg", text: "Hello", lang: "en" }],
-      errors: [{ file: "missing.ogg", code: "file_not_found", message: "File not found" }],
+      errors: [{ file: "missing.ogg", code: "E_INPUT_NOT_FOUND", message: "File not found" }],
     });
   });
 


### PR DESCRIPTION
## What

Implements the structured error-code taxonomy epic: every user-facing failure now emits a **stable, documented, user-visible code** on stderr (`error [E_MODEL_MISSING]: …`), recorded as the leak-free primary signal in Stats and diagnostic logs.

Closes #462. Refs #344 (item 9), #345 (item 17).

## Release note

This adds engine-side changes (new `--error-codes-json` capability, `error [CODE]:` output contract) but is kept **version-neutral** so CI's `integration-tests` runs against the current released engine (the new TS degrades gracefully — engine codes simply aren't present until the engine ships). **Follow-up: a `chore(release): 1.22.0` engine release** bumps `rust/Cargo.toml` + `Cargo.lock` + `package.json` `version`/`keshaEngine.version` together, tags `v1.22.0`, and makes the new engine behavior live. `errors[].code` values in `--include-errors` JSON change from `file_not_found`/`transcribe_failed` to the `E_*` taxonomy (call out in the release notes).

## Approach

- **Engine-origin + hybrid.** The Rust engine defines a canonical `ErrorCode` enum and prints `error [CODE]: <message>` via a top-level chain-walking `report()`. TS extracts the code with an anchored regex (unambiguous even when the message embeds a path/token) and owns codes for failures before/around the engine (`E_ENGINE_SPAWN`, plus `E_INVALID_ARG`/`E_INPUT_NOT_FOUND` shared with the engine).
- **Leak-free by construction.** The code is the stable signal for Stats + diagnostic logs; the human message is still sanitized, but support/analytics no longer depend on regex redaction being complete.
- **Unified.** One taxonomy across the Rust `anyhow`/`TtsError`/`say` paths, the TS engine-error path, `SayError`, and the `errors[].code` JSON field (carries the precise code — no collapsing).

## Codes (18 engine + `E_ENGINE_SPAWN` = 19)

`E_INPUT_NOT_FOUND`, `E_BAD_AUDIO`, `E_MODEL_MISSING`, `E_MODEL_DOWNLOAD`, `E_CACHE_CORRUPT`, `E_MODEL_LOAD`, `E_UNSUPPORTED_PLATFORM`, `E_SIDECAR_MISSING`, `E_NO_BACKEND`, `E_TEXT_EMPTY`, `E_TEXT_TOO_LONG`, `E_VOICE_UNKNOWN`, `E_SSML_INVALID`, `E_SSML_UNSUPPORTED`, `E_TRANSCRIBE_FAILED`, `E_DIARIZE_TIMEOUT`, `E_INVALID_ARG`, `E_INTERNAL` (engine) + `E_ENGINE_SPAWN` (TS). Full reference: `docs/errors.md`.

## Highlights

- `kesha-engine --error-codes-json` introspection.
- **Drift gates:** a Rust test asserts every `ErrorCode` is documented; a TS test asserts `engine ∪ TS-native == documented` (backtick-anchored to avoid false positives).
- Defense-in-depth `E_INPUT_NOT_FOUND` when a missing file reaches the engine directly (kind-aware: permission errors → `E_BAD_AUDIO`).
- Coded errors survive the `say` synthesis boundary (`E_SSML_INVALID` now actually fires) via a `TtsError::Coded` variant.

## Verification

- Rust: `cargo fmt` + `cargo clippy --all-targets` (tts/default/coreml) clean; `cargo nextest run --features tts` → **296 passed**.
- TS: `bun test` → **358 pass / 5 skip / 0 fail**; `bunx tsc --noEmit` clean.
- `cargo check --features coreml --no-default-features` clean.
- New e2e tests assert `E_SSML_INVALID` / `E_VOICE_UNKNOWN` fire on the real binary.

Design + plan: `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`, `docs/superpowers/plans/2026-05-30-structured-error-taxonomy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)