### PR TITLE
docs: add MCP client config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,9 +359,63 @@ Add to your client config:
 { "mcpServers": { "kesha": { "command": "kesha", "args": ["mcp"] } } }
 ```
 
-- **Claude Desktop:** `claude_desktop_config.json`
-- **Claude Code:** `claude mcp add kesha -- kesha mcp`
-- **Cursor:** `.cursor/mcp.json`
+<details>
+<summary>Claude Code</summary>
+
+```bash
+claude mcp add kesha -- kesha mcp
+```
+
+</details>
+
+<details>
+<summary>Codex</summary>
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.kesha]
+command = "kesha"
+args = ["mcp"]
+```
+
+</details>
+
+<details>
+<summary>Gemini CLI</summary>
+
+Add to `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "kesha": {
+      "command": "kesha",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Cursor</summary>
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "kesha": {
+      "command": "kesha",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+</details>
 
 If a tool returns "models not installed", run `kesha install` (ASR) or
 `kesha install --tts` (TTS) once, then retry.

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Add to your client config:
 { "mcpServers": { "kesha": { "command": "kesha", "args": ["mcp"] } } }
 ```
 
+Claude Desktop users can place the same JSON in `claude_desktop_config.json`.
+
 <details>
 <summary>Claude Code</summary>
 


### PR DESCRIPTION
## Summary
- expand README MCP setup docs with collapsible snippets for Claude Code, Codex, Gemini CLI, and Cursor
- keep the universal mcpServers JSON example as the quick-start path
- avoid absolute-path install examples

## Validation
- rg -n "/opt/homebrew|absolute|mcpServers|mcp_servers|claude mcp add|Gemini|Cursor|Codex" README.md

Docs-only change; code tests not run.