### PR TITLE
ci: split integration into fast (no-install) + heavy (gated) test lanes

### DIFF
--- a/.github/actions/install-kesha-backend/action.yml
+++ b/.github/actions/install-kesha-backend/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         case "${{ inputs.ffmpeg-provider }}" in
-          apt) sudo apt-get install -y ffmpeg ;;
+          apt) sudo apt-get update -qq && sudo apt-get install -y ffmpeg ;;
           brew) which ffmpeg || brew install ffmpeg ;;
           skip) exit 0 ;;
           *) echo "Unsupported ffmpeg provider: ${{ inputs.ffmpeg-provider }}" >&2; exit 1 ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
   # commit on `main`, so an unrelated touch doesn't run the full matrix.
   push:
     branches: [main]
+  # Nightly heavy real-engine e2e on main: model-format/engine drift gate, and
+  # it warms the default-branch-scoped model cache so PR heavy runs restore it.
+  schedule:
+    - cron: '0 4 * * *'
 
 permissions:
   contents: read
@@ -31,7 +35,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       integration: ${{ steps.filter.outputs.integration }}
-      tts_e2e: ${{ steps.filter.outputs.tts_e2e }}
+      heavy_e2e: ${{ steps.filter.outputs.heavy_e2e }}
       raycast: ${{ steps.filter.outputs.raycast }}
       nix: ${{ steps.filter.outputs.nix }}
       workflows: ${{ steps.filter.outputs.workflows }}
@@ -51,9 +55,14 @@ jobs:
           #   — the `needs: unit-tests` gate then evaluates predictably without
           #   the skip-propagation hazard that #274 + the pre-rewrite of #280
           #   silently fell into.
-          # - `tts_e2e` is its own filter: rust + the TS files that drive the
-          #   say-e2e test. It is INDEPENDENT — no `unit-tests` gate, because a
-          #   rust-only PR (`code == 'false'`) still needs the e2e to run.
+          # - `heavy_e2e` gates the model-DOWNLOADING lanes (integration-tests-full,
+          #   published-engine-smoke, tts-e2e): engine/model paths only (rust/**,
+          #   model pins, the real-engine e2e test files) — deliberately NOT
+          #   `src/**`, so TS-only PRs skip the 2.4GB download (the fake/stub
+          #   suites cover the TS contract in the fast lane). It is NOT a subset
+          #   of `code` (it includes `rust/**`), so those lanes use an
+          #   `always() && unit-tests != failure` gate to survive a legitimately
+          #   skipped `unit-tests` on a rust-only PR (the #274 skip hazard).
           filters: |
             code:
               - 'src/**'
@@ -78,12 +87,14 @@ jobs:
               - 'bun.lock'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
-            tts_e2e:
-              - 'src/**'
-              - 'tests/integration/say-e2e.test.ts'
+            heavy_e2e:
               - 'rust/**'
               - 'package.json'
               - 'bun.lock'
+              - 'tests/fixtures/**'
+              - 'tests/integration/e2e-engine.test.ts'
+              - 'tests/integration/mcp-e2e.test.ts'
+              - 'tests/integration/say-e2e.test.ts'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
             raycast:
@@ -248,29 +259,25 @@ jobs:
           retention-days: 30
 
   integration-tests:
-    # Skip on release/* branches: this job downloads the released engine
-    # binary (the version in `package.json#keshaEngine.version`), which
-    # doesn't exist yet on a version-bump PR — the tag is pushed AFTER
-    # merge per the CLAUDE.md release flow. `release-branch-engine-smoke`
-    # below covers that high-risk path with a locally built engine instead.
+    # FAST lane: runs the full `tests/integration/` suite WITHOUT installing
+    # the engine or models. The model-dependent e2e suites
+    # (`e2e-engine`, `mcp-e2e`, `say-e2e`) self-skip via
+    # `describe.skipIf(!engineInstalled)` when no engine is present, so this
+    # lane exercises only the fake/stub-based contract suites
+    # (`cli-contracts`, `e2e-cli`, `say`). No `kesha install`, no cache, no
+    # download — so it's safe on every PR including release/* branches
+    # (no published-engine 404 risk without an install step). Real-engine
+    # coverage lives in `integration-tests-full` below, gated to engine/model
+    # changes + nightly.
     #
     # Fail-fast: gate on `unit-tests` so a `tsc --noEmit` failure cancels
-    # this 5-10 min lane. Safe because `integration` is a strict subset of
-    # `code` (see filter design above) — when `integration == 'true'`,
+    # this lane. Safe because `integration` is a strict subset of `code`
+    # (see filter design above) — when `integration == 'true'`,
     # `code == 'true'`, so `unit-tests` is never `skipped` here and the
     # standard `result == 'success'` gate is enough.
     needs: [changes, unit-tests]
-    # Two skip cases for the published-engine download:
-    # 1. PR from a `release/*` branch — the version bump's new tag doesn't
-    #    exist yet (`head_ref` is set on pull_request events only).
-    # 2. Push to main where the merged commit IS the release bump —
-    #    same window between merge and tag-push. `head_commit.message`
-    #    is set on push events; on PRs it's null and `startsWith` short-
-    #    circuits to false so the clause is a no-op there.
     if: |
       needs.changes.outputs.integration == 'true' &&
-      !startsWith(github.head_ref, 'release/') &&
-      !startsWith(github.event.head_commit.message, 'chore(release):') &&
       needs.unit-tests.result == 'success'
     runs-on: macos-latest
     timeout-minutes: 10
@@ -285,14 +292,6 @@ jobs:
 
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
-
-      - name: 🔊 Setup integration backend
-        uses: ./.github/actions/install-kesha-backend
-        with:
-          cache-path: |
-            ~/.cache/kesha
-          cache-key: ${{ runner.os }}-kesha-engine-v1
-          cache-restore-keys: ${{ runner.os }}-kesha-engine-
 
       - name: 🧪 Integration tests
         run: mkdir -p test-results && bun run test:integration --reporter=junit --reporter-outfile=test-results/integration.xml
@@ -318,17 +317,97 @@ jobs:
           bunx @flakiness/junit-xml test-results/integration.xml \
             --category bun --flakiness-project Laputa/kesha-voice-kit
 
+  integration-tests-full:
+    # Real-engine integration: installs the ~2.4GB model bundle and runs the
+    # model-dependent e2e suites (which self-skip in the fast lane). Gated to
+    # engine/model changes, push-to-main of those paths, and the nightly cron —
+    # so doc/TS-only PRs never download models. Nightly run on main also seeds
+    # the default-branch-scoped model cache. Keep the release/* + chore(release)
+    # guards: this lane downloads the PUBLISHED engine, which doesn't exist yet
+    # during the release version-bump window.
+    needs: [changes, unit-tests]
+    # `always()` so a SKIPPED `unit-tests` (rust-only PRs have `code == 'false'`)
+    # doesn't skip-propagate and drop the heavy lane — `heavy_e2e` includes
+    # `rust/**` but `code` does not, so unit-tests is legitimately skipped on a
+    # rust-only PR yet the real-engine e2e must still run (#274 regression class).
+    # Still fail-fast if unit-tests actively FAILED/cancelled.
+    if: |
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.unit-tests.result != 'failure' &&
+      needs.unit-tests.result != 'cancelled' &&
+      (
+        github.event_name == 'schedule' ||
+        (
+          needs.changes.outputs.heavy_e2e == 'true' &&
+          !startsWith(github.head_ref, 'release/') &&
+          !startsWith(github.event.head_commit.message, 'chore(release):')
+        )
+      )
+    runs-on: macos-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+        with:
+          lfs: true
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+      - name: 🔊 Setup integration backend
+        uses: ./.github/actions/install-kesha-backend
+        with:
+          cache-path: |
+            ~/.cache/kesha
+          cache-key: ${{ runner.os }}-kesha-engine-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-engine-
+      - name: 🧪 Integration tests (real engine)
+        run: mkdir -p test-results && bun run test:integration --reporter=junit --reporter-outfile=test-results/integration-full.xml
+        timeout-minutes: 12
+      - name: 📊 Test summary
+        if: always()
+        run: bun .github/scripts/junit-to-markdown.ts "Integration Tests — full (macos)" test-results/integration-full.xml >> $GITHUB_STEP_SUMMARY
+      - name: 📤 Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-integration-full
+          path: test-results/integration-full.xml
+          retention-days: 7
+      - name: 🪼 Upload to Flakiness.io
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          bunx @flakiness/junit-xml test-results/integration-full.xml \
+            --category bun --flakiness-project Laputa/kesha-voice-kit
+
   published-engine-smoke:
     # P1.10: keep at least one non-Darwin lane exercising the published
     # engine install path. Windows is intentionally omitted while
     # `src/engine-install.ts` still reports win32 x64 as unsupported; this
     # Linux x64 lane covers the currently supported non-Darwin release asset.
     needs: [changes, unit-tests]
+    # `always()` so a SKIPPED `unit-tests` (rust-only PRs have `code == 'false'`)
+    # doesn't skip-propagate and drop the heavy lane — `heavy_e2e` includes
+    # `rust/**` but `code` does not, so unit-tests is legitimately skipped on a
+    # rust-only PR yet the real-engine e2e must still run (#274 regression class).
+    # Still fail-fast if unit-tests actively FAILED/cancelled.
     if: |
-      needs.changes.outputs.integration == 'true' &&
-      !startsWith(github.head_ref, 'release/') &&
-      !startsWith(github.event.head_commit.message, 'chore(release):') &&
-      needs.unit-tests.result == 'success'
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.unit-tests.result != 'failure' &&
+      needs.unit-tests.result != 'cancelled' &&
+      (
+        github.event_name == 'schedule' ||
+        (
+          needs.changes.outputs.heavy_e2e == 'true' &&
+          !startsWith(github.head_ref, 'release/') &&
+          !startsWith(github.event.head_commit.message, 'chore(release):')
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
@@ -447,9 +526,17 @@ jobs:
     needs: [changes, unit-tests]
     if: |
       always() &&
-      needs.changes.outputs.tts_e2e == 'true' &&
+      needs.changes.result == 'success' &&
       needs.unit-tests.result != 'failure' &&
-      needs.unit-tests.result != 'cancelled'
+      needs.unit-tests.result != 'cancelled' &&
+      (
+        github.event_name == 'schedule' ||
+        (
+          needs.changes.outputs.heavy_e2e == 'true' &&
+          !startsWith(github.head_ref, 'release/') &&
+          !startsWith(github.event.head_commit.message, 'chore(release):')
+        )
+      )
     runs-on: macos-latest
     timeout-minutes: 20
     permissions:

--- a/docs/superpowers/specs/2026-05-30-ci-fast-heavy-test-lanes-design.md
+++ b/docs/superpowers/specs/2026-05-30-ci-fast-heavy-test-lanes-design.md
@@ -1,0 +1,67 @@
+# CI Fast/Heavy Test-Lane Split
+
+Stop every PR push from downloading the ~2.4 GB model bundle (slow + the source of the `integration-tests` timeout flakes + a cache that's cold across PRs). Split CI integration testing into a **fast lane** that runs on every PR with no model install, and a **heavy lane** that installs real models and runs only when it matters (engine/model changes, push-to-main, nightly).
+
+## Key insight — the split needs (almost) no test changes
+
+The test suite is already cleanly separable:
+
+- **Fake-engine / model-free** (run everywhere): `tests/unit/**`, `tests/integration/say.test.ts`, `cli-contracts.test.ts`, `e2e-cli.test.ts`. These use fake engines — `createFailingEngine`, the inline stub in `e2e-cli` that emits a canned `"Привет с воркшопа"` transcript, and the `cli-scenario` harness. They set `KESHA_ENGINE_BIN` to a fake and never touch real models.
+- **Real-engine / model-dependent** (need the 2.4 GB install): `e2e-engine.test.ts`, `mcp-e2e.test.ts`, `say-e2e.test.ts`. All three **already** self-skip when the engine/models are absent:
+  - `e2e-engine.test.ts`: `describe.skipIf(!engineInstalled)` (`isEngineInstalled()`).
+  - `mcp-e2e.test.ts`: `describe.skipIf(!engineInstalled)` + `test.skipIf(!SPIKE_AVAILABLE)`.
+  - `say-e2e.test.ts`: `it.skipIf(!SPIKE_AVAILABLE)`.
+
+So: **if the fast lane does not run `kesha install`, the heavy suites skip themselves and the fast suites run as fakes.** No stub engine to build; the repo already has the fakes and the skip guards.
+
+## Goals
+
+- Every PR push: fast feedback, no multi-GB download, no model cache, no download-contention flake.
+- Real-engine coverage (model-format compatibility, real transcribe/synth, TS↔engine wire) still runs — on the changes that can affect it, on `main`, and nightly.
+- The model cache becomes a heavy-lane concern only, and push-to-main seeds it in the **default-branch scope** so the heavy lane is warm when it does run.
+
+## Non-goals
+
+- Building a dedicated stub-engine binary (unnecessary — fakes already exist).
+- Removing real-engine e2e tests (they catch the highest-severity "shipped engine is broken" class — kept, just gated).
+- Changing the release draft-asset smoke gate (the real pre-publish validation in CLAUDE.md stays as-is).
+- Touching Rust test lanes (`rust-test.yml`) — unaffected.
+
+## Design
+
+### Lanes (in `.github/workflows/ci.yml`)
+
+1. **`integration-tests` (fast) — every PR + push to main.**
+   - Setup bun, `bun link`, **no `kesha install`**, run `bun test tests/unit tests/integration` (or a dedicated `test:integration-fast` script).
+   - `e2e-engine` / `mcp-e2e` / `say-e2e` skip via their existing guards; fake suites run.
+   - No model cache step, no ffmpeg-apt step needed for the fake suites (confirm none of the fake tests require ffmpeg; `kesha install` is what pulled it in).
+   - Fast (~1–2 min), deterministic, no download.
+
+2. **`integration-tests-full` (heavy) — gated.**
+   - Runs the existing `install-kesha-backend` action (downloads engine + models, with the model cache) then the full `test:integration`. Heavy suites now execute.
+   - **Triggers:**
+     - PRs whose `changes` filter hits engine/model paths: `rust/**`, `rust/src/models.rs`, `package.json` (for `keshaEngine.version`), and the heavy test files themselves (`tests/integration/{e2e-engine,mcp-e2e,say-e2e}.test.ts`).
+     - `push` to `main` (post-merge) — also warms the **main-scoped** model cache.
+     - `schedule:` nightly cron (one run/day) so model-format drift is caught even with no engine PRs.
+   - Keep the existing `!startsWith(github.head_ref, 'release/')` guard (release branches can't download the not-yet-published engine; the release-branch-engine-smoke lane already covers them).
+
+3. **`tts-e2e` / `published-engine-smoke`** (currently every-PR, model-downloading): move under the same heavy-lane gating (engine/model path-filter + push-to-main + nightly). They are real-engine/download jobs and don't need to run on doc/TS-only PRs.
+
+### Cache
+
+- Only the heavy lane keeps the `actions/cache@v5` model step (`~/.cache/kesha`, key `${os}-kesha-engine-v1`).
+- Because the heavy lane runs on `push: main`, a successful main run saves the cache in the **default-branch scope**, which GitHub shares with all PRs — so when a PR does trigger the heavy lane, it restores instead of re-downloading. (Subject to the 10 GB/repo LRU; acceptable now that far fewer runs populate/evict it.)
+
+### Guardrail against silent gaps
+
+Risk: someone adds a new real-engine test WITHOUT a skip guard; it would then **fail** in the fast lane (no models) instead of skipping. Mitigation: a tiny meta-test in the fast suite that asserts the known model-dependent describe blocks are guarded — OR simpler, document the convention in `tests/integration/README` and rely on the fast-lane CI failing loudly (which surfaces the missing guard immediately). Pick the lightweight doc + loud-failure approach first.
+
+## Verification
+
+- **Local:** run the fast set with no engine installed and confirm `e2e-engine`/`mcp-e2e`/`say-e2e` report `skip` (not `fail`), and unit/cli-contracts/e2e-cli/say pass. (`KESHA_ENGINE_BIN` unset + empty cache dir, or temporarily point `isEngineInstalled()` at a missing path.)
+- **PR CI (this PR):** the fast lane runs green with the heavy suites skipped; the heavy lane triggers because this PR touches `.github/**` (or force it once via a label / workflow_dispatch) and passes.
+- Confirm `bun test` total still reports the heavy tests as `skip` (not silently dropped) in the fast lane.
+
+## Rollout
+
+Single PR on `ci/split-test-lanes`. Because it only restructures `ci.yml` (+ maybe a `package.json` script and a one-line test-convention doc), it's reviewable in isolation and its own CI run exercises both lanes. No engine release, no version bump.


### PR DESCRIPTION
## Problem

Every PR push runs the model-downloading integration jobs, pulling the **~2.4 GB** model bundle. That's slow, it's the source of the `integration-tests` 5s-timeout flakes (the download starves the fake-engine contract tests), and the model cache is cold across PRs (it only ever saved to a PR scope, never `main`, and the 10 GB repo limit evicts it).

## Insight — near-zero test changes needed

The suite already separates cleanly:
- **Fake/stub-based (model-free):** `unit`, `cli-contracts`, `e2e-cli` (writes an inline stub engine emitting a canned transcript), `say` — set `KESHA_ENGINE_BIN` to a fake, never download models.
- **Real-engine (need the 2.4 GB install):** `e2e-engine`, `mcp-e2e`, `say-e2e` — **already** self-skip via `describe.skipIf(!engineInstalled)` / `skipIf(!SPIKE_AVAILABLE)`.

Validated locally: `bun test tests/integration/` with no engine installed → **51 pass / 26 skip / 0 fail**, zero downloads. So the fast lane just doesn't `kesha install`; the heavy suites self-skip.

## Change

- **Fast lane** (`integration-tests`, every PR + push): runs the full `tests/integration/` with **no `kesha install`**, no model cache, no ffmpeg. Heavy suites skip; fake suites run. ~fast, deterministic, no flake. Also now runs on `release/*` branches (no download → no 404 risk).
- **Heavy lane** (`integration-tests-full`, new): installs models + runs the real-engine suites. Gated on `heavy_e2e` (engine/model paths: `rust/**`, model pins, the real-engine test files — **not** `src/**`) + push-to-main of those paths + **nightly cron**. Nightly on `main` also seeds the default-branch-scoped model cache so heavy PR runs restore it.
- `published-engine-smoke` and `tts-e2e` moved under the same heavy gate.
- New narrow `heavy_e2e` paths-filter; orphaned `tts_e2e` filter/output pruned.

### Skip-propagation guard (the subtle bit)

`heavy_e2e` includes `rust/**`, which is **not** in the `code` filter — so on a rust-only PR `unit-tests` is legitimately *skipped*. A plain `needs.unit-tests.result == 'success'` gate would skip-propagate and drop the heavy lane on exactly the engine PRs that most need real e2e (the #274 hazard). The three heavy jobs therefore use `always() && needs.unit-tests.result != 'failure' && != 'cancelled' && (schedule || heavy_e2e ...)` — run unless unit-tests actively failed.

## Validation

- `bun test tests/integration/` (no engine) → 51 pass / 26 skip / 0 fail, no downloads.
- YAML parses; repo `check:workflows` gate passes; `actionlint` clean (only pre-existing shellcheck info notes).
- This PR touches `ci.yml` (in `heavy_e2e`), so its own CI exercises **both** lanes.

Spec: `docs/superpowers/specs/2026-05-30-ci-fast-heavy-test-lanes-design.md`. No engine release / version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)