### PR TITLE
feat(tts): expose multilingual FluidAudio Kokoro voices

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,13 @@ Each segment gets a `speaker` integer (cluster ID, stable within one file). Linu
 
 ## Text-to-speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian) — voice auto-picks from the text's language. On darwin-arm64, Kokoro uses FluidAudio CoreML instead of ONNX; FluidAudio stores that CoreML cache at `~/.cache/fluidaudio/Models/kokoro`, outside Kesha's pinned model cache:
+Kesha speaks back via Kokoro-82M (English plus selected multilingual voices on Apple Silicon) and Vosk-TTS (Russian) — voice auto-picks from the text's language. On darwin-arm64, Kokoro uses FluidAudio CoreML instead of ONNX; FluidAudio stores that CoreML cache at `~/.cache/fluidaudio/Models/kokoro`, outside Kesha's pinned model cache:
 
 ```bash
 kesha install --tts                      # TTS, opt-in; Darwin Kokoro uses FluidAudio cache
 kesha say "Hello, world" > hello.wav
 kesha say "Привет, мир" > privet.wav     # auto-routes (Milena on darwin, ru-vosk-m02 elsewhere)
+kesha say --voice es-em_alex "Hola, mundo" > hola.wav
 ```
 
 **Output formats** (`--format`, or inferred from `--out` extension):

--- a/completions/kesha.fish
+++ b/completions/kesha.fish
@@ -67,7 +67,7 @@ complete -c kesha -n '__fish_seen_subcommand_from record' -l debug -d 'Trace eng
 complete -c kesha -n '__fish_seen_subcommand_from say' -l help -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from say' -s h -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l voice -r -d 'Voice id, e.g. en-am_michael'
-complete -c kesha -n '__fish_seen_subcommand_from say' -l lang -r -d 'BCP 47 language code (default en-us)'
+complete -c kesha -n '__fish_seen_subcommand_from say' -l lang -r -d 'BCP 47 language code (default en-us). With no --voice, routes to that language\'s default voice and skips text-language detection.'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l out -r -d 'Write audio to file instead of stdout'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l rate -r -d 'Speaking rate 0.5–2.0'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l list-voices -d 'List installed voices and exit'

--- a/completions/kesha.zsh
+++ b/completions/kesha.zsh
@@ -99,7 +99,7 @@ _kesha() {
       _arguments '--help[Show help]' \
         '-h[Show help]' \
         '--voice=[Voice id, e.g. en-am_michael]:voice:' \
-        '--lang=[BCP 47 language code (default en-us)]:lang:' \
+        '--lang=[BCP 47 language code (default en-us). With no --voice, routes to that language'\''s default voice and skips text-language detection.]:lang:' \
         '--out=[Write audio to file instead of stdout]:out:' \
         '--rate=[Speaking rate 0.5–2.0]:rate:' \
         '--list-voices[List installed voices and exit]' \

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,8 +9,11 @@ kesha say "Привет, мир" > privet.wav    # auto-routes (Milena on darwin
 echo "long text" | kesha say > reply.wav
 kesha say --out reply.wav "text"
 kesha say --voice en-am_michael "text"    # explicit voice overrides auto-routing
+kesha say --lang es "Hola, mundo" > hola.wav   # route by stated language, skip detection
 kesha say --list-voices
 ```
+
+Voice selection precedence: `--voice <id>` (explicit) → `--lang <code>` (route to that language's default voice, skipping detection — also the way to route on Linux/Windows, where text-language detection is macOS-only) → macOS text-language auto-detection → engine default (`en-am_michael`). A `--lang` whose language has no mapped male voice (e.g. French) falls to the engine default rather than re-detecting.
 
 Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Vosk). OGG/Opus and MP3 are tracked in follow-up issues.
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,6 +1,6 @@
 # Text-to-Speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, English Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path. FluidAudio keeps its CoreML Kokoro cache at `~/.cache/fluidaudio/Models/kokoro`; those files are managed by FluidAudio, not Kesha's pinned model downloader.
+Kesha speaks back via Kokoro-82M (English plus selected multilingual voices on Apple Silicon) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path. FluidAudio keeps its CoreML Kokoro cache at `~/.cache/fluidaudio/Models/kokoro`; those files are managed by FluidAudio, not Kesha's pinned model downloader.
 
 ```bash
 kesha install --tts                 # TTS models, opt-in (Darwin Kokoro uses FluidAudio cache)
@@ -15,14 +15,16 @@ kesha say --list-voices
 Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Vosk). OGG/Opus and MP3 are tracked in follow-up issues.
 
 Grapheme-to-phoneme:
-- **English** uses FluidAudio Kokoro CoreML on darwin-arm64 release builds. Other platforms use [misaki-rs](https://github.com/MicheleYin/misaki-rs) plus the ONNX Kokoro model.
+- **Kokoro on darwin-arm64** uses FluidAudio CoreML/ANE for English, Spanish, Hindi, Italian, Japanese, Mandarin Chinese, Brazilian Portuguese, and the single native French Kokoro voice.
+- **English on other platforms** uses [misaki-rs](https://github.com/MicheleYin/misaki-rs) plus the ONNX Kokoro model.
 - **Russian** is handled internally by [Vosk-TTS](https://github.com/alphacep/vosk-tts) — text normalisation, stress, palatalisation, and a BERT prosody model all run inside the bundled ONNX (no separate G2P pass, no system `espeak-ng` dependency).
 - **Other languages**: not supported by the on-disk engines we ship today — tracked per-language in [#212](https://github.com/drakulavich/kesha-voice-kit/issues/212).
 
 Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am_michael` for English Kokoro, `ru-vosk-m02` for Russian Vosk on Linux/Windows. The darwin Russian fallback uses `Milena` (AVSpeech, female) for the zero-install path; pass `--voice ru-vosk-m02` to opt into Vosk on macOS too.
 
 **Supported voices:**
-- English: `en-am_michael` (default). Darwin FluidAudio builds expose the supported FluidAudio Kokoro American-English voices via `kesha say --list-voices`; ONNX builds also see any `.bin` voice you add under `~/.cache/kesha/models/kokoro-82m/voices/`.
+- English: `en-am_michael` (default). Darwin FluidAudio builds expose the supported FluidAudio Kokoro English voices via `kesha say --list-voices`; ONNX builds also see any `.bin` voice you add under `~/.cache/kesha/models/kokoro-82m/voices/`.
+- Apple Silicon Kokoro multilingual voices: `es-em_alex`, `hi-hm_omega`, `it-im_nicola`, `ja-jm_kumo`, `pt-pm_alex`, `zh-zm_yunjian`, and `fr-ff_siwis`. The Spanish, Hindi, Italian, Japanese, Portuguese, and Chinese defaults are male; upstream Kokoro currently has no native male French voice, so French remains explicit-only.
 - Russian: 5 Vosk-TTS speakers baked into the multi-speaker model — `ru-vosk-m02` (default, male), `ru-vosk-m01` (male), `ru-vosk-f01`/`f02`/`f03` (female).
 - macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
 

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -155,7 +155,7 @@ Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)
 Voice id, e.g. en\-am_michael
 .TP
 .B \-\-lang
-BCP 47 language code (default en\-us)
+BCP 47 language code (default en\-us). With no \-\-voice, routes to that language's default voice and skips text\-language detection.
 .TP
 .B \-\-out
 Write audio to file instead of stdout

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -156,16 +156,16 @@ pub fn kokoro_manifest() -> Vec<ModelFile> {
 ///
 /// FluidAudio 0.14.7's `KokoroAneManager` resolves `<voice>.bin` LOCAL-FIRST
 /// from its own cache (`~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/`)
-/// before any download. The ANE English bundle only ships `af_heart`, so
-/// `am_michael` (kesha's male brand default) and the rest of the catalog 404
-/// from the bundle. These packs are 510×256 f32 `.bin` — byte-identical to
-/// the standard onnx-community Kokoro packs kesha used on the ONNX path — so
-/// we download them from onnx-community and stage them into the ANE cache at
-/// install time (see [`stage_ane_kokoro_voices`]). `af_heart` is intentionally
-/// EXCLUDED: FluidAudio 0.14.7 auto-downloads its own `af_heart.bin` into the
-/// ANE dir on first synth, and staging our own copy would risk an SHA mismatch
-/// overwriting FluidAudio's authoritative pack. Kesha only stages the voices
-/// the ANE bundle LACKS (`am_michael` and the rest of the catalog).
+/// before any download. The ANE bundle only ships `af_heart`, so `am_michael`
+/// (kesha's male brand default) and the rest of the advertised Kokoro catalog
+/// 404 from the bundle. These packs are 510×256 f32 `.bin` — byte-identical to
+/// the standard onnx-community Kokoro packs kesha used on the ONNX path — so we
+/// download them from onnx-community and stage them into the ANE cache at install
+/// time (see [`stage_ane_kokoro_voices`]). `af_heart` is intentionally EXCLUDED:
+/// FluidAudio 0.14.7 auto-downloads its own `af_heart.bin` into the ANE dir on
+/// first synth, and staging our own copy would risk an SHA mismatch overwriting
+/// FluidAudio's authoritative pack. Kesha only stages the voices the ANE bundle
+/// LACKS (`am_michael` and the rest of the advertised catalog).
 ///
 /// SHA-256 pins computed from `onnx-community/Kokoro-82M-v1.0-ONNX` — an
 /// upstream rehost becomes a deliberate PR to bump (CLAUDE.md MODEL HASHES).
@@ -274,14 +274,54 @@ const ANE_KOKORO_VOICES: &[ModelFile] = &[
         url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_santa.bin",
         sha256: "61150cf726ab6c5ed7a99f90a304f91f5a72c00c592e89ec94e5df11c319227a",
     },
+    ModelFile {
+        rel_path: "bm_lewis.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/bm_lewis.bin",
+        sha256: "b8f671cef828c30e66fdf0b0756a76bba58f6bb3398cbbf27058642acbcedb97",
+    },
+    ModelFile {
+        rel_path: "em_alex.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/em_alex.bin",
+        sha256: "27809e9eafdcbcfff90a3016c697568676531de2a2c39cee29c96c7bd6b83e95",
+    },
+    ModelFile {
+        rel_path: "ff_siwis.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/ff_siwis.bin",
+        sha256: "a35f5675ad08948e326ae75fd0ea16ba5d0042e4f76b5f3d1df77d0a48c54861",
+    },
+    ModelFile {
+        rel_path: "hm_omega.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/hm_omega.bin",
+        sha256: "b02d9222d9ed00ce26b302173a862c2c93f96cc40b5c422b8d14910b9ff34137",
+    },
+    ModelFile {
+        rel_path: "im_nicola.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/im_nicola.bin",
+        sha256: "bc578e510d52a96d6940d46f12e96d7b3df00905dbea075113226d100e6e1ab0",
+    },
+    ModelFile {
+        rel_path: "jm_kumo.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/jm_kumo.bin",
+        sha256: "09e959d239724c734d65661f06f14cdabcddfd476bfaaad905a937099ae9e64f",
+    },
+    ModelFile {
+        rel_path: "pm_alex.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_alex.bin",
+        sha256: "0175c753f59c54e7fd5a995bedef0c5ff2fb67e0043dd3dcb2ae74ec2acbeb2a",
+    },
+    ModelFile {
+        rel_path: "zm_yunjian.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/zm_yunjian.bin",
+        sha256: "de48a00bdbf3649f07162269a2b6e0513604389bfac8a2e6c75cb34b323ad6fa",
+    },
 ];
 
 /// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
 /// `KESHA_CACHE_DIR` — FluidAudio 0.14.7 owns this path and reads voice packs
 /// from here local-first. We pre-stage onnx-community packs here so the full
-/// en-* catalog (and the male `am_michael` default) resolve without a 404
-/// against the ANE bundle. Mirrors the existing CLAUDE.md note that darwin
-/// Kokoro uses the fluidaudio cache rather than `KESHA_CACHE_DIR`.
+/// advertised Kokoro catalog (and the male `am_michael` default) resolve
+/// without a 404 against the ANE bundle. Mirrors the existing CLAUDE.md note
+/// that darwin Kokoro uses the fluidaudio cache rather than `KESHA_CACHE_DIR`.
 #[cfg(all(
     feature = "system_kokoro",
     target_os = "macos",
@@ -297,7 +337,7 @@ pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
         .join("ANE")
 }
 
-/// Download + SHA-verify every en-* Kokoro voice pack directly into
+/// Download + SHA-verify every advertised Kokoro voice pack directly into
 /// FluidAudio's ANE cache so `KokoroAneManager.ensureVoicePack` resolves them
 /// local-first (#475). Idempotent: an existing pack that already matches its
 /// pinned hash short-circuits the network round-trip, identical to
@@ -891,11 +931,14 @@ mod tts_tests {
             );
         }
         // Every FluidAudio Kokoro voice kesha advertises must have a staged
-        // pack, or `--voice en-<x>` resolves then 404s on the ANE bundle —
+        // pack, or `--voice <lang>-<x>` resolves then 404s on the ANE bundle —
         // EXCEPT `af_heart`, which FluidAudio 0.14.7 auto-provides into the
         // same ANE dir on first synth, so kesha must NOT stage its own copy.
         for v in crate::tts::fluid_kokoro::available_voice_ids() {
-            let bare = v.strip_prefix("en-").unwrap_or(&v);
+            let bare = v
+                .split_once('-')
+                .map(|(_, bare)| bare)
+                .unwrap_or(v.as_str());
             if bare == "af_heart" {
                 continue;
             }

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -17,37 +17,168 @@ use fluidaudio_rs::FluidAudio;
 /// SSML `<break>` silence buffers when the segment walker stitches audio.
 pub const SAMPLE_RATE: u32 = 24_000;
 
-// FluidAudio 0.14.5 voice snapshot. Keep this list in sync with the FluidAudio
+#[derive(Clone, Copy)]
+pub struct VoiceSpec {
+    /// Public Kesha voice id, including the language prefix.
+    pub public_id: &'static str,
+    /// Bare FluidAudio/Kokoro voice id staged in the ANE cache.
+    pub fluid_id: &'static str,
+    /// Language tag used for diagnostics and non-Fluid Kokoro compatibility.
+    pub lang: &'static str,
+}
+
+// FluidAudio 0.14.5 voice snapshot plus the multilingual Kokoro voice packs
+// validated against the ANE cache. Keep this list in sync with the FluidAudio
 // pin in the fluidaudio-rs fork whenever it changes.
-const VOICES: &[&str] = &[
-    "af_alloy",
-    "af_aoede",
-    "af_bella",
-    "af_heart",
-    "af_jessica",
-    "af_kore",
-    "af_nicole",
-    "af_nova",
-    "af_river",
-    "af_sarah",
-    "af_sky",
-    "am_adam",
-    "am_echo",
-    "am_eric",
-    "am_fenrir",
-    "am_liam",
-    "am_michael",
-    "am_onyx",
-    "am_puck",
-    "am_santa",
+const VOICES: &[VoiceSpec] = &[
+    VoiceSpec {
+        public_id: "en-af_alloy",
+        fluid_id: "af_alloy",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_aoede",
+        fluid_id: "af_aoede",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_bella",
+        fluid_id: "af_bella",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_heart",
+        fluid_id: "af_heart",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_jessica",
+        fluid_id: "af_jessica",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_kore",
+        fluid_id: "af_kore",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_nicole",
+        fluid_id: "af_nicole",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_nova",
+        fluid_id: "af_nova",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_river",
+        fluid_id: "af_river",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_sarah",
+        fluid_id: "af_sarah",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-af_sky",
+        fluid_id: "af_sky",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_adam",
+        fluid_id: "am_adam",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_echo",
+        fluid_id: "am_echo",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_eric",
+        fluid_id: "am_eric",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_fenrir",
+        fluid_id: "am_fenrir",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_liam",
+        fluid_id: "am_liam",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_michael",
+        fluid_id: "am_michael",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_onyx",
+        fluid_id: "am_onyx",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_puck",
+        fluid_id: "am_puck",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-am_santa",
+        fluid_id: "am_santa",
+        lang: "en-us",
+    },
+    VoiceSpec {
+        public_id: "en-bm_lewis",
+        fluid_id: "bm_lewis",
+        lang: "en-gb",
+    },
+    VoiceSpec {
+        public_id: "es-em_alex",
+        fluid_id: "em_alex",
+        lang: "es",
+    },
+    VoiceSpec {
+        public_id: "hi-hm_omega",
+        fluid_id: "hm_omega",
+        lang: "hi",
+    },
+    VoiceSpec {
+        public_id: "it-im_nicola",
+        fluid_id: "im_nicola",
+        lang: "it",
+    },
+    VoiceSpec {
+        public_id: "ja-jm_kumo",
+        fluid_id: "jm_kumo",
+        lang: "ja",
+    },
+    VoiceSpec {
+        public_id: "pt-pm_alex",
+        fluid_id: "pm_alex",
+        lang: "pt-br",
+    },
+    VoiceSpec {
+        public_id: "zh-zm_yunjian",
+        fluid_id: "zm_yunjian",
+        lang: "zh",
+    },
+    VoiceSpec {
+        public_id: "fr-ff_siwis",
+        fluid_id: "ff_siwis",
+        lang: "fr-fr",
+    },
 ];
 
 pub fn available_voice_ids() -> Vec<String> {
-    VOICES.iter().map(|v| format!("en-{v}")).collect()
+    VOICES.iter().map(|v| v.public_id.to_string()).collect()
 }
 
-pub fn supports_voice(name: &str) -> bool {
-    VOICES.contains(&name)
+pub fn resolve_voice(public_id: &str) -> Option<VoiceSpec> {
+    VOICES.iter().copied().find(|v| v.public_id == public_id)
 }
 
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
@@ -145,12 +276,24 @@ mod tests {
         let voices = available_voice_ids();
         assert!(voices.contains(&"en-am_michael".to_string()));
         assert!(voices.contains(&"en-af_heart".to_string()));
+        assert!(voices.contains(&"es-em_alex".to_string()));
+        assert!(voices.contains(&"ja-jm_kumo".to_string()));
+        assert!(voices.contains(&"zh-zm_yunjian".to_string()));
     }
 
     #[test]
     fn supports_known_voice() {
-        assert!(supports_voice("am_michael"));
-        assert!(!supports_voice("nonexistent"));
+        assert!(resolve_voice("en-am_michael").is_some());
+        assert!(resolve_voice("es-em_alex").is_some());
+        assert!(resolve_voice("en-em_alex").is_none());
+        assert!(resolve_voice("nonexistent").is_none());
+    }
+
+    #[test]
+    fn resolves_public_voice_to_fluid_id_and_lang() {
+        let spec = resolve_voice("pt-pm_alex").expect("pt voice");
+        assert_eq!(spec.fluid_id, "pm_alex");
+        assert_eq!(spec.lang, "pt-br");
     }
 
     #[test]

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -99,6 +99,12 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
     })?;
     match lang {
         "en" => resolve_kokoro(cache_dir, voice_id, name),
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        "es" | "fr" | "hi" | "it" | "ja" | "pt" | "zh" => resolve_fluid_kokoro(voice_id),
         "ru" => {
             let suffix = name.strip_prefix("vosk-").unwrap_or(name);
             resolve_vosk_ru(cache_dir, voice_id, suffix)
@@ -131,15 +137,8 @@ fn resolve_kokoro(_cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Resu
         target_arch = "aarch64"
     ))]
     {
-        if !crate::tts::fluid_kokoro::supports_voice(name) {
-            anyhow::bail!(
-                "unknown FluidAudio Kokoro voice '{voice_id}'. run: kesha say --list-voices"
-            );
-        }
-        return Ok(ResolvedVoice::FluidKokoro {
-            voice_id: name.to_string(),
-            espeak_lang: "en-us",
-        });
+        let _ = name;
+        return resolve_fluid_kokoro(voice_id);
     }
     #[allow(unreachable_code)]
     {
@@ -162,6 +161,21 @@ fn resolve_kokoro(_cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Resu
             espeak_lang: "en-us",
         })
     }
+}
+
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn resolve_fluid_kokoro(voice_id: &str) -> anyhow::Result<ResolvedVoice> {
+    let Some(spec) = crate::tts::fluid_kokoro::resolve_voice(voice_id) else {
+        anyhow::bail!("unknown FluidAudio Kokoro voice '{voice_id}'. run: kesha say --list-voices");
+    };
+    Ok(ResolvedVoice::FluidKokoro {
+        voice_id: spec.fluid_id.to_string(),
+        espeak_lang: spec.lang,
+    })
 }
 
 fn resolve_vosk_ru(
@@ -299,6 +313,44 @@ mod tests {
             }
             other => panic!("expected FluidKokoro, got {other:?}"),
         }
+    }
+
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    #[test]
+    fn resolve_multilingual_kokoro_voice_uses_fluid_audio_on_darwin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let r = resolve_voice(tmp.path(), "es-em_alex").unwrap();
+        match r {
+            ResolvedVoice::FluidKokoro {
+                voice_id,
+                espeak_lang,
+            } => {
+                assert_eq!(voice_id, "em_alex");
+                assert_eq!(espeak_lang, "es");
+            }
+            other => panic!("expected FluidKokoro, got {other:?}"),
+        }
+    }
+
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    #[test]
+    fn reject_cross_language_fluid_kokoro_alias() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_voice(tmp.path(), "en-em_alex")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("unknown FluidAudio Kokoro voice"),
+            "msg: {err}"
+        );
     }
 
     #[cfg(all(feature = "system_tts", target_os = "macos"))]

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -486,6 +486,15 @@ mod tests {
         assert!(err.contains("install --tts"), "msg: {err}");
     }
 
+    // ONNX Kokoro install-check path: en voices resolve to a cached model file
+    // here, but on darwin-arm64 `system_kokoro` they resolve through FluidAudio
+    // (which validates the id and defers model loading), so the "install --tts"
+    // hint doesn't apply — gate this test off the fluid build.
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
     #[test]
     fn resolve_missing_voice_errors_with_hint() {
         let tmp = tempfile::tempdir().unwrap();
@@ -494,6 +503,13 @@ mod tests {
         assert!(err.to_string().contains("install --tts"), "msg: {err}");
     }
 
+    // ONNX-only path (see resolve_missing_voice_errors_with_hint): not
+    // applicable on darwin-arm64 `system_kokoro` where en routes via FluidAudio.
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
     #[test]
     fn resolve_missing_model_errors() {
         let tmp = tempfile::tempdir().unwrap();
@@ -517,7 +533,14 @@ mod tests {
     fn resolve_unsupported_language() {
         let tmp = tempfile::tempdir().unwrap();
         let err = resolve_voice(tmp.path(), "fr-something").unwrap_err();
-        assert!(err.to_string().contains("not supported"), "msg: {err}");
-        assert_eq!(crate::errors::code_of(&err), ErrorCode::VoiceUnknown);
+        // The human message differs by build — FluidAudio Kokoro (darwin-arm64,
+        // `system_kokoro`) reports "unknown FluidAudio Kokoro voice", other
+        // builds report "language not supported" — but the stable code is the
+        // contract. Match on the code, not the message (see docs/errors.md).
+        assert_eq!(
+            crate::errors::code_of(&err),
+            ErrorCode::VoiceUnknown,
+            "msg: {err}"
+        );
     }
 }

--- a/rust/tests/tts_smoke.rs
+++ b/rust/tests/tts_smoke.rs
@@ -141,6 +141,14 @@ fn empty_text_exits_2() {
     );
 }
 
+// ONNX-path behavior: on darwin-arm64 `system_kokoro` the default en voice
+// resolves through FluidAudio (separate model cache) and synthesizes, so a
+// fresh KESHA_CACHE_DIR neither exits 1 nor prints an install hint.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
 #[test]
 fn missing_voice_in_cache_exits_1_with_install_hint() {
     let tmp = tempfile::tempdir().unwrap();
@@ -194,6 +202,14 @@ fn resolves_from_cache_when_installed() {
     assert_eq!(&out.stdout[..4], b"RIFF");
 }
 
+// ONNX-path behavior: on darwin-arm64 `system_kokoro`, `--list-voices` lists the
+// statically-known FluidAudio voices (no install hint), so this fresh-cache
+// invariant is ONNX/Vosk-only.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
 #[test]
 fn list_voices_empty_on_fresh_cache() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -14,6 +14,25 @@ async function autoRouteVoice(text: string): Promise<string | undefined> {
   return pickVoiceForLang(detected?.code, detected?.confidence ?? 0);
 }
 
+/**
+ * Resolve the voice for `kesha say`. Precedence: explicit `--voice` > explicit
+ * `--lang` (route by the stated language, skipping detection — also the path on
+ * Linux/Windows where text-language detection is unavailable) > macOS
+ * text-language auto-detection > engine default (`undefined`). A `--lang` with
+ * no mapped voice (an unsupported language, or French which has no male Kokoro
+ * voice) resolves to `undefined` (engine default) rather than re-running
+ * detection — the user stated the language explicitly.
+ */
+export async function resolveSayVoice(
+  explicitVoice: string | undefined,
+  langHint: string | undefined,
+  text: string,
+): Promise<string | undefined> {
+  if (explicitVoice !== undefined) return explicitVoice;
+  if (langHint !== undefined) return pickVoiceForLang(langHint, 1);
+  return autoRouteVoice(text);
+}
+
 /** Resolve the text to synthesize: inline positional, else read from stdin. */
 async function resolveText(inline: string | undefined): Promise<string> {
   if (inline !== undefined && inline.length > 0) return inline;
@@ -89,7 +108,11 @@ export const sayCommand = defineCommand({
   args: {
     text: { type: "positional", required: false, description: "Text to speak (stdin if omitted)" },
     voice: { type: "string", description: "Voice id, e.g. en-am_michael" },
-    lang: { type: "string", description: "BCP 47 language code (default en-us)" },
+    lang: {
+      type: "string",
+      description:
+        "BCP 47 language code (default en-us). With no --voice, routes to that language's default voice and skips text-language detection.",
+    },
     out: { type: "string", description: "Write audio to file instead of stdout" },
     rate: { type: "string", description: "Speaking rate 0.5–2.0", default: "1.0" },
     "list-voices": { type: "boolean", description: "List installed voices and exit" },
@@ -183,12 +206,13 @@ export const sayCommand = defineCommand({
     }
     const text = await resolveText(inlineText);
     const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
-    const voice = explicitVoice ?? (await autoRouteVoice(text));
+    const langHint = typeof args.lang === "string" ? args.lang : undefined;
+    const voice = await resolveSayVoice(explicitVoice, langHint, text);
 
     const opts = {
       text,
       voice,
-      lang: typeof args.lang === "string" ? args.lang : undefined,
+      lang: langHint,
       out: typeof args.out === "string" ? args.out : undefined,
       rate,
       ssml: Boolean(args.ssml),

--- a/src/mcp/voices.ts
+++ b/src/mcp/voices.ts
@@ -60,6 +60,22 @@ function parseVoiceInfo(id: string): VoiceInfo {
     };
   }
 
+  const kokoro = id.match(/^(es|fr|hi|it|ja|pt|zh)-([a-z][fm]_.+)$/);
+  if (kokoro) {
+    const languageCode = kokoro[1];
+    const bareVoice = kokoro[2];
+    const genderChar = bareVoice[1];
+    const gender: "male" | "female" = genderChar === "f" ? "female" : "male";
+    return {
+      voiceId: id,
+      modelId: "kokoro",
+      modelName: "Kokoro-82M",
+      languageCode,
+      languageName: langNameFor(languageCode),
+      gender,
+    };
+  }
+
   if (id.startsWith("macos-")) {
     const m = id.match(/[a-z]{2}-[A-Z]{2}/);
     const languageCode = m ? m[0] : "";

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -5,6 +5,15 @@
  */
 const RU_DARWIN_FALLBACK_VOICE = "macos-com.apple.voice.compact.ru-RU.Milena";
 
+const DARWIN_KOKORO_DEFAULTS: Record<string, string> = {
+  es: "es-em_alex",
+  hi: "hi-hm_omega",
+  it: "it-im_nicola",
+  ja: "ja-jm_kumo",
+  pt: "pt-pm_alex",
+  zh: "zh-zm_yunjian",
+};
+
 /** Map a detected language code to a default voice id. Unknown / low-confidence → undefined. */
 export function pickVoiceForLang(
   code: string | undefined,
@@ -12,12 +21,14 @@ export function pickVoiceForLang(
   platform: NodeJS.Platform = process.platform,
 ): string | undefined {
   if (!code || confidence < 0.5) return undefined;
-  switch (code) {
+  const baseCode = code.toLowerCase().split(/[-_]/, 1)[0];
+  switch (baseCode) {
     case "en":
       return "en-am_michael";
     case "ru":
       return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-vosk-m02";
     default:
+      if (platform === "darwin") return DARWIN_KOKORO_DEFAULTS[baseCode];
       return undefined;
   }
 }

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -19,6 +19,7 @@ export function pickVoiceForLang(
   code: string | undefined,
   confidence: number,
   platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
 ): string | undefined {
   if (!code || confidence < 0.5) return undefined;
   const baseCode = code.toLowerCase().split(/[-_]/, 1)[0];
@@ -26,9 +27,13 @@ export function pickVoiceForLang(
     case "en":
       return "en-am_michael";
     case "ru":
+      // AVSpeech Milena is a macOS system voice (any arch); Vosk elsewhere.
       return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-vosk-m02";
     default:
-      if (platform === "darwin") return DARWIN_KOKORO_DEFAULTS[baseCode];
+      // Multilingual Kokoro voices ship only on darwin-arm64 (FluidAudio ANE).
+      // Intel Macs have no such voice pack, so don't auto-route to ids the
+      // engine can't honour — fall through to the engine default instead.
+      if (platform === "darwin" && arch === "arm64") return DARWIN_KOKORO_DEFAULTS[baseCode];
       return undefined;
   }
 }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -387,7 +387,7 @@ ARGUMENTS
 OPTIONS
 
               --voice=<voice>    Voice id, e.g. en-am_michael
-                --lang=<lang>    BCP 47 language code (default en-us)
+                --lang=<lang>    BCP 47 language code (default en-us). With no --voice, routes to that language's default voice and skips text-language detection.
                   --out=<out>    Write audio to file instead of stdout
                 --rate=<rate>    Speaking rate 0.5–2.0 (Default: 1.0)
                 --list-voices    List installed voices and exit

--- a/tests/unit/mcp-voices.test.ts
+++ b/tests/unit/mcp-voices.test.ts
@@ -64,6 +64,36 @@ describe("parseVoiceLines", () => {
     expect(v.languageCode).toBe("");
   });
 
+  test("maps multilingual Kokoro ids", () => {
+    const out = parseVoiceLines("es-em_alex\nja-jm_kumo\nfr-ff_siwis\n");
+    expect(out).toEqual([
+      {
+        voiceId: "es-em_alex",
+        modelId: "kokoro",
+        modelName: "Kokoro-82M",
+        languageCode: "es",
+        languageName: "Spanish",
+        gender: "male",
+      },
+      {
+        voiceId: "ja-jm_kumo",
+        modelId: "kokoro",
+        modelName: "Kokoro-82M",
+        languageCode: "ja",
+        languageName: "Japanese",
+        gender: "male",
+      },
+      {
+        voiceId: "fr-ff_siwis",
+        modelId: "kokoro",
+        modelName: "Kokoro-82M",
+        languageCode: "fr",
+        languageName: "French",
+        gender: "female",
+      },
+    ]);
+  });
+
   test("vosk female voice has gender female", () => {
     const [v] = parseVoiceLines("ru-vosk-f01");
     expect(v.gender).toBe("female");

--- a/tests/unit/say-routing.test.ts
+++ b/tests/unit/say-routing.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSayVoice } from "../../src/cli/say";
+
+// resolveSayVoice precedence: --voice > --lang (route by stated language,
+// skip detection) > macOS auto-detect > engine default (undefined).
+// The --voice and --lang branches return before touching the engine, so these
+// are pure and platform-independent for `en`.
+describe("resolveSayVoice precedence", () => {
+  test("explicit --voice wins over a --lang hint", async () => {
+    expect(await resolveSayVoice("ru-vosk-m02", "es", "Hola mundo")).toBe("ru-vosk-m02");
+  });
+
+  test("--lang routes to that language's default voice (skips detection)", async () => {
+    expect(await resolveSayVoice(undefined, "en", "irrelevant")).toBe("en-am_michael");
+    // BCP 47 region/script subtags are normalized away before lookup.
+    expect(await resolveSayVoice(undefined, "en-US", "irrelevant")).toBe("en-am_michael");
+    expect(await resolveSayVoice(undefined, "EN_us", "irrelevant")).toBe("en-am_michael");
+  });
+
+  test("--lang with no mapped voice → undefined (engine default), no re-detection", async () => {
+    // French has no male Kokoro voice → unmapped on every platform.
+    expect(await resolveSayVoice(undefined, "fr", "Bonjour")).toBeUndefined();
+    // Unknown language code → unmapped.
+    expect(await resolveSayVoice(undefined, "xx", "whatever")).toBeUndefined();
+  });
+});

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -17,6 +17,21 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("ru", 0.95, "win32")).toBe("ru-vosk-m02");
   });
 
+  it("routes supported Kokoro languages to male FluidAudio voices on darwin", () => {
+    expect(pickVoiceForLang("es", 0.95, "darwin")).toBe("es-em_alex");
+    expect(pickVoiceForLang("es-ES", 0.95, "darwin")).toBe("es-em_alex");
+    expect(pickVoiceForLang("hi", 0.95, "darwin")).toBe("hi-hm_omega");
+    expect(pickVoiceForLang("it", 0.95, "darwin")).toBe("it-im_nicola");
+    expect(pickVoiceForLang("ja", 0.95, "darwin")).toBe("ja-jm_kumo");
+    expect(pickVoiceForLang("pt-BR", 0.95, "darwin")).toBe("pt-pm_alex");
+    expect(pickVoiceForLang("zh-Hans", 0.95, "darwin")).toBe("zh-zm_yunjian");
+  });
+
+  it("does not auto-route Kokoro-only languages on non-darwin", () => {
+    expect(pickVoiceForLang("es", 0.95, "linux")).toBeUndefined();
+    expect(pickVoiceForLang("ja", 0.95, "win32")).toBeUndefined();
+  });
+
   it("returns undefined below 0.5 confidence (too ambiguous)", () => {
     expect(pickVoiceForLang("ru", 0.3)).toBeUndefined();
   });

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -17,19 +17,29 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("ru", 0.95, "win32")).toBe("ru-vosk-m02");
   });
 
-  it("routes supported Kokoro languages to male FluidAudio voices on darwin", () => {
-    expect(pickVoiceForLang("es", 0.95, "darwin")).toBe("es-em_alex");
-    expect(pickVoiceForLang("es-ES", 0.95, "darwin")).toBe("es-em_alex");
-    expect(pickVoiceForLang("hi", 0.95, "darwin")).toBe("hi-hm_omega");
-    expect(pickVoiceForLang("it", 0.95, "darwin")).toBe("it-im_nicola");
-    expect(pickVoiceForLang("ja", 0.95, "darwin")).toBe("ja-jm_kumo");
-    expect(pickVoiceForLang("pt-BR", 0.95, "darwin")).toBe("pt-pm_alex");
-    expect(pickVoiceForLang("zh-Hans", 0.95, "darwin")).toBe("zh-zm_yunjian");
+  it("routes supported Kokoro languages to male FluidAudio voices on darwin-arm64", () => {
+    expect(pickVoiceForLang("es", 0.95, "darwin", "arm64")).toBe("es-em_alex");
+    expect(pickVoiceForLang("es-ES", 0.95, "darwin", "arm64")).toBe("es-em_alex");
+    expect(pickVoiceForLang("hi", 0.95, "darwin", "arm64")).toBe("hi-hm_omega");
+    expect(pickVoiceForLang("it", 0.95, "darwin", "arm64")).toBe("it-im_nicola");
+    expect(pickVoiceForLang("ja", 0.95, "darwin", "arm64")).toBe("ja-jm_kumo");
+    expect(pickVoiceForLang("pt-BR", 0.95, "darwin", "arm64")).toBe("pt-pm_alex");
+    expect(pickVoiceForLang("zh-Hans", 0.95, "darwin", "arm64")).toBe("zh-zm_yunjian");
   });
 
   it("does not auto-route Kokoro-only languages on non-darwin", () => {
     expect(pickVoiceForLang("es", 0.95, "linux")).toBeUndefined();
     expect(pickVoiceForLang("ja", 0.95, "win32")).toBeUndefined();
+  });
+
+  it("does not auto-route multilingual Kokoro on Intel macOS (no FluidAudio voice pack)", () => {
+    expect(pickVoiceForLang("es", 0.95, "darwin", "x64")).toBeUndefined();
+    expect(pickVoiceForLang("ja", 0.95, "darwin", "x64")).toBeUndefined();
+    // en (ONNX Kokoro) and ru (AVSpeech Milena) still route on Intel Macs.
+    expect(pickVoiceForLang("en", 0.95, "darwin", "x64")).toBe("en-am_michael");
+    expect(pickVoiceForLang("ru", 0.95, "darwin", "x64")).toBe(
+      "macos-com.apple.voice.compact.ru-RU.Milena",
+    );
   });
 
   it("returns undefined below 0.5 confidence (too ambiguous)", () => {


### PR DESCRIPTION
## Summary
- expose selected multilingual Kokoro voice ids on darwin-arm64 FluidAudio/CoreML builds
- map public `lang-voice` ids to FluidAudio bare voice-pack ids and stage pinned ANE voice packs
- add Darwin auto-routing for Kokoro languages with native male defaults; keep French explicit-only because upstream Kokoro has no native male French voice
- update MCP voice metadata, CLI docs, and README examples

## Validation
- `bun test`
- `bunx tsc --noEmit`
- `cd rust && cargo fmt --check`
- `git diff --check`
- `cd rust && cargo clippy --all-targets --features coreml,tts,system_tts,system_kokoro,system_text_lang --no-default-features -- -D warnings`
- `cd rust && cargo nextest run --features tts`
- `cd rust && cargo test --features coreml,tts,system_tts,system_kokoro,system_text_lang --no-default-features fluid_kokoro -- --nocapture`
- `cd rust && cargo test --features coreml,tts,system_tts,system_kokoro,system_text_lang --no-default-features resolve_multilingual_kokoro_voice_uses_fluid_audio_on_darwin -- --nocapture`
- `cd rust && cargo test --features coreml,tts,system_tts,system_kokoro,system_text_lang --no-default-features ane_kokoro_voices_shape_and_male_default -- --nocapture`
- local darwin-arm64 smoke: `kesha-engine say --list-voices` lists `es-em_alex`, `hi-hm_omega`, `it-im_nicola`, `ja-jm_kumo`, `pt-pm_alex`, `zh-zm_yunjian`, `fr-ff_siwis`, and `en-bm_lewis`; `kesha-engine say --voice es-em_alex|ja-jm_kumo|zh-zm_yunjian|fr-ff_siwis` produced valid 24 kHz mono WAVs