### PR TITLE
chore(release): 1.22.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.21.0",
+  "version": "1.22.0-beta.1",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.21.0"
+    "version": "1.22.0-beta.1"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.21.0"
+version = "1.22.0-beta.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.21.0"
+version = "1.22.0-beta.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Beta engine release. Bumps `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`/`Cargo.lock` to `1.22.0-beta.1`.

## What ships (engine work on main since v1.21.0)

- **#487** — structured error taxonomy: stable `ErrorCode` at every engine failure path, `coded_bail!`/`CodedContext`, and the new `kesha-engine --error-codes-json` capability surface. Lets the CLI/consumers match on code, not message.
- **#490** — multilingual FluidAudio Kokoro voices on darwin-arm64 (ANE), plus `--lang`-driven voice routing in the CLI (`--voice` > `--lang` > macOS text-detect > engine default), arch-gated so Intel Macs / Linux / Windows don't auto-route to ids they can't honour.

(CI-lane split #489 and docs #485/#486/#488 are also on main but don't affect the engine binary.)

## Release mechanics

- Version-neutral feature PRs (#487, #490) are now version-stamped here, per the decoupled CLI/engine release process.
- `release/*` branch → `integration-tests` correctly skips (release chicken-and-egg guard; the `v1.22.0-beta.1` tag doesn't exist yet).
- Drift gate green: `keshaEngine.version == rust/Cargo.toml` and `package.json#version >= keshaEngine.version`.
- Local verification: `bun test` 364 pass / 0 fail, `tsc --noEmit` clean.

After merge: tag `v1.22.0-beta.1` → `build-engine.yml` drafts a prerelease (engine binaries + sidecars + SHA256SUMS + manifest + SBOM + Sigstore; Homebrew/.deb/.rpm intentionally skipped for betas). Validate draft assets via authenticated `gh release download`, then un-draft → `npm publish --tag beta` (so `@latest` stays on 1.21.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)