### PR TITLE
fix(tts): warn on native-script input to non-Latin FluidAudio Kokoro voices

### DIFF
--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -11,6 +11,8 @@
 ))]
 
 use anyhow::{Context, Result};
+use std::sync::Once;
+
 use fluidaudio_rs::FluidAudio;
 
 /// FluidAudio Kokoro native output rate (24 kHz mono, 16-bit PCM). Used to size
@@ -181,6 +183,53 @@ pub fn resolve_voice(public_id: &str) -> Option<VoiceSpec> {
     VOICES.iter().copied().find(|v| v.public_id == public_id)
 }
 
+fn lang_for_fluid_id(fluid_id: &str) -> Option<&'static str> {
+    VOICES
+        .iter()
+        .find(|v| v.fluid_id == fluid_id)
+        .map(|v| v.lang)
+}
+
+fn is_han(c: char) -> bool {
+    matches!(c, '\u{3400}'..='\u{4DBF}' | '\u{4E00}'..='\u{9FFF}' | '\u{F900}'..='\u{FAFF}')
+}
+
+/// FluidAudio's Kokoro G2P only phonemizes **Latin** input; for the non-Latin
+/// languages it ships voices for (hi/ja/zh) native-script text is not converted
+/// to phonemes and synthesizes as noise rather than speech (#492). Returns the
+/// human-facing script name when `text` actually contains characters of the
+/// script `fluid_id`'s language is written in — romanized (Latin) input for the
+/// same voice returns `None` because it works. Latin-script Kokoro languages
+/// (en/es/fr/it/pt) always return `None`.
+fn unsupported_native_script(text: &str, fluid_id: &str) -> Option<&'static str> {
+    let any = |f: fn(char) -> bool| text.chars().any(f);
+    match lang_for_fluid_id(fluid_id)? {
+        "hi" => any(|c| ('\u{0900}'..='\u{097F}').contains(&c)).then_some("Devanagari"),
+        "ja" => any(|c| matches!(c, '\u{3040}'..='\u{30FF}') || is_han(c))
+            .then_some("Japanese (kana/kanji)"),
+        "zh" => any(is_han).then_some("Chinese (Han)"),
+        _ => None,
+    }
+}
+
+/// One-time stderr warning when native-script text is handed to a FluidAudio
+/// Kokoro voice that can't phonemize it (#492). It's a silent failure otherwise:
+/// audio is produced, just not speech. Shared `Once` so a multi-segment SSML
+/// utterance (many `synthesize_pcm` calls) warns at most once per process.
+fn warn_if_unsupported_script(fluid_id: &str, text: &str) {
+    static SCRIPT_WARNING: Once = Once::new();
+    if let Some(script) = unsupported_native_script(text, fluid_id) {
+        SCRIPT_WARNING.call_once(|| {
+            eprintln!(
+                "warning: FluidAudio Kokoro can only phonemize Latin-script input; voice \
+                 '{fluid_id}' received {script} text, which synthesizes as noise rather than \
+                 speech. Romanize the text (transliterate to Latin) for now. \
+                 Tracking: https://github.com/drakulavich/kesha-voice-kit/issues/492"
+            );
+        });
+    }
+}
+
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
 /// with the process's stdout silenced for the whole bridge lifetime (create →
 /// call → drop). FluidAudio's CoreML pipeline writes diagnostics to stdout that
@@ -204,6 +253,7 @@ pub fn synthesize(text: &str, voice_id: &str, speed: f32) -> Result<Vec<u8>> {
     if text.is_empty() {
         anyhow::bail!("fluid-kokoro: text is empty");
     }
+    warn_if_unsupported_script(voice_id, text);
     with_kokoro(voice_id, |audio| {
         audio
             .synthesize_kokoro(text, voice_id, speed)
@@ -226,6 +276,7 @@ pub fn synthesize_pcm(text: &str, voice_id: &str, speed: f32) -> Result<Vec<f32>
     if text.trim().is_empty() {
         return Ok(Vec::new());
     }
+    warn_if_unsupported_script(voice_id, text);
     let wav = with_kokoro(voice_id, |audio| {
         audio
             .synthesize_kokoro(text, voice_id, speed)
@@ -294,6 +345,62 @@ mod tests {
         let spec = resolve_voice("pt-pm_alex").expect("pt voice");
         assert_eq!(spec.fluid_id, "pm_alex");
         assert_eq!(spec.lang, "pt-br");
+    }
+
+    #[test]
+    fn flags_native_script_for_non_latin_voices() {
+        // Native script for hi/ja/zh → flagged (FluidAudio can't phonemize it, #492).
+        assert_eq!(
+            unsupported_native_script("नमस्ते मेरा नाम केशा है", "hm_omega"),
+            Some("Devanagari")
+        );
+        assert_eq!(
+            unsupported_native_script("こんにちは、ケシャです", "jm_kumo"),
+            Some("Japanese (kana/kanji)")
+        );
+        // Kanji-only Japanese still flags via the Han range.
+        assert_eq!(
+            unsupported_native_script("日本語", "jm_kumo"),
+            Some("Japanese (kana/kanji)")
+        );
+        assert_eq!(
+            unsupported_native_script("你好我叫凯沙", "zm_yunjian"),
+            Some("Chinese (Han)")
+        );
+    }
+
+    #[test]
+    fn allows_romanized_input_for_non_latin_voices() {
+        // Romanized (Latin) input for the same voices works — must NOT be flagged.
+        assert_eq!(
+            unsupported_native_script("Namaste! Mera naam Kesha hai.", "hm_omega"),
+            None
+        );
+        assert_eq!(
+            unsupported_native_script("Konnichiwa! Watashi wa Kesha desu.", "jm_kumo"),
+            None
+        );
+        assert_eq!(
+            unsupported_native_script("Ni hao! Wo jiao Kesha.", "zm_yunjian"),
+            None
+        );
+    }
+
+    #[test]
+    fn never_flags_latin_script_voices() {
+        // Latin-script Kokoro languages always pass, including accented/punctuated text.
+        assert_eq!(
+            unsupported_native_script("¡Hola! Soy Kesha.", "em_alex"),
+            None
+        );
+        assert_eq!(
+            unsupported_native_script("Ciao, città però.", "im_nicola"),
+            None
+        );
+        assert_eq!(unsupported_native_script("Olá, coração.", "pm_alex"), None);
+        assert_eq!(unsupported_native_script("Hello world", "am_michael"), None);
+        // Unknown / unmapped fluid id → no language → never flagged.
+        assert_eq!(unsupported_native_script("日本語", "nonexistent"), None);
     }
 
     #[test]

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -191,7 +191,15 @@ fn lang_for_fluid_id(fluid_id: &str) -> Option<&'static str> {
 }
 
 fn is_han(c: char) -> bool {
-    matches!(c, '\u{3400}'..='\u{4DBF}' | '\u{4E00}'..='\u{9FFF}' | '\u{F900}'..='\u{FAFF}')
+    matches!(
+        c,
+        '\u{3400}'..='\u{4DBF}'        // CJK Extension A
+            | '\u{4E00}'..='\u{9FFF}'  // CJK Unified Ideographs
+            | '\u{F900}'..='\u{FAFF}'  // CJK Compatibility Ideographs
+            | '\u{20000}'..='\u{2A6DF}' // Extension B
+            | '\u{2A700}'..='\u{2CEAF}' // Extensions C, D, E
+            | '\u{2CEB0}'..='\u{2EBEF}' // Extension F
+    )
 }
 
 /// FluidAudio's Kokoro G2P only phonemizes **Latin** input; for the non-Latin
@@ -214,20 +222,33 @@ fn unsupported_native_script(text: &str, fluid_id: &str) -> Option<&'static str>
 
 /// One-time stderr warning when native-script text is handed to a FluidAudio
 /// Kokoro voice that can't phonemize it (#492). It's a silent failure otherwise:
-/// audio is produced, just not speech. Shared `Once` so a multi-segment SSML
-/// utterance (many `synthesize_pcm` calls) warns at most once per process.
+/// audio is produced, just not speech.
+///
+/// Deduplication is **per language**, not process-wide: a multi-segment SSML
+/// utterance in one language warns at most once, but a process that synthesizes
+/// two non-Latin languages (e.g. Hindi then Japanese) still warns for each — a
+/// shared `Once` would let whichever fired first swallow the others' warnings.
 fn warn_if_unsupported_script(fluid_id: &str, text: &str) {
-    static SCRIPT_WARNING: Once = Once::new();
-    if let Some(script) = unsupported_native_script(text, fluid_id) {
-        SCRIPT_WARNING.call_once(|| {
-            eprintln!(
-                "warning: FluidAudio Kokoro can only phonemize Latin-script input; voice \
-                 '{fluid_id}' received {script} text, which synthesizes as noise rather than \
-                 speech. Romanize the text (transliterate to Latin) for now. \
-                 Tracking: https://github.com/drakulavich/kesha-voice-kit/issues/492"
-            );
-        });
-    }
+    static WARNED_HI: Once = Once::new();
+    static WARNED_JA: Once = Once::new();
+    static WARNED_ZH: Once = Once::new();
+    let Some(script) = unsupported_native_script(text, fluid_id) else {
+        return;
+    };
+    let once = match lang_for_fluid_id(fluid_id) {
+        Some("hi") => &WARNED_HI,
+        Some("ja") => &WARNED_JA,
+        Some("zh") => &WARNED_ZH,
+        _ => return,
+    };
+    once.call_once(|| {
+        eprintln!(
+            "warning: FluidAudio Kokoro can only phonemize Latin-script input; voice \
+             '{fluid_id}' received {script} text, which synthesizes as noise rather than \
+             speech. Romanize the text (transliterate to Latin) for now. \
+             Tracking: https://github.com/drakulavich/kesha-voice-kit/issues/492"
+        );
+    });
 }
 
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
@@ -365,6 +386,11 @@ mod tests {
         );
         assert_eq!(
             unsupported_native_script("你好我叫凯沙", "zm_yunjian"),
+            Some("Chinese (Han)")
+        );
+        // Supplementary-plane CJK (Extension B, U+20000) must also be detected.
+        assert_eq!(
+            unsupported_native_script("\u{20000}", "zm_yunjian"),
             Some("Chinese (Han)")
         );
     }


### PR DESCRIPTION
## Problem

The multilingual FluidAudio Kokoro voices shipped in #490 (`v1.22.0-beta.1`) **silently emit noise** when given native-script text for non-Latin languages. `kesha say --voice hi-hm_omega` with Devanagari produces a valid WAV that isn't speech.

Round-trip via the kit's own ASR (full evidence in #492):

| Lang | Script | ASR of synth | |
|------|--------|--------------|--|
| es/it/pt/en/fr | Latin | recognizable words | ✅ |
| hi | Devanagari | `"XXXX."` | ❌ noise |
| ja | kana/kanji | `"Cycle."` | ❌ noise |
| zh | Han | `"Mangas Kagakakaki."` | ❌ noise |

**Root cause** (traced through the binding): the `fluidaudio-rs` fork hard-codes `KokoroAneManager(variant: .english)`, so every word goes through the English espeak→IPA G2P. Non-Latin codepoints aren't in that inventory → garbage phonemes. The multilingual G2P (`MultilingualG2PModel`) and a phoneme-bypass FFI exist upstream in 0.14.7 but aren't wired into the Kokoro path or bound by the fork — so there's no zero-cost switch (see #492 for the ranked fix paths).

## This change (the gate)

Detect native-script input for `hi`/`ja`/`zh` FluidAudio Kokoro voices and emit a **one-time stderr warning** instead of silently producing noise:

```
warning: FluidAudio Kokoro can only phonemize Latin-script input; voice 'hm_omega'
received Devanagari text, which synthesizes as noise rather than speech. Romanize
the text (transliterate to Latin) for now. Tracking: .../issues/492
```

- Keyed on the resolved voice's **language** + the Unicode script blocks **actually present** in the text — romanized (Latin) input for the same voice is not flagged (it works), and accented Latin (Spanish/Italian/Portuguese) never false-positives.
- Shared `Once` dedupes across multi-segment SSML utterances.
- **Warn, not error**, and **not** removed from auto-routing: the voices genuinely work with romanized input, so the voice stays usable; this just surfaces the silent failure. (Hard-erroring is an alternative if you'd prefer refusing native-script outright — easy follow-up.)

## Why warn covers all paths

The check sits in `fluid_kokoro::{synthesize, synthesize_pcm}` — the chokepoint for both explicit `--voice` and `--lang` auto-routed calls — so a separate `voice-routing.ts` change isn't needed.

## Verification

`system_kokoro` is compiled but **never run** in CI (rust-test builds `onnx,tts` defaults + `cargo check --features coreml`), so this was verified locally on darwin-arm64:

- `cargo clippy --features system_kokoro --all-targets -- -D warnings` — clean
- `cargo nextest --features system_kokoro` — 12/12 `fluid_kokoro` tests pass (3 new: native-script flagged, romanized allowed, Latin never flagged incl. accents + unknown voice id)
- e2e `say`: warning fires on Devanagari (audio still produced), silent on romanized Hindi + English

Refs #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)