### PR TITLE
fix(util): gate argmax to match its consumer's cfg (onnx, not coreml)

### DIFF
--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -3,10 +3,12 @@
 /// Index of the largest f32 in a slice. Ties pick the lowest index.
 ///
 /// Only the ONNX ASR backend (`backend::onnx`, Parakeet TDT) uses this today;
-/// the ByT5 G2P consumer was removed in #213. Gate it on `onnx` so the
-/// darwin-arm64 `coreml`/`system_kokoro` feature set (which doesn't build the
-/// ONNX backend) doesn't trip clippy's `dead_code` lint under `-D warnings`.
-#[cfg(feature = "onnx")]
+/// the ByT5 G2P consumer was removed in #213. The gate mirrors that module's
+/// own `#[cfg(all(feature = "onnx", not(feature = "coreml")))]` in
+/// `backend/mod.rs` exactly: with both `onnx` and `coreml` enabled the ONNX
+/// backend is cfg'd out, so gating on `onnx` alone would compile `argmax` with
+/// no caller and trip clippy's `dead_code` lint under `-D warnings`.
+#[cfg(all(feature = "onnx", not(feature = "coreml")))]
 pub fn argmax(xs: &[f32]) -> usize {
     let mut best = 0;
     let mut best_v = f32::NEG_INFINITY;


### PR DESCRIPTION
## What

`argmax` in `src/util.rs` was gated `#[cfg(feature = "onnx")]`, but its only caller — `backend/onnx.rs` — is gated `#[cfg(all(feature = "onnx", not(feature = "coreml")))]` (`backend/mod.rs:5`). With **both** `onnx` and `coreml` enabled, the ONNX backend is cfg'd out while `argmax` is still compiled with no caller → clippy `dead_code` under `-D warnings`.

This change makes `argmax`'s gate mirror its consumer's exactly.

## Why it didn't bite CI/releases

- Real release builds use `--no-default-features` (darwin = `coreml` without `onnx`), so `argmax` is cfg'd out there — fine.
- CI clippy runs on default features (`onnx`, no `coreml`) where `argmax` is used — fine.
- Only a local `--features onnx,coreml` build (e.g. forgetting `--no-default-features`) surfaced it. Pure robustness/precision fix; no behavior change.

## Verification

`cargo clippy --all-targets -- -D warnings` clean on:
- default (`onnx,tts`) — `argmax` still used ✅
- `onnx,coreml,tts` — the combo that warned, now clean ✅
- `--no-default-features --features coreml,tts` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)