### PR TITLE
fix(tts)!: fail fast on native-script input to non-Latin Kokoro voices

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -28,6 +28,7 @@ needs sanitizing.
 | `E_VOICE_UNKNOWN` | tts | no | The voice id wasn't recognized. | `kesha say --list-voices`. |
 | `E_SSML_INVALID` | tts | no | SSML was malformed (missing `<speak>` root, DOCTYPE, or unsupported relative rate). | Fix the SSML; see [docs/tts.md](tts.md). |
 | `E_SSML_UNSUPPORTED` | tts | no | SSML isn't supported for this engine/voice. | Use a plain-text request or a supported voice. |
+| `E_SCRIPT_UNSUPPORTED` | tts | no | The text uses a script the chosen voice's G2P can't phonemize (e.g. Devanagari / kana-kanji / Han for the FluidAudio Kokoro `hi`/`ja`/`zh` voices, which only handle Latin input). | Romanize the text (transliterate to Latin), or use a voice whose engine supports the script. See [#492](https://github.com/drakulavich/kesha-voice-kit/issues/492). |
 | `E_TRANSCRIBE_FAILED` | transcribe | no | The ASR pipeline failed. | Re-run; file a bug with a support bundle. |
 | `E_DIARIZE_TIMEOUT` | transcribe | yes | Speaker diarization timed out (cold compile or long audio). | Re-run once warm; shorten the audio. |
 | `E_ENGINE_SPAWN` | internal | no | The CLI couldn't spawn the engine subprocess. | `kesha install`; check the engine binary path (`KESHA_ENGINE_BIN`). |

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -24,6 +24,7 @@ pub enum ErrorCode {
     VoiceUnknown,
     SsmlInvalid,
     SsmlUnsupported,
+    ScriptUnsupported,
     TranscribeFailed,
     DiarizeTimeout,
     InvalidArg,
@@ -42,7 +43,7 @@ pub enum Category {
 }
 
 impl ErrorCode {
-    pub const ALL: [ErrorCode; 18] = [
+    pub const ALL: [ErrorCode; 19] = [
         ErrorCode::InputNotFound,
         ErrorCode::BadAudio,
         ErrorCode::ModelMissing,
@@ -57,6 +58,7 @@ impl ErrorCode {
         ErrorCode::VoiceUnknown,
         ErrorCode::SsmlInvalid,
         ErrorCode::SsmlUnsupported,
+        ErrorCode::ScriptUnsupported,
         ErrorCode::TranscribeFailed,
         ErrorCode::DiarizeTimeout,
         ErrorCode::InvalidArg,
@@ -79,6 +81,7 @@ impl ErrorCode {
             ErrorCode::VoiceUnknown => "E_VOICE_UNKNOWN",
             ErrorCode::SsmlInvalid => "E_SSML_INVALID",
             ErrorCode::SsmlUnsupported => "E_SSML_UNSUPPORTED",
+            ErrorCode::ScriptUnsupported => "E_SCRIPT_UNSUPPORTED",
             ErrorCode::TranscribeFailed => "E_TRANSCRIBE_FAILED",
             ErrorCode::DiarizeTimeout => "E_DIARIZE_TIMEOUT",
             ErrorCode::InvalidArg => "E_INVALID_ARG",
@@ -102,6 +105,7 @@ impl ErrorCode {
             ErrorCode::VoiceUnknown => "Unknown voice id",
             ErrorCode::SsmlInvalid => "Malformed SSML",
             ErrorCode::SsmlUnsupported => "SSML not supported for this engine",
+            ErrorCode::ScriptUnsupported => "Text script not supported for this voice",
             ErrorCode::TranscribeFailed => "Transcription failed",
             ErrorCode::DiarizeTimeout => "Speaker diarization timed out",
             ErrorCode::InvalidArg => "Invalid command-line argument",
@@ -125,7 +129,8 @@ impl ErrorCode {
             | ErrorCode::TextTooLong
             | ErrorCode::VoiceUnknown
             | ErrorCode::SsmlInvalid
-            | ErrorCode::SsmlUnsupported => Category::Tts,
+            | ErrorCode::SsmlUnsupported
+            | ErrorCode::ScriptUnsupported => Category::Tts,
             ErrorCode::TranscribeFailed | ErrorCode::DiarizeTimeout => Category::Transcribe,
             ErrorCode::Internal => Category::Internal,
         }

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -11,9 +11,11 @@
 ))]
 
 use anyhow::{Context, Result};
-use std::sync::Once;
 
 use fluidaudio_rs::FluidAudio;
+
+use crate::coded_bail;
+use crate::errors::ErrorCode;
 
 /// FluidAudio Kokoro native output rate (24 kHz mono, 16-bit PCM). Used to size
 /// SSML `<break>` silence buffers when the segment walker stitches audio.
@@ -220,35 +222,23 @@ fn unsupported_native_script(text: &str, fluid_id: &str) -> Option<&'static str>
     }
 }
 
-/// One-time stderr warning when native-script text is handed to a FluidAudio
-/// Kokoro voice that can't phonemize it (#492). It's a silent failure otherwise:
-/// audio is produced, just not speech.
-///
-/// Deduplication is **per language**, not process-wide: a multi-segment SSML
-/// utterance in one language warns at most once, but a process that synthesizes
-/// two non-Latin languages (e.g. Hindi then Japanese) still warns for each — a
-/// shared `Once` would let whichever fired first swallow the others' warnings.
-fn warn_if_unsupported_script(fluid_id: &str, text: &str) {
-    static WARNED_HI: Once = Once::new();
-    static WARNED_JA: Once = Once::new();
-    static WARNED_ZH: Once = Once::new();
-    let Some(script) = unsupported_native_script(text, fluid_id) else {
-        return;
-    };
-    let once = match lang_for_fluid_id(fluid_id) {
-        Some("hi") => &WARNED_HI,
-        Some("ja") => &WARNED_JA,
-        Some("zh") => &WARNED_ZH,
-        _ => return,
-    };
-    once.call_once(|| {
-        eprintln!(
-            "warning: FluidAudio Kokoro can only phonemize Latin-script input; voice \
-             '{fluid_id}' received {script} text, which synthesizes as noise rather than \
-             speech. Romanize the text (transliterate to Latin) for now. \
-             Tracking: https://github.com/drakulavich/kesha-voice-kit/issues/492"
+/// Fail fast when native-script text is handed to a FluidAudio Kokoro voice
+/// that can't phonemize it (#492). FluidAudio's Kokoro G2P only handles Latin
+/// input, so Devanagari/kana-kanji/Han would synthesize as noise rather than
+/// speech — refusing with a stable [`ErrorCode::ScriptUnsupported`] beats
+/// emitting a successful WAV of garbage. Romanized (Latin) input for the same
+/// voice passes the check.
+fn ensure_script_supported(fluid_id: &str, text: &str) -> Result<()> {
+    if let Some(script) = unsupported_native_script(text, fluid_id) {
+        coded_bail!(
+            ErrorCode::ScriptUnsupported,
+            "FluidAudio Kokoro voice '{fluid_id}' cannot phonemize {script} text; it only \
+             supports Latin-script input. Romanize the text (transliterate to Latin), or use a \
+             voice whose engine supports {script}. \
+             See https://github.com/drakulavich/kesha-voice-kit/issues/492"
         );
-    });
+    }
+    Ok(())
 }
 
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
@@ -274,7 +264,7 @@ pub fn synthesize(text: &str, voice_id: &str, speed: f32) -> Result<Vec<u8>> {
     if text.is_empty() {
         anyhow::bail!("fluid-kokoro: text is empty");
     }
-    warn_if_unsupported_script(voice_id, text);
+    ensure_script_supported(voice_id, text)?;
     with_kokoro(voice_id, |audio| {
         audio
             .synthesize_kokoro(text, voice_id, speed)
@@ -297,7 +287,7 @@ pub fn synthesize_pcm(text: &str, voice_id: &str, speed: f32) -> Result<Vec<f32>
     if text.trim().is_empty() {
         return Ok(Vec::new());
     }
-    warn_if_unsupported_script(voice_id, text);
+    ensure_script_supported(voice_id, text)?;
     let wav = with_kokoro(voice_id, |audio| {
         audio
             .synthesize_kokoro(text, voice_id, speed)
@@ -427,6 +417,36 @@ mod tests {
         assert_eq!(unsupported_native_script("Hello world", "am_michael"), None);
         // Unknown / unmapped fluid id → no language → never flagged.
         assert_eq!(unsupported_native_script("日本語", "nonexistent"), None);
+    }
+
+    #[test]
+    fn ensure_script_supported_bails_with_code_on_native_script() {
+        for (text, voice) in [
+            ("नमस्ते", "hm_omega"),
+            ("こんにちは", "jm_kumo"),
+            ("你好", "zm_yunjian"),
+        ] {
+            let err =
+                ensure_script_supported(voice, text).expect_err("should reject native script");
+            assert_eq!(
+                crate::errors::code_of(&err),
+                ErrorCode::ScriptUnsupported,
+                "voice {voice} text {text:?} -> {err}"
+            );
+        }
+        // Romanized + Latin-script voices pass.
+        ensure_script_supported("hm_omega", "Namaste").expect("romanized hi ok");
+        ensure_script_supported("em_alex", "¡Hola!").expect("latin es ok");
+        ensure_script_supported("am_michael", "Hello").expect("english ok");
+    }
+
+    #[test]
+    fn synthesize_fails_fast_before_model_init() {
+        // Native-script input must error out *before* touching FluidAudio, so this
+        // needs no model download. Proves the gate refuses rather than emitting noise.
+        let err = synthesize("नमस्ते मेरा नाम केशा है", "hm_omega", 1.0)
+            .expect_err("native-script synth must fail fast");
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::ScriptUnsupported);
     }
 
     #[test]

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -113,8 +113,16 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         if opts.ssml {
             return synth_segments_fluid_kokoro(opts.text, voice_id, *speed, opts.format);
         }
-        let wav_bytes = super::fluid_kokoro::synthesize(opts.text, voice_id, *speed)
-            .map_err(|e| TtsError::SynthesisFailed(format!("fluid-kokoro: {e}")))?;
+        let wav_bytes =
+            super::fluid_kokoro::synthesize(opts.text, voice_id, *speed).map_err(|e| {
+                TtsError::Coded {
+                    // Preserve a precise code from the engine chain (e.g.
+                    // ScriptUnsupported for native-script input); plain synthesis
+                    // failures carry no CodedError, so code_of falls back to Internal.
+                    code: crate::errors::code_of(&e),
+                    message: format!("fluid-kokoro: {e}"),
+                }
+            })?;
         return transcode_to(&wav_bytes, opts.format);
     }
 
@@ -402,8 +410,15 @@ fn synth_segments_fluid_kokoro(
     let sample_rate = super::fluid_kokoro::SAMPLE_RATE;
     let mut out: Vec<f32> = Vec::new();
     for seg in &segments {
-        synth_one_fluid_kokoro(&synth, seg, speed, sample_rate, &mut out)
-            .map_err(|e| TtsError::SynthesisFailed(format!("fluid-kokoro: {e}")))?;
+        synth_one_fluid_kokoro(&synth, seg, speed, sample_rate, &mut out).map_err(|e| {
+            TtsError::Coded {
+                // Preserve a precise code from the engine chain (e.g.
+                // ScriptUnsupported for native-script input); plain synthesis
+                // failures carry no CodedError, so code_of falls back to Internal.
+                code: crate::errors::code_of(&e),
+                message: format!("fluid-kokoro: {e}"),
+            }
+        })?;
     }
     if out.is_empty() {
         return Err(TtsError::SynthesisFailed(


### PR DESCRIPTION
## What

Follow-up to #493. That PR **warned** but still emitted the (noise) WAV with exit 0 when native-script text hit the FluidAudio Kokoro `hi`/`ja`/`zh` voices. Producing garbage and reporting success violates "never return success on failure" — so this makes it **fail fast**.

`kesha say --voice hi-hm_omega <Devanagari>` now:
```
error [E_SCRIPT_UNSUPPORTED]: FluidAudio Kokoro voice 'hm_omega' cannot phonemize Devanagari text; it only supports Latin-script input. Romanize the text (transliterate to Latin), or use a voice whose engine supports Devanagari. See .../issues/492
```
…and exits non-zero with **no WAV** on stdout, instead of emitting noise.

## Changes

- **New taxonomy code `E_SCRIPT_UNSUPPORTED`** (`ErrorCode::ScriptUnsupported`, category `tts`) — documented in `docs/errors.md`; consumers can match the stable code instead of the message.
- `fluid_kokoro::{synthesize, synthesize_pcm}` call `ensure_script_supported`, which `coded_bail!`s **before** `with_kokoro` — so the failure needs no model download.
- `say.rs` preserves the code through `TtsError::Coded` (via `code_of`) on the FluidAudio paths → exit 4 with the coded stderr line. Generic synthesis failures still map to `Internal` (exit 4), unchanged.
- Romanized/Latin input and Latin-script voices (en/es/fr/it/pt) are unaffected.

## Behavior change

This is the deliberate warn→error escalation requested after #493 merged. Anyone currently piping native-script text to these voices was already getting unusable noise; now they get a clear, actionable error.

## Verification

`system_kokoro` is compiled-but-not-run in CI, so verified locally on darwin-arm64:
- `cargo clippy --all-targets -- -D warnings` clean on **default (`onnx,tts`)** and **`system_kokoro`**
- `cargo nextest --features system_kokoro` — 33/33, incl. new `ensure_script_supported_bails_with_code_on_native_script` and `synthesize_fails_fast_before_model_init` (proves the bail precedes model init), plus the `error_codes` docs/drift tests
- `bun test` 364 pass / 0 fail, `tsc --noEmit` clean

Refs #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)