### PR TITLE
chore(release): 1.22.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.22.0-beta.1",
+  "version": "1.22.0-beta.2",
   "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.22.0-beta.1"
+    "version": "1.22.0-beta.2"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.22.0-beta.1"
+version = "1.22.0-beta.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.22.0-beta.1"
+version = "1.22.0-beta.2"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Beta engine release. Bumps `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`/`Cargo.lock` to `1.22.0-beta.2`.

## What ships (engine work since v1.22.0-beta.1)

- **#495** — `kesha say` on native-script text (Devanagari/kana-kanji/Han) to the FluidAudio Kokoro `hi`/`ja`/`zh` voices now **fails fast** with `error [E_SCRIPT_UNSUPPORTED]` and emits no WAV, instead of silently producing noise. New stable taxonomy code.
- **#493** — the preceding warn-only gate (superseded by #495; never shipped to users).
- **#494** — `argmax` cfg precision (`onnx, not coreml`).

## Release mechanics

- `release/*` branch → `integration-tests` correctly skips (chicken-and-egg guard; the `v1.22.0-beta.2` tag doesn't exist yet).
- Drift gate green; feature matrix unchanged (`onnx,tts` defaults already mirrored).
- Local: `tsc` clean, drift PASS. `bun test` 363 pass / 0 assertion failures (one heavy diarize e2e hit its 30s cold-ANE-compile timeout — environmental, unrelated to a version bump).

After merge: tag `v1.22.0-beta.2` → `build-engine.yml` drafts a prerelease. Pre-undraft I'll validate draft assets and exercise the real binary — confirming `E_SCRIPT_UNSUPPORTED` fires on native script (no WAV) and en/multilingual romanized synth still works — then un-draft → `npm publish --tag beta` (`@latest` stays on 1.21.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)