### PR TITLE
chore: update package description (drop 107-lang detection, add Hermes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
   "version": "1.22.0-beta.2",
-  "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD + 107-language detection. Rust engine, Bun CLI, OpenClaw skill.",
+  "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD. Rust engine, Bun CLI, OpenClaw/Hermes skills.",
   "type": "module",
   "bin": {
     "kesha": "bin/kesha.js"


### PR DESCRIPTION
Metadata-only tweak to `package.json#description`:

- Drop "107-language detection" from the tagline.
- "OpenClaw skill" → "OpenClaw/Hermes skills".

Now matches the GitHub repo **About** description (already updated) and the new `hermes` repo topic.

Version-neutral (no engine/CLI bump). Ships with the next npm publish; not retroactive to `v1.22.0-beta.2`.

Verified: JSON parses, version-drift gate PASS, `tsc` clean. `bun test` 363 pass / 0 assertion failures (the lone fail is the diarize cold-ANE-compile e2e timeout — a description string can't touch it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)