### PR TITLE
docs: add supported-languages page (STT + TTS, codes + flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center"><b>Give your local tools and LLM agents a voice.</b><br>Fast speech-to-text, text-to-speech, voice-activity detection, and language detection in one local-first CLI: Apple Silicon CoreML first, ONNX fallback on supported Linux/Windows builds.</p>
 
-- **Transcribe locally** — 25 languages, up to ~19x faster than Whisper on Apple Silicon, ~2.5x on CPU
+- **Transcribe locally** — [25 languages](docs/languages.md), up to ~19x faster than Whisper on Apple Silicon, ~2.5x on CPU
 - **Speak back** — Kokoro (EN), Vosk-TTS (RU), macOS system voices, and SSML preview
 - **Plug into agents** — ship voice workflows as CLI commands, an MCP server, or an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill
 - **Small Rust engine** — single ~20MB binary, no ffmpeg, no Python, no native Node addons
@@ -90,8 +90,7 @@ kesha say "Hello" --format flac --out hi.flac     # FLAC — lossless, plays in 
 
 ## Languages
 
-- **Speech-to-text (25):** Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Spanish, Swedish, Ukrainian.
-- **Audio language detection (107):** [full list](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa).
+**Speech-to-text** spans 25 languages and **text-to-speech** covers English, Russian, and select multilingual voices — full tables with codes and flags in **[docs/languages.md](docs/languages.md)**. Audio language detection identifies [107 languages](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa).
 
 ## Performance
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,0 +1,62 @@
+# Supported languages
+
+Kesha does three language-aware things: **speech-to-text** (ASR), **text-to-speech**, and **audio language detection**. Coverage differs per task — see each section below.
+
+> Flags are indicative regional markers, not a claim about dialect or country; languages aren't countries. Codes are ISO 639-1, the same ones `--lang` accepts.
+
+## Speech-to-text (25)
+
+NVIDIA Parakeet TDT 0.6B v3. Language is auto-detected; `--lang <code>` warns if the detected language differs.
+
+| Language | Code | |
+|----------|------|---|
+| Bulgarian | `bg` | 🇧🇬 |
+| Croatian | `hr` | 🇭🇷 |
+| Czech | `cs` | 🇨🇿 |
+| Danish | `da` | 🇩🇰 |
+| Dutch | `nl` | 🇳🇱 |
+| English | `en` | 🇬🇧 |
+| Estonian | `et` | 🇪🇪 |
+| Finnish | `fi` | 🇫🇮 |
+| French | `fr` | 🇫🇷 |
+| German | `de` | 🇩🇪 |
+| Greek | `el` | 🇬🇷 |
+| Hungarian | `hu` | 🇭🇺 |
+| Italian | `it` | 🇮🇹 |
+| Latvian | `lv` | 🇱🇻 |
+| Lithuanian | `lt` | 🇱🇹 |
+| Maltese | `mt` | 🇲🇹 |
+| Polish | `pl` | 🇵🇱 |
+| Portuguese | `pt` | 🇵🇹 |
+| Romanian | `ro` | 🇷🇴 |
+| Russian | `ru` | 🇷🇺 |
+| Slovak | `sk` | 🇸🇰 |
+| Slovenian | `sl` | 🇸🇮 |
+| Spanish | `es` | 🇪🇸 |
+| Swedish | `sv` | 🇸🇪 |
+| Ukrainian | `uk` | 🇺🇦 |
+
+## Text-to-speech
+
+Voice auto-picks from the text's language; pass `--voice <id>` to choose. Run `kesha say --list-voices` to see what's installed. Full voice catalogue and SSML details: [tts.md](tts.md).
+
+| Language | Code | | Engine (voice prefix) | Platform | Notes |
+|----------|------|---|------------------------|----------|-------|
+| English | `en` | 🇬🇧 | Kokoro (`en-*`) | all | default `en-am_michael` |
+| Russian | `ru` | 🇷🇺 | Vosk-TTS (`ru-*`) | all | default `ru-vosk-m02`; macOS also offers `macos-*` Milena |
+| Spanish | `es` | 🇪🇸 | Kokoro (`es-*`) | darwin-arm64 | FluidAudio CoreML |
+| French | `fr` | 🇫🇷 | Kokoro (`fr-*`) | darwin-arm64 | female voice only (`fr-ff_siwis`) |
+| Italian | `it` | 🇮🇹 | Kokoro (`it-*`) | darwin-arm64 | FluidAudio CoreML |
+| Portuguese | `pt` | 🇧🇷 | Kokoro (`pt-*`) | darwin-arm64 | Brazilian (`pt-pm_alex`) |
+| Hindi | `hi` | 🇮🇳 | Kokoro (`hi-*`) | darwin-arm64 | **romanized (Latin) input only** — native Devanagari is rejected with `E_SCRIPT_UNSUPPORTED` ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
+| Japanese | `ja` | 🇯🇵 | Kokoro (`ja-*`) | darwin-arm64 | **romaji (Latin) input only** — native kana/kanji is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
+| Chinese | `zh` | 🇨🇳 | Kokoro (`zh-*`) | darwin-arm64 | **pinyin (Latin) input only** — native Han is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
+| *(system voices)* | — | 🍎 | AVSpeech (`macos-*`) | macOS | any of the 180+ voices already installed on your Mac; zero model download |
+
+On Linux/Windows, text-to-speech covers English (Kokoro ONNX) and Russian (Vosk-TTS); the FluidAudio Kokoro multilingual voices above are darwin-arm64 only.
+
+## Audio language detection (107)
+
+SpeechBrain ECAPA-TDNN identifies the spoken language of audio across 107 languages — broader than the ASR set above. Full list: [speechbrain/lang-id-voxlingua107-ecapa](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa).
+
+Text language detection (for TTS voice routing) uses Apple's `NLLanguageRecognizer` on macOS.


### PR DESCRIPTION
Adds **[docs/languages.md](docs/languages.md)** and links the README hero's "25 languages" to it.

- **Speech-to-text (25):** table with ISO 639-1 codes + flags.
- **Text-to-speech:** per-language table with engine/voice-prefix, platform, and the **romanized-input-only** caveat for `hi`/`ja`/`zh` (native script is rejected with `E_SCRIPT_UNSUPPORTED`, #492) — so the page is accurate, not aspirational.
- **Audio language detection (107):** pointer to the SpeechBrain list.
- README hero "25 languages" → links the page; the README Languages section is trimmed to a one-line pointer (full tables now live on the page).

Branched off current `main` (after #498 merged). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)