### PR TITLE
docs: number language tables + simplify README TTS blurbs + link Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 <p align="center"><b>Give your local tools and LLM agents a voice.</b><br>Fast speech-to-text, text-to-speech, voice-activity detection, and language detection in one local-first CLI: Apple Silicon CoreML first, ONNX fallback on supported Linux/Windows builds.</p>
 
 - **Transcribe locally** — [25 languages](docs/languages.md), up to ~19x faster than Whisper on Apple Silicon, ~2.5x on CPU
-- **Speak back** — Kokoro (EN), Vosk-TTS (RU), macOS system voices, and SSML preview
-- **Plug into agents** — ship voice workflows as CLI commands, an MCP server, or an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill
+- **Speak back** — text-to-speech in [9 languages](docs/languages.md)
+- **Plug into agents** — ship voice workflows as CLI commands, an MCP server, an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill, or a <a href="docs/hermes.md">Hermes</a> agent
 - **Small Rust engine** — single ~20MB binary, no ffmpeg, no Python, no native Node addons
 
 <p align="center">
@@ -69,7 +69,7 @@ $ kesha freedom.ogg tahiti.ogg
 
 ## Text-to-speech
 
-Kesha speaks back via Kokoro-82M (English + select multilingual voices on Apple Silicon) and Vosk-TTS (Russian). The voice auto-picks from the text's language; pass `--voice` to choose.
+Kesha speaks back in [9 languages](docs/languages.md), auto-picking the voice from the text's language. Override with `--lang <code>` or `--voice <id>`.
 
 ```bash
 kesha install --tts                              # opt-in models (~990MB)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -8,50 +8,50 @@ Kesha does three language-aware things: **speech-to-text** (ASR), **text-to-spee
 
 NVIDIA Parakeet TDT 0.6B v3. Language is auto-detected; `--lang <code>` warns if the detected language differs.
 
-| Language | Code | |
-|----------|------|---|
-| Bulgarian | `bg` | 🇧🇬 |
-| Croatian | `hr` | 🇭🇷 |
-| Czech | `cs` | 🇨🇿 |
-| Danish | `da` | 🇩🇰 |
-| Dutch | `nl` | 🇳🇱 |
-| English | `en` | 🇬🇧 |
-| Estonian | `et` | 🇪🇪 |
-| Finnish | `fi` | 🇫🇮 |
-| French | `fr` | 🇫🇷 |
-| German | `de` | 🇩🇪 |
-| Greek | `el` | 🇬🇷 |
-| Hungarian | `hu` | 🇭🇺 |
-| Italian | `it` | 🇮🇹 |
-| Latvian | `lv` | 🇱🇻 |
-| Lithuanian | `lt` | 🇱🇹 |
-| Maltese | `mt` | 🇲🇹 |
-| Polish | `pl` | 🇵🇱 |
-| Portuguese | `pt` | 🇵🇹 |
-| Romanian | `ro` | 🇷🇴 |
-| Russian | `ru` | 🇷🇺 |
-| Slovak | `sk` | 🇸🇰 |
-| Slovenian | `sl` | 🇸🇮 |
-| Spanish | `es` | 🇪🇸 |
-| Swedish | `sv` | 🇸🇪 |
-| Ukrainian | `uk` | 🇺🇦 |
+| # | Language | Code | |
+|---:|----------|------|---|
+| 1 | Bulgarian | `bg` | 🇧🇬 |
+| 2 | Croatian | `hr` | 🇭🇷 |
+| 3 | Czech | `cs` | 🇨🇿 |
+| 4 | Danish | `da` | 🇩🇰 |
+| 5 | Dutch | `nl` | 🇳🇱 |
+| 6 | English | `en` | 🇬🇧 |
+| 7 | Estonian | `et` | 🇪🇪 |
+| 8 | Finnish | `fi` | 🇫🇮 |
+| 9 | French | `fr` | 🇫🇷 |
+| 10 | German | `de` | 🇩🇪 |
+| 11 | Greek | `el` | 🇬🇷 |
+| 12 | Hungarian | `hu` | 🇭🇺 |
+| 13 | Italian | `it` | 🇮🇹 |
+| 14 | Latvian | `lv` | 🇱🇻 |
+| 15 | Lithuanian | `lt` | 🇱🇹 |
+| 16 | Maltese | `mt` | 🇲🇹 |
+| 17 | Polish | `pl` | 🇵🇱 |
+| 18 | Portuguese | `pt` | 🇵🇹 |
+| 19 | Romanian | `ro` | 🇷🇴 |
+| 20 | Russian | `ru` | 🇷🇺 |
+| 21 | Slovak | `sk` | 🇸🇰 |
+| 22 | Slovenian | `sl` | 🇸🇮 |
+| 23 | Spanish | `es` | 🇪🇸 |
+| 24 | Swedish | `sv` | 🇸🇪 |
+| 25 | Ukrainian | `uk` | 🇺🇦 |
 
 ## Text-to-speech
 
 Voice auto-picks from the text's language; pass `--voice <id>` to choose. Run `kesha say --list-voices` to see what's installed. Full voice catalogue and SSML details: [tts.md](tts.md).
 
-| Language | Code | | Engine (voice prefix) | Platform | Notes |
-|----------|------|---|------------------------|----------|-------|
-| English | `en` | 🇬🇧 | Kokoro (`en-*`) | all | default `en-am_michael` |
-| Russian | `ru` | 🇷🇺 | Vosk-TTS (`ru-*`) | all | default `ru-vosk-m02`; macOS also offers `macos-*` Milena |
-| Spanish | `es` | 🇪🇸 | Kokoro (`es-*`) | darwin-arm64 | FluidAudio CoreML |
-| French | `fr` | 🇫🇷 | Kokoro (`fr-*`) | darwin-arm64 | female voice only (`fr-ff_siwis`) |
-| Italian | `it` | 🇮🇹 | Kokoro (`it-*`) | darwin-arm64 | FluidAudio CoreML |
-| Portuguese | `pt` | 🇧🇷 | Kokoro (`pt-*`) | darwin-arm64 | Brazilian (`pt-pm_alex`) |
-| Hindi | `hi` | 🇮🇳 | Kokoro (`hi-*`) | darwin-arm64 | **romanized (Latin) input only** — native Devanagari is rejected with `E_SCRIPT_UNSUPPORTED` ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
-| Japanese | `ja` | 🇯🇵 | Kokoro (`ja-*`) | darwin-arm64 | **romaji (Latin) input only** — native kana/kanji is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
-| Chinese | `zh` | 🇨🇳 | Kokoro (`zh-*`) | darwin-arm64 | **pinyin (Latin) input only** — native Han is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
-| *(system voices)* | — | 🍎 | AVSpeech (`macos-*`) | macOS | any of the 180+ voices already installed on your Mac; zero model download |
+| # | Language | Code | | Engine (voice prefix) | Platform | Notes |
+|---:|----------|------|---|------------------------|----------|-------|
+| 1 | English | `en` | 🇬🇧 | Kokoro (`en-*`) | all | default `en-am_michael` |
+| 2 | Russian | `ru` | 🇷🇺 | Vosk-TTS (`ru-*`) | all | default `ru-vosk-m02`; macOS also offers `macos-*` Milena |
+| 3 | Spanish | `es` | 🇪🇸 | Kokoro (`es-*`) | darwin-arm64 | FluidAudio CoreML |
+| 4 | French | `fr` | 🇫🇷 | Kokoro (`fr-*`) | darwin-arm64 | female voice only (`fr-ff_siwis`) |
+| 5 | Italian | `it` | 🇮🇹 | Kokoro (`it-*`) | darwin-arm64 | FluidAudio CoreML |
+| 6 | Portuguese | `pt` | 🇧🇷 | Kokoro (`pt-*`) | darwin-arm64 | Brazilian (`pt-pm_alex`) |
+| 7 | Hindi | `hi` | 🇮🇳 | Kokoro (`hi-*`) | darwin-arm64 | **romanized (Latin) input only** — native Devanagari is rejected with `E_SCRIPT_UNSUPPORTED` ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
+| 8 | Japanese | `ja` | 🇯🇵 | Kokoro (`ja-*`) | darwin-arm64 | **romaji (Latin) input only** — native kana/kanji is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
+| 9 | Chinese | `zh` | 🇨🇳 | Kokoro (`zh-*`) | darwin-arm64 | **pinyin (Latin) input only** — native Han is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
+| — | *(system voices)* | — | 🍎 | AVSpeech (`macos-*`) | macOS | any of the 180+ voices already installed on your Mac; zero model download |
 
 On Linux/Windows, text-to-speech covers English (Kokoro ONNX) and Russian (Vosk-TTS); the FluidAudio Kokoro multilingual voices above are darwin-arm64 only.
 


### PR DESCRIPTION
Four small doc tweaks (all on `docs/languages.md` + README):

1. **Row numbers** on both `docs/languages.md` tables — STT (1–25) and TTS (1–9; system-voices row marked `—`).
2. **README hero "Speak back"** — drop engine/model names, now just "text-to-speech in [9 languages](docs/languages.md)".
3. **README TTS intro** — drop model names; state **9 languages**, voice auto-picks from text language, override with `--lang <code>` or `--voice <id>`.
4. **README "Plug into agents"** — added a **Hermes** link (`docs/hermes.md`) next to OpenClaw.

Docs-only. All README links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)