### PR TITLE
docs: deep-link README language links to relevant doc sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 
 <p align="center"><b>Give your local tools and LLM agents a voice.</b><br>Fast speech-to-text, text-to-speech, voice-activity detection, and language detection in one local-first CLI: Apple Silicon CoreML first, ONNX fallback on supported Linux/Windows builds.</p>
 
-- **Transcribe locally** — [25 languages](docs/languages.md), up to ~19x faster than Whisper on Apple Silicon, ~2.5x on CPU
-- **Speak back** — text-to-speech in [9 languages](docs/languages.md)
+- **Transcribe locally** — [25 languages](docs/languages.md#speech-to-text-25), up to ~19x faster than Whisper on Apple Silicon, ~2.5x on CPU
+- **Speak back** — text-to-speech in [9 languages](docs/languages.md#text-to-speech)
 - **Plug into agents** — ship voice workflows as CLI commands, an MCP server, an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill, or a <a href="docs/hermes.md">Hermes</a> agent
 - **Small Rust engine** — single ~20MB binary, no ffmpeg, no Python, no native Node addons
 
@@ -69,7 +69,7 @@ $ kesha freedom.ogg tahiti.ogg
 
 ## Text-to-speech
 
-Kesha speaks back in [9 languages](docs/languages.md), auto-picking the voice from the text's language. Override with `--lang <code>` or `--voice <id>`.
+Kesha speaks back in [9 languages](docs/languages.md#text-to-speech), auto-picking the voice from the text's language. Override with `--lang <code>` or `--voice <id>`.
 
 ```bash
 kesha install --tts                              # opt-in models (~990MB)


### PR DESCRIPTION
Per request: the language links should open the **relevant section** of the doc, not the top.

- `25 languages` → [`docs/languages.md#speech-to-text-25`](docs/languages.md#speech-to-text-25)
- `9 languages` (hero + TTS intro) → [`docs/languages.md#text-to-speech`](docs/languages.md#text-to-speech)

Anchors verified against the actual `## Speech-to-text (25)` / `## Text-to-speech` headings.

**Other README→docs links** were audited too: they point at single-topic docs (`docker.md`, `mcp.md`, `vad.md`, `hermes.md`, `errors.md`, etc.), whose top **is** the relevant content — and the `tts.md`/`architecture.md` links are whole-doc references — so no anchors are needed there. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)