### PR TITLE
chore: sync package.json description with the laconic About

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
   "version": "1.22.0-beta.2",
-  "description": "Give your local tools a voice: fast STT in 25 languages (~19x faster than Whisper on Apple Silicon, ONNX CPU fallback), TTS via Kokoro/Vosk/macOS voices, VAD. Rust engine, Bun CLI, OpenClaw/Hermes skills.",
+  "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
     "kesha": "bin/kesha.js"


### PR DESCRIPTION
Match `package.json#description` to the trimmed GitHub About: `Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.` Metadata only; ships with the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)