### PR TITLE
chore(release): 1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.22.0-beta.2",
+  "version": "1.22.0",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
     ]
   },
   "keshaEngine": {
-    "version": "1.22.0-beta.2"
+    "version": "1.22.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.22.0-beta.2"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.22.0-beta.2"
+version = "1.22.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Promotes the validated `v1.22.0-beta.1`/`beta.2` engine work to a stable release. Bumps `package.json#version`, `package.json#keshaEngine.version`, `rust/Cargo.toml`, and `rust/Cargo.lock` from `1.22.0-beta.2` → `1.22.0`.

## What ships in 1.22.0 (since v1.21.0)

- **Structured error taxonomy** — stable `error [CODE]` at every failure path, `--error-codes-json`, `docs/errors.md` drift gate (#487)
- **Multilingual FluidAudio Kokoro voices** (darwin-arm64 / ANE) (#490)
- **Fail-fast on native-script input** to non-Latin Kokoro voices — `E_SCRIPT_UNSUPPORTED` instead of noise (#493 → #495)
- **`argmax` cfg gate fix** — avoids dead_code under onnx+coreml (#494)
- CI: split integration into fast + heavy lanes (#489)
- Docs: README restructure, `docs/languages.md`, MCP config examples (#488, #498–#503)

Validated end-to-end across both betas (real synthesis: en + es + native-script `E_SCRIPT_UNSUPPORTED` exit 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)