### PR TITLE
chore(openclaw): add ClawHub publish metadata + document release process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,42 @@ This is a documented user-config default, not a plugin manifest patch.
 
 **Manifest:** required fields are `id` + `configSchema` (proper JSON Schema shape). `configPatch` is NOT a valid field — the loader silently discards it.
 
+### PUBLISHING THE OPENCLAW PLUGIN TO CLAWHUB
+
+The plugin is distributed on [ClawHub](https://clawhub.com) (the OpenClaw plugin registry), **independently of npm and the engine release**. ClawHub publishing is its own outward-facing step — it is *not* triggered by `kesha` npm publish, GitHub releases, or `build-engine.yml`.
+
+**`package.json#openclaw` must carry the publish metadata** — without it `clawhub package publish` fails with the opaque `Error: package.json required` even though the file exists. A ClawHub **code plugin** needs all three keys (mirror an `@openclaw/*` package such as `@openclaw/imessage`):
+
+```jsonc
+"openclaw": {
+  "extensions": ["./openclaw-plugin.cjs"],
+  "compat": { "pluginApi": ">=<openclaw-version>" },   // min host API the plugin needs
+  "build":  { "openclawVersion": "<openclaw-version>" } // version it was built/validated against
+}
+```
+
+Use the current `openclaw --version` (e.g. `2026.5.27`) for both unless you have evidence the plugin works against an older API. Bump `build.openclawVersion` whenever you re-publish after validating against a newer OpenClaw.
+
+**Publish flow** (CLI is `clawhub`, installed alongside `openclaw`):
+
+1. **Auth + scope.** `clawhub whoami` must report the owner that matches the package scope — `@drakulavich/kesha-voice-kit` → owner `drakulavich`. If not logged in, the user runs `clawhub login` (interactive — suggest `!clawhub login`; the agent cannot complete the browser/device step).
+2. **Publish from a clean checkout at the released tag**, never the root checkout (it goes stale). Provenance flags are recorded on the registry entry and `--source-repo`/`--source-commit` must be set together:
+   ```bash
+   git worktree add .worktrees/clawhub vX.Y.Z
+   cd .worktrees/clawhub
+   clawhub package publish . \
+     --family code-plugin \
+     --version X.Y.Z \
+     --source-repo drakulavich/kesha-voice-kit \
+     --source-commit <sha-of-vX.Y.Z> \
+     --source-ref vX.Y.Z \
+     --changelog "<one-line summary>"
+   ```
+3. **No `--dry-run` in the shipped `clawhub` (2026.5.x)** despite what the docs site shows — the only validation is the real publish, which is server-side scanned and **held in review** ("may stay out of install/download surfaces until review finishes"). Treat publish as the commit point; get the `package.json` metadata right first.
+4. **Verify** with `clawhub search kesha` / `openclaw plugins search kesha-voice-kit`, and that `openclaw plugins install clawhub:@drakulavich/kesha-voice-kit` resolves once review clears.
+
+Gotcha: `clawhub package publish` reads the **local folder's** `package.json` for validation, but records the `--source-*` flags as provenance — keep them consistent (publish from the same commit the metadata lives on, so the recorded source actually contains the `openclaw.compat`/`build` block).
+
 ### JJ + GIT LFS WORKAROUND
 
 This repo uses Git LFS for fixtures/assets. Stock `jj` can surface LFS-managed files as modified in colocated repos. Use the LFS fork until upstream support lands:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,13 @@
   "openclaw": {
     "extensions": [
       "./openclaw-plugin.cjs"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.5.27"
+    },
+    "build": {
+      "openclawVersion": "2026.5.27"
+    }
   },
   "keshaEngine": {
     "version": "1.22.0"


### PR DESCRIPTION
Unblocks publishing the Kesha OpenClaw plugin to [ClawHub](https://clawhub.com).

## Why

`clawhub package publish` fails on our plugin with the opaque `Error: package.json required` — even though `package.json` exists. The real cause: a ClawHub **code plugin** requires `package.json#openclaw.compat.pluginApi` and `openclaw.build.openclawVersion`, and our block only had `extensions`.

## Changes

- **`package.json`** — add the `openclaw.compat`/`openclaw.build` block (values mirror `@openclaw/*` packages, pinned to the current `openclaw --version` `2026.5.27`).
- **`CLAUDE.md`** — new "Publishing the OpenClaw plugin to ClawHub" section documenting the full flow (`clawhub login` → `clawhub package publish <path> --family code-plugin --source-*`), the no-`--dry-run` reality of the shipped CLI, the review hold, and the provenance gotcha. Distinct from npm/engine releases.

Metadata-only (no engine change); does not affect the published `1.22.0` engine. After merge, the plugin can be published from a clean checkout at the new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)