### PR TITLE
docs: slim CLAUDE.md below the 40k always-loaded threshold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,25 +312,11 @@ Gotcha: `clawhub package publish` reads the **local folder's** `package.json` fo
 
 ### JJ + GIT LFS WORKAROUND
 
-This repo uses Git LFS for fixtures/assets. Stock `jj` can surface LFS-managed files as modified in colocated repos. Use the LFS fork until upstream support lands:
+This repo uses Git LFS; stock `jj` surfaces LFS-managed files as modified in colocated repos.
+Use the LFS fork (`gusinacio/jj`, `lfs` branch) + `jj config set --user git.ignore-files '["lfs"]'`
++ `git lfs pull`. If jj looks suspicious, trust Git as source of truth.
 
-```bash
-cargo install --git https://github.com/gusinacio/jj.git \
-  --branch lfs --locked --bin jj jj-cli
-jj config set --user git.ignore-files '["lfs"]'
-git lfs pull
-```
-
-Operational lessons from the 2026-05-16 setup:
-
-- If `jj --version` still shows Homebrew's binary, `which -a jj` usually lists `/opt/homebrew/bin/jj` before `~/.cargo/bin/jj`; run `brew unlink jj`. The fork reporting `jj 0.35.0-<sha>` is expected.
-- Preserve identity after switching: `jj config set --user user.name "<Your Name>"` and `jj config set --user user.email "<your@email.com>"`; use your own credentials, never the repo owner's.
-- Existing `.jj`: do not reclone. Keep the colocated checkout, set config, run `git lfs pull`, verify `jj status`.
-- Normal agent isolation: follow "AGENTS MUST WORK IN ISOLATED TREES FROM FRESH MAIN" above. Use a Git worktree or a separate JJ workspace from fresh `origin/main` / `main@origin`, then edit only inside that isolated tree.
-- Disk model: changes/bookmarks share history and are cheap, but they do not isolate the on-disk working copy. Agent tasks need physical workspace isolation even if that duplicates `node_modules`, `rust/target`, temp caches, and materialized LFS files.
-- A JJ workspace may lack `.git`; inspect with `jj status` / `jj diff` / `jj log`, and use `gh -R drakulavich/kesha-voice-kit ...` for GitHub operations.
-- Before calling files "external changes", distinguish dirty edits from a stale checked-out feature branch: check `jj status` + `jj workspace list` everywhere; in the colocated checkout also `git status --short --branch` + `git log --oneline --decorate -5`. After a PR merges and the remote branch is deleted, fetch, move back to `main`, then start the next task.
-- If JJ looks suspicious, trust Git as the source of truth: `git status --short --branch` must be clean before release/PR decisions.
+**Full setup + operational lessons:** `docs/runbooks/jj-git-lfs.md`.
 
 ### RELEASE CHICKEN-AND-EGG — `integration-tests` SKIPS ON `release/*`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,17 +176,20 @@ Any plan that names a specific upstream artifact ("Silero via ONNX", "statically
 
 ### MODEL HASHES ARE PINNED — UPSTREAM BUMPS GO THROUGH A PR
 
-Every entry in `rust/src/models.rs` (ASR, lang-id, TTS) carries a pinned SHA-256. `download_verified` refuses to cache a file whose hash doesn't match. This makes `KESHA_MODEL_MIRROR` safe (a compromised mirror can't silently swap weights) and turns an upstream HuggingFace republish into a deliberate decision rather than a silent swap.
+Every entry in `rust/src/models.rs` (ASR, lang-id, TTS) carries a pinned SHA-256;
+`download_verified` refuses to cache a file whose hash doesn't match. This makes
+`KESHA_MODEL_MIRROR` safe and turns an upstream HuggingFace republish into a deliberate
+decision. NEVER comment out verification to "get it working" (the #174 regression).
 
-**To bump a model version:**
+To bump a model version, use the `verify-pin-bump` skill — it walks the safe procedure
+(compute the new hash, verify the new upstream weights deliberately, update the `sha256` in
+`rust/src/models.rs`, then `cargo test models::manifest_tests`):
 
 ```bash
 shasum -a 256 ~/.cache/kesha/models/<subdir>/<file>   # compute new hash
 # edit rust/src/models.rs → update sha256 for that ModelFile entry
 cargo test models::manifest_tests                      # confirms shape invariants
 ```
-
-Never comment out the verification to "get it working" — that's the exact regression #174 fixed. If a fresh download produces a different hash, the upstream has actually changed; verify the new weights intentionally and then bump the constant.
 
 ### GREPTILE PR REVIEW IS A GATE
 
@@ -313,33 +316,33 @@ Alternate reproducible build path: the repo also ships a Nix flake (`flake.nix`,
 kesha-voice-kit/
 ├── bin/kesha.js                    # Shebang entry point
 ├── src/                            # Bun/TypeScript CLI + library
-│   ├── cli.ts                      # Argument parsing, --format, install/transcribe/status
-│   ├── lib.ts                      # Public API at `@drakulavich/kesha-voice-kit/core`
-│   ├── engine.ts                   # Engine subprocess wrapper + getEngineCapabilities
-│   ├── engine-install.ts           # Engine binary download (uses keshaEngine.version)
+│   ├── cli.ts                      # Arg parsing, --format, install/transcribe/status
+│   ├── lib.ts                      # Public `./core` API
+│   ├── engine.ts                   # Engine subprocess wrapper + capabilities
+│   ├── engine-install.ts           # Engine binary download
 │   ├── transcribe.ts               # Thin forwarder to the engine
 │   └── __tests__/                  # Unit tests
 ├── rust/                           # kesha-engine (Rust binary)
-│   ├── Cargo.toml                  # `onnx` (default) and `coreml` features
-│   ├── build.rs                    # Swift rpath under `coreml` feature
+│   ├── Cargo.toml                  # `onnx` (default) + `coreml` features
+│   ├── build.rs                    # Swift rpath under `coreml`
 │   └── src/
-│       ├── main.rs                 # clap: transcribe / detect-lang / detect-text-lang / install
-│       ├── audio.rs                # symphonia decode + rubato resample to 16kHz mono f32
-│       ├── models.rs               # HF download + cache for ASR and lang-id models
-│       ├── lang_id.rs              # ONNX speechbrain audio language detection (always built)
+│       ├── main.rs                 # clap subcommands
+│       ├── audio.rs                # symphonia decode + resample to 16kHz
+│       ├── models.rs               # HF download + cache
+│       ├── lang_id.rs              # ONNX audio lang detection (always built)
 │       ├── text_lang.rs            # macOS NLLanguageRecognizer (macOS only)
 │       └── backend/
-│           ├── mod.rs              # TranscribeBackend trait (audio_path → String)
-│           ├── onnx.rs             # ORT pipeline: nemo128 → encoder → decoder_joint (beam=4)
-│           └── fluidaudio.rs       # fluidaudio-rs 0.1 via transcribe_file (coreml feature)
+│           ├── mod.rs              # TranscribeBackend trait
+│           ├── onnx.rs             # ORT pipeline (beam=4)
+│           └── fluidaudio.rs       # fluidaudio-rs 0.1 (coreml feature)
 ├── tests/{unit,integration}/       # bun test
 ├── scripts/                        # benchmark.ts, smoke-test.ts
 ├── .github/workflows/
 │   ├── ci.yml                      # PR: unit + integration + type check
-│   ├── rust-test.yml               # PR: cargo test/fmt/clippy + coreml feature check
-│   └── build-engine.yml            # Tag push or dispatch: build 3 binaries + draft release
+│   ├── rust-test.yml               # PR: cargo test/fmt/clippy + coreml check
+│   └── build-engine.yml            # Tag/dispatch: 3 binaries + draft release
 ├── openclaw.plugin.json            # OpenClaw manifest (id + configSchema)
-├── openclaw-plugin.cjs             # OpenClaw plugin entry (registerMediaUnderstandingProvider)
+├── openclaw-plugin.cjs             # OpenClaw plugin entry
 └── package.json                    # @drakulavich/kesha-voice-kit
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,23 +123,16 @@ Rust verification rules:
 - CI `rustfmt --check` wins over local formatting. If it rejects line wrapping, re-run `cargo fmt` and push the whitespace-only diff (#309).
 - Fresh cargo builds need `protoc` for `vosk-tts-rs`/`prost-build`; macOS: `brew install protobuf` and expose the protobuf bin dir or set `PROTOC`.
 
+**Deep Rust gotchas** (clamp/EPSILON, ort owned ndarrays, clippy needless_update, bindgen
+LIBCLANG_PATH, Silero VAD 576, fluidaudio transcribe_samples, g2p tempdir staging):
+`docs/runbooks/rust-gotchas.md`.
+
 ### NO SPECULATIVE FIELDS OR ENUM VARIANTS
 
 Don't add struct fields, enum variants, or constants "for later." Clippy's `dead_code` lint is a hard error under `-D warnings`, so any unused public item will fail CI.
 
 - **Fix, don't suppress:** delete the unused item. Add `#[allow(dead_code)]` only with a justification in the comment.
 - If something needs to exist but isn't wired up yet, wire it up OR leave a `todo!()` call that exercises the variant.
-
-### CLIPPY `needless_update` BLOCKS `..Default::default()` IF ALL FIELDS ARE SPELLED
-
-Tempting "forward-compat" pattern: `MyStruct { a: 1, b: 2, ..Default::default() }` so a future new field doesn't break the call site. Clippy fires `needless_update` when all current fields are already spelled (the `..` is no-op today), and `-D warnings` promotes it to deny. CI red.
-
-The forward-compat is already there for free: Rust requires exhaustive struct init for any struct NOT marked `#[non_exhaustive]`. Adding a new field makes the call site a compile error pointing at the literal, which is exactly the breakage that needs to be surfaced.
-
-- Spell all fields explicitly.
-- Skip `..Default::default()` — the compile error on field addition is the safety.
-- If callers across crate boundaries need forward-compat (e.g. a published lib), mark the struct `#[non_exhaustive]` instead.
-- Past incident: #290 P2 (F5 follow-up) suggested adding `..Default::default()`, clippy blocked it, the comment explaining the trade-off landed instead.
 
 ### ERROR HANDLING
 
@@ -248,19 +241,6 @@ Hazard severity scales with the job's permissions. Anything that holds `id-token
 GHA security hardening guide: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable.
 
 Past incident: #291 (npm-publish.yml) initial commit interpolated `${{ inputs.tag }}` directly; Greptile P2 caught it before merge. The job holds `id-token: write` — a malicious tag would have given an attacker the signed npm-publish OIDC token.
-
-### BINDGEN ON LINUX NEEDS LIBCLANG_PATH
-
-Any Rust crate using `bindgen` (directly or transitively — e.g. `espeakng-sys` with `clang-runtime` feature) needs `LIBCLANG_PATH` on Linux build runners even with `apt install libclang-dev`. The `clang-runtime` feature makes bindgen `dlopen` libclang at build-script runtime; the apt package installs into a versioned subdir that isn't on the default dlopen path.
-
-Portable recipe for the Linux job:
-```yaml
-- run: |
-    sudo apt-get install -y libclang-dev llvm-dev
-    echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
-```
-
-macOS equivalent is `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`. Windows uses `C:\Program Files\LLVM\bin` with LLVM installed via `choco install llvm` and MSVC tooling activated via `ilammy/msvc-dev-cmd@v1` in CI. espeak-ng on Windows needs an import lib synthesized from the choco-shipped DLL via `dumpbin /exports` + `lib /def:… /machine:x64 /out:espeak-ng.lib` — see the Windows block in `rust-test.yml`.
 
 ### OPENCLAW PLUGIN
 
@@ -379,43 +359,6 @@ permanent. `make smoke-test` can false-green through an old global shim. Details
 winning. Run `bun remove -g @drakulavich/kesha-voice-kit` first, then `bun link`, and
 verify via `readlink ~/.bun/install/global/node_modules/@drakulavich/kesha-voice-kit`.
 Details: `docs/runbooks/release.md`.
-
-### TESTS THAT STAGE A TEMPDIR CACHE MUST STAGE G2P TOO
-
-Post-#123 (v1.4.0), Kokoro + Piper synthesis flows through the ONNX G2P at `$KESHA_CACHE_DIR/models/g2p/byt5-tiny/`. Any test that creates a fresh `KESHA_CACHE_DIR` tempdir and copies in only Kokoro / Piper will fail with `SynthesisFailed("g2p: G2P model not installed")`. Use `models::is_g2p_cached(dir)` + `models::g2p_model_dir()` to gate + copy the ONNX files. Examples: `rust/tests/tts_smoke.rs::resolves_from_cache_when_installed`, `tests/integration/say-e2e.test.ts::beforeAll`.
-
-### `ort 2.0.0-rc.12` `Value::from_array` WANTS OWNED NDARRAYS
-
-`Value::from_array(arr)` consumes its input; views (`ArrayView2`, `.view()`) don't implement `OwnedTensorArrayData`. `Array2::ones((1, n))` inline at the call site is the cleanest fresh owned construction. `Array2::from_shape_vec((...), buf.clone())` also works at the cost of a clone. `Session::builder()` returns `ort::Result` that converts through `anyhow::Context::context("...")?` cleanly — **no `map_err(anyhow::Error::msg)` dance needed**, despite what the #123 spike doc originally claimed. Peer modules (`lang_id.rs`, `vad.rs`, `backend/onnx.rs`, `kokoro.rs`, `piper.rs`) all use `.context()?`; match that style.
-
-### `fluidaudio-rs 0.1.0` LACKS `transcribe_samples`
-
-The method exists on upstream `main` but isn't in the published 0.1.0 crate. The CoreML `TranscribeBackend::transcribe_samples` impl writes a temp IEEE_FLOAT WAV at 16 kHz mono f32 and calls `transcribe_file` — see `rust/src/backend/fluidaudio.rs`. Drop the shim when upstream cuts a new release that exposes `transcribe_samples` directly.
-
-### SILERO VAD V5 NEEDS A 64-SAMPLE ROLLING CONTEXT
-
-Silero VAD v5 at 16 kHz wants ONNX `input` of length **576**, not 512: 64 samples of tail from the previous frame + 512 new samples. Missing this produces per-frame probabilities of ~0.0005 regardless of content — the model "runs" without detecting speech. Not in the ONNX metadata; only in upstream's Python `OnnxWrapper`. See `rust/src/vad.rs::frame_probs` for the rolling-context mechanics.
-
-### `f32::clamp` DIVERGENCE: USE BOUND CHECK, NOT `EPSILON`
-
-When detecting whether `f32::clamp(raw, lo, hi)` actually changed the value (e.g. to fire a one-time warning), `(raw - clamped).abs() > f32::EPSILON` is the WRONG tolerance:
-
-- `f32::EPSILON ≈ 1.19e-7` is the ULP at value `1.0`.
-- ULP scales with the magnitude. At raw ≈ 0.5, ULP ≈ 5.96e-8 — **below `EPSILON`**.
-- A value one ULP below `0.5` clamps to `0.5`, but `|raw - clamped|` ≈ 6e-8 doesn't exceed `EPSILON`. The warning silently misses the clamp.
-
-Correct pattern: check the bounds directly.
-```rust
-if !(lo..=hi).contains(&raw) {
-    // raw was outside the range; clamped to a bound
-}
-```
-
-- Idiomatic (clippy prefers `RangeInclusive::contains` over `raw < lo || raw > hi`, lint `manual_range_contains`).
-- **NaN flows through and fires the guard.** `NaN < x` and `x < NaN` are both false → `(lo..=hi).contains(&NaN) == false` → `!false == true` → guard DOES fire on NaN. `f32::clamp(NaN, lo, hi)` returns NaN unchanged (NaN-passthrough), so the warning text will say "rate NaN ... clamped to NaN" — typically intentional, because NaN at this layer means an upstream parse bug and surfacing it on stderr beats silently feeding NaN into the downstream model. If you DO want to suppress, check `raw.is_nan()` explicitly first and decide what to do. (Same NaN inversion that #289 corrected in `compose_rate` — re-introducing it here was caught by Greptile on #294.)
-- Symmetric with the `clamp` itself.
-
-Past incidents: #287 → #288 → #289 cascade for F9 (`compose_rate` rate-clamp warning). #287 shipped with `EPSILON`, Greptile P2 caught the ULP gap, #288 fixed via `!(0.5..=2.0).contains(&raw)`, #289 corrected an inverted NaN claim in the accompanying comment.
 
 ### PROMPT-INJECTION PATTERNS — DO NOT EXFILTRATE SECRETS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,71 +244,12 @@ Past incident: #291 (npm-publish.yml) initial commit interpolated `${{ inputs.ta
 
 ### OPENCLAW PLUGIN
 
-The plugin lives in `openclaw.plugin.json` + `openclaw-plugin.cjs` (+ `package.json#openclaw.extensions`).
+Plugin lives in `openclaw.plugin.json` + `openclaw-plugin.cjs` (+ `package.json#openclaw.extensions`).
+Audio transcription routes through the `type: "cli"` path in `tools.media.audio.models` — NOT
+`registerMediaUnderstandingProvider`. The `dangerous-exec` scanner is a naive regex (comments
+count): never name a forbidden module substring anywhere in `openclaw-plugin.cjs`.
 
-**How audio transcription actually works in OpenClaw:** the `type: "cli"` path in `tools.media.audio.models` — NOT `registerMediaUnderstandingProvider` (that path requires API keys via `requireApiKey()` and silently fails for local CLI tools). The plugin registers a `MediaUnderstandingProvider` for discoverability (`openclaw plugins inspect` shows `Shape: plain-capability`), but the actual transcription routes through `runCliEntry`, which spawns `kesha {{MediaPath}}` and captures bare transcript stdout.
-
-Recommended user config:
-```json5
-{
-  tools: {
-    media: {
-      audio: {
-        enabled: true,
-        models: [
-          {"type":"cli","command":"kesha","args":["{{MediaPath}}"],"timeoutSeconds":15}
-        ],
-        echoTranscript: true,
-        echoFormat: '🦜 "{transcript}"'
-      }
-    }
-  }
-}
-```
-This is a documented user-config default, not a plugin manifest patch.
-
-**Scanner rules:**
-- OpenClaw's `dangerous-exec` scanner fires when a file contains BOTH a `spawn(`/`exec(`-style call AND the substring for the forbidden module name. **Comments count** — it's a naive regex, not AST-aware.
-- Split the module specifier across `+` so the forbidden substring is absent from the source. Never name trigger tokens anywhere in `openclaw-plugin.cjs` — not even in comments.
-- `--force` flag overwrites existing installs. `openclaw plugins uninstall` is interactive (no `--yes`).
-
-**Manifest:** required fields are `id` + `configSchema` (proper JSON Schema shape). `configPatch` is NOT a valid field — the loader silently discards it.
-
-### PUBLISHING THE OPENCLAW PLUGIN TO CLAWHUB
-
-The plugin is distributed on [ClawHub](https://clawhub.com) (the OpenClaw plugin registry), **independently of npm and the engine release**. ClawHub publishing is its own outward-facing step — it is *not* triggered by `kesha` npm publish, GitHub releases, or `build-engine.yml`.
-
-**`package.json#openclaw` must carry the publish metadata** — without it `clawhub package publish` fails with the opaque `Error: package.json required` even though the file exists. A ClawHub **code plugin** needs all three keys (mirror an `@openclaw/*` package such as `@openclaw/imessage`):
-
-```jsonc
-"openclaw": {
-  "extensions": ["./openclaw-plugin.cjs"],
-  "compat": { "pluginApi": ">=<openclaw-version>" },   // min host API the plugin needs
-  "build":  { "openclawVersion": "<openclaw-version>" } // version it was built/validated against
-}
-```
-
-Use the current `openclaw --version` (e.g. `2026.5.27`) for both unless you have evidence the plugin works against an older API. Bump `build.openclawVersion` whenever you re-publish after validating against a newer OpenClaw.
-
-**Publish flow** (CLI is `clawhub`, installed alongside `openclaw`):
-
-1. **Auth + scope.** `clawhub whoami` must report the owner that matches the package scope — `@drakulavich/kesha-voice-kit` → owner `drakulavich`. If not logged in, the user runs `clawhub login` (interactive — suggest `!clawhub login`; the agent cannot complete the browser/device step).
-2. **Publish from a clean checkout at the released tag**, never the root checkout (it goes stale). Provenance flags are recorded on the registry entry and `--source-repo`/`--source-commit` must be set together:
-   ```bash
-   git worktree add .worktrees/clawhub vX.Y.Z
-   cd .worktrees/clawhub
-   clawhub package publish . \
-     --family code-plugin \
-     --version X.Y.Z \
-     --source-repo drakulavich/kesha-voice-kit \
-     --source-commit <sha-of-vX.Y.Z> \
-     --source-ref vX.Y.Z \
-     --changelog "<one-line summary>"
-   ```
-3. **No `--dry-run` in the shipped `clawhub` (2026.5.x)** despite what the docs site shows — the only validation is the real publish, which is server-side scanned and **held in review** ("may stay out of install/download surfaces until review finishes"). Treat publish as the commit point; get the `package.json` metadata right first.
-4. **Verify** with `clawhub search kesha` / `openclaw plugins search kesha-voice-kit`, and that `openclaw plugins install clawhub:@drakulavich/kesha-voice-kit` resolves once review clears.
-
-Gotcha: `clawhub package publish` reads the **local folder's** `package.json` for validation, but records the `--source-*` flags as provenance — keep them consistent (publish from the same commit the metadata lives on, so the recorded source actually contains the `openclaw.compat`/`build` block).
+**Internals, scanner rules, recommended user config, ClawHub publish:** `docs/runbooks/openclaw-plugin.md`.
 
 ### JJ + GIT LFS WORKAROUND
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,107 +88,24 @@ Clean up after merge: `jj workspace forget <slug> && rm -rf .worktrees/<slug>`.
 
 ### RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY
 
-`package.json#version` (CLI) and `package.json#keshaEngine.version` (engine, mirrored in `rust/Cargo.toml`) are decoupled. `src/engine-install.ts` downloads `v${keshaEngine.version}` with fallback to `package.json#version`.
+`package.json#version` (CLI) and `package.json#keshaEngine.version` + `rust/Cargo.toml`
+(engine) are versioned independently; all releases go through PRs. The drift gate is
+`bun run check:versions`.
 
-Version drift gate: `bun .github/scripts/check-versions.ts` (`bun run check:versions` / `make versions`, CI "🔢 Check version drift") enforces:
-
-1. `keshaEngine.version === rust/Cargo.toml#version` — one engine version stored twice; drift makes `kesha install` fetch the wrong source/release.
-2. `package.json#version >= keshaEngine.version` — CLI may lead for CLI-only patches, never lag.
-
-**CLI-only patch** (docs, TS, plugin): bump only `package.json#version`; leave `keshaEngine.version` + `rust/Cargo.toml`; PR CI uses the existing engine; merge; create a marker release:
-
-CLI-only is allowed only when the changed CLI surface works against the already-published engine pinned by `package.json#keshaEngine.version`. If a CLI command delegates to a new engine subcommand, capability flag, feature behavior, or output contract, it is an **engine release**: bump `package.json#keshaEngine.version`, `rust/Cargo.toml`, and `rust/Cargo.lock` together. Before cutting any `v*-cli` marker, smoke-test new/changed CLI commands against the published pinned engine, not only a repo-local engine build. The `v1.18.2-cli` / `v1.18.3-cli` mistake was exposing `kesha record` while the pinned published engine was still `v1.18.0` and did not implement `kesha-engine record`.
-
-```bash
-gh release create vX.Y.Z-cli --title "vX.Y.Z (CLI-only)" \
-  --notes "Engine: v<keshaEngine.version> (unchanged)."
-npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
-```
-
-`v*-cli` is excluded from `build-engine.yml`; the published marker fires `📦 npm Publish` automatically.
-
-**Engine release** (anything under `rust/` or an engine bump):
-
-1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version`, usually `package.json#version`.
-2. Merge to main.
-3. Tag/push: `git tag vX.Y.Z && git push origin vX.Y.Z` → `build-engine.yml`.
-4. Write release notes before publishing. Draft releases start with an empty body:
-
-   ```bash
-   gh release edit vX.Y.Z --notes "$(cat <<'EOF'
-   <summary of changes, new features, breaking changes, PR list>
-   EOF
-   )"
-   ```
-
-   Template: v1.1.3 style — features → platform support → breaking changes → shipped PRs → follow-up issues → upgrade instructions. If notes were forgotten on a published release, `gh release edit --notes` can silently drop them; patch via API:
-
-   ```bash
-   RELEASE_ID=$(gh api repos/OWNER/REPO/releases/tags/vX.Y.Z --jq '.id')
-   jq -Rs '{body: .}' < notes.md > body.json
-   gh api -X PATCH "repos/OWNER/REPO/releases/$RELEASE_ID" --input body.json
-   ```
-
-5. Validate draft assets before un-drafting. Authenticated `gh release download` works on drafts; anonymous `curl` / `kesha install` 404s. Release drafts must include `SHA256SUMS`, `kesha-release-manifest.json`, one `*.sigstore.json` per non-signature asset, and `kesha-voice-kit-vX.Y.Z.spdx.json`.
-
-   ```bash
-   gh release download vX.Y.Z -p SHA256SUMS -p kesha-release-manifest.json -p '*.sigstore.json' -p 'kesha-*' -p 'say-*' -D <smoke-dir>
-   cd <smoke-dir>
-   sha256sum -c SHA256SUMS
-   cosign verify-blob \
-     --bundle kesha-engine-darwin-arm64.sigstore.json \
-     --certificate-identity "https://github.com/drakulavich/kesha-voice-kit/.github/workflows/build-engine.yml@refs/tags/vX.Y.Z" \
-     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-     kesha-engine-darwin-arm64
-   ```
-
-6. Treat `make smoke-test` as a local sanity check only; it can run the old globally installed CLI/engine. The release gate is draft-asset validation.
-7. Publish: `gh release edit vX.Y.Z --draft=false`. This fires `📦 npm Publish`; verify `npm view @drakulavich/kesha-voice-kit version` within ~60s. Manual fallback: `npm publish --access public` from the maintainer laptop.
-8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo, and attach Linux x64 `.deb`/`.rpm` packages covered by `SHA256SUMS` + Sigstore. CLI-only marker releases skip Homebrew/packages.
-
-**Beta engine release** (unstable channel):
-
-- Use SemVer prerelease versions in all three places: `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`, for example `1.18.7-beta.1`; tag as `v1.18.7-beta.1`.
-- `build-engine.yml` accepts `vX.Y.Z-beta.N`, creates a **draft prerelease**, and uploads engine binaries, sidecars, `SHA256SUMS`, manifest, SBOM, and Sigstore bundles. It intentionally skips Homebrew and Linux `.deb`/`.rpm` packages for beta tags.
-- After draft asset validation, publish with `gh release edit vX.Y.Z-beta.N --draft=false`. `📦 npm Publish` publishes prerelease package versions with `npm publish --tag beta`, so `@latest` stays on the latest stable release.
-- Verify beta with `npm view @drakulavich/kesha-voice-kit@beta version`; user-facing beta install is `bun add -g @drakulavich/kesha-voice-kit@beta && kesha install`.
-- Promote by cutting a later stable `vX.Y.Z` release; do not reuse the beta tag or try to retag it as stable.
-
-**Alternate tag path:** `workflow_dispatch` validates tag shape and authors notes inline, useful when a sandbox cannot push tags:
-
-```bash
-gh workflow run "🔨 Build Engine" \
-  -R drakulavich/kesha-voice-kit \
-  -f tag=vX.Y.Z \
-  -f ref=main \
-  -f notes="$(cat release-notes.md)"
-```
-
-Because `workflow_dispatch` authors release notes inline via `-f notes`, skip engine-release step 4 when using this path.
-
-Known break (v1.16.0, 2026-05-14): `GITHUB_TOKEN` tag pushes do not trigger downstream `on.push.tags`; dispatch ends with `tag: success, build/release: skipped`. Workaround until PAT/GitHub App token fix: fetch tags, delete the remote tag, re-push it from a maintainer laptop so a user-authored push triggers the build:
-
-```bash
-git fetch --tags
-git push origin :refs/tags/vX.Y.Z
-git push origin vX.Y.Z
-```
+**Full procedure (CLI-only / engine / beta / dispatch paths, draft-asset validation,
+known breaks):** `docs/runbooks/release.md`.
 
 ### NPM PUBLISH IS AUTOMATED WITH PROVENANCE ATTESTATION
 
-Post-#291 happy path: publishing a GitHub release runs `.github/workflows/npm-publish.yml` → `npm publish --provenance --access public` in GHA. Do not publish from a maintainer laptop unless the workflow is broken.
-
-- Trigger: `release: published` (engine un-draft or published `v*-cli` marker) plus `workflow_dispatch` re-runs.
-- Provenance: `permissions.id-token: write` gives npm the GHA OIDC chain (`commit SHA` → built tarball) and the npm "verified" badge.
-- Guards: tag must match `package.json#version` after stripping leading `v` and trailing `-cli`; already-published versions skip publish and exit 0.
-- Dist-tags: stable package versions publish to `latest`; SemVer prerelease package versions publish to `beta`.
-- Injection rule: route `inputs.tag` / `github.event.release.tag_name` through `env:`, never directly into `run:` while the job holds `id-token: write`.
-- Required secret: `NPM_TOKEN` (granular publish-only token for `@drakulavich/kesha-voice-kit`), set with `gh secret set NPM_TOKEN -R drakulavich/kesha-voice-kit`. If missing, the release remains published but the publish step fails; fallback is `npm publish --access public` from a laptop.
-- Release implication: un-draft is the commit-to-publish point. Validate draft assets via authenticated `gh release download` before un-drafting; npm publish is effectively permanent (72 h unpublish window, noisy provenance). If validation fails before publish: delete release + tag, bump patch, retry.
+Publishing a GitHub release runs `.github/workflows/npm-publish.yml` →
+`npm publish --provenance --access public` in GHA; don't publish from a laptop unless the
+workflow is broken. The job holds `id-token: write`, so route every user-controlled tag
+input through `env:`, never into `run:` directly. Details: `docs/runbooks/release.md`.
 
 ### TAG NAMES ARE ONE-USE
 
-GitHub's immutable-releases permanently reserves tag names after publish. **Broken release → bump patch version, cut new tag.** Never tag "just to test" — use `gh workflow run "🔨 Build Engine" --ref main` instead. Skipping tags is fine (we skipped `v1.0.1`).
+GitHub permanently reserves tag names after publish. Broken release → bump patch, cut a
+new tag; never tag "just to test". Details: `docs/runbooks/release.md`.
 
 ### VERIFY BEFORE PUSHING
 
@@ -287,11 +204,7 @@ PRs receive automated review from Greptile when a PR opens and when new commits 
 - Past incidents caught this way: `--backend=` forwarded to an engine that didn't accept it (#125 P1); `--rate` silently discarded for Piper voices (#126 P1); hard-coded 22050 Hz assertion that would break on other Piper voices (#126 P2); silent zero-speakers on `transcribe_with_options({with_speakers: true, with_segments: false})` (#290 P1).
 - Exception: findings that are clearly false positives can be dismissed with a PR comment explaining why — but that's rare in practice.
 
-Greptile comment mechanics:
-
-- It updates one existing top-level comment, not a new comment per review. Confirm re-review by checking both the "Last reviewed commit" SHA (`body | match("commit/([a-f0-9]+)")`) and the issue-comment `.updated_at`; `gh pr view --json comments` has null `updatedAt`, so use `gh api repos/OWNER/REPO/issues/<N>/comments`.
-- Do not arm auto-merge before Greptile reviews the latest head; otherwise CI-green can merge before a new P1/P2 arrives (#287→#288→#289; #290→#291→#292 avoided by waiting). Merge by hand after `Confidence Score: ≥4/5` references the latest SHA.
-- If Greptile is the next gate, set a real wait: `ScheduleWakeup(delaySeconds: 300-900, prompt: "<<autonomous-loop-dynamic>>", reason: "<...>")` (270s for cache-warm, 900s+ for cache miss; avoid the dead zone around 300s). Optional auto-merge poll: `while :; do gh api repos/drakulavich/kesha-voice-kit/issues/N/comments --jq '.[] | select(.user.login | contains("greptile"))'; done`, merging only when `Confidence Score: ≥4/5` and `commit/SHA` match head. If the latest head stays uncovered after the wait, leave the PR unmerged and report the stale/missing Greptile review to the maintainer. Stop the poll if the user says to wait.
+Re-review/auto-merge mechanics: `docs/runbooks/release.md`.
 
 ### DO NOT BLINDLY FORWARD CLI FLAGS TO SUBCOMMANDS
 
@@ -441,62 +354,31 @@ Operational lessons from the 2026-05-16 setup:
 
 ### RELEASE CHICKEN-AND-EGG — `integration-tests` SKIPS ON `release/*`
 
-`integration-tests` in `.github/workflows/ci.yml` downloads the RELEASED `kesha-engine` binary at the version pinned in `package.json#keshaEngine.version`. On a version-bump PR (branch `release/X.Y.Z`) that tag doesn't exist yet — HTTP 404, CI red. The job is filtered via `if: needs.changes.outputs.integration == 'true' && !startsWith(github.head_ref, 'release/')`. Don't remove that filter. If you add a new job that downloads release artifacts, use the same branch guard.
+`integration-tests` in `ci.yml` downloads the released engine pinned in
+`package.json#keshaEngine.version`, which 404s on a `release/X.Y.Z` PR before the tag
+exists; the `!startsWith(github.head_ref, 'release/')` filter guards it — don't remove it,
+and reuse it for any new release-artifact job. Details: `docs/runbooks/release.md`.
 
 ### DRAFT RELEASE ASSET URLS ARE 404 TO ANONYMOUS CLIENTS — USE `gh release download`
 
-`build-engine.yml` creates a draft release with 3 platform binaries. Draft asset URLs 404 for unauthenticated clients, so `curl`, `kesha install`, and anonymous `make smoke-test` cannot validate the draft. Authenticated `gh release download vX.Y.Z -p "..." -D <dir>` works on drafts and is the pre-undraft release gate; `make smoke-test` is only a post-undraft sanity check, but post-#291 un-draft also triggers npm publish.
+Draft asset URLs 404 for unauthenticated clients, so `curl` / `kesha install` / anonymous
+`make smoke-test` can't validate a draft; use authenticated `gh release download` as the
+pre-undraft gate. Details: `docs/runbooks/release.md`.
 
 ### `make smoke-test` ALONE DOES NOT VALIDATE A NEW ENGINE — `gh release download` THE DRAFT BINARY AND EXERCISE IT BEFORE `gh release edit --draft=false`
 
-`make smoke-test` runs `bun link @drakulavich/kesha-voice-kit`, `kesha install`, then `bun scripts/smoke-test.ts`, but a prior `bun add -g` can leave the old global shim in front. Then `kesha --version` and `kesha install` exercise the previous CLI/engine and produce a false-green "6/6 passed". v1.5.0 hit this: `--capabilities-json` passed, Kokoro synth crashed (`Invalid input name: tokens`), and local smoke still routed through v1.4.4 CLI + v1.4.1 engine.
-
-Before `gh release edit --draft=false`, always validate the draft binary directly with authenticated `gh release download`, not `curl` (drafts 404 anonymously). Un-draft starts `📦 npm Publish` within ~60 s; npm unpublish is limited/noisy, and #291's Greptile review flagged this ordering.
-
-```bash
-SMOKE=/tmp/kesha-vX.Y.Z-smoke && rm -rf "$SMOKE" && mkdir "$SMOKE" && cd "$SMOKE"
-gh release download vX.Y.Z -R drakulavich/kesha-voice-kit \
-  -p "kesha-engine-darwin-arm64" -D "$SMOKE"
-chmod +x kesha-engine && xattr -d com.apple.quarantine kesha-engine 2>/dev/null
-
-# 1. Version string MUST equal the new tag — sanity check
-./kesha-engine --version          # → "kesha-engine X.Y.Z"
-
-# 2. Capability surface — must include every feature the build matrix promised
-./kesha-engine --capabilities-json | jq .features
-
-# 3. Real end-to-end exercise (the one CI's --capabilities-json check misses).
-#    For TTS: synthesize a known-good voice into a fresh KESHA_CACHE_DIR.
-#    For ASR: transcribe a fixture from rust/tests/fixtures/.
-KESHA_CACHE_DIR="$SMOKE/cache" ./kesha-engine install --tts
-echo "Hello world" | KESHA_CACHE_DIR="$SMOKE/cache" \
-  ./kesha-engine say --voice en-am_michael --out "$SMOKE/en.wav"
-file "$SMOKE/en.wav"              # must report a valid WAV
-[[ -s "$SMOKE/en.wav" ]] || { echo "ERROR: en.wav is empty — synthesis failed"; exit 1; }
-# Optional belt-and-braces: enforce a minimum byte count (1s mono f32 24kHz ≈ 96 KB).
-[[ $(stat -f%z "$SMOKE/en.wav" 2>/dev/null || stat -c%s "$SMOKE/en.wav") -gt 50000 ]] \
-  || { echo "ERROR: en.wav is suspiciously small — header-only stub?"; exit 1; }
-```
-
-Repeat for `kesha-engine-linux-x64` (run via Docker if not on Linux). If ANY of those three steps fail, **DO NOT un-draft** — un-drafting fires `📦 npm Publish` automatically. Either yank the GitHub release (`gh release delete vX.Y.Z --yes`, delete the tag, bump patch, retry) or push a fix and rebuild via `gh workflow run "🔨 Build Engine"`. Since the draft never went public, no recall is needed.
-
-The CI smoke step (`--capabilities-json` only) is a sanity check on the toolchain, not a behavior test. Behavior testing is the human-in-the-loop pre-undraft gate; it lives in this checklist, not in the workflow file.
+Validate the draft binary with authenticated `gh release download` and exercise it
+end-to-end (version, `--capabilities-json`, a real synth/transcribe) before
+`gh release edit --draft=false` — un-draft fires npm publish, which is effectively
+permanent. `make smoke-test` can false-green through an old global shim. Details:
+`docs/runbooks/release.md`.
 
 ### `bun link` DOES NOT OVERRIDE A GLOBALLY-INSTALLED PACKAGE — REMOVE FIRST
 
-`bun link` in the package root only registers the local checkout; it does not replace an existing `~/.bun/install/global/node_modules/<pkg>/` created by `bun add -g`. If the old directory wins, the global `kesha` shim keeps using the previously installed CLI and old embedded `keshaEngine.version`.
-
-Detect with `readlink ~/.bun/install/global/node_modules/@drakulavich/kesha-voice-kit`: no output means a real old directory wins; a path back to the checkout means the link wins. One-time fix:
-
-```bash
-bun remove -g @drakulavich/kesha-voice-kit   # delete the previously-installed copy
-bun link                                      # re-register from package root
-# verify:
-readlink ~/.bun/install/global/node_modules/@drakulavich/kesha-voice-kit
-# should print: /path/to/your/kesha-voice-kit checkout (absolute path)
-```
-
-Incident: `bun link` on local main still reported `kesha --version` 1.14.0, but `kesha install` said `Upgrading engine v1.14.0 → v1.6.0...`; the shim was the old `bun add -g` v1.6.0 install. `bun remove -g` + `bun link` fixed it.
+`bun link` only registers the local checkout; an existing `bun add -g` install keeps
+winning. Run `bun remove -g @drakulavich/kesha-voice-kit` first, then `bun link`, and
+verify via `readlink ~/.bun/install/global/node_modules/@drakulavich/kesha-voice-kit`.
+Details: `docs/runbooks/release.md`.
 
 ### TESTS THAT STAGE A TEMPDIR CACHE MUST STAGE G2P TOO
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,25 +480,12 @@ const text = await transcribe("audio.ogg");
 ## TTS
 
 Text-to-speech via three engines selected by voice id prefix:
+`en-*` → Kokoro-82M (24 kHz), `ru-*` → Vosk-TTS (22.05 kHz), `macos-*` → AVSpeech Swift sidecar.
+Install Kokoro + Vosk explicitly with `kesha install --tts` (~990 MB); `macos-*` voices need no
+model download. Models are NEVER auto-downloaded — `kesha say` fails loudly with a
+`kesha install --tts` hint when models are missing. Default voices MUST be male (see DEFAULT TTS
+VOICES MUST BE MALE above). `kesha say` writes WAV mono f32 to stdout unless `--out` is given;
+stderr is progress/errors only. Auto-routing for an omitted `--voice` is in `src/cli/say.ts::pickVoiceForLang`.
 
-- `en-*` → **Kokoro-82M**. Separate model + per-voice style embedding. Output 24 kHz.
-- `ru-*` → **Vosk-TTS** (`alphacep/vosk-tts`). Multi-speaker model, 5 baked-in speakers. Output 22.05 kHz.
-- `macos-*` → **AVSpeechSynthesizer** Swift sidecar (#141). Zero model download, notification-grade quality, darwin-arm64 release feature set `coreml,tts,system_tts`; `kesha install` places `say-avspeech-darwin-arm64` next to the engine and runtime lookup is sibling-first (`rust/src/tts/avspeech.rs::helper_path`).
-
-Install Kokoro + Vosk-TTS explicitly with `kesha install --tts` (~990 MB). `macos-*` voices use installed macOS voices and need no model install.
-
-- TTS models are **never auto-downloaded** — `kesha say` fails loudly with a `kesha install --tts` hint when models are missing.
-- `kesha say` writes WAV mono f32 to stdout unless `--out` is given. Stderr is progress/errors only.
-- G2P split (post-#213): English (`en`/`en-us`/`en-gb`) uses embedded `misaki-rs` (Kokoro-trained inventory, no system deps, OOV letter-spell); Russian uses Vosk-TTS internals (BERT prosody + dictionary, no system deps); other shipped engines are unsupported ([#212](https://github.com/drakulavich/kesha-voice-kit/issues/212)). CharsiuG2P ([#123](https://github.com/drakulavich/kesha-voice-kit/issues/123)) and espeak-ng ([#210](https://github.com/drakulavich/kesha-voice-kit/issues/210)) were removed in [#213](https://github.com/drakulavich/kesha-voice-kit/issues/213).
-- Auto-routing: omitted `--voice` calls TS `NLLanguageRecognizer` and picks `en-am_michael`, `macos-com.apple.voice.compact.ru-RU.Milena` on darwin Russian, or `ru-vosk-m02` elsewhere. Confidence < 0.5 or unmapped language falls to engine default. Routing table: `src/cli/say.ts::pickVoiceForLang`.
-- SSML (`--ssml`): `ssml-parser`; supports required `<speak>` root and `<break time="...">`; rejects `<!DOCTYPE>`; unknown tags (`<emphasis>`, `<prosody>`, `<phoneme>`, `<say-as>`) warn once and strip tags while synthesizing contained text. `tts::ssml::parse` returns `Vec<Segment>`; `tts::say()` loads the engine once, concatenates text/silence f32 samples, then calls `wav::encode_wav`. Scope/future tags: #122.
-- Kokoro ONNX (post-#207 official `kokoro-onnx` v1.0): inputs `tokens` int64 `[1,N]`, `style` f32 `[1,256]` rank-2, `speed` f32 `[1]`; output `"audio"`; voice file 510x256. The earlier HF onnx-community variant used `input_ids`/`waveform` and broke `af_heart`.
-- Vosk-TTS ONNX (post-#213): one `Synth` + `Model` per call (`Vosk::load`: `model.onnx`, `bert/model.onnx`, dictionary, ~1-2s cold). `Model::new` takes `Option<&str>` dir; `Synth::synth_audio` returns i16 PCM at model sample rate (22050 Hz for `vosk-model-tts-ru-0.9-multi`); `rust/src/tts/vosk.rs` converts to f32 / 32768.0. Speakers 0..4 map to `ru-vosk-{f01,f02,f03,m01,m02}` in `voices::resolve_vosk_ru`; multi-call perf tracked in #213.
-- AVSpeech (#141, `system_tts`, default darwin-arm64): engine spawns `say-avspeech`; path resolution tries sibling-of-exe (`~/.cache/kesha/bin/say-avspeech`) then build-time `$OUT_DIR/say-avspeech`. stdin UTF-8, argv[1] voice id, `--list-voices` emits `identifier|language|name`, Rust prefixes `macos-` and merges into `say --list-voices`. Output: complete mono f32 IEEE_FLOAT WAV @ 22050 Hz. Must pump `CFRunLoopRun()` because callbacks dispatch on main queue; `DispatchSemaphore` hangs. `--rate` mapping TBD; SSML + AVSpeech rejected in v1.
-- `KESHA_ENGINE_BIN` — override the engine-binary path (useful when iterating on `rust/target/release/kesha-engine`).
-- `KESHA_CACHE_DIR` — isolated test cache.
-- `KESHA_MODEL_MIRROR` — redirect HF downloads to an internal mirror (#121), preserving `/<owner>/<repo>/resolve/<ref>/<file>` for `wget --mirror`; empty/unset = no-op. Rust `models.rs::apply_mirror` and TS `status.ts::activeModelMirror` both trim trailing slashes.
-- macOS dev runtime: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`. Release binaries fix up via `install_name_tool`.
-- macOS build env: `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`, `RUSTFLAGS="-L /opt/homebrew/lib"`.
-
-Original spec assumed Silero TTS; pivoted to Piper during M3 spike (Silero ships PyTorch-only, no public ONNX). See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.
+**Engine internals, Kokoro/Vosk ONNX I/O shapes, G2P split, SSML handling, `KESHA_*` env vars,
+macOS dev/build env:** `docs/runbooks/tts-internals.md`.

--- a/docs/runbooks/jj-git-lfs.md
+++ b/docs/runbooks/jj-git-lfs.md
@@ -1,0 +1,27 @@
+# jj + Git LFS Runbook
+
+> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
+> instructions under Claude Code's 40k-char performance threshold. Read this when using jj
+> in this repo, or when jj shows LFS-managed files as modified.
+
+## JJ + Git LFS workaround
+
+This repo uses Git LFS for fixtures/assets. Stock `jj` can surface LFS-managed files as modified in colocated repos. Use the LFS fork until upstream support lands:
+
+```bash
+cargo install --git https://github.com/gusinacio/jj.git \
+  --branch lfs --locked --bin jj jj-cli
+jj config set --user git.ignore-files '["lfs"]'
+git lfs pull
+```
+
+Operational lessons from the 2026-05-16 setup:
+
+- If `jj --version` still shows Homebrew's binary, `which -a jj` usually lists `/opt/homebrew/bin/jj` before `~/.cargo/bin/jj`; run `brew unlink jj`. The fork reporting `jj 0.35.0-<sha>` is expected.
+- Preserve identity after switching: `jj config set --user user.name "<Your Name>"` and `jj config set --user user.email "<your@email.com>"`; use your own credentials, never the repo owner's.
+- Existing `.jj`: do not reclone. Keep the colocated checkout, set config, run `git lfs pull`, verify `jj status`.
+- Normal agent isolation: follow "AGENTS MUST WORK IN ISOLATED TREES FROM FRESH MAIN" above. Use a Git worktree or a separate JJ workspace from fresh `origin/main` / `main@origin`, then edit only inside that isolated tree.
+- Disk model: changes/bookmarks share history and are cheap, but they do not isolate the on-disk working copy. Agent tasks need physical workspace isolation even if that duplicates `node_modules`, `rust/target`, temp caches, and materialized LFS files.
+- A JJ workspace may lack `.git`; inspect with `jj status` / `jj diff` / `jj log`, and use `gh -R drakulavich/kesha-voice-kit ...` for GitHub operations.
+- Before calling files "external changes", distinguish dirty edits from a stale checked-out feature branch: check `jj status` + `jj workspace list` everywhere; in the colocated checkout also `git status --short --branch` + `git log --oneline --decorate -5`. After a PR merges and the remote branch is deleted, fetch, move back to `main`, then start the next task.
+- If JJ looks suspicious, trust Git as the source of truth: `git status --short --branch` must be clean before release/PR decisions.

--- a/docs/runbooks/openclaw-plugin.md
+++ b/docs/runbooks/openclaw-plugin.md
@@ -1,0 +1,73 @@
+# OpenClaw Plugin Runbook
+
+> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
+> instructions under Claude Code's 40k-char performance threshold. Read this when editing the
+> OpenClaw plugin or publishing it to ClawHub.
+
+## OPENCLAW PLUGIN
+
+The plugin lives in `openclaw.plugin.json` + `openclaw-plugin.cjs` (+ `package.json#openclaw.extensions`).
+
+**How audio transcription actually works in OpenClaw:** the `type: "cli"` path in `tools.media.audio.models` — NOT `registerMediaUnderstandingProvider` (that path requires API keys via `requireApiKey()` and silently fails for local CLI tools). The plugin registers a `MediaUnderstandingProvider` for discoverability (`openclaw plugins inspect` shows `Shape: plain-capability`), but the actual transcription routes through `runCliEntry`, which spawns `kesha {{MediaPath}}` and captures bare transcript stdout.
+
+Recommended user config:
+```json5
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [
+          {"type":"cli","command":"kesha","args":["{{MediaPath}}"],"timeoutSeconds":15}
+        ],
+        echoTranscript: true,
+        echoFormat: '🦜 "{transcript}"'
+      }
+    }
+  }
+}
+```
+This is a documented user-config default, not a plugin manifest patch.
+
+**Scanner rules:**
+- OpenClaw's `dangerous-exec` scanner fires when a file contains BOTH a `spawn(`/`exec(`-style call AND the substring for the forbidden module name. **Comments count** — it's a naive regex, not AST-aware.
+- Split the module specifier across `+` so the forbidden substring is absent from the source. Never name trigger tokens anywhere in `openclaw-plugin.cjs` — not even in comments.
+- `--force` flag overwrites existing installs. `openclaw plugins uninstall` is interactive (no `--yes`).
+
+**Manifest:** required fields are `id` + `configSchema` (proper JSON Schema shape). `configPatch` is NOT a valid field — the loader silently discards it.
+
+## PUBLISHING THE OPENCLAW PLUGIN TO CLAWHUB
+
+The plugin is distributed on [ClawHub](https://clawhub.com) (the OpenClaw plugin registry), **independently of npm and the engine release**. ClawHub publishing is its own outward-facing step — it is *not* triggered by `kesha` npm publish, GitHub releases, or `build-engine.yml`.
+
+**`package.json#openclaw` must carry the publish metadata** — without it `clawhub package publish` fails with the opaque `Error: package.json required` even though the file exists. A ClawHub **code plugin** needs all three keys (mirror an `@openclaw/*` package such as `@openclaw/imessage`):
+
+```jsonc
+"openclaw": {
+  "extensions": ["./openclaw-plugin.cjs"],
+  "compat": { "pluginApi": ">=<openclaw-version>" },   // min host API the plugin needs
+  "build":  { "openclawVersion": "<openclaw-version>" } // version it was built/validated against
+}
+```
+
+Use the current `openclaw --version` (e.g. `2026.5.27`) for both unless you have evidence the plugin works against an older API. Bump `build.openclawVersion` whenever you re-publish after validating against a newer OpenClaw.
+
+**Publish flow** (CLI is `clawhub`, installed alongside `openclaw`):
+
+1. **Auth + scope.** `clawhub whoami` must report the owner that matches the package scope — `@drakulavich/kesha-voice-kit` → owner `drakulavich`. If not logged in, the user runs `clawhub login` (interactive — suggest `!clawhub login`; the agent cannot complete the browser/device step).
+2. **Publish from a clean checkout at the released tag**, never the root checkout (it goes stale). Provenance flags are recorded on the registry entry and `--source-repo`/`--source-commit` must be set together:
+   ```bash
+   git worktree add .worktrees/clawhub vX.Y.Z
+   cd .worktrees/clawhub
+   clawhub package publish . \
+     --family code-plugin \
+     --version X.Y.Z \
+     --source-repo drakulavich/kesha-voice-kit \
+     --source-commit <sha-of-vX.Y.Z> \
+     --source-ref vX.Y.Z \
+     --changelog "<one-line summary>"
+   ```
+3. **No `--dry-run` in the shipped `clawhub` (2026.5.x)** despite what the docs site shows — the only validation is the real publish, which is server-side scanned and **held in review** ("may stay out of install/download surfaces until review finishes"). Treat publish as the commit point; get the `package.json` metadata right first.
+4. **Verify** with `clawhub search kesha` / `openclaw plugins search kesha-voice-kit`, and that `openclaw plugins install clawhub:@drakulavich/kesha-voice-kit` resolves once review clears.
+
+Gotcha: `clawhub package publish` reads the **local folder's** `package.json` for validation, but records the `--source-*` flags as provenance — keep them consistent (publish from the same commit the metadata lives on, so the recorded source actually contains the `openclaw.compat`/`build` block).

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -1,0 +1,176 @@
+# Release Runbook
+
+> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
+> instructions under Claude Code's 40k-char performance threshold. Read this when cutting
+> or publishing a release.
+
+## RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY
+
+`package.json#version` (CLI) and `package.json#keshaEngine.version` (engine, mirrored in `rust/Cargo.toml`) are decoupled. `src/engine-install.ts` downloads `v${keshaEngine.version}` with fallback to `package.json#version`.
+
+Version drift gate: `bun .github/scripts/check-versions.ts` (`bun run check:versions` / `make versions`, CI "🔢 Check version drift") enforces:
+
+1. `keshaEngine.version === rust/Cargo.toml#version` — one engine version stored twice; drift makes `kesha install` fetch the wrong source/release.
+2. `package.json#version >= keshaEngine.version` — CLI may lead for CLI-only patches, never lag.
+
+**CLI-only patch** (docs, TS, plugin): bump only `package.json#version`; leave `keshaEngine.version` + `rust/Cargo.toml`; PR CI uses the existing engine; merge; create a marker release:
+
+CLI-only is allowed only when the changed CLI surface works against the already-published engine pinned by `package.json#keshaEngine.version`. If a CLI command delegates to a new engine subcommand, capability flag, feature behavior, or output contract, it is an **engine release**: bump `package.json#keshaEngine.version`, `rust/Cargo.toml`, and `rust/Cargo.lock` together. Before cutting any `v*-cli` marker, smoke-test new/changed CLI commands against the published pinned engine, not only a repo-local engine build. The `v1.18.2-cli` / `v1.18.3-cli` mistake was exposing `kesha record` while the pinned published engine was still `v1.18.0` and did not implement `kesha-engine record`.
+
+```bash
+gh release create vX.Y.Z-cli --title "vX.Y.Z (CLI-only)" \
+  --notes "Engine: v<keshaEngine.version> (unchanged)."
+npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
+```
+
+`v*-cli` is excluded from `build-engine.yml`; the published marker fires `📦 npm Publish` automatically.
+
+**Engine release** (anything under `rust/` or an engine bump):
+
+1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version`, usually `package.json#version`.
+2. Merge to main.
+3. Tag/push: `git tag vX.Y.Z && git push origin vX.Y.Z` → `build-engine.yml`.
+4. Write release notes before publishing. Draft releases start with an empty body:
+
+   ```bash
+   gh release edit vX.Y.Z --notes "$(cat <<'EOF'
+   <summary of changes, new features, breaking changes, PR list>
+   EOF
+   )"
+   ```
+
+   Template: v1.1.3 style — features → platform support → breaking changes → shipped PRs → follow-up issues → upgrade instructions. If notes were forgotten on a published release, `gh release edit --notes` can silently drop them; patch via API:
+
+   ```bash
+   RELEASE_ID=$(gh api repos/OWNER/REPO/releases/tags/vX.Y.Z --jq '.id')
+   jq -Rs '{body: .}' < notes.md > body.json
+   gh api -X PATCH "repos/OWNER/REPO/releases/$RELEASE_ID" --input body.json
+   ```
+
+5. Validate draft assets before un-drafting. Authenticated `gh release download` works on drafts; anonymous `curl` / `kesha install` 404s. Release drafts must include `SHA256SUMS`, `kesha-release-manifest.json`, one `*.sigstore.json` per non-signature asset, and `kesha-voice-kit-vX.Y.Z.spdx.json`.
+
+   ```bash
+   gh release download vX.Y.Z -p SHA256SUMS -p kesha-release-manifest.json -p '*.sigstore.json' -p 'kesha-*' -p 'say-*' -D <smoke-dir>
+   cd <smoke-dir>
+   sha256sum -c SHA256SUMS
+   cosign verify-blob \
+     --bundle kesha-engine-darwin-arm64.sigstore.json \
+     --certificate-identity "https://github.com/drakulavich/kesha-voice-kit/.github/workflows/build-engine.yml@refs/tags/vX.Y.Z" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     kesha-engine-darwin-arm64
+   ```
+
+6. Treat `make smoke-test` as a local sanity check only; it can run the old globally installed CLI/engine. The release gate is draft-asset validation.
+7. Publish: `gh release edit vX.Y.Z --draft=false`. This fires `📦 npm Publish`; verify `npm view @drakulavich/kesha-voice-kit version` within ~60s. Manual fallback: `npm publish --access public` from the maintainer laptop.
+8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo, and attach Linux x64 `.deb`/`.rpm` packages covered by `SHA256SUMS` + Sigstore. CLI-only marker releases skip Homebrew/packages.
+
+**Beta engine release** (unstable channel):
+
+- Use SemVer prerelease versions in all three places: `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`, for example `1.18.7-beta.1`; tag as `v1.18.7-beta.1`.
+- `build-engine.yml` accepts `vX.Y.Z-beta.N`, creates a **draft prerelease**, and uploads engine binaries, sidecars, `SHA256SUMS`, manifest, SBOM, and Sigstore bundles. It intentionally skips Homebrew and Linux `.deb`/`.rpm` packages for beta tags.
+- After draft asset validation, publish with `gh release edit vX.Y.Z-beta.N --draft=false`. `📦 npm Publish` publishes prerelease package versions with `npm publish --tag beta`, so `@latest` stays on the latest stable release.
+- Verify beta with `npm view @drakulavich/kesha-voice-kit@beta version`; user-facing beta install is `bun add -g @drakulavich/kesha-voice-kit@beta && kesha install`.
+- Promote by cutting a later stable `vX.Y.Z` release; do not reuse the beta tag or try to retag it as stable.
+
+**Alternate tag path:** `workflow_dispatch` validates tag shape and authors notes inline, useful when a sandbox cannot push tags:
+
+```bash
+gh workflow run "🔨 Build Engine" \
+  -R drakulavich/kesha-voice-kit \
+  -f tag=vX.Y.Z \
+  -f ref=main \
+  -f notes="$(cat release-notes.md)"
+```
+
+Because `workflow_dispatch` authors release notes inline via `-f notes`, skip engine-release step 4 when using this path.
+
+Known break (v1.16.0, 2026-05-14): `GITHUB_TOKEN` tag pushes do not trigger downstream `on.push.tags`; dispatch ends with `tag: success, build/release: skipped`. Workaround until PAT/GitHub App token fix: fetch tags, delete the remote tag, re-push it from a maintainer laptop so a user-authored push triggers the build:
+
+```bash
+git fetch --tags
+git push origin :refs/tags/vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## NPM PUBLISH IS AUTOMATED WITH PROVENANCE ATTESTATION
+
+Post-#291 happy path: publishing a GitHub release runs `.github/workflows/npm-publish.yml` → `npm publish --provenance --access public` in GHA. Do not publish from a maintainer laptop unless the workflow is broken.
+
+- Trigger: `release: published` (engine un-draft or published `v*-cli` marker) plus `workflow_dispatch` re-runs.
+- Provenance: `permissions.id-token: write` gives npm the GHA OIDC chain (`commit SHA` → built tarball) and the npm "verified" badge.
+- Guards: tag must match `package.json#version` after stripping leading `v` and trailing `-cli`; already-published versions skip publish and exit 0.
+- Dist-tags: stable package versions publish to `latest`; SemVer prerelease package versions publish to `beta`.
+- Injection rule: route `inputs.tag` / `github.event.release.tag_name` through `env:`, never directly into `run:` while the job holds `id-token: write`.
+- Required secret: `NPM_TOKEN` (granular publish-only token for `@drakulavich/kesha-voice-kit`), set with `gh secret set NPM_TOKEN -R drakulavich/kesha-voice-kit`. If missing, the release remains published but the publish step fails; fallback is `npm publish --access public` from a laptop.
+- Release implication: un-draft is the commit-to-publish point. Validate draft assets via authenticated `gh release download` before un-drafting; npm publish is effectively permanent (72 h unpublish window, noisy provenance). If validation fails before publish: delete release + tag, bump patch, retry.
+
+## TAG NAMES ARE ONE-USE
+
+GitHub's immutable-releases permanently reserves tag names after publish. **Broken release → bump patch version, cut new tag.** Never tag "just to test" — use `gh workflow run "🔨 Build Engine" --ref main` instead. Skipping tags is fine (we skipped `v1.0.1`).
+
+## RELEASE CHICKEN-AND-EGG — `integration-tests` SKIPS ON `release/*`
+
+`integration-tests` in `.github/workflows/ci.yml` downloads the RELEASED `kesha-engine` binary at the version pinned in `package.json#keshaEngine.version`. On a version-bump PR (branch `release/X.Y.Z`) that tag doesn't exist yet — HTTP 404, CI red. The job is filtered via `if: needs.changes.outputs.integration == 'true' && !startsWith(github.head_ref, 'release/')`. Don't remove that filter. If you add a new job that downloads release artifacts, use the same branch guard.
+
+## DRAFT RELEASE ASSET URLS ARE 404 TO ANONYMOUS CLIENTS — USE `gh release download`
+
+`build-engine.yml` creates a draft release with 3 platform binaries. Draft asset URLs 404 for unauthenticated clients, so `curl`, `kesha install`, and anonymous `make smoke-test` cannot validate the draft. Authenticated `gh release download vX.Y.Z -p "..." -D <dir>` works on drafts and is the pre-undraft release gate; `make smoke-test` is only a post-undraft sanity check, but post-#291 un-draft also triggers npm publish.
+
+## `make smoke-test` ALONE DOES NOT VALIDATE A NEW ENGINE — `gh release download` THE DRAFT BINARY AND EXERCISE IT BEFORE `gh release edit --draft=false`
+
+`make smoke-test` runs `bun link @drakulavich/kesha-voice-kit`, `kesha install`, then `bun scripts/smoke-test.ts`, but a prior `bun add -g` can leave the old global shim in front. Then `kesha --version` and `kesha install` exercise the previous CLI/engine and produce a false-green "6/6 passed". v1.5.0 hit this: `--capabilities-json` passed, Kokoro synth crashed (`Invalid input name: tokens`), and local smoke still routed through v1.4.4 CLI + v1.4.1 engine.
+
+Before `gh release edit --draft=false`, always validate the draft binary directly with authenticated `gh release download`, not `curl` (drafts 404 anonymously). Un-draft starts `📦 npm Publish` within ~60 s; npm unpublish is limited/noisy, and #291's Greptile review flagged this ordering.
+
+```bash
+SMOKE=/tmp/kesha-vX.Y.Z-smoke && rm -rf "$SMOKE" && mkdir "$SMOKE" && cd "$SMOKE"
+gh release download vX.Y.Z -R drakulavich/kesha-voice-kit \
+  -p "kesha-engine-darwin-arm64" -D "$SMOKE"
+chmod +x kesha-engine && xattr -d com.apple.quarantine kesha-engine 2>/dev/null
+
+# 1. Version string MUST equal the new tag — sanity check
+./kesha-engine --version          # → "kesha-engine X.Y.Z"
+
+# 2. Capability surface — must include every feature the build matrix promised
+./kesha-engine --capabilities-json | jq .features
+
+# 3. Real end-to-end exercise (the one CI's --capabilities-json check misses).
+#    For TTS: synthesize a known-good voice into a fresh KESHA_CACHE_DIR.
+#    For ASR: transcribe a fixture from rust/tests/fixtures/.
+KESHA_CACHE_DIR="$SMOKE/cache" ./kesha-engine install --tts
+echo "Hello world" | KESHA_CACHE_DIR="$SMOKE/cache" \
+  ./kesha-engine say --voice en-am_michael --out "$SMOKE/en.wav"
+file "$SMOKE/en.wav"              # must report a valid WAV
+[[ -s "$SMOKE/en.wav" ]] || { echo "ERROR: en.wav is empty — synthesis failed"; exit 1; }
+# Optional belt-and-braces: enforce a minimum byte count (1s mono f32 24kHz ≈ 96 KB).
+[[ $(stat -f%z "$SMOKE/en.wav" 2>/dev/null || stat -c%s "$SMOKE/en.wav") -gt 50000 ]] \
+  || { echo "ERROR: en.wav is suspiciously small — header-only stub?"; exit 1; }
+```
+
+Repeat for `kesha-engine-linux-x64` (run via Docker if not on Linux). If ANY of those three steps fail, **DO NOT un-draft** — un-drafting fires `📦 npm Publish` automatically. Either yank the GitHub release (`gh release delete vX.Y.Z --yes`, delete the tag, bump patch, retry) or push a fix and rebuild via `gh workflow run "🔨 Build Engine"`. Since the draft never went public, no recall is needed.
+
+The CI smoke step (`--capabilities-json` only) is a sanity check on the toolchain, not a behavior test. Behavior testing is the human-in-the-loop pre-undraft gate; it lives in this checklist, not in the workflow file.
+
+## `bun link` DOES NOT OVERRIDE A GLOBALLY-INSTALLED PACKAGE — REMOVE FIRST
+
+`bun link` in the package root only registers the local checkout; it does not replace an existing `~/.bun/install/global/node_modules/<pkg>/` created by `bun add -g`. If the old directory wins, the global `kesha` shim keeps using the previously installed CLI and old embedded `keshaEngine.version`.
+
+Detect with `readlink ~/.bun/install/global/node_modules/@drakulavich/kesha-voice-kit`: no output means a real old directory wins; a path back to the checkout means the link wins. One-time fix:
+
+```bash
+bun remove -g @drakulavich/kesha-voice-kit   # delete the previously-installed copy
+bun link                                      # re-register from package root
+# verify:
+readlink ~/.bun/install/global/node_modules/@drakulavich/kesha-voice-kit
+# should print: /path/to/your/kesha-voice-kit checkout (absolute path)
+```
+
+Incident: `bun link` on local main still reported `kesha --version` 1.14.0, but `kesha install` said `Upgrading engine v1.14.0 → v1.6.0...`; the shim was the old `bun add -g` v1.6.0 install. `bun remove -g` + `bun link` fixed it.
+
+## Greptile re-review & auto-merge mechanics
+
+Greptile comment mechanics:
+
+- It updates one existing top-level comment, not a new comment per review. Confirm re-review by checking both the "Last reviewed commit" SHA (`body | match("commit/([a-f0-9]+)")`) and the issue-comment `.updated_at`; `gh pr view --json comments` has null `updatedAt`, so use `gh api repos/OWNER/REPO/issues/<N>/comments`.
+- Do not arm auto-merge before Greptile reviews the latest head; otherwise CI-green can merge before a new P1/P2 arrives (#287→#288→#289; #290→#291→#292 avoided by waiting). Merge by hand after `Confidence Score: ≥4/5` references the latest SHA.
+- If Greptile is the next gate, set a real wait: `ScheduleWakeup(delaySeconds: 300-900, prompt: "<<autonomous-loop-dynamic>>", reason: "<...>")` (270s for cache-warm, 900s+ for cache miss; avoid the dead zone around 300s). Optional auto-merge poll: `while :; do gh api repos/drakulavich/kesha-voice-kit/issues/N/comments --jq '.[] | select(.user.login | contains("greptile"))'; done`, merging only when `Confidence Score: ≥4/5` and `commit/SHA` match head. If the latest head stays uncovered after the wait, leave the PR unmerged and report the stale/missing Greptile review to the maintainer. Stop the poll if the user says to wait.

--- a/docs/runbooks/rust-gotchas.md
+++ b/docs/runbooks/rust-gotchas.md
@@ -1,0 +1,66 @@
+# Rust Gotchas Runbook
+
+> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
+> instructions under Claude Code's 40k-char performance threshold. Read this when writing
+> or debugging Rust in `rust/`.
+
+## `f32::clamp` DIVERGENCE: USE BOUND CHECK, NOT `EPSILON`
+
+When detecting whether `f32::clamp(raw, lo, hi)` actually changed the value (e.g. to fire a one-time warning), `(raw - clamped).abs() > f32::EPSILON` is the WRONG tolerance:
+
+- `f32::EPSILON ≈ 1.19e-7` is the ULP at value `1.0`.
+- ULP scales with the magnitude. At raw ≈ 0.5, ULP ≈ 5.96e-8 — **below `EPSILON`**.
+- A value one ULP below `0.5` clamps to `0.5`, but `|raw - clamped|` ≈ 6e-8 doesn't exceed `EPSILON`. The warning silently misses the clamp.
+
+Correct pattern: check the bounds directly.
+```rust
+if !(lo..=hi).contains(&raw) {
+    // raw was outside the range; clamped to a bound
+}
+```
+
+- Idiomatic (clippy prefers `RangeInclusive::contains` over `raw < lo || raw > hi`, lint `manual_range_contains`).
+- **NaN flows through and fires the guard.** `NaN < x` and `x < NaN` are both false → `(lo..=hi).contains(&NaN) == false` → `!false == true` → guard DOES fire on NaN. `f32::clamp(NaN, lo, hi)` returns NaN unchanged (NaN-passthrough), so the warning text will say "rate NaN ... clamped to NaN" — typically intentional, because NaN at this layer means an upstream parse bug and surfacing it on stderr beats silently feeding NaN into the downstream model. If you DO want to suppress, check `raw.is_nan()` explicitly first and decide what to do. (Same NaN inversion that #289 corrected in `compose_rate` — re-introducing it here was caught by Greptile on #294.)
+- Symmetric with the `clamp` itself.
+
+Past incidents: #287 → #288 → #289 cascade for F9 (`compose_rate` rate-clamp warning). #287 shipped with `EPSILON`, Greptile P2 caught the ULP gap, #288 fixed via `!(0.5..=2.0).contains(&raw)`, #289 corrected an inverted NaN claim in the accompanying comment.
+
+## `ort 2.0.0-rc.12` `Value::from_array` WANTS OWNED NDARRAYS
+
+`Value::from_array(arr)` consumes its input; views (`ArrayView2`, `.view()`) don't implement `OwnedTensorArrayData`. `Array2::ones((1, n))` inline at the call site is the cleanest fresh owned construction. `Array2::from_shape_vec((...), buf.clone())` also works at the cost of a clone. `Session::builder()` returns `ort::Result` that converts through `anyhow::Context::context("...")?` cleanly — **no `map_err(anyhow::Error::msg)` dance needed**, despite what the #123 spike doc originally claimed. Peer modules (`lang_id.rs`, `vad.rs`, `backend/onnx.rs`, `kokoro.rs`, `piper.rs`) all use `.context()?`; match that style.
+
+## CLIPPY `needless_update` BLOCKS `..Default::default()` IF ALL FIELDS ARE SPELLED
+
+Tempting "forward-compat" pattern: `MyStruct { a: 1, b: 2, ..Default::default() }` so a future new field doesn't break the call site. Clippy fires `needless_update` when all current fields are already spelled (the `..` is no-op today), and `-D warnings` promotes it to deny. CI red.
+
+The forward-compat is already there for free: Rust requires exhaustive struct init for any struct NOT marked `#[non_exhaustive]`. Adding a new field makes the call site a compile error pointing at the literal, which is exactly the breakage that needs to be surfaced.
+
+- Spell all fields explicitly.
+- Skip `..Default::default()` — the compile error on field addition is the safety.
+- If callers across crate boundaries need forward-compat (e.g. a published lib), mark the struct `#[non_exhaustive]` instead.
+- Past incident: #290 P2 (F5 follow-up) suggested adding `..Default::default()`, clippy blocked it, the comment explaining the trade-off landed instead.
+
+## BINDGEN ON LINUX NEEDS LIBCLANG_PATH
+
+Any Rust crate using `bindgen` (directly or transitively — e.g. `espeakng-sys` with `clang-runtime` feature) needs `LIBCLANG_PATH` on Linux build runners even with `apt install libclang-dev`. The `clang-runtime` feature makes bindgen `dlopen` libclang at build-script runtime; the apt package installs into a versioned subdir that isn't on the default dlopen path.
+
+Portable recipe for the Linux job:
+```yaml
+- run: |
+    sudo apt-get install -y libclang-dev llvm-dev
+    echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
+```
+
+macOS equivalent is `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`. Windows uses `C:\Program Files\LLVM\bin` with LLVM installed via `choco install llvm` and MSVC tooling activated via `ilammy/msvc-dev-cmd@v1` in CI. espeak-ng on Windows needs an import lib synthesized from the choco-shipped DLL via `dumpbin /exports` + `lib /def:… /machine:x64 /out:espeak-ng.lib` — see the Windows block in `rust-test.yml`.
+
+## SILERO VAD V5 NEEDS A 64-SAMPLE ROLLING CONTEXT
+
+Silero VAD v5 at 16 kHz wants ONNX `input` of length **576**, not 512: 64 samples of tail from the previous frame + 512 new samples. Missing this produces per-frame probabilities of ~0.0005 regardless of content — the model "runs" without detecting speech. Not in the ONNX metadata; only in upstream's Python `OnnxWrapper`. See `rust/src/vad.rs::frame_probs` for the rolling-context mechanics.
+
+## `fluidaudio-rs 0.1.0` LACKS `transcribe_samples`
+
+The method exists on upstream `main` but isn't in the published 0.1.0 crate. The CoreML `TranscribeBackend::transcribe_samples` impl writes a temp IEEE_FLOAT WAV at 16 kHz mono f32 and calls `transcribe_file` — see `rust/src/backend/fluidaudio.rs`. Drop the shim when upstream cuts a new release that exposes `transcribe_samples` directly.
+
+## TESTS THAT STAGE A TEMPDIR CACHE MUST STAGE G2P TOO
+
+Post-#123 (v1.4.0), Kokoro + Piper synthesis flows through the ONNX G2P at `$KESHA_CACHE_DIR/models/g2p/byt5-tiny/`. Any test that creates a fresh `KESHA_CACHE_DIR` tempdir and copies in only Kokoro / Piper will fail with `SynthesisFailed("g2p: G2P model not installed")`. Use `models::is_g2p_cached(dir)` + `models::g2p_model_dir()` to gate + copy the ONNX files. Examples: `rust/tests/tts_smoke.rs::resolves_from_cache_when_installed`, `tests/integration/say-e2e.test.ts::beforeAll`.

--- a/docs/runbooks/tts-internals.md
+++ b/docs/runbooks/tts-internals.md
@@ -1,0 +1,41 @@
+# TTS Internals Runbook
+
+> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
+> instructions under Claude Code's 40k-char performance threshold. Read this when changing
+> TTS synthesis, voices, G2P, or SSML.
+
+## Engines
+
+Text-to-speech via three engines selected by voice id prefix:
+
+- `en-*` → **Kokoro-82M**. Separate model + per-voice style embedding. Output 24 kHz.
+- `ru-*` → **Vosk-TTS** (`alphacep/vosk-tts`). Multi-speaker model, 5 baked-in speakers. Output 22.05 kHz.
+- `macos-*` → **AVSpeechSynthesizer** Swift sidecar (#141). Zero model download, notification-grade quality, darwin-arm64 release feature set `coreml,tts,system_tts`; `kesha install` places `say-avspeech-darwin-arm64` next to the engine and runtime lookup is sibling-first (`rust/src/tts/avspeech.rs::helper_path`).
+
+Install Kokoro + Vosk-TTS explicitly with `kesha install --tts` (~990 MB). `macos-*` voices use installed macOS voices and need no model install.
+
+## Behavior, G2P, and SSML
+
+- TTS models are **never auto-downloaded** — `kesha say` fails loudly with a `kesha install --tts` hint when models are missing.
+- `kesha say` writes WAV mono f32 to stdout unless `--out` is given. Stderr is progress/errors only.
+- G2P split (post-#213): English (`en`/`en-us`/`en-gb`) uses embedded `misaki-rs` (Kokoro-trained inventory, no system deps, OOV letter-spell); Russian uses Vosk-TTS internals (BERT prosody + dictionary, no system deps); other shipped engines are unsupported ([#212](https://github.com/drakulavich/kesha-voice-kit/issues/212)). CharsiuG2P ([#123](https://github.com/drakulavich/kesha-voice-kit/issues/123)) and espeak-ng ([#210](https://github.com/drakulavich/kesha-voice-kit/issues/210)) were removed in [#213](https://github.com/drakulavich/kesha-voice-kit/issues/213).
+- Auto-routing: omitted `--voice` calls TS `NLLanguageRecognizer` and picks `en-am_michael`, `macos-com.apple.voice.compact.ru-RU.Milena` on darwin Russian, or `ru-vosk-m02` elsewhere. Confidence < 0.5 or unmapped language falls to engine default. Routing table: `src/cli/say.ts::pickVoiceForLang`.
+- SSML (`--ssml`): `ssml-parser`; supports required `<speak>` root and `<break time="...">`; rejects `<!DOCTYPE>`; unknown tags (`<emphasis>`, `<prosody>`, `<phoneme>`, `<say-as>`) warn once and strip tags while synthesizing contained text. `tts::ssml::parse` returns `Vec<Segment>`; `tts::say()` loads the engine once, concatenates text/silence f32 samples, then calls `wav::encode_wav`. Scope/future tags: #122.
+
+## ONNX I/O shapes
+
+- Kokoro ONNX (post-#207 official `kokoro-onnx` v1.0): inputs `tokens` int64 `[1,N]`, `style` f32 `[1,256]` rank-2, `speed` f32 `[1]`; output `"audio"`; voice file 510x256. The earlier HF onnx-community variant used `input_ids`/`waveform` and broke `af_heart`.
+- Vosk-TTS ONNX (post-#213): one `Synth` + `Model` per call (`Vosk::load`: `model.onnx`, `bert/model.onnx`, dictionary, ~1-2s cold). `Model::new` takes `Option<&str>` dir; `Synth::synth_audio` returns i16 PCM at model sample rate (22050 Hz for `vosk-model-tts-ru-0.9-multi`); `rust/src/tts/vosk.rs` converts to f32 / 32768.0. Speakers 0..4 map to `ru-vosk-{f01,f02,f03,m01,m02}` in `voices::resolve_vosk_ru`; multi-call perf tracked in #213.
+- AVSpeech (#141, `system_tts`, default darwin-arm64): engine spawns `say-avspeech`; path resolution tries sibling-of-exe (`~/.cache/kesha/bin/say-avspeech`) then build-time `$OUT_DIR/say-avspeech`. stdin UTF-8, argv[1] voice id, `--list-voices` emits `identifier|language|name`, Rust prefixes `macos-` and merges into `say --list-voices`. Output: complete mono f32 IEEE_FLOAT WAV @ 22050 Hz. Must pump `CFRunLoopRun()` because callbacks dispatch on main queue; `DispatchSemaphore` hangs. `--rate` mapping TBD; SSML + AVSpeech rejected in v1.
+
+## Environment variables
+
+- `KESHA_ENGINE_BIN` — override the engine-binary path (useful when iterating on `rust/target/release/kesha-engine`).
+- `KESHA_CACHE_DIR` — isolated test cache.
+- `KESHA_MODEL_MIRROR` — redirect HF downloads to an internal mirror (#121), preserving `/<owner>/<repo>/resolve/<ref>/<file>` for `wget --mirror`; empty/unset = no-op. Rust `models.rs::apply_mirror` and TS `status.ts::activeModelMirror` both trim trailing slashes.
+- macOS dev runtime: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`. Release binaries fix up via `install_name_tool`.
+- macOS build env: `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`, `RUSTFLAGS="-L /opt/homebrew/lib"`.
+
+## History
+
+Original spec assumed Silero TTS; pivoted to Piper during M3 spike (Silero ships PyTorch-only, no public ONNX). See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.

--- a/docs/superpowers/plans/2026-05-31-slim-claudemd.md
+++ b/docs/superpowers/plans/2026-05-31-slim-claudemd.md
@@ -1,0 +1,341 @@
+# Slim CLAUDE.md Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move task-triggered runbooks out of the always-loaded `CLAUDE.md` into `docs/runbooks/*.md`, dropping it from ~53.7k to ~26k chars while losing nothing.
+
+**Architecture:** Each extracted section moves **verbatim** into a topic runbook file. In `CLAUDE.md` it is replaced by its `###` heading + the one-sentence hard rule + a `See docs/runbooks/<topic>.md` pointer. Hard always-on safety/brand/workflow rules stay inline untouched.
+
+**Tech Stack:** Markdown only. No code changes. Verification via `wc -c`, `grep`, and `git diff`.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-slim-claudemd-design.md`
+
+---
+
+## Working context
+
+- Worktree: `.worktrees/slim-claudemd`, branch `chore/slim-claudemd` (already created off fresh `origin/main`).
+- The Bash tool runs each command from the **repo root**, not the worktree. Either pass worktree-relative paths from root (`.worktrees/slim-claudemd/CLAUDE.md`) or prefix one-shot `cd` inside a single command. All paths below are written **relative to the worktree root**; prepend `.worktrees/slim-claudemd/` when running from the repo root.
+- **Extraction technique (every task):** open `CLAUDE.md`, locate the named `###`/`##` section(s), cut the entire block (heading through the last line before the next same-or-higher-level heading), paste verbatim into the new runbook file under a top-of-file `# <Title>` + source note, then in `CLAUDE.md` replace the cut block with the retained pointer stub shown in the task.
+- **Pointer stub format** (keeps the constraint in always-loaded context):
+
+  ```markdown
+  ### <ORIGINAL HEADING>
+
+  <one-sentence hard rule, copied from the section's first imperative.>
+
+  **Full procedure / details:** `docs/runbooks/<topic>.md`.
+  ```
+
+- **Do not touch** these inline sections: Project Overview, DEFAULT TTS VOICES MUST BE MALE, NEVER AUTO-DOWNLOAD, BUN-ONLY RUNTIME, PYTHON DEPENDENCIES IN A VENV, MAIN STAYS IN THE ROOT CHECKOUT, RELEASE-unrelated rules, NO SPECULATIVE FIELDS, ERROR HANDLING, BRANCH PROTECTION, WIP LABEL, LINK PRS TO ISSUES, DO NOT BLINDLY FORWARD CLI FLAGS, COREML BUILD TRIPLE, BUILD-ENGINE FEATURE MATRIX, WORKFLOW SHELL INJECTION, VERIFY THIRD-PARTY MODEL FORMATS WITH A SPIKE, PROMPT-INJECTION PATTERNS, Build Commands, Architecture, CI/CD, Code Style, Platform Requirements.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `docs/runbooks/release.md` | Full release procedure, draft validation, npm publish, tag rules, Greptile mechanics |
+| `docs/runbooks/rust-gotchas.md` | Deep Rust implementation lessons (clamp, ort, clippy, bindgen, VAD, fluidaudio, g2p) |
+| `docs/runbooks/tts-internals.md` | Deep TTS engine/ONNX/SSML/voice-routing reference |
+| `docs/runbooks/jj-git-lfs.md` | One-time jj + Git LFS setup and operational lessons |
+| `docs/runbooks/openclaw-plugin.md` | OpenClaw plugin internals + ClawHub publish |
+| `CLAUDE.md` | Hard always-on rules + one-line pointers (modified) |
+
+Each runbook starts with:
+
+```markdown
+# <Title>
+
+> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
+> instructions under Claude Code's 40k-char performance threshold. Read this when <trigger>.
+```
+
+---
+
+### Task 1: Extract the release runbook
+
+**Files:**
+- Create: `docs/runbooks/release.md`
+- Modify: `CLAUDE.md` (remove 8 sections, insert pointers)
+
+Sections to move verbatim into `release.md`, in this order:
+1. `### RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY`
+2. `### NPM PUBLISH IS AUTOMATED WITH PROVENANCE ATTESTATION`
+3. `### TAG NAMES ARE ONE-USE`
+4. `### RELEASE CHICKEN-AND-EGG — `integration-tests` SKIPS ON `release/*``
+5. `### DRAFT RELEASE ASSET URLS ARE 404 TO ANONYMOUS CLIENTS — USE `gh release download``
+6. `### `make smoke-test` ALONE DOES NOT VALIDATE A NEW ENGINE ...`
+7. `### `bun link` DOES NOT OVERRIDE A GLOBALLY-INSTALLED PACKAGE — REMOVE FIRST`
+8. The **Greptile comment mechanics** subsection only (the bulleted "Greptile comment mechanics:" block + the auto-merge/ScheduleWakeup paragraph) from `### GREPTILE PR REVIEW IS A GATE`. Leave the gate rule + the "Pattern:" / "Past incidents" bullets inline.
+
+- [ ] **Step 1: Create `docs/runbooks/release.md`** with the header block (trigger: "cutting or publishing a release") followed by the 8 section blocks pasted verbatim, in the order above. Use `## ` for each instead of the original `### ` (they are now top-level within the runbook).
+
+- [ ] **Step 2: Replace sections 1–7 in `CLAUDE.md` with pointer stubs.** Each keeps its original `### ` heading and one hard sentence. Examples:
+
+  ```markdown
+  ### RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY
+
+  `package.json#version` (CLI) and `package.json#keshaEngine.version` + `rust/Cargo.toml`
+  (engine) are versioned independently; all releases go through PRs. The drift gate is
+  `bun run check:versions`.
+
+  **Full procedure (CLI-only / engine / beta / dispatch paths, draft-asset validation,
+  known breaks):** `docs/runbooks/release.md`.
+  ```
+
+  ```markdown
+  ### TAG NAMES ARE ONE-USE
+
+  GitHub permanently reserves tag names after publish. Broken release → bump patch, cut a
+  new tag; never tag "just to test". Details: `docs/runbooks/release.md`.
+  ```
+
+  (Write equivalent 1–2 sentence stubs for sections 2, 4, 5, 6, 7, each ending with `Details: \`docs/runbooks/release.md\`.`)
+
+- [ ] **Step 3: Trim the Greptile section.** Under `### GREPTILE PR REVIEW IS A GATE`, delete the "Greptile comment mechanics:" block and the auto-merge/ScheduleWakeup paragraph; append `Re-review/auto-merge mechanics: \`docs/runbooks/release.md\`.` Leave the gate rule intact.
+
+- [ ] **Step 4: Verify the move preserved content.** Pick distinctive strings and confirm each now lives in the runbook and is gone from CLAUDE.md (except the retained rule words):
+
+  Run (from repo root):
+  ```bash
+  cd .worktrees/slim-claudemd
+  for s in "v1.18.2-cli" "id-token: write" "GITHUB_TOKEN tag pushes" "false-green" "Confidence Score"; do
+    printf '%-22s runbook=%s claude=%s\n' "$s" \
+      "$(grep -c -F "$s" docs/runbooks/release.md)" \
+      "$(grep -c -F "$s" CLAUDE.md)"
+  done
+  ```
+  Expected: every string `runbook=1+` and `claude=0`.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  cd .worktrees/slim-claudemd
+  git add docs/runbooks/release.md CLAUDE.md
+  git commit -m "docs: extract release runbook from CLAUDE.md"
+  ```
+
+---
+
+### Task 2: Extract the Rust gotchas runbook
+
+**Files:**
+- Create: `docs/runbooks/rust-gotchas.md`
+- Modify: `CLAUDE.md`
+
+Sections to move verbatim:
+1. `### `f32::clamp` DIVERGENCE: USE BOUND CHECK, NOT `EPSILON``
+2. `### `ort 2.0.0-rc.12` `Value::from_array` WANTS OWNED NDARRAYS`
+3. `### CLIPPY `needless_update` BLOCKS `..Default::default()` IF ALL FIELDS ARE SPELLED`
+4. `### BINDGEN ON LINUX NEEDS LIBCLANG_PATH`
+5. `### SILERO VAD V5 NEEDS A 64-SAMPLE ROLLING CONTEXT`
+6. `### `fluidaudio-rs 0.1.0` LACKS `transcribe_samples``
+7. `### TESTS THAT STAGE A TEMPDIR CACHE MUST STAGE G2P TOO`
+
+- [ ] **Step 1: Create `docs/runbooks/rust-gotchas.md`** with header (trigger: "writing or debugging Rust in `rust/`") + the 7 blocks verbatim (`## ` headings).
+
+- [ ] **Step 2: Remove the 7 sections from `CLAUDE.md`.** These are deep lessons, not always-on rules — replace all 7 with a **single** pointer line appended to the `### VERIFY BEFORE PUSHING` section:
+
+  ```markdown
+  **Deep Rust gotchas** (clamp/EPSILON, ort owned ndarrays, clippy needless_update, bindgen
+  LIBCLANG_PATH, Silero VAD 576, fluidaudio transcribe_samples, g2p tempdir staging):
+  `docs/runbooks/rust-gotchas.md`.
+  ```
+
+- [ ] **Step 3: Verify.**
+  ```bash
+  cd .worktrees/slim-claudemd
+  for s in "f32::EPSILON" "OwnedTensorArrayData" "needless_update" "LIBCLANG_PATH" "576" "transcribe_samples" "is_g2p_cached"; do
+    printf '%-22s runbook=%s claude=%s\n' "$s" \
+      "$(grep -c -F "$s" docs/runbooks/rust-gotchas.md)" "$(grep -c -F "$s" CLAUDE.md)"
+  done
+  ```
+  Expected: each `runbook=1+`. `claude=0` for all except `LIBCLANG_PATH` (also appears in the COREML/macOS build-env lines, which stay) — confirm any remaining CLAUDE.md hit is **not** inside a removed gotcha.
+
+- [ ] **Step 4: Commit**
+  ```bash
+  cd .worktrees/slim-claudemd
+  git add docs/runbooks/rust-gotchas.md CLAUDE.md
+  git commit -m "docs: extract Rust gotchas runbook from CLAUDE.md"
+  ```
+
+---
+
+### Task 3: Extract the TTS internals runbook
+
+**Files:**
+- Create: `docs/runbooks/tts-internals.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/runbooks/tts-internals.md`** with header (trigger: "changing TTS synthesis, voices, G2P, or SSML"). Move the **deep-reference bullets** of `## TTS` verbatim: everything from the engine/G2P internals down (the `en-*`/`ru-*`/`macos-*` model details, Kokoro/Vosk ONNX I/O shapes, AVSpeech CFRunLoop notes, SSML parsing internals, the `KESHA_*` env-var list, dev/build env lines, and the Silero/Piper pivot note).
+
+- [ ] **Step 2: Replace `## TTS` body in `CLAUDE.md` with a short user-facing summary + pointer.** Keep inline:
+
+  ```markdown
+  ## TTS
+
+  Text-to-speech via three engines selected by voice id prefix:
+  `en-*` → Kokoro-82M (24 kHz), `ru-*` → Vosk-TTS (22.05 kHz), `macos-*` → AVSpeech sidecar.
+  Install Kokoro + Vosk with `kesha install --tts` (~990 MB); `macos-*` needs no download.
+  Models are never auto-downloaded — `kesha say` fails loudly with a `kesha install --tts` hint.
+  Default voices MUST be male (see the male-voice rule above). `kesha say` writes WAV to stdout
+  unless `--out`; stderr is progress only.
+
+  **Engine internals, ONNX I/O shapes, G2P split, SSML handling, env vars, dev/build setup:**
+  `docs/runbooks/tts-internals.md`.
+  ```
+
+  (The "DEFAULT TTS VOICES MUST BE MALE" section under Critical Development Rules is **not** touched.)
+
+- [ ] **Step 3: Verify.**
+  ```bash
+  cd .worktrees/slim-claudemd
+  for s in "510x256" "resolve_vosk_ru" "CFRunLoopRun" "KESHA_MODEL_MIRROR" "byt5-tiny" "DYLD_FALLBACK_LIBRARY_PATH"; do
+    printf '%-26s runbook=%s claude=%s\n' "$s" \
+      "$(grep -c -F "$s" docs/runbooks/tts-internals.md)" "$(grep -c -F "$s" CLAUDE.md)"
+  done
+  ```
+  Expected: each `runbook=1+`, `claude=0`.
+
+- [ ] **Step 4: Commit**
+  ```bash
+  cd .worktrees/slim-claudemd
+  git add docs/runbooks/tts-internals.md CLAUDE.md
+  git commit -m "docs: extract TTS internals runbook from CLAUDE.md"
+  ```
+
+---
+
+### Task 4: Extract the jj + Git LFS runbook
+
+**Files:**
+- Create: `docs/runbooks/jj-git-lfs.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Create `docs/runbooks/jj-git-lfs.md`** with header (trigger: "using jj in this repo, or jj shows LFS files as modified") + the entire `### JJ + GIT LFS WORKAROUND` section verbatim.
+
+- [ ] **Step 2: Replace the section in `CLAUDE.md` with a stub:**
+
+  ```markdown
+  ### JJ + GIT LFS WORKAROUND
+
+  This repo uses Git LFS; stock `jj` surfaces LFS files as modified. Use the LFS fork
+  (`gusinacio/jj` `lfs` branch) + `jj config set --user git.ignore-files '["lfs"]'`.
+
+  **Full setup + operational lessons:** `docs/runbooks/jj-git-lfs.md`.
+  ```
+
+- [ ] **Step 3: Verify.**
+  ```bash
+  cd .worktrees/slim-claudemd
+  grep -c -F "gusinacio" docs/runbooks/jj-git-lfs.md   # expect 1+
+  grep -c -F "brew unlink jj" CLAUDE.md                # expect 0
+  ```
+
+- [ ] **Step 4: Commit**
+  ```bash
+  cd .worktrees/slim-claudemd
+  git add docs/runbooks/jj-git-lfs.md CLAUDE.md
+  git commit -m "docs: extract jj+Git LFS runbook from CLAUDE.md"
+  ```
+
+---
+
+### Task 5: Extract the OpenClaw plugin runbook
+
+**Files:**
+- Create: `docs/runbooks/openclaw-plugin.md`
+- Modify: `CLAUDE.md`
+
+Sections to move verbatim: `### OPENCLAW PLUGIN` and `### PUBLISHING THE OPENCLAW PLUGIN TO CLAWHUB`.
+
+- [ ] **Step 1: Create `docs/runbooks/openclaw-plugin.md`** with header (trigger: "editing the OpenClaw plugin or publishing it to ClawHub") + both sections verbatim (`## ` headings).
+
+- [ ] **Step 2: Replace both sections in `CLAUDE.md` with one stub:**
+
+  ```markdown
+  ### OPENCLAW PLUGIN
+
+  Plugin lives in `openclaw.plugin.json` + `openclaw-plugin.cjs`. Audio transcription routes
+  through the `type: "cli"` path (NOT `registerMediaUnderstandingProvider`). The `dangerous-exec`
+  scanner is a naive regex — never name forbidden module substrings, even in comments.
+
+  **Internals, scanner rules, recommended config, ClawHub publish:** `docs/runbooks/openclaw-plugin.md`.
+  ```
+
+- [ ] **Step 3: Verify.**
+  ```bash
+  cd .worktrees/slim-claudemd
+  grep -c -F "dangerous-exec" docs/runbooks/openclaw-plugin.md   # expect 1+
+  grep -c -F "ClawHub" docs/runbooks/openclaw-plugin.md          # expect 1+
+  grep -c -F "registerMediaUnderstandingProvider" CLAUDE.md      # expect 1 (the stub mention only)
+  ```
+
+- [ ] **Step 4: Commit**
+  ```bash
+  cd .worktrees/slim-claudemd
+  git add docs/runbooks/openclaw-plugin.md CLAUDE.md
+  git commit -m "docs: extract OpenClaw plugin runbook from CLAUDE.md"
+  ```
+
+---
+
+### Task 6: Trim in-place sections, final-verify, open PR
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Shorten `### MODEL HASHES ARE PINNED`.** Keep the rule + the bump-command block, but replace the prose tail with a skill pointer:
+
+  ```markdown
+  ### MODEL HASHES ARE PINNED — UPSTREAM BUMPS GO THROUGH A PR
+
+  Every entry in `rust/src/models.rs` carries a pinned SHA-256; `download_verified` refuses a
+  mismatched file. Never comment out verification to "get it working" (the #174 regression).
+  To bump a model version, use the `verify-pin-bump` skill — it walks the safe procedure
+  (verify the new upstream weights deliberately, then update the pin + `cargo test models::manifest_tests`).
+  ```
+
+- [ ] **Step 2: Trim the `## Project Structure` tree** to load-bearing paths only: keep `bin/`, the `src/*.ts` list, the `rust/src/` tree (main/audio/models/lang_id/text_lang + `backend/`), `tests/`, and the workflow files; drop inline path comments longer than ~6 words. Keep it a valid tree.
+
+- [ ] **Step 3: Final size + dangling-link check.**
+  ```bash
+  cd .worktrees/slim-claudemd
+  wc -c CLAUDE.md                      # expect < 40000, target ~26000
+  # every runbook pointer resolves to a real file:
+  for f in $(grep -oE 'docs/runbooks/[a-z-]+\.md' CLAUDE.md | sort -u); do
+    test -f "$f" && echo "OK $f" || echo "MISSING $f"
+  done
+  ```
+  Expected: size under 40k; every line `OK`.
+
+- [ ] **Step 4: Repo pre-push sanity (no code changed, but the rule applies).**
+  ```bash
+  cd .worktrees/slim-claudemd
+  bun test && bunx tsc --noEmit
+  ```
+  Expected: green. (If LFS/test fixtures aren't materialized in the worktree, note it; this is docs-only.)
+
+- [ ] **Step 5: Commit + push + open PR.**
+  ```bash
+  cd .worktrees/slim-claudemd
+  git add CLAUDE.md
+  git commit -m "docs: trim model-hash + project-structure sections inline"
+  git push -u origin chore/slim-claudemd
+  gh pr create --base main --head chore/slim-claudemd \
+    --title "docs: slim CLAUDE.md below the 40k always-loaded threshold" \
+    --body "Moves task-triggered runbooks to docs/runbooks/*, leaving the hard rules + pointers inline. ~53.7k → ~26k chars, content preserved verbatim. Spec: docs/superpowers/specs/2026-05-31-slim-claudemd-design.md"
+  ```
+
+- [ ] **Step 6: Wait for CI + Greptile, address P1/P2, merge after the latest head SHA is green and reviewed** (per the repo's Greptile-gate rule).
+
+---
+
+## Self-Review
+
+**Spec coverage:** release.md (Task 1), rust-gotchas.md (Task 2), tts-internals.md (Task 3), jj-git-lfs.md (Task 4), openclaw-plugin.md (Task 5), MODEL HASHES shorten + Project Structure trim + size verification (Task 6). All "stays inline" sections are listed in the do-not-touch block. ✔ every spec section maps to a task.
+
+**Placeholder scan:** No TBD/TODO. Pointer-stub wording is given concretely; the moved content is referenced by exact heading rather than re-pasted (it already exists in CLAUDE.md — re-pasting 50k chars here would be the failure mode, not the fix). ✔
+
+**Type consistency:** Runbook filenames are identical across the File Structure table, every task's create-path, every pointer stub, and the Task 6 dangling-link check (`release.md`, `rust-gotchas.md`, `tts-internals.md`, `jj-git-lfs.md`, `openclaw-plugin.md`). ✔

--- a/docs/superpowers/specs/2026-05-31-slim-claudemd-design.md
+++ b/docs/superpowers/specs/2026-05-31-slim-claudemd-design.md
@@ -1,0 +1,138 @@
+# Slim CLAUDE.md below the 40k always-loaded threshold
+
+**Date:** 2026-05-31
+**Status:** Approved (design)
+**Branch:** `chore/slim-claudemd`
+
+## Problem
+
+`CLAUDE.md` is 53.7k chars. Claude Code warns at >40k ("Large CLAUDE.md will
+impact performance"). The file is loaded into context on **every** turn, so its
+weight is paid continuously regardless of the task at hand.
+
+Most of the bulk is **incident archaeology** — war stories with PR numbers,
+dates, and full bash recipes — and **task-triggered runbooks** (how to cut a
+release, set up jj, OpenClaw internals). These are read on-demand when doing
+that specific task; they do not need to occupy always-loaded context.
+
+## Goal
+
+Get `CLAUDE.md` to roughly **26k chars** with headroom for future rules, while
+**losing nothing** — extracted content moves verbatim into `docs/runbooks/`,
+reachable from a one-line pointer that retains the bare rule.
+
+Non-goals: rewriting/condensing the substance of any rule, changing any actual
+project behavior, touching the global `~/.claude/CLAUDE.md`.
+
+## Approach
+
+**Extract runbooks, leave pointers.** Split each section by whether the agent
+must see it *every turn* (hard safety/brand/workflow rule) or only *when doing a
+specific task* (a procedure it would `Read` at that point anyway).
+
+- **Always-on rules** stay inline, verbatim or lightly tightened.
+- **Task-triggered runbooks** move to `docs/runbooks/<topic>.md`. In CLAUDE.md
+  they are replaced by the one-sentence rule plus a pointer:
+  `See docs/runbooks/<topic>.md`.
+
+The pointer preserves the *constraint's existence* in always-loaded context
+(the agent still knows the rule applies) while moving the *procedure* out.
+
+## Target layout
+
+```
+CLAUDE.md                        # hard always-on rules + 1-line pointers   (~26k)
+docs/runbooks/
+  release.md                     # full release process + validation        (~14k)
+  rust-gotchas.md                # deep Rust implementation lessons          (~6k)
+  tts-internals.md               # deep TTS engine reference                 (~3.5k)
+  jj-git-lfs.md                  # one-time jj/LFS setup                      (~2k)
+  openclaw-plugin.md             # plugin internals + ClawHub publish         (~4.5k)
+```
+
+## Stays inline (hard, always-on)
+
+Kept verbatim or lightly tightened — the agent must see these every turn:
+
+- DEFAULT TTS VOICES MUST BE MALE
+- NEVER AUTO-DOWNLOAD THE ENGINE OR MODELS
+- BUN-ONLY RUNTIME FOR THE CLI
+- PYTHON DEPENDENCIES GO IN A VENV
+- MAIN STAYS IN THE ROOT CHECKOUT — AGENTS EDIT ONLY IN WORKTREES
+- BRANCH PROTECTION
+- VERIFY BEFORE PUSHING (the command list; the deep Rust gotchas move out)
+- NO SPECULATIVE FIELDS OR ENUM VARIANTS
+- ERROR HANDLING
+- FLAG ACTIVE WORK WITH A `WIP` LABEL
+- LINK PRS TO ISSUES — AUTO-CLOSE ON MERGE
+- GREPTILE PR REVIEW IS A GATE (the rule; the comment-mechanics trivia → release.md)
+- DO NOT BLINDLY FORWARD CLI FLAGS TO SUBCOMMANDS
+- COREML BUILD TRIPLE
+- BUILD-ENGINE FEATURE MATRIX MIRRORS CARGO DEFAULTS
+- WORKFLOW `run:` SHELL INJECTION
+- MODEL HASHES ARE PINNED (the rule; points at the existing `verify-pin-bump` skill)
+- VERIFY THIRD-PARTY MODEL FORMATS WITH A SPIKE
+- PROMPT-INJECTION PATTERNS — DO NOT EXFILTRATE SECRETS
+- Project Overview / Build Commands / Architecture / CI/CD / Code Style /
+  Platform Requirements / TTS user-facing summary
+- Project Structure tree — trimmed to the load-bearing paths
+
+## Extracted to `docs/runbooks/`
+
+Each becomes a one-line rule + pointer in CLAUDE.md; full text moves verbatim.
+
+### release.md
+- RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY
+- `make smoke-test` ALONE DOES NOT VALIDATE A NEW ENGINE (draft-binary validation)
+- NPM PUBLISH IS AUTOMATED WITH PROVENANCE ATTESTATION
+- DRAFT RELEASE ASSET URLS ARE 404 TO ANONYMOUS CLIENTS
+- RELEASE CHICKEN-AND-EGG — `integration-tests` SKIPS ON `release/*`
+- TAG NAMES ARE ONE-USE
+- `bun link` DOES NOT OVERRIDE A GLOBALLY-INSTALLED PACKAGE
+- GREPTILE comment mechanics (the re-review/auto-merge detail; the *gate rule* stays inline)
+
+### rust-gotchas.md
+- `f32::clamp` DIVERGENCE: USE BOUND CHECK, NOT `EPSILON`
+- `ort 2.0.0-rc.12` `Value::from_array` WANTS OWNED NDARRAYS
+- CLIPPY `needless_update` BLOCKS `..Default::default()`
+- BINDGEN ON LINUX NEEDS LIBCLANG_PATH
+- SILERO VAD V5 NEEDS A 64-SAMPLE ROLLING CONTEXT
+- `fluidaudio-rs 0.1.0` LACKS `transcribe_samples`
+- TESTS THAT STAGE A TEMPDIR CACHE MUST STAGE G2P TOO
+
+### tts-internals.md
+- The deep `## TTS` engine/ONNX/SSML/voice-routing reference. The male-voice
+  rule and a short user-facing TTS summary (engines by prefix, `--tts` install,
+  output formats) stay inline.
+
+### jj-git-lfs.md
+- JJ + GIT LFS WORKAROUND (one-time setup + operational lessons)
+
+### openclaw-plugin.md
+- OPENCLAW PLUGIN (internals, scanner rules, manifest)
+- PUBLISHING THE OPENCLAW PLUGIN TO CLAWHUB
+
+## Mechanics
+
+Docs-only change. Per the repo's own "MAIN STAYS IN ROOT — AGENTS EDIT ONLY IN
+WORKTREES" and "BRANCH PROTECTION" rules: work in `.worktrees/slim-claudemd`
+off fresh `origin/main`, open a PR. No engine bump, no version bump — pure docs,
+so CLI/engine versions are untouched.
+
+## Verification
+
+- `wc -c CLAUDE.md` < 40000 (target ~26k).
+- No content lost: for each extracted section, the text in the runbook file is
+  byte-identical to what was removed (diff-check during implementation).
+- Every extracted section leaves a pointer in CLAUDE.md naming its runbook path.
+- All runbook pointer paths resolve to a real file (no dangling links).
+- `bun test && bunx tsc --noEmit` still green (sanity — no code touched, but the
+  repo's pre-push rule applies).
+
+## Risks
+
+- **A pointer-only rule loses nuance the agent needed inline.** Mitigation: the
+  inline pointer always keeps the one-sentence hard rule, not just the path.
+- **An extracted runbook is never read when relevant.** Mitigation: pointers are
+  placed at the exact spot the old section lived, so the trigger context (e.g.
+  "cutting a release") still surfaces the path.


### PR DESCRIPTION
## Why

`CLAUDE.md` grew to **53.7k chars**, tripping Claude Code's >40k "Large CLAUDE.md will impact performance" warning. The file is loaded into agent context on every turn, so its weight is paid continuously — even when the task at hand has nothing to do with releases, jj setup, or OpenClaw internals.

## What

Moves **task-triggered runbooks** (procedures you'd `Read` only when doing that specific task) out of the always-loaded `CLAUDE.md` into `docs/runbooks/*.md`, leaving the one-sentence hard rule + a pointer inline. **Hard always-on rules** (male default voices, never auto-download, worktree isolation, prompt-injection refusal, COREML build triple, feature-matrix gate, etc.) stay inline untouched.

Content moves **verbatim** — nothing is lost, just relocated out of the per-turn context budget.

| | chars |
|---|---|
| `CLAUDE.md` before | 53,707 |
| `CLAUDE.md` after | **26,789** (~50% reduction, well under 40k) |

New runbooks:
- `docs/runbooks/release.md` — full release process, draft-asset validation, npm-publish automation, tag rules, Greptile re-review mechanics
- `docs/runbooks/rust-gotchas.md` — f32::clamp/EPSILON, ort owned ndarrays, clippy needless_update, bindgen LIBCLANG_PATH, Silero VAD 576, fluidaudio transcribe_samples, g2p tempdir staging
- `docs/runbooks/tts-internals.md` — engine/ONNX I/O shapes, G2P split, SSML internals, `KESHA_*` env vars, dev/build env
- `docs/runbooks/jj-git-lfs.md` — one-time jj + Git LFS setup and operational lessons
- `docs/runbooks/openclaw-plugin.md` — plugin internals, scanner rules, recommended config, ClawHub publish

Plus the design spec and implementation plan under `docs/superpowers/`.

## Verification

- `bun test` → 364 pass, 6 skip, 0 fail
- `bunx tsc --noEmit` → clean
- All inline `docs/runbooks/*.md` pointers resolve; no orphan runbooks
- Every original `###`/`##` section accounted for (inline / stubbed+moved / trimmed) — no content dropped
- Docs-only: no engine or CLI version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)