### PR TITLE
chore(claude): add 5 project slash commands (preflight, worktree, start-issue, await-review, land)

### DIFF
--- a/.claude/commands/await-review.md
+++ b/.claude/commands/await-review.md
@@ -1,0 +1,26 @@
+---
+description: Wait for CI + Greptile to cover a PR's latest head SHA, then summarize the verdict and any P1/P2 findings.
+argument-hint: "[pr-number] (defaults to the current branch's PR)"
+allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(git rev-parse:*)
+---
+
+Wait for CI **and** Greptile to finish on the PR's **latest head SHA**, then report whether it's green/reviewed or still pending. This enforces the repo's "GREPTILE PR REVIEW IS A GATE" rule: never stop at the PR URL — confirm the latest commit is actually covered.
+
+Arguments: `$ARGUMENTS` → optional PR number. If omitted, resolve the PR for the current branch (`gh pr view --json number`).
+
+## Steps
+
+1. Resolve the PR number and capture the **current head SHA**:
+   ```bash
+   gh pr view <N> -R drakulavich/kesha-voice-kit --json number,headRefOid,mergeStateStatus
+   ```
+
+2. Poll until both CI and Greptile are non-pending **on that head SHA**. Use a background poll so you don't block the session — re-check every ~50s, up to ~20 min. Parse `gh pr checks <N>` (tab-separated: name TAB state); for Greptile, also confirm via `gh pr view --json statusCheckRollup` that its `conclusion` is set (an empty conclusion = still reviewing the new SHA, even if a stale pass shows). Do **not** trust a pass whose timestamp predates the latest push.
+
+3. When both settle, summarize:
+   - CI: which jobs passed / failed / were skipped (path-filtered jobs skipping is normal for docs-only PRs).
+   - Greptile: the top-level summary and every inline **P1/P2** finding (treat these as merge blockers). Pull them via `gh pr view <N> --json reviews,comments` filtering authors matching `greptile`.
+
+4. State plainly: is the **latest head SHA** green + reviewed, or still waiting? If there are P1/P2 findings, list them as the blockers to fix before merge (or note a clear false positive to dismiss with a comment).
+
+Reference: CLAUDE.md "GREPTILE PR REVIEW IS A GATE".

--- a/.claude/commands/land.md
+++ b/.claude/commands/land.md
@@ -1,0 +1,43 @@
+---
+description: Land a green PR — verify CI+Greptile on head SHA, confirm issue linkage, merge, and clean up the worktree.
+argument-hint: "[pr-number] (defaults to the current branch's PR)"
+allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh issue view:*), Bash(gh issue close:*), Bash(git worktree:*), Bash(git rev-parse:*)
+---
+
+Finish and merge a PR safely, enforcing the repo's review gate, issue-linkage, and worktree-cleanup rules. **Do not merge** unless CI and Greptile are both green on the latest head SHA.
+
+Arguments: `$ARGUMENTS` → optional PR number (defaults to the current branch's PR).
+
+## Steps
+
+1. Resolve the PR and its current head SHA:
+   ```bash
+   gh pr view <N> -R drakulavich/kesha-voice-kit --json number,headRefOid,mergeStateStatus,body,headRefName,closingIssuesReferences
+   ```
+
+2. **Gate — refuse to merge if not satisfied:**
+   - CI checks all passing/skipped on the head SHA (`gh pr checks <N>`).
+   - Greptile review `conclusion` is success **on that head SHA** (not a stale pass — see `/await-review`). If P1/P2 findings are open, stop and list them.
+   - `mergeStateStatus` is `CLEAN`.
+   If any fails, report what's blocking and stop.
+
+3. **Issue linkage:** confirm the PR body/commits contain a `Closes #N` / `Fixes #N` / `Resolves #N` keyword so the issue auto-closes. If the work fully addresses an issue but the keyword is missing, tell the user (don't silently merge a partial link). `Refs #N` is correct for partial work — in that case the issue should stay open.
+
+4. **Merge** (match the repo's convention — squash unless told otherwise):
+   ```bash
+   gh pr merge <N> -R drakulavich/kesha-voice-kit --squash
+   ```
+
+5. **Clean up the worktree** for the merged branch (from the root checkout):
+   ```bash
+   git worktree remove .worktrees/<slug> && git worktree prune
+   ```
+
+6. **Verify the issue actually closed** (auto-close can lag for partial links). If it should be closed but isn't:
+   ```bash
+   gh issue view <N> -R drakulavich/kesha-voice-kit --json state
+   gh issue close <N> -R drakulavich/kesha-voice-kit --comment "Landed in #<N>."
+   ```
+   The `WIP` label is removed automatically on merge; if it lingers, remove it.
+
+Reference: CLAUDE.md "GREPTILE PR REVIEW IS A GATE", "LINK PRS TO ISSUES", "MAIN STAYS IN THE ROOT CHECKOUT".

--- a/.claude/commands/land.md
+++ b/.claude/commands/land.md
@@ -10,22 +10,22 @@ Arguments: `$ARGUMENTS` → optional PR number (defaults to the current branch's
 
 ## Steps
 
-1. Resolve the PR and its current head SHA:
+1. Resolve the PR and its current head SHA (`<PR_N>` is the PR number from `$ARGUMENTS`):
    ```bash
-   gh pr view <N> -R drakulavich/kesha-voice-kit --json number,headRefOid,mergeStateStatus,body,headRefName,closingIssuesReferences
+   gh pr view <PR_N> -R drakulavich/kesha-voice-kit --json number,headRefOid,mergeStateStatus,body,headRefName,closingIssuesReferences
    ```
 
 2. **Gate — refuse to merge if not satisfied:**
-   - CI checks all passing/skipped on the head SHA (`gh pr checks <N>`).
+   - CI checks all passing/skipped on the head SHA (`gh pr checks <PR_N>`).
    - Greptile review `conclusion` is success **on that head SHA** (not a stale pass — see `/await-review`). If P1/P2 findings are open, stop and list them.
    - `mergeStateStatus` is `CLEAN`.
    If any fails, report what's blocking and stop.
 
 3. **Issue linkage:** confirm the PR body/commits contain a `Closes #N` / `Fixes #N` / `Resolves #N` keyword so the issue auto-closes. If the work fully addresses an issue but the keyword is missing, tell the user (don't silently merge a partial link). `Refs #N` is correct for partial work — in that case the issue should stay open.
 
-4. **Merge** (match the repo's convention — squash unless told otherwise):
+4. **Merge** (match the repo's convention — squash unless told otherwise). `--delete-branch` removes the remote feature branch regardless of the repo's auto-delete setting:
    ```bash
-   gh pr merge <N> -R drakulavich/kesha-voice-kit --squash
+   gh pr merge <PR_N> -R drakulavich/kesha-voice-kit --squash --delete-branch
    ```
 
 5. **Clean up the worktree** for the merged branch (from the root checkout):
@@ -33,10 +33,10 @@ Arguments: `$ARGUMENTS` → optional PR number (defaults to the current branch's
    git worktree remove .worktrees/<slug> && git worktree prune
    ```
 
-6. **Verify the issue actually closed** (auto-close can lag for partial links). If it should be closed but isn't:
+6. **Verify the issue actually closed** (auto-close can lag for partial links). If it should be closed but isn't (`<ISSUE_N>` is the issue, `<PR_N>` is the PR that landed it):
    ```bash
-   gh issue view <N> -R drakulavich/kesha-voice-kit --json state
-   gh issue close <N> -R drakulavich/kesha-voice-kit --comment "Landed in #<N>."
+   gh issue view <ISSUE_N> -R drakulavich/kesha-voice-kit --json state
+   gh issue close <ISSUE_N> -R drakulavich/kesha-voice-kit --comment "Landed in #<PR_N>."
    ```
    The `WIP` label is removed automatically on merge; if it lingers, remove it.
 

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,7 +1,7 @@
 ---
 description: Run the full pre-push verification gate (bun + rust) per CLAUDE.md's VERIFY BEFORE PUSHING rules.
 argument-hint: "[--all] (force the rust gate even if no rust changed)"
-allowed-tools: Bash(bun test:*), Bash(bunx tsc:*), Bash(make:*), Bash(cd rust && cargo fmt:*), Bash(cd rust && cargo clippy:*), Bash(cd rust && cargo nextest:*), Bash(cd rust && cargo check:*), Bash(git status:*), Bash(git diff:*)
+allowed-tools: Bash(bun test:*), Bash(bunx tsc:*), Bash(make:*), Bash(cd:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo nextest:*), Bash(cargo check:*), Bash(git status:*), Bash(git diff:*)
 ---
 
 Run this repo's mandatory pre-push verification gate and report pass/fail with the actual command output. Do **not** claim success on any failure — surface the failing output verbatim and stop.

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,0 +1,31 @@
+---
+description: Run the full pre-push verification gate (bun + rust) per CLAUDE.md's VERIFY BEFORE PUSHING rules.
+argument-hint: "[--all] (force the rust gate even if no rust changed)"
+allowed-tools: Bash(bun test:*), Bash(bunx tsc:*), Bash(make:*), Bash(cd rust && cargo fmt:*), Bash(cd rust && cargo clippy:*), Bash(cd rust && cargo nextest:*), Bash(cd rust && cargo check:*), Bash(git status:*), Bash(git diff:*)
+---
+
+Run this repo's mandatory pre-push verification gate and report pass/fail with the actual command output. Do **not** claim success on any failure — surface the failing output verbatim and stop.
+
+## Steps
+
+1. Determine what changed: `git diff --name-only origin/main...HEAD` (and `git status --porcelain` for uncommitted work). Note whether anything under `rust/**` changed, and specifically whether `rust/src/backend/**` changed.
+
+2. **Always run the TypeScript/CLI gate:**
+   ```bash
+   bun test && bunx tsc --noEmit
+   ```
+
+3. **If `rust/**` changed (or `$ARGUMENTS` contains `--all`), run the Rust gate** — use the exact flags; `--all-targets` and `nextest` are mandatory (plain `cargo test` is NOT acceptable in this repo):
+   ```bash
+   cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts
+   ```
+   (`make rust-test` wraps the nextest call if you prefer.)
+
+4. **If `rust/src/backend/**` changed, also run the CoreML build check:**
+   ```bash
+   cd rust && cargo check --features coreml --no-default-features
+   ```
+
+5. Report a concise PASS/FAIL summary per gate. If `cargo fmt` made changes, mention the whitespace diff to commit. If clippy fails only because CI rustc is newer, point at `gh run view <id> --log-failed`.
+
+Reference: CLAUDE.md "VERIFY BEFORE PUSHING".

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,35 @@
+---
+description: Pick up a GitHub issue — tag it WIP and spin up a worktree off fresh origin/main.
+argument-hint: "<issue-number> [slug]"
+allowed-tools: Bash(gh issue view:*), Bash(gh issue edit:*), Bash(gh label create:*), Bash(gh label list:*), Bash(git fetch:*), Bash(git worktree:*)
+---
+
+Start work on a GitHub issue, following the repo's "FLAG ACTIVE WORK WITH A WIP LABEL" and worktree rules in one step.
+
+Arguments: `$ARGUMENTS` → first token is the issue number (required), optional second token is a worktree slug (default `issue-<N>`).
+
+## Steps
+
+1. Read the issue and summarize its acceptance criteria for the user:
+   ```bash
+   gh issue view <N> -R drakulavich/kesha-voice-kit
+   ```
+
+2. Tag it `WIP` so drakulavich sees it's in flight. Create the label first only if it doesn't exist:
+   ```bash
+   gh label list -R drakulavich/kesha-voice-kit | grep -q '^WIP' || \
+     gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
+       --description "An agent or contributor is actively working on this"
+   gh issue edit <N> -R drakulavich/kesha-voice-kit --add-label WIP
+   ```
+
+3. Create the worktree off **fresh** `origin/main` (never local main, never the root checkout):
+   ```bash
+   git fetch origin main
+   git worktree add .worktrees/<slug> -b fix/issue-<N> origin/main
+   ```
+   Pick a descriptive branch prefix (`fix/`, `feat/`, `chore/`) based on the issue type.
+
+4. Tell the user to `cd .worktrees/<slug>` and remind them: link the PR back with `Closes #<N>` in the body, and the WIP label is removed automatically when that PR merges (or run `gh issue edit <N> --remove-label WIP` if abandoned).
+
+Reference: CLAUDE.md "FLAG ACTIVE WORK WITH A WIP LABEL", "LINK PRS TO ISSUES", "MAIN STAYS IN THE ROOT CHECKOUT".

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,0 +1,33 @@
+---
+description: Create a gitignored worktree off fresh origin/main per CLAUDE.md's "MAIN STAYS IN ROOT" rule.
+argument-hint: "<slug> [branch-name]"
+allowed-tools: Bash(git fetch:*), Bash(git worktree:*), Bash(git branch:*), Bash(git rev-parse:*)
+---
+
+Create an isolated worktree for new work, strictly following the repo's "MAIN STAYS IN THE ROOT CHECKOUT — AGENTS EDIT ONLY IN WORKTREES" rule. **Never** switch the root checkout to a feature branch; **never** branch off the (possibly stale) local `main`.
+
+Arguments: `$ARGUMENTS` → first token is `<slug>` (required), optional second token is the branch name.
+
+## Steps
+
+1. Parse `<slug>` (required) and the optional branch. If no branch given, default to the slug (e.g. slug `vad-fix` → branch `vad-fix`). If the slug is missing, ask for it and stop.
+
+2. Confirm you are in the **root checkout** (not already inside `.worktrees/`): `git rev-parse --show-toplevel`. If inside a worktree, cd to the root checkout first.
+
+3. Branch off **fresh** `origin/main`:
+   ```bash
+   git fetch origin main
+   git worktree add .worktrees/<slug> -b <branch> origin/main
+   ```
+   If the branch already exists, stop and report rather than clobbering.
+
+4. Print the next step for the user:
+   ```
+   cd .worktrees/<slug>
+   ```
+   and remind that edit/test/commit/PR all happen inside the worktree, and cleanup after merge is:
+   ```
+   git worktree remove .worktrees/<slug> && git worktree prune
+   ```
+
+Reference: CLAUDE.md "MAIN STAYS IN THE ROOT CHECKOUT".


### PR DESCRIPTION
Adds `.claude/commands/` (new in this repo) with five project slash commands that encode CLAUDE.md's most error-prone manual rituals:

| Command | Encodes |
|---|---|
| `/preflight` | VERIFY BEFORE PUSHING — bun test + tsc, rust fmt/clippy `--all-targets`/`nextest --features tts`, coreml check (conditional on what changed) |
| `/worktree <slug>` | MAIN STAYS IN ROOT — worktree off fresh origin/main |
| `/start-issue <N>` | FLAG WITH WIP + worktree, in one step |
| `/await-review [pr]` | GREPTILE IS A GATE — wait for CI+Greptile on the latest head SHA, summarize P1/P2 |
| `/land [pr]` | review gate + `Closes #N` linkage + merge + worktree cleanup |

Markdown only — no code paths touched. Each command references the exact CLAUDE.md section it automates. (Files force-added past the local `.git/info/exclude` `.claude/` rule, same as the existing tracked `.claude/agents`, `.claude/hooks`, `.claude/skills`.)