### PR TITLE
feat(tts): multilingual Kokoro on ONNX — es/fr/it/pt via CharsiuG2P (Refs #212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,5 +417,12 @@ model download. Models are NEVER auto-downloaded — `kesha say` fails loudly wi
 VOICES MUST BE MALE above). `kesha say` writes WAV mono f32 to stdout unless `--out` is given;
 stderr is progress/errors only. Auto-routing for an omitted `--voice` is in `src/cli/say.ts::pickVoiceForLang`.
 
+**Multilingual (es/fr/it/pt):** on the **ONNX build** (Linux/Windows and macOS without `system_kokoro`),
+Spanish, French, Italian, and Portuguese are supported via CharsiuG2P (klebster ONNX export, CC-BY 4.0)
++ a per-language numbers/acronym normalizer (#212). Default voices: `es-em_alex` (LatAm Spanish, male),
+`it-im_nicola` (male), `pt-pm_alex` (male), `fr-ff_siwis` (female — **documented brand-rule exception**:
+Kokoro v1.0 ships no male French voice; revisit when one exists). macOS CoreML (`system_kokoro`/FluidAudio)
+multilingual is a follow-up — those voices currently route through the English G2P.
+
 **Engine internals, Kokoro/Vosk ONNX I/O shapes, G2P split, SSML handling, `KESHA_*` env vars,
 macOS dev/build env:** `docs/runbooks/tts-internals.md`.

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -33,6 +33,16 @@ Text-to-speech (Russian, 5 baked-in speakers). Apache 2.0. Model: [alphacep/vosk
 
 **Runtime code:** Originally pulled from `crates.io` as `vosk-tts-rs 0.1.0`. As of #216 the runtime subset is **vendored** under `rust/vendor/vosk-tts/` (Apache 2.0; copied from [`andreytkachenko/vosk-tts-rs`](https://github.com/andreytkachenko/vosk-tts-rs) — see `rust/vendor/vosk-tts/LICENSE` and `rust/vendor/vosk-tts/NOTICE`). The vendored copy drops the upstream gRPC server/CLI/HTTP-model-fetch modules and replaces the `tokenizers` crate with a small inline BERT WordPiece tokenizer, eliminating the `prost`, `tonic`, `tokio`, `axum`, `hyper`, `reqwest`, `tokenizers`, `onig_sys`, `esaxx-rs`, `bzip2-sys`, `lzma-sys`, and `zstd-sys` transitive dependencies that broke Windows MSVC linkage.
 
+### klebster — CharsiuG2P byt5-tiny ONNX (multilingual G2P)
+
+Grapheme-to-phoneme for es/fr/it/pt Kokoro voices (`kesha install --tts`, #212).
+CC-BY 4.0. ONNX export by [klebster](https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx)
+from the original CharsiuG2P model.
+
+**Original model:** Zhu et al. 2022, "Multilingual Grapheme-to-Phoneme Conversion
+with Language Neutral and Language Specific Representations",
+[arXiv:2204.03067](https://arxiv.org/abs/2204.03067).
+
 ### misaki-rs (English G2P)
 
 Embedded grapheme-to-phoneme for English (Kokoro pipeline, #207). MIT. Source: [`misaki-rs`](https://github.com/MicheleYin/misaki-rs).

--- a/docs/runbooks/tts-internals.md
+++ b/docs/runbooks/tts-internals.md
@@ -36,6 +36,30 @@ Install Kokoro + Vosk-TTS explicitly with `kesha install --tts` (~990 MB). `maco
 - macOS dev runtime: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`. Release binaries fix up via `install_name_tool`.
 - macOS build env: `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`, `RUSTFLAGS="-L /opt/homebrew/lib"`.
 
+## CharsiuG2P engine (es/fr/it/pt on ONNX builds)
+
+Romance-language G2P uses the **klebster 3-file KV-cache ONNX export** of CharsiuG2P
+(Zhu et al. 2022). Three `ort` sessions implement an autoregressive byte-level seq2seq decode:
+`encoder_model.onnx` (run once), `decoder_model.onnx` (step 0, seeds all 16 KV presents),
+`decoder_with_past_model.onnx` (steps 1..N, 8 rolling decoder KV + 8 constant encoder KV).
+License: CC-BY 4.0 (attribution in `NOTICES`).
+
+**Tokenizer:** ByT5 byte-level — input format `"<tag>: word"` where tag is one of
+`<spa>` (es), `<fra>` (fr), `<ita>` (it), `<por-bz>` (pt). Each byte maps to
+`byte_value + 3` (special-token offset), followed by EOS id 1.
+
+**OOV remap:** Charsiu can emit IPA symbols outside Kokoro's phoneme vocabulary
+(tie-bar affricates `t͡s/t͡ʃ/d͡ʒ`, Latin `g` U+0067, pre-composed nasals `õ/ũ/ẽ`).
+`tts::charsiu::remap` normalizes these to Kokoro-vocab equivalents (`ʦ/ʧ/ʤ`,
+script-g U+0261, NFD base+combining-tilde); locked by a zero-residual-OOV regression test.
+
+**Normalize pass:** numbers and acronyms are expanded before G2P (`512` → `quinientos doce`
+in es, etc.) via `tts::normalize::{numbers,acronyms}`. CharsiuG2P collapses raw digits;
+the normalizer runs first so digit sentences produce longer, correctly-paced audio.
+
+**IO contract and latency reference:** `docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md`
+(PR #185) — verified ~36 ms/word on M2, byte-identical Rust↔Python IPA for es/fr/it/pt.
+
 ## History
 
 Original spec assumed Silero TTS; pivoted to Piper during M3 spike (Silero ships PyTorch-only, no public ONNX). See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.

--- a/docs/superpowers/plans/2026-06-01-onnx-kokoro-multilang-trackB.md
+++ b/docs/superpowers/plans/2026-06-01-onnx-kokoro-multilang-trackB.md
@@ -647,13 +647,22 @@ git add rust/src/tts/g2p.rs
 git commit -m "feat(tts): route es/fr/it/pt G2P through normalize+charsiu (refs #212)"
 ```
 
-### Task 3.2: kokoro.rs — f32 clamp + style-row index fix
+### Task 3.2: kokoro.rs — f32 clamp fix (style-row VERIFIED already-correct)
 
 **Files:**
 - Modify: `rust/src/tts/kokoro.rs`
 - Test: inline
 
-- [ ] **Step 1: Write failing tests**
+> **Correction (post-implementation):** The plan originally listed a
+> `style_row = phonemeCount-1` fix alongside the f32 clamp. That was
+> **WRONG**. `voices::select_style` already uses `voice[token_count]`
+> (clamped to `VOICE_ROWS-1`), which matches the `kokoro-onnx` upstream
+> exactly — the `token_count-1` form was the off-by-one fixed in #207.
+> Phase 3 correctly applied ONLY the f32 clamp; `select_style` was not
+> changed. The `style_row_uses_phoneme_count_minus_one` test step below
+> was NOT implemented (there is no `style_row` helper in the shipped code).
+
+- [x] **Step 1: Write failing test**
 
 ```rust
 #[test]
@@ -662,20 +671,11 @@ fn clamp_keeps_samples_in_range() {
     assert!(out.iter().all(|s| (-1.0..=1.0).contains(s)), "{out:?}");
     assert_eq!(out[1], -0.2); // in-range untouched
 }
-#[test]
-fn style_row_uses_phoneme_count_minus_one() {
-    assert_eq!(style_row(8), 7);
-    assert_eq!(style_row(0), 0);     // saturating
-    assert_eq!(style_row(10_000), 509);
-}
 ```
 
-- [ ] **Step 2: Run to verify fail**
+- [x] **Step 2: Run to verify fail** — DONE
 
-Run: `cd rust && cargo nextest run --features tts kokoro:: 2>&1 | tail`
-Expected: FAIL.
-
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```rust
 /// Clamp synthesized audio to [-1.0, 1.0]; Kokoro can emit out-of-range
@@ -686,25 +686,16 @@ pub fn clamp_audio(mut samples: Vec<f32>) -> Vec<f32> {
     }
     samples
 }
-
-/// Voice-pack style row index = min(max(phonemeCount-1, 0), 509)
-/// (FluidAudio KokoroAne docs; spike used the padded length).
-pub fn style_row(phoneme_count: usize) -> usize {
-    phoneme_count.saturating_sub(1).min(509)
-}
 ```
-Wire `clamp_audio` into the synth path before WAV encode, and use `style_row` where the style slice is selected.
+Wired `clamp_audio` into `Kokoro::infer` before returning. `select_style` unchanged.
 
-- [ ] **Step 4: Run to verify pass**
+- [x] **Step 4: Run to verify pass** — DONE
 
-Run: `cd rust && cargo nextest run --features tts kokoro:: 2>&1 | tail`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add rust/src/tts/kokoro.rs
-git commit -m "fix(tts): clamp Kokoro audio pre-encode + phonemeCount-1 style row (refs #212)"
+git commit -m "fix(tts): clamp Kokoro audio pre-encode (refs #212)"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-01-onnx-kokoro-multilang-trackB.md
+++ b/docs/superpowers/plans/2026-06-01-onnx-kokoro-multilang-trackB.md
@@ -4,100 +4,59 @@
 
 **Goal:** Give the ONNX TTS path real per-language G2P for Spanish, French, Italian, Portuguese so `kesha say --voice {es,fr,it,pt}-*` produces natural (not English-accented, not digit-collapsed) speech.
 
-**Architecture:** A new `tts::charsiu` ONNX G2P engine (ByT5-tiny exported to ONNX, byte tokenizer, greedy autoregressive decode on the existing `ort`) feeding the existing Kokoro tokenizer/session, with a per-language `tts::normalize` pass (numbers + acronyms) ahead of it. Routing/model-pin wiring in `voices.rs`/`models.rs`. English (misaki) and the CoreML path are untouched.
+**Architecture:** A new `tts::charsiu` ONNX G2P engine — loading the **pre-converted [`klebster/g2p_multilingual_byT5_tiny_onnx`](https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx)** export (encoder + decoder + KV-cache `decoder_with_past`), byte tokenizer, KV-cache autoregressive decode on the existing `ort` — feeding the existing Kokoro tokenizer/session, with a per-language `tts::normalize` pass (numbers + acronyms) ahead of it. Routing/model-pin wiring in `voices.rs`/`models.rs`. English (misaki) and the CoreML path are untouched.
 
-**Tech Stack:** Rust (`ort`, `ndarray`), the existing `tts::{tokenizer, kokoro}`, a disposable Python venv for the Phase 0 export/spike, `cargo nextest`.
+**Tech Stack:** Rust (`ort 2.0.0-rc.12`, `ndarray`), the existing `tts::{tokenizer, kokoro}`, `cargo nextest`. No Python / no model export — we consume a published ONNX artifact.
 
 **Spec:** `docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md`
-**Predecessor spike:** PR #507 (`spike/onnx-kokoro-multilang-g2p`).
+**Predecessor spikes:** Track-B-choice spike PR #507; **and the authoritative G2P-ONNX feasibility spike — `docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md` (PR #185, on `main`)**, which already downloaded klebster, pinned its SHA-256 hashes, documented the full IO contract + `ort 2.0` gotchas, and verified byte-identical Rust↔Python IPA across 7 scripts.
 **Tracking issue:** #212
 
-> **Spike-gated plan.** Phase 0 is a hard gate. It writes a findings file `docs/superpowers/specs/charsiu-onnx-contract.md` recording the concrete ONNX IO contract — encoder/decoder input+output tensor names, the byte-token special-id offset, EOS id, and the per-language tag strings. **Phases 1+ reference those recorded values.** If Phase 0 fails (export infeasible, decode can't reproduce the Python IPA, or latency unacceptable for interactive `kesha say`), STOP and re-brainstorm the offline-lexicon fallback — do not proceed into Phase 1.
+> **Not a spike-gated plan.** Feasibility is already established by the April #185 spike (real, on-main, byte-identical Rust/ort parity with the klebster artifact). We pin and load that published export rather than exporting anything ourselves. The IO contract, hashes, decode algorithm, and `ort 2.0` gotchas all come from #185 — treat that doc as the source of truth.
 
-> **Path note:** `Run:` blocks use this worktree (`/Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl`) and the scratch dir `/tmp/charsiu-onnx-spike/`. Substitute your own roots if re-running elsewhere.
+> **Path note:** `Run:` blocks use this worktree (`/Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl`). Cache path for models is `~/.cache/kesha/models/`.
 
 ---
 
-## Phase 0 — Feasibility + latency spike (GATE)
+## Phase 0 — Stage & verify the klebster artifact (no export)
 
-### Task 0.1: Export CharsiuG2P ByT5 to ONNX
+Feasibility is already proven by the #185 spike. This phase only confirms the published artifact we'll pin is the exact one #185 validated — no export, no Python, no throwaway code.
 
-**Files:**
-- Create: `/tmp/charsiu-onnx-spike/export.sh` (scratch, not committed)
-
-- [ ] **Step 1: Disposable venv (CLAUDE.md: never system-wide)**
-
-Run:
-```bash
-mkdir -p /tmp/charsiu-onnx-spike
-python3 -m venv /tmp/charsiu-onnx-spike/venv
-/tmp/charsiu-onnx-spike/venv/bin/pip install --quiet "optimum[exporters]" transformers onnxruntime
-echo ok
-```
-Expected: `ok`.
-
-- [ ] **Step 2: Export the model to ONNX**
-
-Run:
-```bash
-/tmp/charsiu-onnx-spike/venv/bin/optimum-cli export onnx \
-  --model charsiu/g2p_multilingual_byT5_tiny_16_layers_100 \
-  --task text2text-generation \
-  /tmp/charsiu-onnx-spike/onnx/
-ls /tmp/charsiu-onnx-spike/onnx/
-```
-Expected: an `encoder_model.onnx` + `decoder_model.onnx` (and possibly `decoder_with_past_model.onnx`), plus `config.json`. If the export errors, record the failure in the findings file and STOP (gate fail).
-
-- [ ] **Step 3: Record the IO contract**
-
-Run (inspect tensor names + special tokens):
-```bash
-/tmp/charsiu-onnx-spike/venv/bin/python3 - <<'PY'
-import onnxruntime as ort, json, pathlib
-base = pathlib.Path("/tmp/charsiu-onnx-spike/onnx")
-for f in ["encoder_model.onnx","decoder_model.onnx"]:
-    s = ort.InferenceSession(str(base/f))
-    print(f"== {f} ==")
-    print(" inputs :", [(i.name, i.shape) for i in s.get_inputs()])
-    print(" outputs:", [(o.name, o.shape) for o in s.get_outputs()])
-cfg = json.loads((base/"config.json").read_text())
-print("eos_token_id:", cfg.get("eos_token_id"), "decoder_start_token_id:", cfg.get("decoder_start_token_id"), "pad:", cfg.get("pad_token_id"), "vocab_size:", cfg.get("vocab_size"))
-PY
-```
-Expected: prints the encoder/decoder input+output names, EOS id, decoder-start id, vocab size. **Write these into `docs/superpowers/specs/charsiu-onnx-contract.md`** along with the ByT5 byte-offset (3) and the per-language tag strings (`<spa>`, `<fra>`, `<ita>`, `<por-bz>` — confirm against the spike's `spike/charsiu_g2p.py` on PR #507).
-
-### Task 0.2: Prove a Rust/ort greedy decode reproduces the Python IPA
+### Task 0.1: Download + hash-verify the klebster ONNX export
 
 **Files:**
-- Create: `rust/examples/charsiu_spike.rs` (throwaway; removed before the feature PR)
+- None (stages cache files; the source pins land in Task 4.1).
 
-- [ ] **Step 1: Write a minimal greedy-decode example using the recorded contract**
-
-Implement: byte-tokenize `"<spa> hola"` (UTF-8 bytes + offset 3, append EOS), run encoder once, loop decoder (start token → argmax → append → until EOS/maxlen), map output ids back to bytes→UTF-8 IPA. Use the exact tensor names from `charsiu-onnx-contract.md`.
-
-- [ ] **Step 2: Build and run on the spike corpus**
+- [ ] **Step 1: Download the three klebster ONNX files into the kesha cache**
 
 Run:
 ```bash
-cd /Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl/rust
-cargo run --example charsiu_spike --features onnx -- /tmp/charsiu-onnx-spike/onnx "hola mundo"
+mkdir -p ~/.cache/kesha/models/g2p/byt5-tiny
+cd ~/.cache/kesha/models/g2p/byt5-tiny
+for f in encoder_model.onnx decoder_model.onnx decoder_with_past_model.onnx; do
+  curl -fsSL -o "$f" "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/$f"
+done
+ls -la
 ```
-Expected: an IPA string (e.g. `ola mundo`-like phonemes). Compare against the Python `transformers` output for the same words; they must match.
+Expected: three files (~55 MB / 25 MB / 22 MB).
 
-- [ ] **Step 3: Latency check**
+- [ ] **Step 2: Verify SHA-256 against the #185-pinned hashes**
 
-Run the example over the 16-sentence corpus (es/fr/it/pt) and print total + per-utterance ms.
-Expected: record the number. **Gate:** if a typical sentence takes longer than ~300 ms of pure G2P, flag it — the findings file records whether latency is acceptable for interactive `kesha say` or whether the lexicon fallback is needed.
-
-- [ ] **Step 4: Record the gate decision + clean up**
-
-Append to `charsiu-onnx-contract.md`: feasibility (export ✅/❌), IPA match (✅/❌), latency (ms). Commit the findings file. Then `rm rust/examples/charsiu_spike.rs` (throwaway) and commit its removal. If any gate failed → STOP, re-brainstorm the lexicon approach.
-
+Run:
 ```bash
-cd /Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl
-git add docs/superpowers/specs/charsiu-onnx-contract.md
-git commit -m "spike(tts): record CharsiuG2P ONNX IO contract + feasibility (refs #212)"
+cd ~/.cache/kesha/models/g2p/byt5-tiny
+shasum -a 256 encoder_model.onnx decoder_model.onnx decoder_with_past_model.onnx
 ```
+Expected — must match the #185 pins exactly. A mismatch means upstream rehosted; STOP and treat it as a deliberate model bump (MODEL HASHES rule), not a "get it working" override:
+```
+1ac7aca11845527873f9e0e870fbe1e3c3ac2cb009d8852230332d10541aab04  encoder_model.onnx
+de32477aae14e254d4a7dee4b2c324fb39f93a0dc254181c5bfdd8fc67492919  decoder_model.onnx
+fae30b9f3a8d935be01b32af851bae6d54f330813167073e84caf6d0a1890fcb  decoder_with_past_model.onnx
+```
+
+- [ ] **Step 3: Confirm the IO contract still matches #185 §3**
+
+The three sessions must expose the inputs/outputs #185 documented (encoder: `input_ids`,`attention_mask`→`last_hidden_state`; `decoder_model`: +`encoder_hidden_states`,`encoder_attention_mask`→`logits` + 16 `present.*` KV; `decoder_with_past_model`: +16 `past_key_values.*`→`logits` + 8 decoder-only `present.*`). These are the names Phase 1's decode loop wires against. No source change and no commit in this phase — it only stages the cache and confirms the contract is current.
 
 ---
 
@@ -151,7 +110,7 @@ Expected: FAIL (module/functions not defined).
 
 - [ ] **Step 3: Implement the tokenizer**
 
-In `tokenizer.rs` (constants from `charsiu-onnx-contract.md`):
+In `tokenizer.rs` (constants per #185 §2):
 ```rust
 //! ByT5 byte-level tokenizer for CharsiuG2P. ByT5 maps each UTF-8 byte to
 //! `byte + BYTE_OFFSET`; the first ids are reserved (pad/eos/unk). No
@@ -159,12 +118,14 @@ In `tokenizer.rs` (constants from `charsiu-onnx-contract.md`):
 
 /// ByT5 reserves ids 0..3 (pad=0, eos=1, unk=2) and offsets bytes by 3.
 pub const BYTE_OFFSET: i64 = 3;
-/// EOS token id (confirmed in charsiu-onnx-contract.md).
+/// EOS token id (#185 §2).
 pub const EOS_ID: i64 = 1;
 
-/// Encode `tag` + space + `text` into ByT5 byte ids with a trailing EOS.
+/// Encode `"<tag>: text"` into ByT5 byte ids with a trailing EOS.
+/// The `": "` separator matches CharsiuG2P's training format (#185 §4,
+/// e.g. `"<spa>: hola"`).
 pub fn encode_with_tag(text: &str, tag: &str) -> Vec<i64> {
-    let mut ids: Vec<i64> = format!("{tag} {text}")
+    let mut ids: Vec<i64> = format!("{tag}: {text}")
         .bytes()
         .map(|b| b as i64 + BYTE_OFFSET)
         .collect();
@@ -303,7 +264,7 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    /// Gated on CHARSIU_ONNX (dir with encoder_model.onnx/decoder_model.onnx).
+    /// Gated on CHARSIU_ONNX (klebster dir: encoder/decoder/decoder_with_past .onnx).
     #[test]
     fn to_ipa_phonemizes_spanish_when_model_available() {
         let Some(dir) = std::env::var_os("CHARSIU_ONNX") else {
@@ -328,82 +289,106 @@ Expected: FAIL (no `Charsiu`/`load`/`to_ipa`).
 
 - [ ] **Step 3: Implement decode + engine**
 
-`decode.rs` — greedy loop over two `ort` sessions, using tensor names from `charsiu-onnx-contract.md` (shown here with the canonical optimum names; adjust to the recorded contract):
+`decode.rs` — **KV-cache** greedy decode over the klebster 3-session split. Step 0 runs `decoder_model` (seeds all 16 `present.*` KV); steps 1..N run `decoder_with_past_model`, re-feeding the constant encoder KV and the updated decoder KV. **Exact IO names + shapes are in #185 §3** — the KV plumbing below follows that name list verbatim:
 ```rust
-//! Greedy autoregressive decode for CharsiuG2P ByT5 on ort.
-use anyhow::Result;
-use ndarray::{Array1, Array2};
+//! KV-cache autoregressive decode for the klebster CharsiuG2P ByT5 export.
+//! Three ort sessions (encoder, decoder, decoder_with_past). IO per #185 §3.
+use anyhow::{anyhow, Result};
+use ndarray::{Array2, Array3, Array4};
 use ort::session::Session;
 use ort::value::Value;
 
-const MAX_NEW_TOKENS: usize = 64;
-const DECODER_START_ID: i64 = 0; // pad id; per charsiu-onnx-contract.md
+const MAX_NEW_TOKENS: usize = 128;
+const DECODER_START_ID: i64 = 0; // pad id (#185 §2)
+const N_LAYERS: usize = 4;       // num_decoder_layers (#185 §2)
 
-/// Run encoder once, then greedily decode token-by-token until EOS/cap.
+/// argmax over the last decoder position of a `[1, S, 384]` logits tensor.
+fn argmax_last(logits: &Value) -> Result<i64> {
+    let (shape, data) = logits.try_extract_tensor::<f32>()?;
+    let vocab = shape[shape.len() - 1] as usize;
+    let last = &data[data.len() - vocab..];
+    Ok(last
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .map(|(i, _)| i as i64)
+        .unwrap())
+}
+
+/// Holds the 4 layers × {decoder,encoder} × {key,value} cache tensors as owned
+/// `Array4<f32>` (`[1, 6, seq, 64]`, #185 §3). `seed` captures step-0 `present.*`;
+/// `bind_past` feeds them as `past_key_values.{i}.{decoder,encoder}.{key,value}`;
+/// `update_decoder` overwrites only the decoder entries from each step's `present.*`
+/// (encoder entries are constant across steps — #185 §3 note).
+struct KvCache { /* 16 named Array4<f32>, keyed by (layer, decoder|encoder, key|value) */ }
+impl KvCache {
+    fn seed(out: &ort::session::SessionOutputs, layers: usize) -> Result<Self> { /* read present.* */ }
+    fn bind_past<'a>(&'a self, inputs: &mut Vec<(&'static str, Value)>) -> Result<()> { /* past_key_values.* */ }
+    fn update_decoder(&mut self, out: &ort::session::SessionOutputs, layers: usize) -> Result<()> { /* present.*.decoder.* */ }
+}
+
+/// Encode once, then KV-cache greedy decode until EOS / MAX_NEW_TOKENS.
 pub fn greedy(
     encoder: &mut Session,
     decoder: &mut Session,
+    decoder_past: &mut Session,
     input_ids: &[i64],
 ) -> Result<Vec<i64>> {
     let n = input_ids.len();
     let ids = Value::from_array(Array2::<i64>::from_shape_vec((1, n), input_ids.to_vec())?)?;
-    let mask = Value::from_array(Array2::<i64>::from_shape_vec((1, n), vec![1i64; n])?)?;
-    let enc = encoder.run(ort::inputs![
-        "input_ids" => ids, "attention_mask" => mask,
-    ])?;
-    let (eshape, edata) = enc["last_hidden_state"].try_extract_tensor::<f32>()?;
-    let hidden = Array2::from_shape_vec(
-        (eshape[1] as usize, eshape[2] as usize),
-        edata.to_vec(),
-    )?;
+    let mask = || Value::from_array(Array2::<i64>::from_shape_vec((1, n), vec![1i64; n]).unwrap());
+    let enc = encoder.run(ort::inputs!["input_ids" => ids, "attention_mask" => mask()])?;
+    let (hs, hd) = enc["last_hidden_state"].try_extract_tensor::<f32>()?;
+    let hidden = Array3::from_shape_vec((1, hs[1] as usize, hs[2] as usize), hd.to_vec())?;
 
-    let mut out = vec![DECODER_START_ID];
-    for _ in 0..MAX_NEW_TOKENS {
-        let dn = out.len();
-        let dec_ids = Value::from_array(Array2::<i64>::from_shape_vec((1, dn), out.clone())?)?;
-        let enc_hs = Value::from_array(
-            hidden.clone().insert_axis(ndarray::Axis(0)),
-        )?;
-        let enc_mask = Value::from_array(Array2::<i64>::from_shape_vec((1, n), vec![1i64; n])?)?;
-        let dec = decoder.run(ort::inputs![
-            "input_ids" => dec_ids,
-            "encoder_hidden_states" => enc_hs,
-            "encoder_attention_mask" => enc_mask,
-        ])?;
-        let (lshape, logits) = dec["logits"].try_extract_tensor::<f32>()?;
-        let vocab = lshape[2] as usize;
-        let last = &logits[(logits.len() - vocab)..];
-        let next = last
-            .iter()
-            .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .map(|(i, _)| i as i64)
-            .unwrap();
-        if next == super::tokenizer::EOS_ID {
-            break;
-        }
-        out.push(next);
+    // Step 0 — full decoder seeds all KV.
+    let start = Value::from_array(Array2::<i64>::from_shape_vec((1, 1), vec![DECODER_START_ID])?)?;
+    let out0 = decoder.run(ort::inputs![
+        "input_ids" => start,
+        "encoder_hidden_states" => Value::from_array(hidden)?,
+        "encoder_attention_mask" => mask(),
+    ])?;
+    let mut next = argmax_last(&out0["logits"])?;
+    let mut kv = KvCache::seed(&out0, N_LAYERS)?;
+
+    // Steps 1..N — decoder_with_past, feeding last token + past KV.
+    let mut tokens = Vec::new();
+    let mut step = 0;
+    while next != super::tokenizer::EOS_ID && step < MAX_NEW_TOKENS {
+        tokens.push(next);
+        let mut inputs = ort::inputs![
+            "input_ids" => Value::from_array(Array2::<i64>::from_shape_vec((1, 1), vec![next])?)?,
+            "encoder_attention_mask" => mask(),
+        ];
+        kv.bind_past(&mut inputs)?;
+        let out = decoder_past.run(inputs)?;
+        next = argmax_last(&out["logits"])?;
+        kv.update_decoder(&out, N_LAYERS)?;
+        step += 1;
     }
-    Ok(out)
+    Ok(tokens)
 }
 ```
 
-`mod.rs` — engine wrapper:
+> `KvCache`'s three method bodies are mechanical 16-tensor plumbing — read each `present.{0..3}.{decoder,encoder}.{key,value}` from the `SessionOutputs` into an owned `Array4<f32>`, and feed them back under the `past_key_values.*` names. The exact name list and `[1,6,seq,64]` shapes are in **#185 §3**; implement them straight from that table.
+
+`mod.rs` — engine wrapper (note the `ort 2.0` `Session::builder()` gotcha from #185 §7: its error is not `Send`, so `?` won't coerce to `anyhow` — wrap with `map_err`):
 ```rust
 pub(crate) mod decode;
 pub(crate) mod remap;
 pub(crate) mod tokenizer;
 
 use std::path::Path;
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use ort::session::Session;
 
 pub struct Charsiu {
     encoder: Session,
     decoder: Session,
+    decoder_past: Session,
 }
 
-/// CharsiuG2P language tags (from charsiu-onnx-contract.md / spike).
+/// CharsiuG2P language tags (#185 §4). LatAm Spanish is `<spa>`.
 fn tag_for(lang: &str) -> Result<&'static str> {
     Ok(match lang {
         "es" => "<spa>",
@@ -416,9 +401,17 @@ fn tag_for(lang: &str) -> Result<&'static str> {
 
 impl Charsiu {
     pub fn load(dir: &Path) -> Result<Self> {
-        let enc = Session::builder()?.commit_from_file(dir.join("encoder_model.onnx"))?;
-        let dec = Session::builder()?.commit_from_file(dir.join("decoder_model.onnx"))?;
-        Ok(Self { encoder: enc, decoder: dec })
+        let open = |f: &str| -> Result<Session> {
+            Session::builder()
+                .map_err(|e| anyhow!("ort session builder: {e}"))? // #185 §7: non-Send error
+                .commit_from_file(dir.join(f))
+                .map_err(|e| anyhow!("ort load {f}: {e}"))
+        };
+        Ok(Self {
+            encoder: open("encoder_model.onnx")?,
+            decoder: open("decoder_model.onnx")?,
+            decoder_past: open("decoder_with_past_model.onnx")?,
+        })
     }
 
     /// Phonemize one chunk of text to Kokoro-vocab IPA.
@@ -431,8 +424,10 @@ impl Charsiu {
         let mut words = Vec::new();
         for w in text.split_whitespace() {
             let ids = tokenizer::encode_with_tag(w, tag);
-            let out = decode::greedy(&mut self.encoder, &mut self.decoder, &ids)
-                .with_context(|| format!("charsiu decode failed for {w:?}"))?;
+            let out = decode::greedy(
+                &mut self.encoder, &mut self.decoder, &mut self.decoder_past, &ids,
+            )
+            .with_context(|| format!("charsiu decode failed for {w:?}"))?;
             words.push(remap::remap(&tokenizer::decode(&out)));
         }
         Ok(words.join(" "))
@@ -444,9 +439,9 @@ impl Charsiu {
 
 Run:
 ```bash
-cd rust && CHARSIU_ONNX=/tmp/charsiu-onnx-spike/onnx cargo nextest run --features tts charsiu:: 2>&1 | tail
+cd rust && CHARSIU_ONNX=~/.cache/kesha/models/g2p/byt5-tiny cargo nextest run --features tts charsiu:: 2>&1 | tail
 ```
-Expected: PASS (and the un-gated tokenizer/remap tests still pass). If decode output diverges from Phase 0's Python IPA, fix tensor names/decoder-start id against `charsiu-onnx-contract.md`.
+Expected: PASS (and the un-gated tokenizer/remap tests still pass). If decode output diverges from #185's reference IPA (e.g. `hola → olao`), fix the KV-cache name binding against #185 §3.
 
 - [ ] **Step 5: Commit**
 
@@ -638,7 +633,7 @@ Expected: FAIL (still bails to #212).
 
 - [ ] **Step 3: Implement routing**
 
-In `text_to_ipa`, before the misaki `match`, add: if lang ∈ {es,fr,it,pt}, run `normalize::normalize(text, lang)` then load `Charsiu` from the cached model dir (`models/charsiu-g2p/` under the kesha cache) and return `to_ipa`. If the model dir is missing, bail with the loud `kesha install --tts` message (never auto-download). English/`en-*` keep the existing misaki path untouched.
+In `text_to_ipa`, before the misaki `match`, add: if lang ∈ {es,fr,it,pt}, run `normalize::normalize(text, lang)` then load `Charsiu` from the cached model dir (`models/g2p/byt5-tiny/` under the kesha cache) and return `to_ipa`. If the model dir is missing, bail with the loud `kesha install --tts` message (never auto-download). English/`en-*` keep the existing misaki path untouched.
 
 - [ ] **Step 4: Run to verify pass**
 
@@ -716,27 +711,34 @@ git commit -m "fix(tts): clamp Kokoro audio pre-encode + phonemeCount-1 style ro
 
 ## Phase 4 — Voices + model distribution
 
-### Task 4.1: Pin CharsiuG2P ONNX + multilingual voices in `models.rs`
+### Task 4.1: Pin the klebster G2P ONNX + multilingual voices in `models.rs`
 
 **Files:**
-- Modify: `rust/src/tts/charsiu/` (none) — `rust/src/models.rs`
+- Modify: `rust/src/models.rs`, `NOTICES`
 - Test: `cargo test models::manifest_tests` (existing shape invariants)
 
-- [ ] **Step 1: Compute SHA-256 of the artifacts**
+- [ ] **Step 1: Hashes are already pinned by #185 — reuse them**
 
-Run:
+The three klebster files' SHA-256 are recorded in #185 §1 (verified in Phase 0 Task 0.1 Step 2):
+```
+encoder_model.onnx              1ac7aca11845527873f9e0e870fbe1e3c3ac2cb009d8852230332d10541aab04
+decoder_model.onnx              de32477aae14e254d4a7dee4b2c324fb39f93a0dc254181c5bfdd8fc67492919
+decoder_with_past_model.onnx    fae30b9f3a8d935be01b32af851bae6d54f330813167073e84caf6d0a1890fcb
+```
+For the four voice `.bin` packs (onnx-community, same family as the existing `am_michael.bin`), compute hashes from the staged cache:
 ```bash
-shasum -a 256 /tmp/charsiu-onnx-spike/onnx/encoder_model.onnx /tmp/charsiu-onnx-spike/onnx/decoder_model.onnx
-# voice .bin packs (already used by the spike harness / onnx-community):
 for v in em_alex ff_siwis im_nicola pm_alex; do
-  shasum -a 256 /tmp/kokoro-mlang-spike/voices/$v.bin 2>/dev/null || echo "re-extract $v"
+  shasum -a 256 ~/.cache/kesha/models/kokoro-82m/voices/$v.bin
 done
 ```
-Record the hashes.
 
-- [ ] **Step 2: Add `ModelFile` entries**
+- [ ] **Step 2: Add `ModelFile` entries + NOTICES attribution**
 
-In `models.rs`, add to the ONNX (non-`system_kokoro`) TTS manifest: the two CharsiuG2P ONNX files under `rel_path: "models/charsiu-g2p/{encoder,decoder}_model.onnx"` with their HF `resolve` URLs + pinned `sha256`, and the four voice `.bin` packs under `models/kokoro-82m/voices/{em_alex,ff_siwis,im_nicola,pm_alex}.bin` from onnx-community with pinned `sha256` (mirror the existing `am_michael.bin` entry shape).
+In `models.rs`, add to the ONNX (non-`system_kokoro`) TTS manifest:
+- The **three** klebster G2P files under `rel_path: "models/g2p/byt5-tiny/{encoder_model,decoder_model,decoder_with_past_model}.onnx"`, `url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/<file>"`, with the pinned `sha256` above (mirror #185's Phase-1 `g2p_onnx_manifest()` snippet exactly).
+- The four voice `.bin` packs under `models/kokoro-82m/voices/{em_alex,ff_siwis,im_nicola,pm_alex}.bin` from onnx-community with pinned `sha256` (mirror the existing `am_michael.bin` entry).
+
+**CC-BY 4.0 attribution (required):** add a `NOTICES` entry crediting **Kleber Noel** (ONNX export) and **Zhu et al. 2022** (upstream CharsiuG2P, arXiv:2204.03067). This is the license obligation — not optional.
 
 - [ ] **Step 3: Run manifest shape tests**
 
@@ -846,7 +848,7 @@ Render each corpus sentence (gated on `CHARSIU_ONNX` + Kokoro model present), th
 
 Run:
 ```bash
-cd rust && CHARSIU_ONNX=/tmp/charsiu-onnx-spike/onnx cargo nextest run --features tts tts_multilang_audio 2>&1 | tail
+cd rust && CHARSIU_ONNX=~/.cache/kesha/models/g2p/byt5-tiny cargo nextest run --features tts tts_multilang_audio 2>&1 | tail
 ```
 Expected: PASS.
 
@@ -894,7 +896,8 @@ Per CLAUDE.md: wait for CI + Greptile to cover the head SHA; address P1/P2 findi
 
 ---
 
-## Pre-merge blockers (carry from the spec)
-- **CharsiuG2P weights license** — code is MIT; the HF weights repo lacks an explicit license. Clarify with the author before Task 4.1's pin merges. If unresolved, this blocks the model-pin PR.
-- **Phase 0 gate** — if the ONNX decode spike fails feasibility/latency, STOP and re-brainstorm the offline-lexicon fallback; do not proceed into Phase 1.
-- **French-female exception** — needs drakulavich sign-off in the PR (brand-rule carve-out).
+## Pre-merge blockers
+- **CC-BY 4.0 attribution** — the klebster export is CC-BY 4.0 (resolved: permissive, no copyleft). The obligation is the `NOTICES` entry (Task 4.1 Step 2) crediting Kleber Noel + Zhu et al. — easy to forget, easy to satisfy.
+- **French-female exception** — needs drakulavich sign-off in the PR (brand-rule carve-out: no male French voice exists in Kokoro v1.0).
+
+> Resolved vs. the original plan: the "export it ourselves / Phase 0 feasibility gate" and the "weights license unresolved" blockers are both gone — feasibility is established by #185 and the artifact is CC-BY 4.0.

--- a/docs/superpowers/plans/2026-06-01-onnx-kokoro-multilang-trackB.md
+++ b/docs/superpowers/plans/2026-06-01-onnx-kokoro-multilang-trackB.md
@@ -1,0 +1,900 @@
+# Multilingual Kokoro on ONNX (es/fr/it/pt) — Track B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the ONNX TTS path real per-language G2P for Spanish, French, Italian, Portuguese so `kesha say --voice {es,fr,it,pt}-*` produces natural (not English-accented, not digit-collapsed) speech.
+
+**Architecture:** A new `tts::charsiu` ONNX G2P engine (ByT5-tiny exported to ONNX, byte tokenizer, greedy autoregressive decode on the existing `ort`) feeding the existing Kokoro tokenizer/session, with a per-language `tts::normalize` pass (numbers + acronyms) ahead of it. Routing/model-pin wiring in `voices.rs`/`models.rs`. English (misaki) and the CoreML path are untouched.
+
+**Tech Stack:** Rust (`ort`, `ndarray`), the existing `tts::{tokenizer, kokoro}`, a disposable Python venv for the Phase 0 export/spike, `cargo nextest`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md`
+**Predecessor spike:** PR #507 (`spike/onnx-kokoro-multilang-g2p`).
+**Tracking issue:** #212
+
+> **Spike-gated plan.** Phase 0 is a hard gate. It writes a findings file `docs/superpowers/specs/charsiu-onnx-contract.md` recording the concrete ONNX IO contract — encoder/decoder input+output tensor names, the byte-token special-id offset, EOS id, and the per-language tag strings. **Phases 1+ reference those recorded values.** If Phase 0 fails (export infeasible, decode can't reproduce the Python IPA, or latency unacceptable for interactive `kesha say`), STOP and re-brainstorm the offline-lexicon fallback — do not proceed into Phase 1.
+
+> **Path note:** `Run:` blocks use this worktree (`/Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl`) and the scratch dir `/tmp/charsiu-onnx-spike/`. Substitute your own roots if re-running elsewhere.
+
+---
+
+## Phase 0 — Feasibility + latency spike (GATE)
+
+### Task 0.1: Export CharsiuG2P ByT5 to ONNX
+
+**Files:**
+- Create: `/tmp/charsiu-onnx-spike/export.sh` (scratch, not committed)
+
+- [ ] **Step 1: Disposable venv (CLAUDE.md: never system-wide)**
+
+Run:
+```bash
+mkdir -p /tmp/charsiu-onnx-spike
+python3 -m venv /tmp/charsiu-onnx-spike/venv
+/tmp/charsiu-onnx-spike/venv/bin/pip install --quiet "optimum[exporters]" transformers onnxruntime
+echo ok
+```
+Expected: `ok`.
+
+- [ ] **Step 2: Export the model to ONNX**
+
+Run:
+```bash
+/tmp/charsiu-onnx-spike/venv/bin/optimum-cli export onnx \
+  --model charsiu/g2p_multilingual_byT5_tiny_16_layers_100 \
+  --task text2text-generation \
+  /tmp/charsiu-onnx-spike/onnx/
+ls /tmp/charsiu-onnx-spike/onnx/
+```
+Expected: an `encoder_model.onnx` + `decoder_model.onnx` (and possibly `decoder_with_past_model.onnx`), plus `config.json`. If the export errors, record the failure in the findings file and STOP (gate fail).
+
+- [ ] **Step 3: Record the IO contract**
+
+Run (inspect tensor names + special tokens):
+```bash
+/tmp/charsiu-onnx-spike/venv/bin/python3 - <<'PY'
+import onnxruntime as ort, json, pathlib
+base = pathlib.Path("/tmp/charsiu-onnx-spike/onnx")
+for f in ["encoder_model.onnx","decoder_model.onnx"]:
+    s = ort.InferenceSession(str(base/f))
+    print(f"== {f} ==")
+    print(" inputs :", [(i.name, i.shape) for i in s.get_inputs()])
+    print(" outputs:", [(o.name, o.shape) for o in s.get_outputs()])
+cfg = json.loads((base/"config.json").read_text())
+print("eos_token_id:", cfg.get("eos_token_id"), "decoder_start_token_id:", cfg.get("decoder_start_token_id"), "pad:", cfg.get("pad_token_id"), "vocab_size:", cfg.get("vocab_size"))
+PY
+```
+Expected: prints the encoder/decoder input+output names, EOS id, decoder-start id, vocab size. **Write these into `docs/superpowers/specs/charsiu-onnx-contract.md`** along with the ByT5 byte-offset (3) and the per-language tag strings (`<spa>`, `<fra>`, `<ita>`, `<por-bz>` — confirm against the spike's `spike/charsiu_g2p.py` on PR #507).
+
+### Task 0.2: Prove a Rust/ort greedy decode reproduces the Python IPA
+
+**Files:**
+- Create: `rust/examples/charsiu_spike.rs` (throwaway; removed before the feature PR)
+
+- [ ] **Step 1: Write a minimal greedy-decode example using the recorded contract**
+
+Implement: byte-tokenize `"<spa> hola"` (UTF-8 bytes + offset 3, append EOS), run encoder once, loop decoder (start token → argmax → append → until EOS/maxlen), map output ids back to bytes→UTF-8 IPA. Use the exact tensor names from `charsiu-onnx-contract.md`.
+
+- [ ] **Step 2: Build and run on the spike corpus**
+
+Run:
+```bash
+cd /Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl/rust
+cargo run --example charsiu_spike --features onnx -- /tmp/charsiu-onnx-spike/onnx "hola mundo"
+```
+Expected: an IPA string (e.g. `ola mundo`-like phonemes). Compare against the Python `transformers` output for the same words; they must match.
+
+- [ ] **Step 3: Latency check**
+
+Run the example over the 16-sentence corpus (es/fr/it/pt) and print total + per-utterance ms.
+Expected: record the number. **Gate:** if a typical sentence takes longer than ~300 ms of pure G2P, flag it — the findings file records whether latency is acceptable for interactive `kesha say` or whether the lexicon fallback is needed.
+
+- [ ] **Step 4: Record the gate decision + clean up**
+
+Append to `charsiu-onnx-contract.md`: feasibility (export ✅/❌), IPA match (✅/❌), latency (ms). Commit the findings file. Then `rm rust/examples/charsiu_spike.rs` (throwaway) and commit its removal. If any gate failed → STOP, re-brainstorm the lexicon approach.
+
+```bash
+cd /Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl
+git add docs/superpowers/specs/charsiu-onnx-contract.md
+git commit -m "spike(tts): record CharsiuG2P ONNX IO contract + feasibility (refs #212)"
+```
+
+---
+
+## Phase 1 — `charsiu` ONNX G2P engine
+
+### Task 1.1: ByT5 byte tokenizer
+
+**Files:**
+- Create: `rust/src/tts/charsiu/mod.rs` (module decl + re-exports)
+- Create: `rust/src/tts/charsiu/tokenizer.rs`
+- Modify: `rust/src/tts/mod.rs` (add `pub(crate) mod charsiu;` under the `tts` feature)
+- Test: inline `#[cfg(test)]` in `tokenizer.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tokenizer.rs`:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_ascii_as_bytes_plus_offset_with_eos() {
+        // ByT5: token id = byte value + BYTE_OFFSET (3); EOS appended.
+        let ids = encode_with_tag("hi", "<spa>");
+        // "<spa>" tag is encoded as its UTF-8 bytes too, then a space, then "hi".
+        assert_eq!(*ids.last().unwrap(), EOS_ID);
+        // 'h'=104 -> 107, 'i'=105 -> 108 appear in order somewhere before EOS.
+        let win = ids.windows(2).any(|w| w == [107, 108]);
+        assert!(win, "expected h,i byte tokens: {ids:?}");
+    }
+
+    #[test]
+    fn decodes_byte_ids_back_to_utf8() {
+        let s = decode(&[107, 108]); // 104,105 after removing offset
+        assert_eq!(s, "hi");
+    }
+
+    #[test]
+    fn decode_skips_special_ids() {
+        // ids below BYTE_OFFSET (pad/eos/bos) are not literal bytes.
+        assert_eq!(decode(&[EOS_ID, 107, 108]), "hi");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts charsiu::tokenizer 2>&1 | tail`
+Expected: FAIL (module/functions not defined).
+
+- [ ] **Step 3: Implement the tokenizer**
+
+In `tokenizer.rs` (constants from `charsiu-onnx-contract.md`):
+```rust
+//! ByT5 byte-level tokenizer for CharsiuG2P. ByT5 maps each UTF-8 byte to
+//! `byte + BYTE_OFFSET`; the first ids are reserved (pad/eos/unk). No
+//! sentencepiece — encode/decode are pure byte arithmetic.
+
+/// ByT5 reserves ids 0..3 (pad=0, eos=1, unk=2) and offsets bytes by 3.
+pub const BYTE_OFFSET: i64 = 3;
+/// EOS token id (confirmed in charsiu-onnx-contract.md).
+pub const EOS_ID: i64 = 1;
+
+/// Encode `tag` + space + `text` into ByT5 byte ids with a trailing EOS.
+pub fn encode_with_tag(text: &str, tag: &str) -> Vec<i64> {
+    let mut ids: Vec<i64> = format!("{tag} {text}")
+        .bytes()
+        .map(|b| b as i64 + BYTE_OFFSET)
+        .collect();
+    ids.push(EOS_ID);
+    ids
+}
+
+/// Decode generated ids back to a UTF-8 string, dropping reserved ids.
+pub fn decode(ids: &[i64]) -> String {
+    let bytes: Vec<u8> = ids
+        .iter()
+        .filter(|&&id| id >= BYTE_OFFSET)
+        .map(|&id| (id - BYTE_OFFSET) as u8)
+        .collect();
+    String::from_utf8_lossy(&bytes).trim().to_string()
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd rust && cargo nextest run --features tts charsiu::tokenizer 2>&1 | tail`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/charsiu/ rust/src/tts/mod.rs
+git commit -m "feat(tts): ByT5 byte tokenizer for CharsiuG2P (refs #212)"
+```
+
+### Task 1.2: IPA-remap table (ported from spike, locked by regression test)
+
+**Files:**
+- Create: `rust/src/tts/charsiu/remap.rs`
+- Modify: `rust/src/tts/charsiu/mod.rs` (`mod remap;`)
+- Test: inline in `remap.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_tie_bar_affricates() {
+        // t͡s -> ʦ, t͡ʃ -> ʧ, d͡ʒ -> ʤ (tie bar U+0361 consumed by the rule)
+        assert_eq!(remap("a t͡s b"), "a ʦ b");
+        assert_eq!(remap("d͡ʒusto"), "ʤusto");
+        assert_eq!(remap("t͡ʃiko"), "ʧiko");
+    }
+
+    #[test]
+    fn normalizes_latin_g_to_script_g() {
+        assert_eq!(remap("gato"), "ɡato"); // U+0067 -> U+0261
+    }
+
+    #[test]
+    fn decomposes_precomposed_nasals_to_nfd() {
+        // õ U+00F5 -> o + U+0303 ; same for ũ ẽ
+        assert_eq!(remap("õ"), "o\u{0303}");
+        assert_eq!(remap("ũ"), "u\u{0303}");
+        assert_eq!(remap("ẽ"), "e\u{0303}");
+    }
+
+    #[test]
+    fn remapped_output_has_zero_oov_vs_kokoro_vocab() {
+        let vocab = crate::tts::tokenizer::Tokenizer::load().unwrap();
+        // Sample CharsiuG2P-style strings exercising every OOV class.
+        for s in ["t͡salat͡so", "d͡ʒusto", "gato", "kõsiderasõw", "t͡ʃiko"] {
+            let mapped = remap(s);
+            let ids = vocab.encode(&mapped);
+            // encode drops unknowns; require it kept every non-space char.
+            let nonspace = mapped.chars().filter(|c| !c.is_whitespace()).count();
+            assert_eq!(ids.len(), nonspace, "OOV leaked for {s:?} -> {mapped:?}");
+        }
+    }
+}
+```
+
+> Note: `Tokenizer::encode` is `pub` (confirmed in spike). If `encode` length-vs-char comparison needs a space-aware count, keep spaces out of the assertion as above.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts charsiu::remap 2>&1 | tail`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement remap**
+
+```rust
+//! CharsiuG2P → Kokoro-vocab IPA remap. Ported from the spike (PR #507).
+//! CharsiuG2P emits a few symbols Kokoro's vocab lacks; map them to the
+//! in-vocab equivalents. Locked by a zero-residual-OOV regression test.
+
+/// Remap CharsiuG2P IPA into Kokoro's phoneme inventory.
+pub fn remap(ipa: &str) -> String {
+    // Order matters: collapse tie-bar affricates before stripping stray ties.
+    let s = ipa
+        .replace("t͡s", "ʦ")
+        .replace("t͡ʃ", "ʧ")
+        .replace("d͡ʒ", "ʤ")
+        .replace('\u{0067}', "\u{0261}") // Latin g -> script ɡ
+        .replace('õ', "o\u{0303}")
+        .replace('ũ', "u\u{0303}")
+        .replace('ẽ', "e\u{0303}")
+        .replace('\u{0361}', ""); // drop any residual standalone tie bar
+    s
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd rust && cargo nextest run --features tts charsiu::remap 2>&1 | tail`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/charsiu/remap.rs rust/src/tts/charsiu/mod.rs
+git commit -m "feat(tts): CharsiuG2P IPA->Kokoro-vocab remap with zero-OOV regression (refs #212)"
+```
+
+### Task 1.3: Greedy decode + engine entrypoint
+
+**Files:**
+- Create: `rust/src/tts/charsiu/decode.rs`
+- Modify: `rust/src/tts/charsiu/mod.rs` (`to_ipa` entrypoint)
+- Test: inline (gated on a `CHARSIU_ONNX` env var like `kokoro.rs`'s `KOKORO_MODEL` pattern, so default CI stays fast)
+
+- [ ] **Step 1: Write the gated integration test**
+
+In `mod.rs`:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Gated on CHARSIU_ONNX (dir with encoder_model.onnx/decoder_model.onnx).
+    #[test]
+    fn to_ipa_phonemizes_spanish_when_model_available() {
+        let Some(dir) = std::env::var_os("CHARSIU_ONNX") else {
+            eprintln!("CHARSIU_ONNX not set; skipping");
+            return;
+        };
+        let mut g = Charsiu::load(Path::new(&dir)).unwrap();
+        let ipa = g.to_ipa("hola mundo", "es").unwrap();
+        assert!(!ipa.is_empty(), "empty IPA");
+        // remap guarantees vocab membership:
+        let vocab = crate::tts::tokenizer::Tokenizer::load().unwrap();
+        let nonspace = ipa.chars().filter(|c| !c.is_whitespace()).count();
+        assert_eq!(vocab.encode(&ipa).len(), nonspace, "OOV leaked: {ipa:?}");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts charsiu:: 2>&1 | tail`
+Expected: FAIL (no `Charsiu`/`load`/`to_ipa`).
+
+- [ ] **Step 3: Implement decode + engine**
+
+`decode.rs` — greedy loop over two `ort` sessions, using tensor names from `charsiu-onnx-contract.md` (shown here with the canonical optimum names; adjust to the recorded contract):
+```rust
+//! Greedy autoregressive decode for CharsiuG2P ByT5 on ort.
+use anyhow::Result;
+use ndarray::{Array1, Array2};
+use ort::session::Session;
+use ort::value::Value;
+
+const MAX_NEW_TOKENS: usize = 64;
+const DECODER_START_ID: i64 = 0; // pad id; per charsiu-onnx-contract.md
+
+/// Run encoder once, then greedily decode token-by-token until EOS/cap.
+pub fn greedy(
+    encoder: &mut Session,
+    decoder: &mut Session,
+    input_ids: &[i64],
+) -> Result<Vec<i64>> {
+    let n = input_ids.len();
+    let ids = Value::from_array(Array2::<i64>::from_shape_vec((1, n), input_ids.to_vec())?)?;
+    let mask = Value::from_array(Array2::<i64>::from_shape_vec((1, n), vec![1i64; n])?)?;
+    let enc = encoder.run(ort::inputs![
+        "input_ids" => ids, "attention_mask" => mask,
+    ])?;
+    let (eshape, edata) = enc["last_hidden_state"].try_extract_tensor::<f32>()?;
+    let hidden = Array2::from_shape_vec(
+        (eshape[1] as usize, eshape[2] as usize),
+        edata.to_vec(),
+    )?;
+
+    let mut out = vec![DECODER_START_ID];
+    for _ in 0..MAX_NEW_TOKENS {
+        let dn = out.len();
+        let dec_ids = Value::from_array(Array2::<i64>::from_shape_vec((1, dn), out.clone())?)?;
+        let enc_hs = Value::from_array(
+            hidden.clone().insert_axis(ndarray::Axis(0)),
+        )?;
+        let enc_mask = Value::from_array(Array2::<i64>::from_shape_vec((1, n), vec![1i64; n])?)?;
+        let dec = decoder.run(ort::inputs![
+            "input_ids" => dec_ids,
+            "encoder_hidden_states" => enc_hs,
+            "encoder_attention_mask" => enc_mask,
+        ])?;
+        let (lshape, logits) = dec["logits"].try_extract_tensor::<f32>()?;
+        let vocab = lshape[2] as usize;
+        let last = &logits[(logits.len() - vocab)..];
+        let next = last
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(i, _)| i as i64)
+            .unwrap();
+        if next == super::tokenizer::EOS_ID {
+            break;
+        }
+        out.push(next);
+    }
+    Ok(out)
+}
+```
+
+`mod.rs` — engine wrapper:
+```rust
+pub(crate) mod decode;
+pub(crate) mod remap;
+pub(crate) mod tokenizer;
+
+use std::path::Path;
+use anyhow::{Context, Result};
+use ort::session::Session;
+
+pub struct Charsiu {
+    encoder: Session,
+    decoder: Session,
+}
+
+/// CharsiuG2P language tags (from charsiu-onnx-contract.md / spike).
+fn tag_for(lang: &str) -> Result<&'static str> {
+    Ok(match lang {
+        "es" => "<spa>",
+        "fr" => "<fra>",
+        "it" => "<ita>",
+        "pt" => "<por-bz>",
+        other => anyhow::bail!("charsiu: unsupported lang '{other}'"),
+    })
+}
+
+impl Charsiu {
+    pub fn load(dir: &Path) -> Result<Self> {
+        let enc = Session::builder()?.commit_from_file(dir.join("encoder_model.onnx"))?;
+        let dec = Session::builder()?.commit_from_file(dir.join("decoder_model.onnx"))?;
+        Ok(Self { encoder: enc, decoder: dec })
+    }
+
+    /// Phonemize one chunk of text to Kokoro-vocab IPA.
+    pub fn to_ipa(&mut self, text: &str, lang: &str) -> Result<String> {
+        if text.trim().is_empty() {
+            return Ok(String::new());
+        }
+        let tag = tag_for(lang)?;
+        // Word-by-word: CharsiuG2P is trained on single tokens.
+        let mut words = Vec::new();
+        for w in text.split_whitespace() {
+            let ids = tokenizer::encode_with_tag(w, tag);
+            let out = decode::greedy(&mut self.encoder, &mut self.decoder, &ids)
+                .with_context(|| format!("charsiu decode failed for {w:?}"))?;
+            words.push(remap::remap(&tokenizer::decode(&out)));
+        }
+        Ok(words.join(" "))
+    }
+}
+```
+
+- [ ] **Step 4: Run the gated test with a model**
+
+Run:
+```bash
+cd rust && CHARSIU_ONNX=/tmp/charsiu-onnx-spike/onnx cargo nextest run --features tts charsiu:: 2>&1 | tail
+```
+Expected: PASS (and the un-gated tokenizer/remap tests still pass). If decode output diverges from Phase 0's Python IPA, fix tensor names/decoder-start id against `charsiu-onnx-contract.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/charsiu/
+git commit -m "feat(tts): CharsiuG2P greedy ONNX decode engine (refs #212)"
+```
+
+---
+
+## Phase 2 — `normalize` (numbers + acronyms)
+
+### Task 2.1: Decide number-to-words crate vs hand-roll
+
+**Files:**
+- Modify: `rust/Cargo.toml` (only if a crate is chosen)
+
+- [ ] **Step 1: Evaluate crates**
+
+Run:
+```bash
+cd rust && cargo search num2words 2>&1 | head; cargo search numbers_to_words 2>&1 | head
+```
+Decide: a crate is acceptable ONLY if it is MIT/Apache-2.0 (CLAUDE.md license posture) AND supports es/fr/it/pt. Record the decision in a one-line comment at the top of `numbers.rs`. If none qualifies, hand-roll (Task 2.2 covers the hand-rolled path; if a crate is used, replace the body with crate calls but keep the same tests).
+
+### Task 2.2: Per-language integer→words
+
+**Files:**
+- Create: `rust/src/tts/normalize/mod.rs`
+- Create: `rust/src/tts/normalize/numbers.rs`
+- Modify: `rust/src/tts/mod.rs` (`pub(crate) mod normalize;`)
+- Test: inline in `numbers.rs`
+
+- [ ] **Step 1: Write failing tests (table-driven, per language)**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn spanish_integers() {
+        assert_eq!(to_words(27, "es"), "veintisiete");
+        assert_eq!(to_words(512, "es"), "quinientos doce");
+        assert_eq!(to_words(936, "es"), "novecientos treinta y seis");
+    }
+    #[test]
+    fn italian_integers() {
+        assert_eq!(to_words(512, "it"), "cinquecento dodici");
+    }
+    #[test]
+    fn portuguese_integers() {
+        assert_eq!(to_words(936, "pt"), "novecentos e trinta e seis");
+    }
+    #[test]
+    fn french_integers() {
+        assert_eq!(to_words(348, "fr"), "trois cent quarante-huit");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd rust && cargo nextest run --features tts normalize::numbers 2>&1 | tail`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `to_words`**
+
+Implement integer→words for es/fr/it/pt (0..=999_999 is sufficient for v1; cap larger inputs by reading digit-by-digit). If a crate was chosen in 2.1, delegate to it here; otherwise hand-roll the four Romance grammars. Keep each language in its own `fn` for clarity.
+
+The four grammars are regular — encode each as a table-driven function over units/teens/tens/hundreds with per-language connectors. Spanish template (the others follow the same shape with their own tables/connectors):
+```rust
+const ES_UNITS: [&str; 20] = ["cero","uno","dos","tres","cuatro","cinco","seis","siete","ocho","nueve","diez","once","doce","trece","catorce","quince","dieciséis","diecisiete","dieciocho","diecinueve"];
+const ES_TENS: [&str; 10] = ["","","veinte","treinta","cuarenta","cincuenta","sesenta","setenta","ochenta","noventa"];
+const ES_HUNDREDS: [&str; 10] = ["","ciento","doscientos","trescientos","cuatrocientos","quinientos","seiscientos","setecientos","ochocientos","novecientos"];
+
+fn es_under_1000(n: u32) -> String {
+    let (h, r) = (n / 100, n % 100);
+    let mut parts = Vec::new();
+    if n == 100 { return "cien".into(); }
+    if h > 0 { parts.push(ES_HUNDREDS[h as usize].to_string()); }
+    if r < 20 { if r > 0 || n == 0 { parts.push(ES_UNITS[r as usize].into()); } }
+    else if r < 30 { parts.push(format!("veinti{}", ES_UNITS[(r-20) as usize])); } // veintisiete
+    else { let (t,u) = (r/10, r%10); parts.push(ES_TENS[t as usize].into());
+           if u > 0 { parts.push(format!("y {}", ES_UNITS[u as usize])); } } // treinta y seis
+    parts.join(" ")
+}
+```
+fr adds hyphenation + "et un"/"quatre-vingts"; it elides ("ventuno", "trentotto"); pt inserts "e" connectors ("novecentos e trinta e seis"). The Step 1 tests pin the exact expected strings for each.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd rust && cargo nextest run --features tts normalize::numbers 2>&1 | tail`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/normalize/ rust/src/tts/mod.rs
+git commit -m "feat(tts): per-language integer->words normalization (refs #212)"
+```
+
+### Task 2.3: Per-language acronym spell-out + normalize dispatch
+
+**Files:**
+- Create: `rust/src/tts/normalize/acronyms.rs`
+- Modify: `rust/src/tts/normalize/mod.rs` (`normalize(text, lang)` wiring digits + acronyms)
+- Test: inline
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn spells_acronyms_with_spanish_letter_names() {
+        // RAI -> "erre a i", IBGE handled in pt test
+        assert_eq!(spell("RAI", "es"), "erre a i");
+    }
+    #[test]
+    fn normalize_expands_digits_and_acronyms() {
+        // integration: numbers + acronym together
+        let out = super::normalize("Compré 27 libros RAI", "es");
+        assert!(out.contains("veintisiete"), "got: {out}");
+        assert!(out.contains("erre a i"), "got: {out}");
+        assert!(!out.contains("27"), "digit leaked: {out}");
+    }
+    #[test]
+    fn normalize_leaves_english_untouched() {
+        assert_eq!(super::normalize("hello 5", "en"), "hello 5");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd rust && cargo nextest run --features tts normalize:: 2>&1 | tail`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement acronym spell-out + dispatch**
+
+`acronyms.rs`: per-language letter-name tables (es: a,be,ce,…,erre,…; fr; it; pt), spell all-caps tokens (length 2..=5, mirroring the gate logic in `tts/en/acronym.rs::is_acronym_token`) by joining letter names with spaces. `mod.rs::normalize(text, lang)`: for es/fr/it/pt, replace integer tokens via `numbers::to_words` and acronym tokens via `acronyms::spell`; for any other lang (incl. `en`), return text unchanged.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd rust && cargo nextest run --features tts normalize:: 2>&1 | tail`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/normalize/
+git commit -m "feat(tts): per-language acronym spell-out + normalize dispatch (refs #212)"
+```
+
+---
+
+## Phase 3 — Wire G2P dispatch + kokoro fixes
+
+### Task 3.1: Route es/fr/it/pt through normalize → charsiu in `g2p.rs`
+
+**Files:**
+- Modify: `rust/src/tts/g2p.rs`
+- Test: inline
+
+- [ ] **Step 1: Update the failing tests**
+
+`g2p.rs` currently has `unsupported_language_errors_with_pointer` asserting `fr` bails. Replace with routing expectations:
+```rust
+#[test]
+fn romance_langs_no_longer_bail() {
+    // Without a model present, routing still must not hit the misaki bail path.
+    for lang in ["es", "fr", "it", "pt"] {
+        let err = text_to_ipa("hola", lang).unwrap_err().to_string();
+        // Acceptable failure is "model not installed", NOT "not supported / #212".
+        assert!(
+            err.contains("install --tts") || err.contains("charsiu"),
+            "lang {lang} should route to charsiu, got: {err}"
+        );
+        assert!(!err.contains("212"), "lang {lang} still bails to #212");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd rust && cargo nextest run --features tts g2p:: 2>&1 | tail`
+Expected: FAIL (still bails to #212).
+
+- [ ] **Step 3: Implement routing**
+
+In `text_to_ipa`, before the misaki `match`, add: if lang ∈ {es,fr,it,pt}, run `normalize::normalize(text, lang)` then load `Charsiu` from the cached model dir (`models/charsiu-g2p/` under the kesha cache) and return `to_ipa`. If the model dir is missing, bail with the loud `kesha install --tts` message (never auto-download). English/`en-*` keep the existing misaki path untouched.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd rust && cargo nextest run --features tts g2p:: 2>&1 | tail`
+Expected: PASS (routes to charsiu/install error, not #212).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/g2p.rs
+git commit -m "feat(tts): route es/fr/it/pt G2P through normalize+charsiu (refs #212)"
+```
+
+### Task 3.2: kokoro.rs — f32 clamp + style-row index fix
+
+**Files:**
+- Modify: `rust/src/tts/kokoro.rs`
+- Test: inline
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[test]
+fn clamp_keeps_samples_in_range() {
+    let out = clamp_audio(vec![-1.5, -0.2, 0.5, 1.8]);
+    assert!(out.iter().all(|s| (-1.0..=1.0).contains(s)), "{out:?}");
+    assert_eq!(out[1], -0.2); // in-range untouched
+}
+#[test]
+fn style_row_uses_phoneme_count_minus_one() {
+    assert_eq!(style_row(8), 7);
+    assert_eq!(style_row(0), 0);     // saturating
+    assert_eq!(style_row(10_000), 509);
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd rust && cargo nextest run --features tts kokoro:: 2>&1 | tail`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Clamp synthesized audio to [-1.0, 1.0]; Kokoro can emit out-of-range
+/// samples that would hard-clip on i16 encode (spike fr_0). Apply before encode.
+pub fn clamp_audio(mut samples: Vec<f32>) -> Vec<f32> {
+    for s in &mut samples {
+        *s = s.clamp(-1.0, 1.0);
+    }
+    samples
+}
+
+/// Voice-pack style row index = min(max(phonemeCount-1, 0), 509)
+/// (FluidAudio KokoroAne docs; spike used the padded length).
+pub fn style_row(phoneme_count: usize) -> usize {
+    phoneme_count.saturating_sub(1).min(509)
+}
+```
+Wire `clamp_audio` into the synth path before WAV encode, and use `style_row` where the style slice is selected.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd rust && cargo nextest run --features tts kokoro:: 2>&1 | tail`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/kokoro.rs
+git commit -m "fix(tts): clamp Kokoro audio pre-encode + phonemeCount-1 style row (refs #212)"
+```
+
+---
+
+## Phase 4 — Voices + model distribution
+
+### Task 4.1: Pin CharsiuG2P ONNX + multilingual voices in `models.rs`
+
+**Files:**
+- Modify: `rust/src/tts/charsiu/` (none) — `rust/src/models.rs`
+- Test: `cargo test models::manifest_tests` (existing shape invariants)
+
+- [ ] **Step 1: Compute SHA-256 of the artifacts**
+
+Run:
+```bash
+shasum -a 256 /tmp/charsiu-onnx-spike/onnx/encoder_model.onnx /tmp/charsiu-onnx-spike/onnx/decoder_model.onnx
+# voice .bin packs (already used by the spike harness / onnx-community):
+for v in em_alex ff_siwis im_nicola pm_alex; do
+  shasum -a 256 /tmp/kokoro-mlang-spike/voices/$v.bin 2>/dev/null || echo "re-extract $v"
+done
+```
+Record the hashes.
+
+- [ ] **Step 2: Add `ModelFile` entries**
+
+In `models.rs`, add to the ONNX (non-`system_kokoro`) TTS manifest: the two CharsiuG2P ONNX files under `rel_path: "models/charsiu-g2p/{encoder,decoder}_model.onnx"` with their HF `resolve` URLs + pinned `sha256`, and the four voice `.bin` packs under `models/kokoro-82m/voices/{em_alex,ff_siwis,im_nicola,pm_alex}.bin` from onnx-community with pinned `sha256` (mirror the existing `am_michael.bin` entry shape).
+
+- [ ] **Step 3: Run manifest shape tests**
+
+Run: `cd rust && cargo test --features tts models::manifest_tests 2>&1 | tail`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/src/models.rs
+git commit -m "feat(tts): pin CharsiuG2P ONNX + es/fr/it/pt voice packs (refs #212)"
+```
+
+### Task 4.2: Route voices in `voices.rs` (with documented French exception)
+
+**Files:**
+- Modify: `rust/src/tts/voices.rs`
+- Test: inline
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[test]
+fn resolves_romance_default_voices() {
+    let tmp = /* staged cache dir like existing tests */;
+    for (id, _) in [("es-em_alex", "es"), ("it-im_nicola", "it"), ("pt-pm_alex", "pt"), ("fr-ff_siwis", "fr")] {
+        // Without models staged this returns the install error; with the
+        // charsiu+voice files staged it resolves to the ONNX Kokoro path.
+        let _ = resolve_voice(tmp.path(), id); // assert it does NOT bail "language not supported"
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd rust && cargo nextest run --features tts voices:: 2>&1 | tail`
+Expected: FAIL (es/fr/it/pt unsupported on the non-`system_kokoro` build).
+
+- [ ] **Step 3: Implement routing + default-voice resolution**
+
+On the ONNX (non-`system_kokoro`) path, map `es-*`/`fr-*`/`it-*`/`pt-*` to a `ResolvedVoice::Kokoro` using `models/kokoro-82m/voices/<voice>.bin` + the charsiu G2P dir, with `espeak_lang` set to the language code consumed by `g2p::text_to_ipa`. Add a code comment at the French default documenting the brand-rule exception:
+```rust
+// BRAND-RULE EXCEPTION (CLAUDE.md "default voices must be male"):
+// Kokoro v1.0 ships NO male French voice — only ff_siwis (female). fr
+// therefore defaults to ff_siwis until a male fr voice exists. es/it/pt
+// default to male (em_alex/im_nicola/pm_alex). Revisit on a male fr voice.
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd rust && cargo nextest run --features tts voices:: 2>&1 | tail`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/src/tts/voices.rs
+git commit -m "feat(tts): route es/fr/it/pt voices on ONNX path; doc French exception (refs #212)"
+```
+
+### Task 4.3: Add the new models to `kesha install --tts`
+
+**Files:**
+- Modify: `src/install-plan.ts` (and `src/cli/install.ts` if it enumerates sizes)
+- Test: `src/__tests__/` (bun) for the install plan
+
+- [ ] **Step 1: Write failing bun test**
+
+In an install-plan test: assert the `--tts` plan now includes `charsiu-g2p` and the four voice packs, and that total size string updates.
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `bun test src/__tests__ 2>&1 | tail`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Add the CharsiuG2P + voice-pack entries to the `--tts` install plan so they download explicitly (never auto-download).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bun test src/__tests__ 2>&1 | tail && bunx tsc --noEmit`
+Expected: PASS + clean types.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/install-plan.ts src/cli/install.ts src/__tests__/
+git commit -m "feat(cli): add CharsiuG2P + multilingual voices to kesha install --tts (refs #212)"
+```
+
+---
+
+## Phase 5 — CI audio-regression gate + finalize
+
+### Task 5.1: Audio-regression test over the corpus
+
+**Files:**
+- Create: `rust/tests/tts_multilang_audio.rs` (gated integration test) + corpus fixture from the spike
+- Create: `rust/fixtures/tts/multilang_corpus.json` (port `spike/corpus.json` from PR #507)
+
+- [ ] **Step 1: Write the gated test**
+
+Render each corpus sentence (gated on `CHARSIU_ONNX` + Kokoro model present), then assert the spike's deterministic checks: non-silent (RMS > threshold), no clipping (peak ≤ 1.0 — locks Task 3.2), duration within a grapheme-ratio band, 24 kHz mono.
+
+- [ ] **Step 2: Run with models present**
+
+Run:
+```bash
+cd rust && CHARSIU_ONNX=/tmp/charsiu-onnx-spike/onnx cargo nextest run --features tts tts_multilang_audio 2>&1 | tail
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tests/tts_multilang_audio.rs rust/fixtures/tts/multilang_corpus.json
+git commit -m "test(tts): multilingual audio-regression gate (no-clip, length band) (refs #212)"
+```
+
+### Task 5.2: Full verification + docs + PR
+
+- [ ] **Step 1: Full local verification**
+
+Run:
+```bash
+cd /Users/anton/Personal/repos/kesha-voice-kit/.worktrees/trackb-impl
+cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts && cargo check --features coreml --no-default-features
+cd .. && bun test && bunx tsc --noEmit
+```
+Expected: all green. (`--all-targets` + the coreml check are required per CLAUDE.md.)
+
+- [ ] **Step 2: Update user docs**
+
+Update `docs/runbooks/tts-internals.md` + `CLAUDE.md` TTS section: es/fr/it/pt now supported on the ONNX path via CharsiuG2P + normalizer; note the LatAm-Spanish default and the French-female exception.
+
+- [ ] **Step 3: Verify build-engine matrix unaffected**
+
+Run: `diff <(grep 'features = ' .github/workflows/build-engine.yml) <(grep default rust/Cargo.toml)` — confirm no new default feature was added (charsiu rides the existing `tts`). If a feature was added, mirror it into every matrix row (CLAUDE.md).
+
+- [ ] **Step 4: Commit docs + open PR**
+
+```bash
+git add docs/ CLAUDE.md
+git commit -m "docs(tts): document es/fr/it/pt ONNX support (LatAm es, fr-female exception) (refs #212)"
+git push -u origin feat/onnx-kokoro-multilang-trackb
+gh pr create --base main --head feat/onnx-kokoro-multilang-trackb \
+  --title "feat(tts): multilingual Kokoro on ONNX — es/fr/it/pt via CharsiuG2P (refs #212)" \
+  --body "Implements Track B from the spike (#507). CharsiuG2P ByT5→ONNX G2P + per-language numbers/acronym normalizer + voice/model wiring + kokoro clamp/style fixes + audio-regression gate. Spanish defaults LatAm; French defaults ff_siwis (female, documented brand-rule exception — no male fr voice in Kokoro v1.0). Weights-license clarification with the CharsiuG2P author tracked before merge. Refs #212."
+```
+
+- [ ] **Step 5: Wait for CI + Greptile**
+
+Per CLAUDE.md: wait for CI + Greptile to cover the head SHA; address P1/P2 findings; merge only when both are green. Tag #212 `WIP` while in flight; add `Closes #212` only once all four languages have landed (or keep `Refs` if French is split out).
+
+---
+
+## Pre-merge blockers (carry from the spec)
+- **CharsiuG2P weights license** — code is MIT; the HF weights repo lacks an explicit license. Clarify with the author before Task 4.1's pin merges. If unresolved, this blocks the model-pin PR.
+- **Phase 0 gate** — if the ONNX decode spike fails feasibility/latency, STOP and re-brainstorm the offline-lexicon fallback; do not proceed into Phase 1.
+- **French-female exception** — needs drakulavich sign-off in the PR (brand-rule carve-out).

--- a/docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md
+++ b/docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md
@@ -19,7 +19,7 @@ Give the ONNX TTS path real per-language G2P for **Spanish, French, Italian, Por
 | Decision | Choice | Rationale |
 |---|---|---|
 | Languages (v1) | es, fr, it, pt | All four; Kokoro-82M speaks them, only G2P was missing. |
-| G2P runtime | **CharsiuG2P ByT5 → ONNX → `ort` greedy decode**, spike-gated | Repo-aligned (ort already unconditional, SHA-256-pinnable), generalizes to OOV. Fallback: offline lexicon. |
+| G2P runtime | **Pre-converted klebster CharsiuG2P ByT5 ONNX → `ort` KV-cache decode** | Repo-aligned (ort already unconditional, SHA-256-pinnable), generalizes to OOV. Feasibility + byte-identical Rust parity already proven by #185 — no self-export, no spike gate. |
 | Spanish dialect | **Latin-American** (`<spa>`) default | Largest speaker base; spike-validated natural by ear. Castilian deferred. |
 | Normalizer | **numbers + acronyms**, per language | The two weaknesses the spike measured; integers + acronym spell-out only (YAGNI). |
 | French default voice | `fr-ff_siwis` (**female**) | **Documented exception** to the male-default brand rule: Kokoro v1.0 ships **no male French voice** (only `ff_siwis`). es/it/pt default to male (`em_alex`, `im_nicola`, `pm_alex`). Revisit French when a male voice exists. |
@@ -52,9 +52,9 @@ Each unit is independently testable: the normalizer is pure text→text; `charsi
 ## Components
 
 ### `charsiu` — ONNX G2P engine
-Wraps a pinned ByT5-tiny ONNX export (`encoder.onnx` + `decoder.onnx`) on the existing `ort`.
-- `tokenizer.rs`: ByT5 is byte-level — encode = UTF-8 bytes + 3 (offset for special tokens), plus EOS; no sentencepiece. The CharsiuG2P language tag (e.g. `<spa>`, `<fra>`, `<ita>`, `<por-bz>`) is prepended per the model's convention.
-- `decode.rs`: greedy autoregressive decode — run encoder once, loop decoder feeding the growing token sequence until EOS or a max-length cap; map output bytes back to the IPA string. A small per-word in-memory cache amortizes repeated tokens within an utterance.
+Loads the pinned **klebster 3-file ONNX export** (`encoder_model.onnx` + `decoder_model.onnx` + `decoder_with_past_model.onnx`) on the existing `ort`. IO contract per #185 §3.
+- `tokenizer.rs`: ByT5 is byte-level — encode = `"<tag>: word"` → UTF-8 bytes + 3 (special-token offset), plus EOS; no sentencepiece. Tags `<spa>`/`<fra>`/`<ita>`/`<por-bz>` (#185 §4).
+- `decode.rs`: **KV-cache** autoregressive decode — encoder once; step 0 via `decoder_model` (seeds all `present.*` KV); steps 1..N via `decoder_with_past_model` (re-feed constant encoder KV + updated decoder KV) until EOS or a max-length cap; map output bytes back to IPA.
 - `mod.rs`: word-segments the normalized text, phonemizes each, joins with spaces.
 
 ### `charsiu/remap.rs` — OOV → Kokoro vocab
@@ -74,14 +74,9 @@ CharsiuG2P collapses digits and acronyms, so normalize first:
 1. **Clamp** synthesized f32 to `[-1, 1]` before WAV encode — Kokoro can emit samples >1.0 (the spike's `fr_0` clipped); locked by the audio-regression "no clipping" check.
 2. Style-row index = `min(max(phonemeCount-1, 0), 509)` (the spike render used the padded length; FluidAudio's docs confirm `phonemeCount-1`).
 
-## The spike gate (Plan Phase 0 — mandatory)
+## Feasibility — already established (no spike gate)
 
-Per CLAUDE.md ("verify third-party model formats with a spike"), the ByT5→ONNX export is a named third-party artifact and must be proven before the engine commits to it. Phase 0 spike:
-1. Export `charsiu/g2p_multilingual_byT5_tiny_16_layers_100` to ONNX (optimum/transformers).
-2. Reproduce the spike's Python IPA from a Rust/`ort` greedy decode on the fixed corpus (es/fr/it/pt).
-3. Measure per-utterance latency for interactive `kesha say`.
-
-**Gate:** if export fails, decode-in-`ort` is infeasible, or latency is unacceptable → fall back to the **offline-lexicon** approach (bake `{word:IPA}` per language via CharsiuG2P + a rule-based OOV fallback, the misaki pattern). Record the decision before further work.
+CLAUDE.md's "verify third-party model formats with a spike" rule is **already satisfied** by the prior April spike `docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md` (PR #185, on `main`): it downloaded the klebster export, pinned its SHA-256 hashes, documented the full IO contract (§3) + the `ort 2.0` gotchas (§7), and verified **byte-identical Rust↔Python IPA** across 7 scripts (incl. es/fr/it/pt) at ~36 ms/word. So this design pins and loads that published artifact rather than exporting anything. Plan Phase 0 is reduced to *download + hash-verify against the #185 pins*. If those hashes ever stop matching (upstream rehost), that's a deliberate model bump — not a "get it working" override.
 
 ## Error handling
 - Missing G2P/voice model → the existing loud `kesha install --tts` error (never auto-download).
@@ -94,13 +89,13 @@ Per CLAUDE.md ("verify third-party model formats with a spike"), the ByT5→ONNX
 - **Verification:** `cargo nextest run --features tts` + clippy `--all-targets` + fmt; Greptile + CI gate per repo rules.
 
 ## Rollout (PR-able increments)
-1. **Phase 0 spike** (feasibility/latency) — decision recorded.
-2. `charsiu` engine (tokenizer + decode + remap) behind tests, model pinned.
+1. **Phase 0** — download + hash-verify the klebster artifact against the #185 pins (no export).
+2. `charsiu` engine (tokenizer + KV-cache decode + remap) behind tests, model pinned.
 3. `normalize/` (numbers + acronyms).
 4. `voices.rs`/`models.rs` wiring + `kesha install --tts` + the `kokoro.rs` clamp/style fixes.
 5. CI audio-regression gate.
 
-**Before the model-pin PR merges:** clarify the CharsiuG2P **weights** license with the author (the code is MIT; the HF weights repo lacks an explicit license — flagged in the spike).
+**License:** the klebster export is **CC-BY 4.0** (permissive — resolves the earlier "weights license unresolved" concern). Obligation is a `NOTICES` attribution crediting Kleber Noel (ONNX export) + Zhu et al. 2022 (upstream CharsiuG2P), landed with the model-pin PR.
 
 ## Risks
 - **Autoregressive ONNX decode in `ort`** (KV-cache, EOS, latency) is the primary unknown — Phase 0 spike de-risks it; lexicon fallback if it fails.

--- a/docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md
+++ b/docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md
@@ -41,7 +41,7 @@ rust/src/tts/
 │   ├── decode.rs          # greedy autoregressive decode loop (EOS stop, max-len cap)
 │   └── remap.rs           # OOV-symbol → Kokoro-vocab table (ported from spike, tested)
 ├── tokenizer.rs           # unchanged (IPA → Kokoro token ids)
-└── kokoro.rs              # FIX: clamp f32 to [-1,1] before encode; style row = phonemeCount-1
+└── kokoro.rs              # FIX: clamp f32 to [-1,1] before encode; select_style VERIFIED already-correct (see below)
 ```
 
 **Data flow (ONNX path, non-English):**
@@ -70,9 +70,10 @@ CharsiuG2P collapses digits and acronyms, so normalize first:
 - `voices.rs`: route `es-*`/`fr-*`/`it-*`/`pt-*` on the ONNX path to `charsiu` (today they bail). Defaults: `es-em_alex`, `it-im_nicola`, `pt-pm_alex` (male), `fr-ff_siwis` (female, documented exception — comment in code + PR body, flagged "revisit when a male fr voice exists").
 - `models.rs`: pin the CharsiuG2P ONNX files (SHA-256) and the four voice `.bin` packs from onnx-community via the existing `download_verified` mechanism; add to `kesha install --tts`. **No new cargo feature** — this is part of the existing `tts`/`onnx` build, so `build-engine.yml`'s matrix is unaffected (verify with the matrix-vs-defaults diff before any release).
 
-### `kokoro.rs` — two correctness fixes surfaced by the spike
+### `kokoro.rs` — one correctness fix surfaced by the spike
 1. **Clamp** synthesized f32 to `[-1, 1]` before WAV encode — Kokoro can emit samples >1.0 (the spike's `fr_0` clipped); locked by the audio-regression "no clipping" check.
-2. Style-row index = `min(max(phonemeCount-1, 0), 509)` (the spike render used the padded length; FluidAudio's docs confirm `phonemeCount-1`).
+
+`voices::select_style` was **VERIFIED already-correct** per #207: it uses `voice[token_count]` (clamped to `VOICE_ROWS-1`), which matches the `kokoro-onnx` upstream exactly. The earlier `token_count-1` form was the off-by-one fixed in #207. Phase 3 correctly did NOT change `select_style`; only the f32 clamp was applied.
 
 ## Feasibility — already established (no spike gate)
 

--- a/docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md
+++ b/docs/superpowers/specs/2026-06-01-onnx-kokoro-multilang-trackB-implementation-design.md
@@ -1,0 +1,109 @@
+# Track B Implementation Design — multilingual Kokoro on ONNX (es/fr/it/pt) via CharsiuG2P
+
+- **Date:** 2026-06-01
+- **Status:** Design (pre-plan)
+- **Tracking issue:** [#212](https://github.com/drakulavich/kesha-voice-kit/issues/212)
+- **Predecessor spike:** `docs/superpowers/specs/2026-05-31-onnx-kokoro-multilang-g2p-spike-design.md` (PR #507) — chose Track B (CharsiuG2P + remap + text-normalizer) over espeak-ng (GPL-blocked vs Kesha's MIT). The spike also established that the CoreML es/fr/it/pt voices are the **English** G2P applied to foreign text, so the quality bar here is the **upstream misaki reference**, and this work is an *upgrade* over today's CoreML behavior.
+
+## Goal
+
+Give the ONNX TTS path real per-language G2P for **Spanish, French, Italian, Portuguese**, so `kesha say --voice {es,fr,it,pt}-*` produces natural speech (not English-accented, not digit-collapsed). English (misaki) and the CoreML path are untouched.
+
+### Non-goals
+- hi/ja/zh and any non-Latin script (need script-aware G2P; out of scope).
+- Castilian Spanish, decimals/currency/dates/ordinals in the normalizer (deferred; v1 is integers + acronyms).
+- Changing the CoreML/FluidAudio path or the English misaki path.
+
+## Decisions (from brainstorming, 2026-06-01)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Languages (v1) | es, fr, it, pt | All four; Kokoro-82M speaks them, only G2P was missing. |
+| G2P runtime | **CharsiuG2P ByT5 → ONNX → `ort` greedy decode**, spike-gated | Repo-aligned (ort already unconditional, SHA-256-pinnable), generalizes to OOV. Fallback: offline lexicon. |
+| Spanish dialect | **Latin-American** (`<spa>`) default | Largest speaker base; spike-validated natural by ear. Castilian deferred. |
+| Normalizer | **numbers + acronyms**, per language | The two weaknesses the spike measured; integers + acronym spell-out only (YAGNI). |
+| French default voice | `fr-ff_siwis` (**female**) | **Documented exception** to the male-default brand rule: Kokoro v1.0 ships **no male French voice** (only `ff_siwis`). es/it/pt default to male (`em_alex`, `im_nicola`, `pm_alex`). Revisit French when a male voice exists. |
+
+## Architecture
+
+New ONNX-path G2P slotting into the existing `g2p::text_to_ipa` dispatch, with a normalization pass in front. Nothing changes for English or CoreML.
+
+```
+rust/src/tts/
+├── g2p.rs                 # add es/fr/it/pt branches → charsiu path (currently bails to #212)
+├── normalize/             # NEW — runs BEFORE g2p, per language
+│   ├── mod.rs             # normalize(text, lang) → text ; dispatch + shared segmenting
+│   ├── numbers.rs         # integer → words (es/fr/it/pt)
+│   └── acronyms.rs        # per-language letter-name spell-out
+├── charsiu/               # NEW — the ONNX G2P engine
+│   ├── mod.rs             # to_ipa(text, lang) → IPA via encoder+decoder ort sessions
+│   ├── tokenizer.rs       # ByT5 byte-level tokenizer (raw UTF-8 + special ids)
+│   ├── decode.rs          # greedy autoregressive decode loop (EOS stop, max-len cap)
+│   └── remap.rs           # OOV-symbol → Kokoro-vocab table (ported from spike, tested)
+├── tokenizer.rs           # unchanged (IPA → Kokoro token ids)
+└── kokoro.rs              # FIX: clamp f32 to [-1,1] before encode; style row = phonemeCount-1
+```
+
+**Data flow (ONNX path, non-English):**
+`text → normalize(text, lang) → charsiu::to_ipa(·, lang) → remap → tokenizer.encode → kokoro.infer → WAV`
+
+Each unit is independently testable: the normalizer is pure text→text; `charsiu` is text→IPA; `remap` is IPA→IPA; none depend on the others' internals.
+
+## Components
+
+### `charsiu` — ONNX G2P engine
+Wraps a pinned ByT5-tiny ONNX export (`encoder.onnx` + `decoder.onnx`) on the existing `ort`.
+- `tokenizer.rs`: ByT5 is byte-level — encode = UTF-8 bytes + 3 (offset for special tokens), plus EOS; no sentencepiece. The CharsiuG2P language tag (e.g. `<spa>`, `<fra>`, `<ita>`, `<por-bz>`) is prepended per the model's convention.
+- `decode.rs`: greedy autoregressive decode — run encoder once, loop decoder feeding the growing token sequence until EOS or a max-length cap; map output bytes back to the IPA string. A small per-word in-memory cache amortizes repeated tokens within an utterance.
+- `mod.rs`: word-segments the normalized text, phonemizes each, joins with spaces.
+
+### `charsiu/remap.rs` — OOV → Kokoro vocab
+The spike's table, ported verbatim and **locked by a regression test**: tie-bar affricates `t͡s/t͡ʃ/d͡ʒ` → `ʦ/ʧ/ʤ`; Latin `g` (U+0067) → script `ɡ` (U+0261); pre-composed nasals `õ/ũ/ẽ` → NFD `o/u/e` + combining tilde U+0303. Test asserts **zero residual OOV** against `fixtures/tts/kokoro_vocab.json` for the corpus.
+
+### `normalize/` — text normalization (before G2P)
+CharsiuG2P collapses digits and acronyms, so normalize first:
+- `numbers.rs`: integer→words per language (`512`→`quinientos doce`, `cinquecento dodici`, …). Romance number-to-words is well-defined. The plan first checks for a license-clean (MIT/Apache) Rust crate covering es/fr/it/pt; if none fits, a compact hand-rolled module (the four Romance systems are regular).
+- `acronyms.rs`: per-language letter-name spell-out (`RAI`→`erre a i`), mirroring the English `tts/en/acronym.rs` + `letter_table.rs` Segment approach with es/fr/it/pt letter-name tables.
+- `mod.rs`: dispatch by lang; English is unaffected (keeps its existing path).
+
+### `voices.rs` / `models.rs` — routing & distribution
+- `voices.rs`: route `es-*`/`fr-*`/`it-*`/`pt-*` on the ONNX path to `charsiu` (today they bail). Defaults: `es-em_alex`, `it-im_nicola`, `pt-pm_alex` (male), `fr-ff_siwis` (female, documented exception — comment in code + PR body, flagged "revisit when a male fr voice exists").
+- `models.rs`: pin the CharsiuG2P ONNX files (SHA-256) and the four voice `.bin` packs from onnx-community via the existing `download_verified` mechanism; add to `kesha install --tts`. **No new cargo feature** — this is part of the existing `tts`/`onnx` build, so `build-engine.yml`'s matrix is unaffected (verify with the matrix-vs-defaults diff before any release).
+
+### `kokoro.rs` — two correctness fixes surfaced by the spike
+1. **Clamp** synthesized f32 to `[-1, 1]` before WAV encode — Kokoro can emit samples >1.0 (the spike's `fr_0` clipped); locked by the audio-regression "no clipping" check.
+2. Style-row index = `min(max(phonemeCount-1, 0), 509)` (the spike render used the padded length; FluidAudio's docs confirm `phonemeCount-1`).
+
+## The spike gate (Plan Phase 0 — mandatory)
+
+Per CLAUDE.md ("verify third-party model formats with a spike"), the ByT5→ONNX export is a named third-party artifact and must be proven before the engine commits to it. Phase 0 spike:
+1. Export `charsiu/g2p_multilingual_byT5_tiny_16_layers_100` to ONNX (optimum/transformers).
+2. Reproduce the spike's Python IPA from a Rust/`ort` greedy decode on the fixed corpus (es/fr/it/pt).
+3. Measure per-utterance latency for interactive `kesha say`.
+
+**Gate:** if export fails, decode-in-`ort` is infeasible, or latency is unacceptable → fall back to the **offline-lexicon** approach (bake `{word:IPA}` per language via CharsiuG2P + a rule-based OOV fallback, the misaki pattern). Record the decision before further work.
+
+## Error handling
+- Missing G2P/voice model → the existing loud `kesha install --tts` error (never auto-download).
+- Decode produces empty IPA → bail with context (lang, input), mirroring `g2p.rs`'s "empty after G2P" trace; never synthesize silent audio as success.
+- Unsupported non-Latin script for these voices → keep the `#492`-style `ScriptUnsupported` guard.
+
+## Testing
+- **Unit:** ByT5 byte-tokenizer round-trip; `remap` zero-residual-OOV regression over the spike corpus; numbers/acronyms per language (table-driven); `g2p` dispatch routes es/fr/it/pt to `charsiu`.
+- **Audio regression (CI gate):** render the fixed corpus; deterministic checks from the spike (no all-silence, length-vs-grapheme band, **no clipping**). Spike reference WAVs become fixtures.
+- **Verification:** `cargo nextest run --features tts` + clippy `--all-targets` + fmt; Greptile + CI gate per repo rules.
+
+## Rollout (PR-able increments)
+1. **Phase 0 spike** (feasibility/latency) — decision recorded.
+2. `charsiu` engine (tokenizer + decode + remap) behind tests, model pinned.
+3. `normalize/` (numbers + acronyms).
+4. `voices.rs`/`models.rs` wiring + `kesha install --tts` + the `kokoro.rs` clamp/style fixes.
+5. CI audio-regression gate.
+
+**Before the model-pin PR merges:** clarify the CharsiuG2P **weights** license with the author (the code is MIT; the HF weights repo lacks an explicit license — flagged in the spike).
+
+## Risks
+- **Autoregressive ONNX decode in `ort`** (KV-cache, EOS, latency) is the primary unknown — Phase 0 spike de-risks it; lexicon fallback if it fails.
+- **Number-to-words crate** may not cleanly cover all four languages → hand-rolled fallback (bounded, regular grammars).
+- **Weights license** unresolved → blocks the model-pin merge until clarified.
+- **French female default** is a brand-rule exception → must be explicitly signed off and documented.

--- a/rust/fixtures/tts/multilang_corpus.json
+++ b/rust/fixtures/tts/multilang_corpus.json
@@ -1,0 +1,6 @@
+{
+  "es": ["El veloz murciélago hindú comía feliz cardillo y kiwi.", "Compré 27 libros y el código ISBN empezaba por X."],
+  "fr": ["Un bon vin blanc, un grand pont, enfin les enfants chantent."],
+  "it": ["Ma la volpe col suo balzo ha raggiunto il quieto Fido."],
+  "pt": ["Um pequeno jabuti xereta viu dez cegonhas felizes."]
+}

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -151,6 +151,49 @@ pub fn kokoro_manifest() -> Vec<ModelFile> {
             url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin",
             sha256: "1d1f21dd8da39c30705cd4c75d039d265e9bc4a2a93ed09bc9e1b1225eb95ba1",
         },
+        // klebster CharsiuG2P byt5-tiny ONNX export (CC-BY 4.0).
+        // Pinned hashes from #185 (see NOTICES.md for attribution).
+        // These 3 files enable multilingual G2P for es/fr/it/pt voices.
+        ModelFile {
+            rel_path: "models/g2p/byt5-tiny/encoder_model.onnx",
+            url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/encoder_model.onnx",
+            sha256: "1ac7aca11845527873f9e0e870fbe1e3c3ac2cb009d8852230332d10541aab04",
+        },
+        ModelFile {
+            rel_path: "models/g2p/byt5-tiny/decoder_model.onnx",
+            url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_model.onnx",
+            sha256: "de32477aae14e254d4a7dee4b2c324fb39f93a0dc254181c5bfdd8fc67492919",
+        },
+        ModelFile {
+            rel_path: "models/g2p/byt5-tiny/decoder_with_past_model.onnx",
+            url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_with_past_model.onnx",
+            sha256: "fae30b9f3a8d935be01b32af851bae6d54f330813167073e84caf6d0a1890fcb",
+        },
+        // Multilingual Kokoro voice packs (es/fr/it/pt). All from
+        // onnx-community/Kokoro-82M-v1.0-ONNX on HuggingFace.
+        // em_alex (es, male), im_nicola (it, male), pm_alex (pt, male)
+        // satisfy the brand male-default rule. ff_siwis (fr, female) is
+        // the sole French voice Kokoro v1.0 ships — see voices.rs comment.
+        ModelFile {
+            rel_path: "models/kokoro-82m/voices/em_alex.bin",
+            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/em_alex.bin",
+            sha256: "27809e9eafdcbcfff90a3016c697568676531de2a2c39cee29c96c7bd6b83e95",
+        },
+        ModelFile {
+            rel_path: "models/kokoro-82m/voices/ff_siwis.bin",
+            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/ff_siwis.bin",
+            sha256: "a35f5675ad08948e326ae75fd0ea16ba5d0042e4f76b5f3d1df77d0a48c54861",
+        },
+        ModelFile {
+            rel_path: "models/kokoro-82m/voices/im_nicola.bin",
+            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/im_nicola.bin",
+            sha256: "bc578e510d52a96d6940d46f12e96d7b3df00905dbea075113226d100e6e1ab0",
+        },
+        ModelFile {
+            rel_path: "models/kokoro-82m/voices/pm_alex.bin",
+            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_alex.bin",
+            sha256: "0175c753f59c54e7fd5a995bedef0c5ff2fb67e0043dd3dcb2ae74ec2acbeb2a",
+        },
     ]
     }
 }

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -108,6 +108,11 @@ struct LoopState {
     /// Vosk cache by model directory. The Russian path uses one model dir
     /// today, but keep it map-shaped so adding more languages is a no-op.
     vosk: tts::sessions::VoskCache,
+    /// Cached CharsiuG2P session (three ONNX sessions, ~100 MB). Loaded once
+    /// on the first Romance-language (es/fr/it/pt) request and reused for all
+    /// subsequent ones. Fixes Greptile P1 (#509): previously `text_to_ipa`
+    /// reloaded the three sessions from disk on every request.
+    charsiu: tts::sessions::CharsiuCache,
 }
 
 /// Drive the loop. Returns 0 on clean stdin EOF, 4 on read error.
@@ -119,6 +124,7 @@ pub fn run() -> i32 {
     let mut state = LoopState {
         kokoro: None,
         vosk: tts::sessions::VoskCache::new(),
+        charsiu: tts::sessions::CharsiuCache::new(),
     };
 
     let mut buf: Vec<u8> = Vec::with_capacity(4096);
@@ -257,9 +263,24 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
                 )
                 .map_err(|e| e.to_string())
             } else {
-                // Non-English Kokoro: legacy G2P + infer_ipa path.
-                let ipa = tts::g2p::text_to_ipa(&req.text, espeak_lang)
-                    .map_err(|e| format!("g2p: {e}"))?;
+                // Non-English Kokoro: G2P + infer_ipa path.
+                // Romance languages (es/fr/it/pt) use the cached CharsiuG2P
+                // session to avoid reloading ~100 MB of ONNX models per request.
+                // All other languages fall through to the one-shot text_to_ipa
+                // path (which will error with a lang-specific hint for ru etc.).
+                let ipa = if matches!(espeak_lang, "es" | "fr" | "it" | "pt") {
+                    state
+                        .charsiu
+                        .to_ipa(
+                            &models::cache_dir().join("models/g2p/byt5-tiny"),
+                            &req.text,
+                            espeak_lang,
+                        )
+                        .map_err(|e| format!("g2p: {e}"))?
+                } else {
+                    tts::g2p::text_to_ipa(&req.text, espeak_lang)
+                        .map_err(|e| format!("g2p: {e}"))?
+                };
                 if ipa.trim().is_empty() {
                     return Err("no phonemes produced for input (empty after G2P)".into());
                 }
@@ -619,6 +640,7 @@ mod tests {
         let mut state = LoopState {
             kokoro: None,
             vosk: tts::sessions::VoskCache::new(),
+            charsiu: tts::sessions::CharsiuCache::new(),
         };
 
         let err = handle(&req, &mut state).unwrap_err();

--- a/rust/src/tts/charsiu/decode.rs
+++ b/rust/src/tts/charsiu/decode.rs
@@ -94,6 +94,7 @@ pub fn greedy(
 
     // --- Steps 1..MAX: decoder_with_past_model ---
     let mut last_token = next;
+    let mut hit_eos = false;
     for _ in 1..MAX_STEPS {
         let mut inputs = ort::inputs![
             "input_ids" => Value::from_array(Array2::<i64>::from_shape_vec((1, 1), vec![last_token])?)?,
@@ -122,6 +123,7 @@ pub fn greedy(
         let out = decoder_past.run(inputs)?;
         let next = argmax_last_logit(&out["logits"])?;
         if next == EOS_ID {
+            hit_eos = true;
             break;
         }
         generated.push(next);
@@ -134,6 +136,12 @@ pub fn greedy(
         }
     }
 
+    if !hit_eos {
+        // Loop exhausted the cap without an EOS — the IPA is truncated, which
+        // surfaces as a clipped/mispronounced tail rather than an error. One
+        // boundary trace (lazy, #313) so it's diagnosable; not per-token.
+        crate::dtrace!("charsiu::decode hit MAX_STEPS={MAX_STEPS} without EOS; IPA may be truncated");
+    }
     Ok(generated)
 }
 

--- a/rust/src/tts/charsiu/decode.rs
+++ b/rust/src/tts/charsiu/decode.rs
@@ -1,0 +1,177 @@
+//! KV-cache autoregressive greedy decode over the three CharsiuG2P sessions.
+//!
+//! Threading (IO contract #185 §3, byt5-tiny config: 4 layers, 6 heads, d_kv=64):
+//!
+//! - **Step 0** runs `decoder_model` with `decoder_start_token_id` (0) and the
+//!   encoder outputs. It emits 16 present tensors:
+//!   `present.{0..3}.{decoder,encoder}.{key,value}`. We seed the 8 encoder K/V
+//!   (constant for the whole decode) and the 8 decoder K/V (which grow each step).
+//! - **Steps 1..MAX** run `decoder_with_past_model` with the single last token,
+//!   the 8 constant encoder K/V re-fed verbatim, and the 8 rolling decoder K/V.
+//!   It emits ONLY 8 decoder presents (`present.{0..3}.decoder.{key,value}`),
+//!   each one row longer; we adopt them as the next step's decoder past.
+//!
+//! Stops on EOS (1) or after [`MAX_STEPS`]. Returns generated ids (start token
+//! excluded), EOS excluded.
+
+use anyhow::Result;
+use ndarray::{Array2, Array3, Array4};
+use ort::session::Session;
+use ort::value::Value;
+
+use super::tokenizer::EOS_ID;
+
+/// byt5-tiny decoder start token id (#185 §3).
+const DECODER_START_TOKEN_ID: i64 = 0;
+/// Number of decoder layers in byt5-tiny (#185 §3).
+const NUM_LAYERS: usize = 4;
+/// Hard cap on generated tokens. IPA words are short; this guards a runaway decode.
+const MAX_STEPS: usize = 128;
+
+/// One layer's cached key/value pair, shape [B, num_heads, seq, d_kv].
+struct LayerKv {
+    key: Array4<f32>,
+    value: Array4<f32>,
+}
+
+/// Greedy-decode `input_ids` (already tag-prefixed + EOS-terminated) to output token ids.
+pub fn greedy(
+    encoder: &mut Session,
+    decoder: &mut Session,
+    decoder_past: &mut Session,
+    input_ids: &[i64],
+) -> Result<Vec<i64>> {
+    anyhow::ensure!(!input_ids.is_empty(), "input_ids must be non-empty");
+    let s_enc = input_ids.len();
+
+    // --- Encode once ---
+    let enc_ids = Value::from_array(Array2::<i64>::from_shape_vec(
+        (1, s_enc),
+        input_ids.to_vec(),
+    )?)?;
+    let enc_mask_vec = vec![1_i64; s_enc];
+    let enc_mask = Value::from_array(Array2::<i64>::from_shape_vec(
+        (1, s_enc),
+        enc_mask_vec.clone(),
+    )?)?;
+    let enc_out = encoder.run(ort::inputs![
+        "input_ids" => enc_ids,
+        "attention_mask" => enc_mask,
+    ])?;
+    let (eh_shape, eh_data) = enc_out["last_hidden_state"].try_extract_tensor::<f32>()?;
+    let d_model = eh_shape[2] as usize;
+    let encoder_hidden = Array3::<f32>::from_shape_vec((1, s_enc, d_model), eh_data.to_vec())?;
+
+    // --- Step 0: decoder_model, seeds all 16 presents ---
+    let start = Array2::<i64>::from_shape_vec((1, 1), vec![DECODER_START_TOKEN_ID])?;
+    let step0_out = decoder.run(ort::inputs![
+        "input_ids" => Value::from_array(start)?,
+        "encoder_attention_mask" => Value::from_array(Array2::<i64>::from_shape_vec((1, s_enc), enc_mask_vec.clone())?)?,
+        "encoder_hidden_states" => Value::from_array(encoder_hidden)?,
+    ])?;
+
+    let mut generated: Vec<i64> = Vec::new();
+    let next = argmax_last_logit(&step0_out["logits"])?;
+    if next == EOS_ID {
+        return Ok(generated);
+    }
+    generated.push(next);
+
+    // Seed constant encoder K/V and rolling decoder K/V from step 0's presents.
+    let mut encoder_kv: Vec<LayerKv> = Vec::with_capacity(NUM_LAYERS);
+    let mut decoder_kv: Vec<LayerKv> = Vec::with_capacity(NUM_LAYERS);
+    for layer in 0..NUM_LAYERS {
+        encoder_kv.push(LayerKv {
+            key: extract_kv(&step0_out, &format!("present.{layer}.encoder.key"))?,
+            value: extract_kv(&step0_out, &format!("present.{layer}.encoder.value"))?,
+        });
+        decoder_kv.push(LayerKv {
+            key: extract_kv(&step0_out, &format!("present.{layer}.decoder.key"))?,
+            value: extract_kv(&step0_out, &format!("present.{layer}.decoder.value"))?,
+        });
+    }
+    drop(step0_out);
+
+    // --- Steps 1..MAX: decoder_with_past_model ---
+    let mut last_token = next;
+    for _ in 1..MAX_STEPS {
+        let mut inputs = ort::inputs![
+            "input_ids" => Value::from_array(Array2::<i64>::from_shape_vec((1, 1), vec![last_token])?)?,
+            "encoder_attention_mask" => Value::from_array(Array2::<i64>::from_shape_vec((1, s_enc), enc_mask_vec.clone())?)?,
+        ];
+        // 16 past_key_values: 8 constant encoder + 8 rolling decoder.
+        for (layer, (dec, enc)) in decoder_kv.iter().zip(encoder_kv.iter()).enumerate() {
+            inputs.push((
+                format!("past_key_values.{layer}.decoder.key").into(),
+                Value::from_array(dec.key.clone())?.into(),
+            ));
+            inputs.push((
+                format!("past_key_values.{layer}.decoder.value").into(),
+                Value::from_array(dec.value.clone())?.into(),
+            ));
+            inputs.push((
+                format!("past_key_values.{layer}.encoder.key").into(),
+                Value::from_array(enc.key.clone())?.into(),
+            ));
+            inputs.push((
+                format!("past_key_values.{layer}.encoder.value").into(),
+                Value::from_array(enc.value.clone())?.into(),
+            ));
+        }
+
+        let out = decoder_past.run(inputs)?;
+        let next = argmax_last_logit(&out["logits"])?;
+        if next == EOS_ID {
+            break;
+        }
+        generated.push(next);
+        last_token = next;
+
+        // Adopt the 8 decoder presents as the next step's decoder past.
+        for (layer, kv) in decoder_kv.iter_mut().enumerate() {
+            kv.key = extract_kv(&out, &format!("present.{layer}.decoder.key"))?;
+            kv.value = extract_kv(&out, &format!("present.{layer}.decoder.value"))?;
+        }
+    }
+
+    Ok(generated)
+}
+
+/// Argmax over the vocab axis of the last decode position. Logits shape [1, S, V].
+fn argmax_last_logit(logits: &Value) -> Result<i64> {
+    let (shape, data) = logits.try_extract_tensor::<f32>()?;
+    anyhow::ensure!(
+        shape.len() == 3,
+        "expected logits rank 3 [B,S,V], got shape {shape:?}"
+    );
+    let s = shape[1] as usize;
+    let v = shape[2] as usize;
+    anyhow::ensure!(s >= 1 && v >= 1, "empty logits, shape {shape:?}");
+    // Last position's row of length v.
+    let row = &data[(s - 1) * v..s * v];
+    let mut best = 0_usize;
+    let mut best_val = row[0];
+    for (i, &val) in row.iter().enumerate().skip(1) {
+        if val > best_val {
+            best_val = val;
+            best = i;
+        }
+    }
+    Ok(best as i64)
+}
+
+/// Extract a 4-D KV tensor [B, num_heads, seq, d_kv] from a named output.
+fn extract_kv(outputs: &ort::session::SessionOutputs, name: &str) -> Result<Array4<f32>> {
+    let (shape, data) = outputs[name].try_extract_tensor::<f32>()?;
+    anyhow::ensure!(
+        shape.len() == 4,
+        "expected KV rank 4 for {name}, got shape {shape:?}"
+    );
+    let dims = (
+        shape[0] as usize,
+        shape[1] as usize,
+        shape[2] as usize,
+        shape[3] as usize,
+    );
+    Ok(Array4::<f32>::from_shape_vec(dims, data.to_vec())?)
+}

--- a/rust/src/tts/charsiu/decode.rs
+++ b/rust/src/tts/charsiu/decode.rs
@@ -140,7 +140,9 @@ pub fn greedy(
         // Loop exhausted the cap without an EOS — the IPA is truncated, which
         // surfaces as a clipped/mispronounced tail rather than an error. One
         // boundary trace (lazy, #313) so it's diagnosable; not per-token.
-        crate::dtrace!("charsiu::decode hit MAX_STEPS={MAX_STEPS} without EOS; IPA may be truncated");
+        crate::dtrace!(
+            "charsiu::decode hit MAX_STEPS={MAX_STEPS} without EOS; IPA may be truncated"
+        );
     }
     Ok(generated)
 }

--- a/rust/src/tts/charsiu/mod.rs
+++ b/rust/src/tts/charsiu/mod.rs
@@ -6,12 +6,6 @@
 //! the 8 encoder K/V stay constant). Output IPA is remapped into Kokoro's
 //! phoneme inventory (see [`remap`]). IO contract from #185 §3.
 //!
-// The decode engine is complete and fully exercised by the gated lib test
-// (`CHARSIU_ONNX`). The CLI `say`/g2p caller lands in the next Track-B task, so
-// the public surface reads as dead code to the `bin` target until then; allow it
-// module-wide rather than scattering per-item suppressions.
-#![allow(dead_code)]
-
 use std::path::Path;
 
 use anyhow::Result;

--- a/rust/src/tts/charsiu/mod.rs
+++ b/rust/src/tts/charsiu/mod.rs
@@ -1,2 +1,115 @@
+//! CharsiuG2P: multilingual byte-level G2P via a ByT5-tiny seq2seq ONNX model.
+//!
+//! Three `ort` sessions implement the KV-cache autoregressive decode:
+//! `encoder_model` (once), `decoder_model` (step 0, seeds all 16 KV presents),
+//! and `decoder_with_past_model` (steps 1..N, 8 rolling decoder presents while
+//! the 8 encoder K/V stay constant). Output IPA is remapped into Kokoro's
+//! phoneme inventory (see [`remap`]). IO contract from #185 §3.
+//!
+// The decode engine is complete and fully exercised by the gated lib test
+// (`CHARSIU_ONNX`). The CLI `say`/g2p caller lands in the next Track-B task, so
+// the public surface reads as dead code to the `bin` target until then; allow it
+// module-wide rather than scattering per-item suppressions.
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use anyhow::Result;
+use ort::session::Session;
+
+pub(crate) mod decode;
 pub(crate) mod remap;
 pub(crate) mod tokenizer;
+
+/// CharsiuG2P phonemizer holding the three decode sessions.
+pub struct Charsiu {
+    encoder: Session,
+    decoder: Session,
+    decoder_past: Session,
+}
+
+impl Charsiu {
+    /// Open the three ONNX sessions from a model directory containing
+    /// `encoder_model.onnx`, `decoder_model.onnx`, `decoder_with_past_model.onnx`.
+    pub fn load(dir: &Path) -> Result<Self> {
+        let open = |name: &str| -> Result<Session> {
+            let path = dir.join(name);
+            Session::builder()
+                .map_err(|e| anyhow::anyhow!("ort: failed to create session builder: {e}"))?
+                .commit_from_file(&path)
+                .map_err(|e| anyhow::anyhow!("ort: failed to load {}: {e}", path.display()))
+        };
+        Ok(Self {
+            encoder: open("encoder_model.onnx")?,
+            decoder: open("decoder_model.onnx")?,
+            decoder_past: open("decoder_with_past_model.onnx")?,
+        })
+    }
+
+    /// Phonemize `text` in language `lang` into Kokoro-vocab IPA.
+    ///
+    /// Splits on whitespace, runs the KV-cache greedy decode per word, decodes
+    /// the byte ids, remaps to Kokoro's inventory, and rejoins with spaces.
+    /// Supported langs map to CharsiuG2P tags: `es`→`<spa>`, `fr`→`<fra>`,
+    /// `it`→`<ita>`, `pt`→`<por-bz>`. Other langs bail.
+    // `&mut self` is required: ort `Session::run` mutates the session. The `to_`
+    // name reflects the conversion semantics, so silence wrong_self_convention.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_ipa(&mut self, text: &str, lang: &str) -> Result<String> {
+        let tag = match lang {
+            "es" => "<spa>",
+            "fr" => "<fra>",
+            "it" => "<ita>",
+            "pt" => "<por-bz>",
+            other => anyhow::bail!("CharsiuG2P: unsupported language {other:?}"),
+        };
+
+        let mut words = Vec::new();
+        for word in text.split_whitespace() {
+            let input_ids = tokenizer::encode_with_tag(word, tag);
+            let out_ids = decode::greedy(
+                &mut self.encoder,
+                &mut self.decoder,
+                &mut self.decoder_past,
+                &input_ids,
+            )?;
+            let raw = tokenizer::decode(&out_ids);
+            words.push(remap::remap(&raw));
+        }
+        Ok(words.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Gated on CHARSIU_ONNX env var. Skipped when unset so default CI stays fast.
+    #[test]
+    fn to_ipa_phonemizes_when_model_available() {
+        let Some(dir) = std::env::var_os("CHARSIU_ONNX") else {
+            eprintln!("CHARSIU_ONNX not set; skipping");
+            return;
+        };
+        let mut g = Charsiu::load(std::path::Path::new(&dir)).unwrap();
+        // Authoritative #185 reference: French "bonjour" → "bɔ̃ʒuʁ".
+        assert_eq!(g.to_ipa("bonjour", "fr").unwrap(), "bɔ̃ʒuʁ");
+        // Spanish/Italian/Portuguese: non-empty AND zero-OOV after remap.
+        let vocab = crate::tts::tokenizer::Tokenizer::load().unwrap();
+        for (w, lang) in [
+            ("hola", "es"),
+            ("mundo", "es"),
+            ("cucina", "it"),
+            ("jabuti", "pt"),
+        ] {
+            let ipa = g.to_ipa(w, lang).unwrap();
+            assert!(!ipa.is_empty(), "empty IPA for {w}");
+            let nonspace = ipa.chars().filter(|c| !c.is_whitespace()).count();
+            assert_eq!(
+                vocab.encode(&ipa).len(),
+                nonspace,
+                "OOV leaked: {w} -> {ipa:?}"
+            );
+        }
+    }
+}

--- a/rust/src/tts/charsiu/mod.rs
+++ b/rust/src/tts/charsiu/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod remap;
+pub(crate) mod tokenizer;

--- a/rust/src/tts/charsiu/remap.rs
+++ b/rust/src/tts/charsiu/remap.rs
@@ -3,8 +3,6 @@
 //! in-vocab equivalents. Locked by a zero-residual-OOV regression test.
 
 /// Remap CharsiuG2P IPA into Kokoro's phoneme inventory.
-// Callers land in the next task (Charsiu struct + G2P pipeline).
-#[allow(dead_code)]
 pub fn remap(ipa: &str) -> String {
     ipa.replace("t͡s", "ʦ")
         .replace("t͡ʃ", "ʧ")

--- a/rust/src/tts/charsiu/remap.rs
+++ b/rust/src/tts/charsiu/remap.rs
@@ -1,0 +1,55 @@
+//! CharsiuG2P → Kokoro-vocab IPA remap. Ported from the spike (PR #507).
+//! CharsiuG2P emits a few symbols Kokoro's vocab lacks; map them to the
+//! in-vocab equivalents. Locked by a zero-residual-OOV regression test.
+
+/// Remap CharsiuG2P IPA into Kokoro's phoneme inventory.
+// Callers land in the next task (Charsiu struct + G2P pipeline).
+#[allow(dead_code)]
+pub fn remap(ipa: &str) -> String {
+    ipa.replace("t͡s", "ʦ")
+        .replace("t͡ʃ", "ʧ")
+        .replace("d͡ʒ", "ʤ")
+        .replace('\u{0067}', "\u{0261}") // Latin g -> script ɡ
+        .replace('õ', "o\u{0303}")
+        .replace('ũ', "u\u{0303}")
+        .replace('ẽ', "e\u{0303}")
+        .replace('\u{0361}', "") // drop any residual standalone tie bar
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_tie_bar_affricates() {
+        assert_eq!(remap("a t͡s b"), "a ʦ b");
+        assert_eq!(remap("d͡ʒusto"), "ʤusto");
+        assert_eq!(remap("t͡ʃiko"), "ʧiko");
+    }
+
+    #[test]
+    fn normalizes_latin_g_to_script_g() {
+        assert_eq!(remap("gato"), "ɡato"); // U+0067 -> U+0261
+    }
+
+    #[test]
+    fn decomposes_precomposed_nasals_to_nfd() {
+        assert_eq!(remap("õ"), "o\u{0303}");
+        assert_eq!(remap("ũ"), "u\u{0303}");
+        assert_eq!(remap("ẽ"), "e\u{0303}");
+    }
+
+    #[test]
+    fn remapped_output_has_zero_oov_vs_kokoro_vocab() {
+        let vocab = crate::tts::tokenizer::Tokenizer::load().unwrap();
+        for s in ["t͡salat͡so", "d͡ʒusto", "gato", "kõsiderasõw", "t͡ʃiko"] {
+            let mapped = remap(s);
+            let nonspace = mapped.chars().filter(|c| !c.is_whitespace()).count();
+            assert_eq!(
+                vocab.encode(&mapped).len(),
+                nonspace,
+                "OOV leaked for {s:?} -> {mapped:?}"
+            );
+        }
+    }
+}

--- a/rust/src/tts/charsiu/tokenizer.rs
+++ b/rust/src/tts/charsiu/tokenizer.rs
@@ -3,18 +3,12 @@
 //! sentencepiece — encode/decode are pure byte arithmetic.
 
 /// ByT5 reserves ids 0..3 (pad=0, eos=1, unk=2) and offsets bytes by 3 (#185 §2).
-// Callers land in the next task (Charsiu struct + decode pipeline).
-#[allow(dead_code)]
 pub const BYTE_OFFSET: i64 = 3;
 /// EOS token id (#185 §2).
-// Callers land in the next task (Charsiu struct + decode pipeline).
-#[allow(dead_code)]
 pub const EOS_ID: i64 = 1;
 
 /// Encode `"<tag>: text"` into ByT5 byte ids with a trailing EOS.
 /// The `": "` separator matches CharsiuG2P's training format (#185 §4, e.g. `"<spa>: hola"`).
-// Callers land in the next task (Charsiu struct + decode pipeline).
-#[allow(dead_code)]
 pub fn encode_with_tag(text: &str, tag: &str) -> Vec<i64> {
     let mut ids: Vec<i64> = format!("{tag}: {text}")
         .bytes()
@@ -25,8 +19,6 @@ pub fn encode_with_tag(text: &str, tag: &str) -> Vec<i64> {
 }
 
 /// Decode generated ids back to a UTF-8 string, dropping reserved ids.
-// Callers land in the next task (Charsiu struct + decode pipeline).
-#[allow(dead_code)]
 pub fn decode(ids: &[i64]) -> String {
     let bytes: Vec<u8> = ids
         .iter()

--- a/rust/src/tts/charsiu/tokenizer.rs
+++ b/rust/src/tts/charsiu/tokenizer.rs
@@ -1,0 +1,63 @@
+//! ByT5 byte-level tokenizer for CharsiuG2P. ByT5 maps each UTF-8 byte to
+//! `byte + BYTE_OFFSET`; the first ids are reserved (pad/eos/unk). No
+//! sentencepiece — encode/decode are pure byte arithmetic.
+
+/// ByT5 reserves ids 0..3 (pad=0, eos=1, unk=2) and offsets bytes by 3 (#185 §2).
+// Callers land in the next task (Charsiu struct + decode pipeline).
+#[allow(dead_code)]
+pub const BYTE_OFFSET: i64 = 3;
+/// EOS token id (#185 §2).
+// Callers land in the next task (Charsiu struct + decode pipeline).
+#[allow(dead_code)]
+pub const EOS_ID: i64 = 1;
+
+/// Encode `"<tag>: text"` into ByT5 byte ids with a trailing EOS.
+/// The `": "` separator matches CharsiuG2P's training format (#185 §4, e.g. `"<spa>: hola"`).
+// Callers land in the next task (Charsiu struct + decode pipeline).
+#[allow(dead_code)]
+pub fn encode_with_tag(text: &str, tag: &str) -> Vec<i64> {
+    let mut ids: Vec<i64> = format!("{tag}: {text}")
+        .bytes()
+        .map(|b| b as i64 + BYTE_OFFSET)
+        .collect();
+    ids.push(EOS_ID);
+    ids
+}
+
+/// Decode generated ids back to a UTF-8 string, dropping reserved ids.
+// Callers land in the next task (Charsiu struct + decode pipeline).
+#[allow(dead_code)]
+pub fn decode(ids: &[i64]) -> String {
+    let bytes: Vec<u8> = ids
+        .iter()
+        .filter(|&&id| id >= BYTE_OFFSET)
+        .map(|&id| (id - BYTE_OFFSET) as u8)
+        .collect();
+    String::from_utf8_lossy(&bytes).trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_ascii_as_bytes_plus_offset_with_eos() {
+        let ids = encode_with_tag("hi", "<spa>");
+        assert_eq!(*ids.last().unwrap(), EOS_ID);
+        // 'h'=104 -> 107, 'i'=105 -> 108 appear in order before EOS.
+        assert!(
+            ids.windows(2).any(|w| w == [107, 108]),
+            "expected h,i byte tokens: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn decodes_byte_ids_back_to_utf8() {
+        assert_eq!(decode(&[107, 108]), "hi");
+    }
+
+    #[test]
+    fn decode_skips_special_ids() {
+        assert_eq!(decode(&[EOS_ID, 107, 108]), "hi");
+    }
+}

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -23,20 +23,10 @@ pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
     // Romance languages: normalize then CharsiuG2P (ONNX ByT5-tiny, #212).
     if matches!(lower.as_str(), "es" | "fr" | "it" | "pt") {
         crate::dtrace!("g2p::route lang={lang} backend=charsiu text_chars={text_chars}");
-        let normalized = crate::tts::normalize::normalize(text, &lower);
         let dir = crate::models::cache_dir().join("models/g2p/byt5-tiny");
-        let required = [
-            "encoder_model.onnx",
-            "decoder_model.onnx",
-            "decoder_with_past_model.onnx",
-        ];
-        for file in &required {
-            if !dir.join(file).exists() {
-                anyhow::bail!("G2P model not installed. Run `kesha install --tts` to download.");
-            }
-        }
+        check_charsiu_files(&dir)?;
         let mut g = crate::tts::charsiu::Charsiu::load(&dir)?;
-        let ipa = g.to_ipa(&normalized, &lower)?;
+        let ipa = charsiu_ipa(&mut g, text, &lower)?;
         crate::dtrace!("g2p::result ipa_chars={}", ipa.chars().count());
         return Ok(ipa);
     }
@@ -57,6 +47,34 @@ pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
     let ipa = misaki_to_ipa(text, misaki_lang)?;
     crate::dtrace!("g2p::result ipa_chars={}", ipa.chars().count());
     Ok(ipa)
+}
+
+/// Check that the three required Charsiu ONNX files exist in `dir`.
+/// Returns a user-facing error pointing at `kesha install --tts` if any are missing.
+pub(crate) fn check_charsiu_files(dir: &std::path::Path) -> Result<()> {
+    let required = [
+        "encoder_model.onnx",
+        "decoder_model.onnx",
+        "decoder_with_past_model.onnx",
+    ];
+    for file in &required {
+        if !dir.join(file).exists() {
+            anyhow::bail!("G2P model not installed. Run `kesha install --tts` to download.");
+        }
+    }
+    Ok(())
+}
+
+/// Normalize `text` for `lang` then run CharsiuG2P on the already-loaded session.
+/// Shared by the one-shot path (`text_to_ipa`) and the cached loop path
+/// (`CharsiuCache::to_ipa`).
+pub(crate) fn charsiu_ipa(
+    g: &mut crate::tts::charsiu::Charsiu,
+    text: &str,
+    lang: &str,
+) -> Result<String> {
+    let normalized = crate::tts::normalize::normalize(text, lang);
+    g.to_ipa(&normalized, lang)
 }
 
 /// Run misaki-rs and strip the U+200D zero-width joiners it inserts for

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -1,16 +1,17 @@
 //! Grapheme-to-phoneme dispatch.
 //!
-//! Post #213: only English uses our G2P (misaki-rs embedded lexicon + POS).
-//! Russian routes through Vosk's internal G2P inside `tts::vosk`. Other
-//! languages are not supported by the on-disk engines we ship today.
-//! CharsiuG2P (ONNX ByT5-tiny) and espeak-ng (subprocess) were both removed
-//! in PR #213 — see the spec for the migration trail.
+//! Post #213: English uses our G2P (misaki-rs embedded lexicon + POS).
+//! Russian routes through Vosk's internal G2P inside `tts::vosk`.
+//! Romance languages (es/fr/it/pt) route through CharsiuG2P (ONNX ByT5-tiny)
+//! after text normalisation (#212).
 
 use anyhow::Result;
 
 /// Convert `text` to IPA for the given espeak-style language code.
-/// Only English is supported; everything else errors with a pointer to the
-/// engine-specific G2P (Russian → use a `ru-vosk-*` voice; others → not yet).
+///
+/// - `en`/`en-us`/`en-gb`/`en-uk` → misaki-rs
+/// - `es`/`fr`/`it`/`pt` → normalize → CharsiuG2P (byt5-tiny ONNX)
+/// - `ru` and others → error with a pointer to the engine-specific G2P
 pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
     let text_chars = text.chars().count();
     if text.trim().is_empty() {
@@ -18,6 +19,28 @@ pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
         return Ok(String::new());
     }
     let lower = lang.to_ascii_lowercase();
+
+    // Romance languages: normalize then CharsiuG2P (ONNX ByT5-tiny, #212).
+    if matches!(lower.as_str(), "es" | "fr" | "it" | "pt") {
+        crate::dtrace!("g2p::route lang={lang} backend=charsiu text_chars={text_chars}");
+        let normalized = crate::tts::normalize::normalize(text, &lower);
+        let dir = crate::models::cache_dir().join("models/g2p/byt5-tiny");
+        let required = [
+            "encoder_model.onnx",
+            "decoder_model.onnx",
+            "decoder_with_past_model.onnx",
+        ];
+        for file in &required {
+            if !dir.join(file).exists() {
+                anyhow::bail!("G2P model not installed. Run `kesha install --tts` to download.");
+            }
+        }
+        let mut g = crate::tts::charsiu::Charsiu::load(&dir)?;
+        let ipa = g.to_ipa(&normalized, &lower)?;
+        crate::dtrace!("g2p::result ipa_chars={}", ipa.chars().count());
+        return Ok(ipa);
+    }
+
     let misaki_lang = match lower.as_str() {
         "en" | "en-us" => misaki_rs::Language::EnglishUS,
         "en-gb" | "en-uk" => misaki_rs::Language::EnglishGB,
@@ -95,13 +118,24 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_language_errors_with_pointer() {
-        let err = text_to_ipa("bonjour", "fr").unwrap_err().to_string();
-        assert!(err.contains("fr"), "msg: {err}");
-        assert!(
-            err.contains("212") || err.contains("supported"),
-            "msg: {err}"
-        );
+    fn romance_langs_route_to_charsiu_not_212_bail() {
+        for lang in ["es", "fr", "it", "pt"] {
+            match text_to_ipa("hola", lang) {
+                Ok(ipa) => assert!(!ipa.is_empty(), "{lang}: empty IPA"), // model present (dev)
+                Err(e) => {
+                    // model absent (CI)
+                    let m = e.to_string();
+                    assert!(
+                        m.contains("install") || m.contains("G2P"),
+                        "{lang}: unexpected err: {m}"
+                    );
+                    assert!(
+                        !m.contains("not supported in this build") && !m.contains("212"),
+                        "{lang}: still bails to #212: {m}"
+                    );
+                }
+            }
+        }
     }
 
     /// Locks the letter-spell fallback behavior we ship in v1.4.x — without

--- a/rust/src/tts/kokoro.rs
+++ b/rust/src/tts/kokoro.rs
@@ -53,13 +53,34 @@ impl Kokoro {
         ])?;
 
         let (_shape, data) = outputs["audio"].try_extract_tensor::<f32>()?;
-        Ok(data.to_vec())
+        Ok(clamp_audio(data.to_vec()))
     }
+}
+
+/// Clamp each sample to `[-1.0, 1.0]`.
+///
+/// Kokoro can produce |sample| > 1.0 on multilingual voices (observed on
+/// French voices in the Track-B spike). WAV float files technically allow
+/// any value, but downstream re-encoders (Opus, FLAC) and players clip
+/// at ±1.0, producing hard distortion. Clamping here is the single
+/// choke-point that protects every downstream format.
+pub fn clamp_audio(mut samples: Vec<f32>) -> Vec<f32> {
+    for s in &mut samples {
+        *s = s.clamp(-1.0, 1.0);
+    }
+    samples
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clamp_keeps_samples_in_range() {
+        let out = clamp_audio(vec![-1.5, -0.2, 0.5, 1.8]);
+        assert!(out.iter().all(|s| (-1.0..=1.0).contains(s)), "{out:?}");
+        assert_eq!(out[1], -0.2);
+    }
 
     /// Gated on KOKORO_MODEL env var. Skipped when unset so default CI stays fast.
     #[test]

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -8,6 +8,7 @@
 
 use std::path::Path;
 
+pub mod charsiu;
 pub mod en;
 pub mod encode;
 #[cfg(all(

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -19,6 +19,7 @@ pub mod encode;
 pub mod fluid_kokoro;
 pub mod g2p;
 pub mod kokoro;
+pub mod normalize;
 pub mod ru;
 pub mod say;
 pub mod sessions;

--- a/rust/src/tts/normalize/acronyms.rs
+++ b/rust/src/tts/normalize/acronyms.rs
@@ -1,0 +1,187 @@
+//! Per-language letter-name spelling for all-caps acronym tokens.
+// The CLI g2p caller lands in a later task; allow dead code until then.
+#![allow(dead_code)]
+
+// ── Letter-name tables ────────────────────────────────────────────────────────
+
+/// Spanish letter names (a-z).
+/// Source: Real Academia Española standard names.
+const ES_LETTERS: [(&str, &str); 27] = [
+    ("A", "a"),
+    ("B", "be"),
+    ("C", "ce"),
+    ("D", "de"),
+    ("E", "e"),
+    ("F", "efe"),
+    ("G", "ge"),
+    ("H", "hache"),
+    ("I", "i"),
+    ("J", "jota"),
+    ("K", "ka"),
+    ("L", "ele"),
+    ("M", "eme"),
+    ("N", "ene"),
+    ("O", "o"),
+    ("P", "pe"),
+    ("Q", "cu"),
+    ("R", "erre"),
+    ("S", "ese"),
+    ("T", "te"),
+    ("U", "u"),
+    ("V", "uve"),
+    ("W", "uve doble"),
+    ("X", "equis"),
+    ("Y", "i griega"),
+    ("Z", "zeta"),
+    // Ñ is not typically in acronyms but include for completeness
+    ("Ñ", "eñe"),
+];
+
+/// French letter names (a-z).
+/// Source: standard French alphabet letter names.
+const FR_LETTERS: [(&str, &str); 26] = [
+    ("A", "a"),
+    ("B", "bé"),
+    ("C", "cé"),
+    ("D", "dé"),
+    ("E", "e"),
+    ("F", "effe"),
+    ("G", "gé"),
+    ("H", "ache"),
+    ("I", "i"),
+    ("J", "ji"),
+    ("K", "ka"),
+    ("L", "elle"),
+    ("M", "emme"),
+    ("N", "enne"),
+    ("O", "o"),
+    ("P", "pé"),
+    ("Q", "ku"),
+    ("R", "erre"),
+    ("S", "esse"),
+    ("T", "té"),
+    ("U", "u"),
+    ("V", "vé"),
+    ("W", "double vé"),
+    ("X", "ixe"),
+    ("Y", "i grec"),
+    ("Z", "zède"),
+];
+
+/// Italian letter names (a-z).
+/// Source: standard Italian alphabet letter names.
+const IT_LETTERS: [(&str, &str); 21] = [
+    ("A", "a"),
+    ("B", "bi"),
+    ("C", "ci"),
+    ("D", "di"),
+    ("E", "e"),
+    ("F", "effe"),
+    ("G", "gi"),
+    ("H", "acca"),
+    ("I", "i"),
+    ("L", "elle"),
+    ("M", "emme"),
+    ("N", "enne"),
+    ("O", "o"),
+    ("P", "pi"),
+    ("Q", "cu"),
+    ("R", "erre"),
+    ("S", "esse"),
+    ("T", "ti"),
+    ("U", "u"),
+    ("V", "vi"),
+    ("Z", "zeta"),
+];
+
+/// Portuguese letter names (a-z).
+/// Source: standard Portuguese alphabet letter names.
+const PT_LETTERS: [(&str, &str); 26] = [
+    ("A", "á"),
+    ("B", "bê"),
+    ("C", "cê"),
+    ("D", "dê"),
+    ("E", "é"),
+    ("F", "efe"),
+    ("G", "gê"),
+    ("H", "agá"),
+    ("I", "i"),
+    ("J", "jota"),
+    ("K", "cá"),
+    ("L", "ele"),
+    ("M", "eme"),
+    ("N", "ene"),
+    ("O", "ó"),
+    ("P", "pê"),
+    ("Q", "quê"),
+    ("R", "erre"),
+    ("S", "esse"),
+    ("T", "tê"),
+    ("U", "u"),
+    ("V", "vê"),
+    ("W", "dáblio"),
+    ("X", "xis"),
+    ("Y", "ípsilon"),
+    ("Z", "zê"),
+];
+
+fn lookup_letter(ch: char, table: &[(&str, &str)]) -> String {
+    let s = ch.to_string();
+    table
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(&s))
+        .map(|(_, v)| v.to_string())
+        .unwrap_or_else(|| ch.to_lowercase().to_string())
+}
+
+/// Returns true if `token` is a candidate for letter-by-letter spelling.
+/// Mirrors `en/acronym.rs::is_acronym_token`: all-caps, length 2..=5.
+pub fn is_acronym_token(token: &str) -> bool {
+    let len = token.chars().count();
+    if !(2..=5).contains(&len) {
+        return false;
+    }
+    token.chars().all(|c| c.is_ascii_uppercase())
+}
+
+/// Spell `token` letter-by-letter using the language's standard letter names.
+///
+/// `token` should be the punct-stripped core (all ASCII uppercase, 2..=5 chars).
+/// Letter names are joined with spaces. Unknown languages fall back to lowercased
+/// individual characters joined with spaces.
+pub fn spell(token: &str, lang: &str) -> String {
+    let names: Vec<String> = match lang {
+        "es" => token
+            .chars()
+            .map(|c| lookup_letter(c, &ES_LETTERS))
+            .collect(),
+        "fr" => token
+            .chars()
+            .map(|c| lookup_letter(c, &FR_LETTERS))
+            .collect(),
+        "it" => token
+            .chars()
+            .map(|c| lookup_letter(c, &IT_LETTERS))
+            .collect(),
+        "pt" => token
+            .chars()
+            .map(|c| lookup_letter(c, &PT_LETTERS))
+            .collect(),
+        _ => token
+            .chars()
+            .map(|c| c.to_lowercase().to_string())
+            .collect(),
+    };
+    names.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spells_acronyms_with_spanish_letter_names() {
+        assert_eq!(spell("RAI", "es"), "erre a i");
+        assert_eq!(spell("IBGE", "pt"), "i bê gê é");
+    }
+}

--- a/rust/src/tts/normalize/acronyms.rs
+++ b/rust/src/tts/normalize/acronyms.rs
@@ -1,6 +1,4 @@
 //! Per-language letter-name spelling for all-caps acronym tokens.
-// The CLI g2p caller lands in a later task; allow dead code until then.
-#![allow(dead_code)]
 
 // ── Letter-name tables ────────────────────────────────────────────────────────
 

--- a/rust/src/tts/normalize/acronyms.rs
+++ b/rust/src/tts/normalize/acronyms.rs
@@ -68,7 +68,9 @@ const FR_LETTERS: [(&str, &str); 26] = [
 
 /// Italian letter names (a-z).
 /// Source: standard Italian alphabet letter names.
-const IT_LETTERS: [(&str, &str); 21] = [
+// Includes J/K/W/X/Y (not in the traditional 21-letter alphabet but common in
+// modern Italian acronyms — WC, OK, etc.); standard letter names. Greptile #509 P2.
+const IT_LETTERS: [(&str, &str); 26] = [
     ("A", "a"),
     ("B", "bi"),
     ("C", "ci"),
@@ -78,6 +80,8 @@ const IT_LETTERS: [(&str, &str); 21] = [
     ("G", "gi"),
     ("H", "acca"),
     ("I", "i"),
+    ("J", "i lunga"),
+    ("K", "cappa"),
     ("L", "elle"),
     ("M", "emme"),
     ("N", "enne"),
@@ -89,6 +93,9 @@ const IT_LETTERS: [(&str, &str); 21] = [
     ("T", "ti"),
     ("U", "u"),
     ("V", "vi"),
+    ("W", "doppia vu"),
+    ("X", "ics"),
+    ("Y", "ipsilon"),
     ("Z", "zeta"),
 ];
 
@@ -181,5 +188,13 @@ mod tests {
     fn spells_acronyms_with_spanish_letter_names() {
         assert_eq!(spell("RAI", "es"), "erre a i");
         assert_eq!(spell("IBGE", "pt"), "i bê gê é");
+    }
+
+    #[test]
+    fn spells_italian_acronyms_including_jkwxy() {
+        assert_eq!(spell("RAI", "it"), "erre a i");
+        // J/K/W/X/Y now resolve to standard Italian names, not raw-lowercase fallback.
+        assert_eq!(spell("WC", "it"), "doppia vu ci");
+        assert_eq!(spell("OK", "it"), "o cappa");
     }
 }

--- a/rust/src/tts/normalize/mod.rs
+++ b/rust/src/tts/normalize/mod.rs
@@ -40,9 +40,14 @@ fn split_punct(token: &str) -> (&str, &str, &str) {
 fn normalize_token(token: &str, lang: &str) -> String {
     let (head, core, tail) = split_punct(token);
 
-    // Integer token?
+    // Integer token? Only expand numbers in the 0..=999_999 band that the
+    // per-language word tables cover. Larger numbers (≥ 1_000_000) are left
+    // verbatim so the G2P / synth still receives *something* and never crashes.
     if let Ok(n) = core.parse::<u32>() {
-        return format!("{head}{}{tail}", to_words(n, lang));
+        if n <= 999_999 {
+            return format!("{head}{}{tail}", to_words(n, lang));
+        }
+        return token.to_string();
     }
 
     // Acronym token?
@@ -102,5 +107,21 @@ mod tests {
     #[test]
     fn normalize_leaves_english_untouched() {
         assert_eq!(normalize("hello 5", "en"), "hello 5");
+    }
+
+    #[test]
+    fn normalize_large_number_does_not_panic() {
+        // Numbers >= 1_000_000 are outside the word-table range; they must pass
+        // through verbatim rather than panicking.
+        let out = normalize("Año 1000000", "es");
+        assert!(
+            out.contains("1000000"),
+            "large number should be verbatim, got: {out}"
+        );
+        // Surrounding words and punctuation are still handled normally.
+        assert!(out.contains("Año"), "got: {out}");
+        // u32::MAX must also be safe.
+        let max = normalize("4294967295", "es");
+        assert!(max.contains("4294967295"), "got: {max}");
     }
 }

--- a/rust/src/tts/normalize/mod.rs
+++ b/rust/src/tts/normalize/mod.rs
@@ -1,0 +1,109 @@
+//! Per-language text normalizer: expands digits and all-caps acronyms before G2P.
+//!
+//! Supports es (Spanish), fr (French), it (Italian), pt (Portuguese).
+//! For any other language (including en) the text is returned unchanged —
+//! English normalization is handled upstream in `tts::en`.
+// The CLI g2p caller lands in a later task; allow dead code until then.
+#![allow(dead_code)]
+
+pub(crate) mod acronyms;
+pub(crate) mod numbers;
+
+use acronyms::{is_acronym_token, spell};
+use numbers::to_words;
+
+const TRAILING_PUNCT: &[char] = &[
+    '.', ',', ':', ';', '!', '?', '»', ')', '„', '"', '…', '—', '–', '-',
+];
+const LEADING_PUNCT: &[char] = &['«', '(', '"', '„'];
+
+/// Split a token into (leading_punct, core, trailing_punct).
+fn split_punct(token: &str) -> (&str, &str, &str) {
+    let start = token
+        .char_indices()
+        .find(|(_, c)| !LEADING_PUNCT.contains(c))
+        .map(|(i, _)| i)
+        .unwrap_or(token.len());
+    let rest = &token[start..];
+    let mut end = rest.len();
+    for (idx, c) in rest.char_indices().rev() {
+        if TRAILING_PUNCT.contains(&c) {
+            end = idx;
+        } else {
+            break;
+        }
+    }
+    let head = &token[..start];
+    let core = &rest[..end];
+    let tail = &rest[end..];
+    (head, core, tail)
+}
+
+/// Normalize one whitespace-separated token for lang ∈ {es, fr, it, pt}.
+fn normalize_token(token: &str, lang: &str) -> String {
+    let (head, core, tail) = split_punct(token);
+
+    // Integer token?
+    if let Ok(n) = core.parse::<u32>() {
+        return format!("{head}{}{tail}", to_words(n, lang));
+    }
+
+    // Acronym token?
+    if is_acronym_token(core) {
+        return format!("{head}{}{tail}", spell(core, lang));
+    }
+
+    // Pass through verbatim.
+    token.to_string()
+}
+
+/// Normalize `text` for the given language before G2P.
+///
+/// For lang ∈ {`"es"`, `"fr"`, `"it"`, `"pt"`}: walks whitespace-separated
+/// tokens, expanding integers to words and all-caps 2..=5 letter runs to their
+/// per-language letter names. Surrounding punctuation is preserved.
+///
+/// For any other language (including `"en"`): returns `text` unchanged.
+pub fn normalize(text: &str, lang: &str) -> String {
+    if !matches!(lang, "es" | "fr" | "it" | "pt") {
+        return text.to_string();
+    }
+
+    let mut result = String::with_capacity(text.len() + 32);
+    let mut tok_buf = String::new();
+
+    for c in text.chars() {
+        if c.is_whitespace() {
+            if !tok_buf.is_empty() {
+                result.push_str(&normalize_token(&tok_buf, lang));
+                tok_buf.clear();
+            }
+            result.push(c);
+        } else {
+            tok_buf.push(c);
+        }
+    }
+    if !tok_buf.is_empty() {
+        result.push_str(&normalize_token(&tok_buf, lang));
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_expands_digits_and_acronyms_es() {
+        let out = normalize("Compré 27 libros RAI", "es");
+        assert!(out.contains("veintisiete"), "got: {out}");
+        assert!(out.contains("erre a i"), "got: {out}");
+        assert!(!out.contains("27"), "digit leaked: {out}");
+    }
+
+    #[test]
+    fn normalize_leaves_english_untouched() {
+        assert_eq!(normalize("hello 5", "en"), "hello 5");
+    }
+}

--- a/rust/src/tts/normalize/mod.rs
+++ b/rust/src/tts/normalize/mod.rs
@@ -3,9 +3,6 @@
 //! Supports es (Spanish), fr (French), it (Italian), pt (Portuguese).
 //! For any other language (including en) the text is returned unchanged —
 //! English normalization is handled upstream in `tts::en`.
-// The CLI g2p caller lands in a later task; allow dead code until then.
-#![allow(dead_code)]
-
 pub(crate) mod acronyms;
 pub(crate) mod numbers;
 

--- a/rust/src/tts/normalize/numbers.rs
+++ b/rust/src/tts/normalize/numbers.rs
@@ -2,8 +2,6 @@
 //!
 //! Covers es (Spanish), fr (French), it (Italian), pt (Portuguese).
 //! Unknown languages return the digit string unchanged.
-// The CLI g2p caller lands in a later task; allow dead code until then.
-#![allow(dead_code)]
 
 // ── Spanish ──────────────────────────────────────────────────────────────────
 

--- a/rust/src/tts/normalize/numbers.rs
+++ b/rust/src/tts/normalize/numbers.rs
@@ -1,0 +1,467 @@
+//! Per-language integer → words conversion for 0..=999_999.
+//!
+//! Covers es (Spanish), fr (French), it (Italian), pt (Portuguese).
+//! Unknown languages return the digit string unchanged.
+// The CLI g2p caller lands in a later task; allow dead code until then.
+#![allow(dead_code)]
+
+// ── Spanish ──────────────────────────────────────────────────────────────────
+
+const ES_UNITS: [&str; 20] = [
+    "cero",
+    "uno",
+    "dos",
+    "tres",
+    "cuatro",
+    "cinco",
+    "seis",
+    "siete",
+    "ocho",
+    "nueve",
+    "diez",
+    "once",
+    "doce",
+    "trece",
+    "catorce",
+    "quince",
+    "dieciséis",
+    "diecisiete",
+    "dieciocho",
+    "diecinueve",
+];
+const ES_TENS: [&str; 10] = [
+    "",
+    "",
+    "veinte",
+    "treinta",
+    "cuarenta",
+    "cincuenta",
+    "sesenta",
+    "setenta",
+    "ochenta",
+    "noventa",
+];
+const ES_HUNDREDS: [&str; 10] = [
+    "",
+    "ciento",
+    "doscientos",
+    "trescientos",
+    "cuatrocientos",
+    "quinientos",
+    "seiscientos",
+    "setecientos",
+    "ochocientos",
+    "novecientos",
+];
+
+fn es_under_1000(n: u32) -> String {
+    if n == 100 {
+        return "cien".into();
+    }
+    let (h, r) = (n / 100, n % 100);
+    let mut parts: Vec<String> = Vec::new();
+    if h > 0 {
+        parts.push(ES_HUNDREDS[h as usize].to_string());
+    }
+    if r < 20 {
+        if r > 0 || n == 0 {
+            parts.push(ES_UNITS[r as usize].into());
+        }
+    } else if r < 30 {
+        // 21-29: veinti + unit (no space)
+        parts.push(format!("veinti{}", ES_UNITS[(r - 20) as usize]));
+    } else {
+        let (t, u) = (r / 10, r % 10);
+        parts.push(ES_TENS[t as usize].into());
+        if u > 0 {
+            parts.push(format!("y {}", ES_UNITS[u as usize]));
+        }
+    }
+    parts.join(" ")
+}
+
+fn es_words(n: u32) -> String {
+    if n == 0 {
+        return "cero".into();
+    }
+    let (thousands, rem) = (n / 1000, n % 1000);
+    let mut parts: Vec<String> = Vec::new();
+    if thousands > 0 {
+        if thousands == 1 {
+            parts.push("mil".into());
+        } else {
+            parts.push(format!("{} mil", es_under_1000(thousands)));
+        }
+    }
+    if rem > 0 {
+        parts.push(es_under_1000(rem));
+    }
+    parts.join(" ")
+}
+
+// ── French ────────────────────────────────────────────────────────────────────
+
+const FR_UNITS: [&str; 20] = [
+    "zéro", "un", "deux", "trois", "quatre", "cinq", "six", "sept", "huit", "neuf", "dix", "onze",
+    "douze", "treize", "quatorze", "quinze", "seize", "dix-sept", "dix-huit", "dix-neuf",
+];
+const FR_TENS: [&str; 10] = [
+    "",
+    "",
+    "vingt",
+    "trente",
+    "quarante",
+    "cinquante",
+    "soixante",
+    "soixante",
+    "quatre-vingt",
+    "quatre-vingt",
+];
+
+fn fr_under_100(n: u32) -> String {
+    debug_assert!(n < 100);
+    if n < 20 {
+        return FR_UNITS[n as usize].into();
+    }
+    match n {
+        // 80 = quatre-vingts (with trailing s when standalone)
+        80 => "quatre-vingts".into(),
+        // 81-89 = quatre-vingt-X (no trailing s)
+        81..=89 => format!("quatre-vingt-{}", FR_UNITS[(n - 80) as usize]),
+        // 70-79 = soixante + 10..19
+        70..=79 => {
+            let sub = FR_UNITS[(n - 60) as usize];
+            format!("soixante-{sub}")
+        }
+        // 90-99 = quatre-vingt + 10..19
+        90..=99 => {
+            let sub = FR_UNITS[(n - 80) as usize];
+            format!("quatre-vingt-{sub}")
+        }
+        _ => {
+            let (t, u) = (n / 10, n % 10);
+            let tens = FR_TENS[t as usize];
+            if u == 0 {
+                tens.into()
+            } else if u == 1 && t < 8 {
+                // et un for tens 2-7 (not 80s)
+                format!("{tens}-et-un")
+            } else {
+                format!("{}-{}", tens, FR_UNITS[u as usize])
+            }
+        }
+    }
+}
+
+fn fr_under_1000(n: u32) -> String {
+    debug_assert!(n < 1000);
+    if n == 0 {
+        return String::new();
+    }
+    let (h, r) = (n / 100, n % 100);
+    if h == 0 {
+        return fr_under_100(r);
+    }
+    let cent = if h == 1 {
+        "cent".to_string()
+    } else {
+        // plural cent only when no remainder
+        if r == 0 {
+            format!("{} cents", FR_UNITS[h as usize])
+        } else {
+            format!("{} cent", FR_UNITS[h as usize])
+        }
+    };
+    if r == 0 {
+        cent
+    } else {
+        format!("{cent} {}", fr_under_100(r))
+    }
+}
+
+fn fr_words(n: u32) -> String {
+    if n == 0 {
+        return "zéro".into();
+    }
+    let (thousands, rem) = (n / 1000, n % 1000);
+    let mut parts: Vec<String> = Vec::new();
+    if thousands > 0 {
+        if thousands == 1 {
+            parts.push("mille".into());
+        } else {
+            parts.push(format!("{} mille", fr_under_1000(thousands)));
+        }
+    }
+    if rem > 0 {
+        parts.push(fr_under_1000(rem));
+    }
+    parts.join(" ")
+}
+
+// ── Italian ───────────────────────────────────────────────────────────────────
+
+const IT_UNITS: [&str; 20] = [
+    "zero",
+    "uno",
+    "due",
+    "tre",
+    "quattro",
+    "cinque",
+    "sei",
+    "sette",
+    "otto",
+    "nove",
+    "dieci",
+    "undici",
+    "dodici",
+    "tredici",
+    "quattordici",
+    "quindici",
+    "sedici",
+    "diciassette",
+    "diciotto",
+    "diciannove",
+];
+
+// Italian tens (20, 30, ..., 90)
+const IT_TENS: [&str; 10] = [
+    "",
+    "",
+    "venti",
+    "trenta",
+    "quaranta",
+    "cinquanta",
+    "sessanta",
+    "settanta",
+    "ottanta",
+    "novanta",
+];
+
+const IT_HUNDREDS: [&str; 10] = [
+    "",
+    "cento",
+    "duecento",
+    "trecento",
+    "quattrocento",
+    "cinquecento",
+    "seicento",
+    "settecento",
+    "ottocento",
+    "novecento",
+];
+
+fn it_under_100(n: u32) -> String {
+    debug_assert!(n < 100);
+    if n < 20 {
+        return IT_UNITS[n as usize].into();
+    }
+    let (t, u) = (n / 10, n % 10);
+    let tens_str = IT_TENS[t as usize];
+    if u == 0 {
+        tens_str.into()
+    } else {
+        // Elision: drop trailing vowel of tens before uno (1) or otto (8)
+        let unit_str = IT_UNITS[u as usize];
+        if u == 1 || u == 8 {
+            // Strip trailing vowel from tens word
+            let trimmed = tens_str.trim_end_matches(['a', 'i', 'o']);
+            format!("{trimmed}{unit_str}")
+        } else {
+            format!("{tens_str}{unit_str}")
+        }
+    }
+}
+
+fn it_under_1000(n: u32) -> String {
+    debug_assert!(n < 1000);
+    if n == 0 {
+        return String::new();
+    }
+    let (h, r) = (n / 100, n % 100);
+    if h == 0 {
+        return it_under_100(r);
+    }
+    let hundreds = IT_HUNDREDS[h as usize];
+    if r == 0 {
+        hundreds.into()
+    } else {
+        // hundreds and remainder are separated by a space in Italian
+        // (e.g. "cinquecento dodici", "trecento ventuno")
+        format!("{hundreds} {}", it_under_100(r))
+    }
+}
+
+fn it_words(n: u32) -> String {
+    if n == 0 {
+        return "zero".into();
+    }
+    let (thousands, rem) = (n / 1000, n % 1000);
+    let mut parts: Vec<String> = Vec::new();
+    if thousands > 0 {
+        if thousands == 1 {
+            parts.push("mille".into());
+        } else {
+            parts.push(format!("{}mila", it_under_1000(thousands)));
+        }
+    }
+    if rem > 0 {
+        parts.push(it_under_1000(rem));
+    }
+    parts.join("")
+}
+
+// ── Portuguese ────────────────────────────────────────────────────────────────
+
+const PT_UNITS: [&str; 20] = [
+    "zero",
+    "um",
+    "dois",
+    "três",
+    "quatro",
+    "cinco",
+    "seis",
+    "sete",
+    "oito",
+    "nove",
+    "dez",
+    "onze",
+    "doze",
+    "treze",
+    "catorze",
+    "quinze",
+    "dezasseis",
+    "dezassete",
+    "dezoito",
+    "dezanove",
+];
+
+const PT_TENS: [&str; 10] = [
+    "",
+    "",
+    "vinte",
+    "trinta",
+    "quarenta",
+    "cinquenta",
+    "sessenta",
+    "setenta",
+    "oitenta",
+    "noventa",
+];
+
+const PT_HUNDREDS: [&str; 10] = [
+    "",
+    "cem",
+    "duzentos",
+    "trezentos",
+    "quatrocentos",
+    "quinhentos",
+    "seiscentos",
+    "setecentos",
+    "oitocentos",
+    "novecentos",
+];
+
+fn pt_under_100(n: u32) -> String {
+    debug_assert!(n < 100);
+    if n < 20 {
+        return PT_UNITS[n as usize].into();
+    }
+    let (t, u) = (n / 10, n % 10);
+    let tens = PT_TENS[t as usize];
+    if u == 0 {
+        tens.into()
+    } else {
+        format!("{tens} e {}", PT_UNITS[u as usize])
+    }
+}
+
+fn pt_under_1000(n: u32) -> String {
+    debug_assert!(n < 1000);
+    if n == 0 {
+        return String::new();
+    }
+    let (h, r) = (n / 100, n % 100);
+    if h == 0 {
+        return pt_under_100(r);
+    }
+    // 100 = cem; 101-199 = cento e ...
+    let hundreds = if h == 1 {
+        if r == 0 {
+            "cem".to_string()
+        } else {
+            "cento".to_string()
+        }
+    } else {
+        PT_HUNDREDS[h as usize].to_string()
+    };
+    if r == 0 {
+        hundreds
+    } else {
+        format!("{hundreds} e {}", pt_under_100(r))
+    }
+}
+
+fn pt_words(n: u32) -> String {
+    if n == 0 {
+        return "zero".into();
+    }
+    let (thousands, rem) = (n / 1000, n % 1000);
+    let mut parts: Vec<String> = Vec::new();
+    if thousands > 0 {
+        if thousands == 1 {
+            parts.push("mil".into());
+        } else {
+            parts.push(format!("{} mil", pt_under_1000(thousands)));
+        }
+    }
+    if rem > 0 {
+        parts.push(pt_under_1000(rem));
+    }
+    parts.join(" e ")
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Convert an integer `n` to its spoken-word form in the given language.
+///
+/// Supported: `"es"` (Spanish), `"fr"` (French), `"it"` (Italian),
+/// `"pt"` (Portuguese). Unknown languages return the digit string.
+pub fn to_words(n: u32, lang: &str) -> String {
+    match lang {
+        "es" => es_words(n),
+        "fr" => fr_words(n),
+        "it" => it_words(n),
+        "pt" => pt_words(n),
+        _ => n.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spanish_integers() {
+        assert_eq!(to_words(27, "es"), "veintisiete");
+        assert_eq!(to_words(512, "es"), "quinientos doce");
+        assert_eq!(to_words(936, "es"), "novecientos treinta y seis");
+        assert_eq!(to_words(100, "es"), "cien");
+    }
+
+    #[test]
+    fn italian_integers() {
+        assert_eq!(to_words(512, "it"), "cinquecento dodici");
+        assert_eq!(to_words(21, "it"), "ventuno");
+    }
+
+    #[test]
+    fn portuguese_integers() {
+        assert_eq!(to_words(936, "pt"), "novecentos e trinta e seis");
+    }
+
+    #[test]
+    fn french_integers() {
+        assert_eq!(to_words(348, "fr"), "trois cent quarante-huit");
+        assert_eq!(to_words(80, "fr"), "quatre-vingts");
+    }
+}

--- a/rust/src/tts/normalize/numbers.rs
+++ b/rust/src/tts/normalize/numbers.rs
@@ -53,6 +53,9 @@ const ES_HUNDREDS: [&str; 10] = [
 ];
 
 fn es_under_1000(n: u32) -> String {
+    if n >= 1000 {
+        return n.to_string();
+    }
     if n == 100 {
         return "cien".into();
     }
@@ -117,7 +120,9 @@ const FR_TENS: [&str; 10] = [
 ];
 
 fn fr_under_100(n: u32) -> String {
-    debug_assert!(n < 100);
+    if n >= 100 {
+        return n.to_string();
+    }
     if n < 20 {
         return FR_UNITS[n as usize].into();
     }
@@ -152,7 +157,9 @@ fn fr_under_100(n: u32) -> String {
 }
 
 fn fr_under_1000(n: u32) -> String {
-    debug_assert!(n < 1000);
+    if n >= 1000 {
+        return n.to_string();
+    }
     if n == 0 {
         return String::new();
     }
@@ -249,7 +256,9 @@ const IT_HUNDREDS: [&str; 10] = [
 ];
 
 fn it_under_100(n: u32) -> String {
-    debug_assert!(n < 100);
+    if n >= 100 {
+        return n.to_string();
+    }
     if n < 20 {
         return IT_UNITS[n as usize].into();
     }
@@ -271,7 +280,9 @@ fn it_under_100(n: u32) -> String {
 }
 
 fn it_under_1000(n: u32) -> String {
-    debug_assert!(n < 1000);
+    if n >= 1000 {
+        return n.to_string();
+    }
     if n == 0 {
         return String::new();
     }
@@ -360,7 +371,9 @@ const PT_HUNDREDS: [&str; 10] = [
 ];
 
 fn pt_under_100(n: u32) -> String {
-    debug_assert!(n < 100);
+    if n >= 100 {
+        return n.to_string();
+    }
     if n < 20 {
         return PT_UNITS[n as usize].into();
     }
@@ -374,7 +387,9 @@ fn pt_under_100(n: u32) -> String {
 }
 
 fn pt_under_1000(n: u32) -> String {
-    debug_assert!(n < 1000);
+    if n >= 1000 {
+        return n.to_string();
+    }
     if n == 0 {
         return String::new();
     }
@@ -437,6 +452,15 @@ pub fn to_words(n: u32, lang: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn large_numbers_do_not_panic() {
+        // Beyond the 0..=999_999 support band — must NOT panic; return *something* safe.
+        for lang in ["es", "fr", "it", "pt"] {
+            let _ = to_words(1_000_000, lang);
+            let _ = to_words(u32::MAX, lang);
+        }
+    }
 
     #[test]
     fn spanish_integers() {

--- a/rust/src/tts/normalize/numbers.rs
+++ b/rust/src/tts/normalize/numbers.rs
@@ -336,13 +336,16 @@ const PT_UNITS: [&str; 20] = [
     "onze",
     "doze",
     "treze",
-    "catorze",
+    "quatorze",
     "quinze",
-    "dezasseis",
-    "dezassete",
+    "dezesseis",
+    "dezessete",
     "dezoito",
-    "dezanove",
+    "dezenove",
 ];
+// NB: Brazilian Portuguese forms (quatorze/dezesseis/dezessete/dezenove) — the
+// CharsiuG2P tag is <por-bz>, so feeding European forms (catorze/dezasseis/…)
+// mispronounces. Greptile #509 P1.
 
 const PT_TENS: [&str; 10] = [
     "",
@@ -479,6 +482,11 @@ mod tests {
     #[test]
     fn portuguese_integers() {
         assert_eq!(to_words(936, "pt"), "novecentos e trinta e seis");
+        // Brazilian forms (G2P tag is <por-bz>), not European catorze/dezasseis/…
+        assert_eq!(to_words(14, "pt"), "quatorze");
+        assert_eq!(to_words(16, "pt"), "dezesseis");
+        assert_eq!(to_words(17, "pt"), "dezessete");
+        assert_eq!(to_words(19, "pt"), "dezenove");
     }
 
     #[test]

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -22,7 +22,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::{kokoro::Kokoro, tokenizer::Tokenizer, voices, vosk::Vosk};
+use super::{charsiu::Charsiu, kokoro::Kokoro, tokenizer::Tokenizer, voices, vosk::Vosk};
 
 /// Cached Kokoro inference state. One ONNX session, one tokenizer, one voice
 /// cache. Cheap to clone-key (`PathBuf`); the actual session is non-Clone.
@@ -157,5 +157,100 @@ impl VoskCache {
                 ))
             }
         }
+    }
+}
+
+/// Cached CharsiuG2P session keyed by the g2p model directory.
+///
+/// CharsiuG2P loads three ONNX sessions (~100 MB total). In the long-lived
+/// `--stdin-loop` process each Romance-language request would reload them from
+/// disk without this cache. The `Charsiu` session is stateless between calls
+/// (each `to_ipa` runs a fresh encode/decode pass), so unlike Vosk there is no
+/// per-call mutable state that a synth error can corrupt — we never evict on
+/// error.
+#[derive(Default)]
+pub struct CharsiuCache {
+    inner: Option<(PathBuf, Charsiu)>,
+}
+
+impl CharsiuCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn ensure(&mut self, model_dir: &Path) -> anyhow::Result<&mut Charsiu> {
+        // Evict if the caller asks for a different directory (shouldn't happen
+        // in practice — there's only one byt5-tiny dir — but keeps the API
+        // safe if a test ever passes a different path).
+        if let Some((ref dir, _)) = self.inner {
+            if dir != model_dir {
+                self.inner = None;
+            }
+        }
+        if self.inner.is_none() {
+            super::g2p::check_charsiu_files(model_dir)?;
+            let g = Charsiu::load(model_dir)?;
+            self.inner = Some((model_dir.to_path_buf(), g));
+        }
+        Ok(&mut self.inner.as_mut().unwrap().1)
+    }
+
+    /// Phonemize `text` in `lang` (es/fr/it/pt) using the cached session.
+    /// Loads the three ONNX sessions on first call; reuses them on subsequent
+    /// calls. Surfaces the same "model not installed → kesha install --tts"
+    /// error as the one-shot path when the model directory is absent.
+    // `&mut self` is required: ort `Session::run` mutates the session.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_ipa(&mut self, model_dir: &Path, text: &str, lang: &str) -> anyhow::Result<String> {
+        let g = self.ensure(model_dir)?;
+        super::g2p::charsiu_ipa(g, text, lang)
+    }
+
+    /// Returns `true` if a session has been loaded (used in tests to verify
+    /// caching without re-loading).
+    #[cfg(test)]
+    pub fn is_loaded(&self) -> bool {
+        self.inner.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Gated on CHARSIU_ONNX env var (mirrors charsiu::tests). Skipped when
+    /// unset so default CI stays fast. Proves:
+    /// 1. `CharsiuCache::to_ipa` phonemizes Spanish correctly.
+    /// 2. The session is cached after the first call (not reloaded).
+    /// 3. A second call succeeds and returns the same IPA (no state corruption).
+    #[test]
+    fn charsiu_cache_loads_once_and_reuses() {
+        let Some(dir_os) = std::env::var_os("CHARSIU_ONNX") else {
+            eprintln!("CHARSIU_ONNX not set; skipping");
+            return;
+        };
+        let dir = std::path::PathBuf::from(dir_os);
+
+        let mut cache = CharsiuCache::new();
+        assert!(!cache.is_loaded(), "cache must start empty");
+
+        let ipa1 = cache.to_ipa(&dir, "hola", "es").unwrap();
+        assert!(!ipa1.is_empty(), "first call: empty IPA for 'hola'");
+        assert!(
+            cache.is_loaded(),
+            "cache must be populated after first call"
+        );
+
+        // Second call must reuse the cached session (no reload) and return
+        // the identical IPA — Charsiu is deterministic for the same input.
+        let ipa2 = cache.to_ipa(&dir, "hola", "es").unwrap();
+        assert_eq!(
+            ipa1, ipa2,
+            "second call returned different IPA — session may have been reloaded"
+        );
+
+        // Confirm it works across languages too (no cross-lang state leak).
+        let ipa_fr = cache.to_ipa(&dir, "bonjour", "fr").unwrap();
+        assert!(!ipa_fr.is_empty(), "French 'bonjour' returned empty IPA");
     }
 }

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -111,6 +111,12 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
             target_arch = "aarch64"
         ))]
         "es" | "fr" | "hi" | "it" | "ja" | "pt" | "zh" => resolve_fluid_kokoro(voice_id),
+        #[cfg(not(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        )))]
+        "es" | "fr" | "it" | "pt" => resolve_multilang_kokoro(cache_dir, voice_id, lang, name),
         "ru" => {
             let suffix = name.strip_prefix("vosk-").unwrap_or(name);
             resolve_vosk_ru(cache_dir, voice_id, suffix)
@@ -135,9 +141,94 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
         other => {
             coded_bail!(
                 ErrorCode::VoiceUnknown,
-                "language '{other}' not supported (use 'en-*', 'ru-*', or 'macos-*')"
+                "language '{other}' not supported (use 'en-*', 'es-*', 'fr-*', 'it-*', 'pt-*', 'ru-*', or 'macos-*')"
             )
         }
+    }
+}
+
+/// ONNX Kokoro path for es/fr/it/pt voices. Uses the same model graph as
+/// `resolve_kokoro` but picks the language-appropriate voice pack and passes
+/// the correct espeak language code so CharsiuG2P receives the right language.
+///
+/// Only compiled on non-`system_kokoro` builds; on darwin-arm64 `system_kokoro`
+/// these languages route through `resolve_fluid_kokoro` instead.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+fn resolve_multilang_kokoro(
+    cache_dir: &Path,
+    voice_id: &str,
+    lang: &str,
+    name: &str,
+) -> anyhow::Result<ResolvedVoice> {
+    // Resolve the bare voice name: if the user passed only the language prefix
+    // (e.g. "es") there is no name part after the dash, so apply the default.
+    let resolved_name = if name.is_empty() {
+        default_voice_for_lang(lang)
+    } else {
+        name
+    };
+
+    let espeak_lang: &'static str = match lang {
+        "es" => "es",
+        // BRAND-RULE EXCEPTION (CLAUDE.md "default voices must be male"):
+        // Kokoro v1.0 ships NO male French voice — only ff_siwis (female). fr
+        // therefore defaults to ff_siwis until a male fr voice exists. es/it/pt
+        // default to male (em_alex/im_nicola/pm_alex). Revisit on a male fr voice.
+        "fr" => "fr",
+        "it" => "it",
+        "pt" => "pt",
+        _ => unreachable!("resolve_multilang_kokoro called with unexpected lang '{lang}'"),
+    };
+
+    let model_path = cache_dir.join("models/kokoro-82m/model.onnx");
+    let voice_path = cache_dir
+        .join("models/kokoro-82m/voices")
+        .join(format!("{resolved_name}.bin"));
+
+    if !voice_path.exists() {
+        coded_bail!(
+            ErrorCode::ModelMissing,
+            "voice '{voice_id}' not installed. run: kesha install --tts"
+        );
+    }
+    if !model_path.exists() {
+        coded_bail!(
+            ErrorCode::ModelMissing,
+            "kokoro model not installed at {}. run: kesha install --tts",
+            model_path.display()
+        );
+    }
+
+    Ok(ResolvedVoice::Kokoro {
+        model_path,
+        voice_path,
+        espeak_lang,
+    })
+}
+
+/// Default voice pack name (without `.bin`) for each supported non-English
+/// Kokoro language. Must satisfy CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE"
+/// for all languages where a male voice exists in Kokoro v1.0.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+fn default_voice_for_lang(lang: &str) -> &'static str {
+    match lang {
+        "es" => "em_alex", // male ✓
+        // BRAND-RULE EXCEPTION (CLAUDE.md "default voices must be male"):
+        // Kokoro v1.0 ships NO male French voice — only ff_siwis (female). fr
+        // therefore defaults to ff_siwis until a male fr voice exists. es/it/pt
+        // default to male (em_alex/im_nicola/pm_alex). Revisit on a male fr voice.
+        "fr" => "ff_siwis",  // female — sole French voice in Kokoro v1.0
+        "it" => "im_nicola", // male ✓
+        "pt" => "pm_alex",   // male ✓
+        _ => unreachable!("default_voice_for_lang called with unexpected lang '{lang}'"),
     }
 }
 
@@ -532,15 +623,129 @@ mod tests {
     #[test]
     fn resolve_unsupported_language() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = resolve_voice(tmp.path(), "fr-something").unwrap_err();
-        // The human message differs by build — FluidAudio Kokoro (darwin-arm64,
-        // `system_kokoro`) reports "unknown FluidAudio Kokoro voice", other
-        // builds report "language not supported" — but the stable code is the
-        // contract. Match on the code, not the message (see docs/errors.md).
+        // Use a language that is unsupported on all builds (zh is only available
+        // on darwin-arm64 system_kokoro; de is never supported).
+        let err = resolve_voice(tmp.path(), "de-something").unwrap_err();
+        // The error code is the stable contract across builds (docs/errors.md).
         assert_eq!(
             crate::errors::code_of(&err),
             ErrorCode::VoiceUnknown,
             "msg: {err}"
         );
+    }
+
+    // ONNX-only multilang path: es/fr/it/pt route to resolve_multilang_kokoro
+    // on non-`system_kokoro` builds. Not applicable on darwin-arm64
+    // `system_kokoro` where these route through FluidAudio.
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    fn populate_multilang_cache(cache: &Path) {
+        let voices = cache.join("models/kokoro-82m/voices");
+        std::fs::create_dir_all(&voices).unwrap();
+        for name in ["em_alex", "ff_siwis", "im_nicola", "pm_alex"] {
+            std::fs::write(
+                voices.join(format!("{name}.bin")),
+                vec![0u8; VOICE_FILE_BYTES],
+            )
+            .unwrap();
+        }
+        std::fs::write(cache.join("models/kokoro-82m/model.onnx"), b"dummy").unwrap();
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn resolve_multilang_voices_on_onnx_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_multilang_cache(tmp.path());
+
+        let cases = [
+            ("es-em_alex", "em_alex", "es"),
+            ("fr-ff_siwis", "ff_siwis", "fr"),
+            ("it-im_nicola", "im_nicola", "it"),
+            ("pt-pm_alex", "pm_alex", "pt"),
+        ];
+        for (voice_id, expected_pack, expected_lang) in cases {
+            let r = resolve_voice(tmp.path(), voice_id)
+                .unwrap_or_else(|e| panic!("{voice_id} failed: {e}"));
+            match r {
+                ResolvedVoice::Kokoro {
+                    voice_path,
+                    model_path,
+                    espeak_lang,
+                } => {
+                    assert!(
+                        voice_path.ends_with(format!("{expected_pack}.bin")),
+                        "{voice_id}: wrong voice_path {voice_path:?}"
+                    );
+                    assert!(
+                        model_path.ends_with("model.onnx"),
+                        "{voice_id}: wrong model_path {model_path:?}"
+                    );
+                    assert_eq!(espeak_lang, expected_lang, "{voice_id}: wrong espeak_lang");
+                }
+                other => panic!("{voice_id}: expected Kokoro, got {other:?}"),
+            }
+        }
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn multilang_default_voices_resolve_correctly() {
+        // Verify each language default (lang-only prefix, no explicit name)
+        // resolves to the expected pack. Note: the voice_id format requires
+        // split_once('-') to succeed — supply a minimal name here by using the
+        // explicit pack names; default resolution is tested via resolve_multilang_kokoro.
+        let tmp = tempfile::tempdir().unwrap();
+        populate_multilang_cache(tmp.path());
+
+        // es default → em_alex (male ✓)
+        let r = resolve_voice(tmp.path(), "es-em_alex").unwrap();
+        match r {
+            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "es"),
+            other => panic!("es: expected Kokoro, got {other:?}"),
+        }
+        // fr default → ff_siwis (female, brand-rule exception documented)
+        let r = resolve_voice(tmp.path(), "fr-ff_siwis").unwrap();
+        match r {
+            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "fr"),
+            other => panic!("fr: expected Kokoro, got {other:?}"),
+        }
+        // it default → im_nicola (male ✓)
+        let r = resolve_voice(tmp.path(), "it-im_nicola").unwrap();
+        match r {
+            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "it"),
+            other => panic!("it: expected Kokoro, got {other:?}"),
+        }
+        // pt default → pm_alex (male ✓)
+        let r = resolve_voice(tmp.path(), "pt-pm_alex").unwrap();
+        match r {
+            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "pt"),
+            other => panic!("pt: expected Kokoro, got {other:?}"),
+        }
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn multilang_missing_voice_errors_with_install_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No models on disk — should prompt `kesha install --tts`
+        let err = resolve_voice(tmp.path(), "es-em_alex").unwrap_err();
+        assert!(err.to_string().contains("install --tts"), "msg: {err}");
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::ModelMissing);
     }
 }

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -321,11 +321,40 @@ fn resolve_vosk_ru(
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::path::PathBuf;
 
     fn write_bytes(bytes: &[u8]) -> tempfile::NamedTempFile {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         tmp.write_all(bytes).unwrap();
         tmp
+    }
+
+    /// Extract Kokoro fields from a ResolvedVoice, panicking if it's not Kokoro.
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    fn unwrap_kokoro(r: ResolvedVoice) -> (PathBuf, PathBuf, &'static str) {
+        match r {
+            ResolvedVoice::Kokoro {
+                model_path,
+                voice_path,
+                espeak_lang,
+            } => (model_path, voice_path, espeak_lang),
+            _ => panic!("expected ResolvedVoice::Kokoro"),
+        }
+    }
+
+    /// Extract Vosk fields from a ResolvedVoice, panicking if it's not Vosk.
+    fn unwrap_vosk(r: ResolvedVoice) -> (PathBuf, u32) {
+        match r {
+            ResolvedVoice::Vosk {
+                model_dir,
+                speaker_id,
+            } => (model_dir, speaker_id),
+            _ => panic!("expected ResolvedVoice::Vosk"),
+        }
     }
 
     #[test]
@@ -393,18 +422,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         populate_cache(tmp.path());
         let r = resolve_voice(tmp.path(), "en-am_michael").unwrap();
-        match r {
-            ResolvedVoice::Kokoro {
-                voice_path,
-                model_path,
-                espeak_lang,
-            } => {
-                assert!(voice_path.ends_with("am_michael.bin"));
-                assert!(model_path.ends_with("model.onnx"));
-                assert_eq!(espeak_lang, "en-us");
-            }
-            other => panic!("expected Kokoro, got {other:?}"),
-        }
+        let (model_path, voice_path, espeak_lang) = unwrap_kokoro(r);
+        assert!(voice_path.ends_with("am_michael.bin"));
+        assert!(model_path.ends_with("model.onnx"));
+        assert_eq!(espeak_lang, "en-us");
     }
 
     #[cfg(all(
@@ -526,16 +547,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         populate_vosk_ru(tmp.path());
         let r = resolve_voice(tmp.path(), "ru-vosk-m02").unwrap();
-        match r {
-            ResolvedVoice::Vosk {
-                model_dir,
-                speaker_id,
-            } => {
-                assert!(model_dir.ends_with("models/vosk-ru"));
-                assert_eq!(speaker_id, 4);
-            }
-            other => panic!("expected Vosk, got {other:?}"),
-        }
+        let (model_dir, speaker_id) = unwrap_vosk(r);
+        assert!(model_dir.ends_with("models/vosk-ru"));
+        assert_eq!(speaker_id, 4);
+    }
+
+    #[test]
+    fn espeak_lang_vosk_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_vosk_ru(tmp.path());
+        let r = resolve_voice(tmp.path(), "ru-vosk-m01").unwrap();
+        assert_eq!(r.espeak_lang(), "");
     }
 
     #[test]
@@ -550,10 +572,8 @@ mod tests {
             ("m02", 4),
         ] {
             let voice = format!("ru-vosk-{id}");
-            match resolve_voice(tmp.path(), &voice).unwrap() {
-                ResolvedVoice::Vosk { speaker_id, .. } => assert_eq!(speaker_id, n, "{voice}"),
-                other => panic!("{voice}: expected Vosk, got {other:?}"),
-            }
+            let (_, speaker_id) = unwrap_vosk(resolve_voice(tmp.path(), &voice).unwrap());
+            assert_eq!(speaker_id, n, "{voice}");
         }
     }
 
@@ -674,24 +694,16 @@ mod tests {
         for (voice_id, expected_pack, expected_lang) in cases {
             let r = resolve_voice(tmp.path(), voice_id)
                 .unwrap_or_else(|e| panic!("{voice_id} failed: {e}"));
-            match r {
-                ResolvedVoice::Kokoro {
-                    voice_path,
-                    model_path,
-                    espeak_lang,
-                } => {
-                    assert!(
-                        voice_path.ends_with(format!("{expected_pack}.bin")),
-                        "{voice_id}: wrong voice_path {voice_path:?}"
-                    );
-                    assert!(
-                        model_path.ends_with("model.onnx"),
-                        "{voice_id}: wrong model_path {model_path:?}"
-                    );
-                    assert_eq!(espeak_lang, expected_lang, "{voice_id}: wrong espeak_lang");
-                }
-                other => panic!("{voice_id}: expected Kokoro, got {other:?}"),
-            }
+            let (model_path, voice_path, espeak_lang) = unwrap_kokoro(r);
+            assert!(
+                voice_path.ends_with(format!("{expected_pack}.bin")),
+                "{voice_id}: wrong voice_path {voice_path:?}"
+            );
+            assert!(
+                model_path.ends_with("model.onnx"),
+                "{voice_id}: wrong model_path {model_path:?}"
+            );
+            assert_eq!(espeak_lang, expected_lang, "{voice_id}: wrong espeak_lang");
         }
     }
 
@@ -711,28 +723,20 @@ mod tests {
 
         // es default → em_alex (male ✓)
         let r = resolve_voice(tmp.path(), "es-em_alex").unwrap();
-        match r {
-            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "es"),
-            other => panic!("es: expected Kokoro, got {other:?}"),
-        }
+        let (_, _, espeak_lang) = unwrap_kokoro(r);
+        assert_eq!(espeak_lang, "es");
         // fr default → ff_siwis (female, brand-rule exception documented)
         let r = resolve_voice(tmp.path(), "fr-ff_siwis").unwrap();
-        match r {
-            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "fr"),
-            other => panic!("fr: expected Kokoro, got {other:?}"),
-        }
+        let (_, _, espeak_lang) = unwrap_kokoro(r);
+        assert_eq!(espeak_lang, "fr");
         // it default → im_nicola (male ✓)
         let r = resolve_voice(tmp.path(), "it-im_nicola").unwrap();
-        match r {
-            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "it"),
-            other => panic!("it: expected Kokoro, got {other:?}"),
-        }
+        let (_, _, espeak_lang) = unwrap_kokoro(r);
+        assert_eq!(espeak_lang, "it");
         // pt default → pm_alex (male ✓)
         let r = resolve_voice(tmp.path(), "pt-pm_alex").unwrap();
-        match r {
-            ResolvedVoice::Kokoro { espeak_lang, .. } => assert_eq!(espeak_lang, "pt"),
-            other => panic!("pt: expected Kokoro, got {other:?}"),
-        }
+        let (_, _, espeak_lang) = unwrap_kokoro(r);
+        assert_eq!(espeak_lang, "pt");
     }
 
     #[cfg(not(all(
@@ -744,6 +748,103 @@ mod tests {
     fn multilang_missing_voice_errors_with_install_hint() {
         let tmp = tempfile::tempdir().unwrap();
         // No models on disk — should prompt `kesha install --tts`
+        let err = resolve_voice(tmp.path(), "es-em_alex").unwrap_err();
+        assert!(err.to_string().contains("install --tts"), "msg: {err}");
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::ModelMissing);
+    }
+
+    // Test that each language defaults to the expected voice when name is empty.
+    // Voice id "es-" splits to lang="es", name="" — triggers default_voice_for_lang.
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn multilang_default_voice_for_lang_es() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_multilang_cache(tmp.path());
+        // "es-" → name="" → default_voice_for_lang("es") = "em_alex"
+        let r = resolve_voice(tmp.path(), "es-").unwrap();
+        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
+        assert!(
+            voice_path.ends_with("em_alex.bin"),
+            "wrong voice_path: {voice_path:?}"
+        );
+        assert_eq!(espeak_lang, "es");
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn multilang_default_voice_for_lang_fr() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_multilang_cache(tmp.path());
+        // "fr-" → name="" → default_voice_for_lang("fr") = "ff_siwis"
+        let r = resolve_voice(tmp.path(), "fr-").unwrap();
+        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
+        assert!(
+            voice_path.ends_with("ff_siwis.bin"),
+            "wrong voice_path: {voice_path:?}"
+        );
+        assert_eq!(espeak_lang, "fr");
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn multilang_default_voice_for_lang_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_multilang_cache(tmp.path());
+        // "it-" → name="" → default_voice_for_lang("it") = "im_nicola"
+        let r = resolve_voice(tmp.path(), "it-").unwrap();
+        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
+        assert!(
+            voice_path.ends_with("im_nicola.bin"),
+            "wrong voice_path: {voice_path:?}"
+        );
+        assert_eq!(espeak_lang, "it");
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn multilang_default_voice_for_lang_pt() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_multilang_cache(tmp.path());
+        // "pt-" → name="" → default_voice_for_lang("pt") = "pm_alex"
+        let r = resolve_voice(tmp.path(), "pt-").unwrap();
+        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
+        assert!(
+            voice_path.ends_with("pm_alex.bin"),
+            "wrong voice_path: {voice_path:?}"
+        );
+        assert_eq!(espeak_lang, "pt");
+    }
+
+    // Test the "voice file present but model.onnx missing" branch in resolve_multilang_kokoro.
+    // This exercises lines 198-203 (model_path check), which the "no files at all" test skips.
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn multilang_missing_model_errors_with_install_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Write only the voice file; leave model.onnx absent.
+        let voices = tmp.path().join("models/kokoro-82m/voices");
+        std::fs::create_dir_all(&voices).unwrap();
+        std::fs::write(voices.join("em_alex.bin"), vec![0u8; VOICE_FILE_BYTES]).unwrap();
         let err = resolve_voice(tmp.path(), "es-em_alex").unwrap_err();
         assert!(err.to_string().contains("install --tts"), "msg: {err}");
         assert_eq!(crate::errors::code_of(&err), ErrorCode::ModelMissing);

--- a/rust/tests/tts_multilang_audio.rs
+++ b/rust/tests/tts_multilang_audio.rs
@@ -1,0 +1,203 @@
+//! Gated multilingual audio-regression test.
+//!
+//! Synthesizes each (lang, sentence) pair in `fixtures/tts/multilang_corpus.json`
+//! via the real ONNX Kokoro path and asserts:
+//! - non-empty WAV with correct 24000 Hz mono header,
+//! - no clipping (locks Phase 3 `kokoro::clamp_audio`),
+//! - non-silent RMS,
+//! - plausible duration relative to grapheme count.
+//!
+//! Skip condition: `CHARSIU_ONNX` unset OR Kokoro model/voice absent from cache.
+//! Run with:
+//!   cd rust && CHARSIU_ONNX=~/.cache/kesha/models/g2p/byt5-tiny \
+//!     cargo nextest run --features tts tts_multilang_audio
+
+#![cfg(feature = "tts")]
+
+mod common;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use hound::SampleFormat;
+use kesha_engine::tts::{self, EngineChoice, OutputFormat, SayOptions};
+
+/// Default ONNX voice for each language (mirrors `voices::default_voice_for_lang`).
+fn default_voice(lang: &str) -> &'static str {
+    match lang {
+        "es" => "em_alex",
+        "fr" => "ff_siwis",
+        "it" => "im_nicola",
+        "pt" => "pm_alex",
+        _ => panic!("no default voice for lang {lang}"),
+    }
+}
+
+/// Skip gate: both `CHARSIU_ONNX` must be set AND Kokoro model + the relevant
+/// voice must be present. Returns `(model_path, voice_path)` or `None`.
+fn multilang_paths_or_skip(lang: &str) -> Option<(PathBuf, PathBuf)> {
+    // Gate 1: G2P model present.
+    if std::env::var_os("CHARSIU_ONNX").is_none() {
+        eprintln!("skipping tts_multilang_audio: CHARSIU_ONNX not set");
+        return None;
+    }
+    // Gate 2: Kokoro model + voice from cache.
+    let cache = common::kokoro_cache_dir_or_skip()?;
+    let model = cache.join("models/kokoro-82m/model.onnx");
+    let voice_name = default_voice(lang);
+    let voice = cache
+        .join("models/kokoro-82m/voices")
+        .join(format!("{voice_name}.bin"));
+    if !model.exists() || !voice.exists() {
+        eprintln!("skipping tts_multilang_audio[{lang}]: model or voice {voice_name} not in cache");
+        return None;
+    }
+    Some((model, voice))
+}
+
+/// Parse a WAV buffer with `hound` and return `(sample_rate, channel_count, f32_samples)`.
+/// Panics on malformed input so failures surface as assertion errors.
+fn parse_wav(wav: &[u8]) -> (u32, u16, Vec<f32>) {
+    let cursor = std::io::Cursor::new(wav);
+    let mut reader = hound::WavReader::new(cursor).expect("WAV bytes must be parseable by hound");
+    let spec = reader.spec();
+    let samples: Vec<f32> = match spec.sample_format {
+        SampleFormat::Float => reader
+            .samples::<f32>()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("f32 sample read"),
+        SampleFormat::Int => {
+            let max = (1i64 << (spec.bits_per_sample - 1)) as f32;
+            reader
+                .samples::<i32>()
+                .map(|s| s.map(|v| v as f32 / max))
+                .collect::<Result<Vec<_>, _>>()
+                .expect("int→f32 sample conversion")
+        }
+    };
+    (spec.sample_rate, spec.channels, samples)
+}
+
+/// RMS of a sample slice.
+fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+    (sum_sq / samples.len() as f32).sqrt()
+}
+
+fn run_corpus_for_lang(lang: &str, sentences: &[String]) {
+    let Some((model_path, voice_path)) = multilang_paths_or_skip(lang) else {
+        return;
+    };
+
+    for sentence in sentences {
+        let grapheme_count = sentence.chars().count() as f32;
+
+        let wav = tts::say(SayOptions {
+            text: sentence,
+            lang,
+            engine: EngineChoice::Kokoro {
+                model_path: &model_path,
+                voice_path: &voice_path,
+                speed: 1.0,
+            },
+            ssml: false,
+            format: OutputFormat::Wav,
+            expand_abbrev: true,
+        })
+        .unwrap_or_else(|e| panic!("[{lang}] synthesis failed for {:?}: {e}", sentence));
+
+        // 1. Non-empty bytes.
+        assert!(!wav.is_empty(), "[{lang}] WAV is empty for {:?}", sentence);
+
+        // Parse WAV properly via hound (handles variable fmt chunk sizes).
+        let (sample_rate, channels, samples) = parse_wav(&wav);
+
+        // 2. 24000 Hz mono.
+        assert_eq!(
+            sample_rate, 24_000,
+            "[{lang}] expected 24000 Hz, got {sample_rate}"
+        );
+        assert_eq!(
+            channels, 1,
+            "[{lang}] expected mono (1 channel), got {channels}"
+        );
+
+        assert!(
+            !samples.is_empty(),
+            "[{lang}] audio is empty for {:?}",
+            sentence
+        );
+
+        // 3. No clipping — locks `kokoro::clamp_audio` (Phase 3).
+        for (i, &s) in samples.iter().enumerate() {
+            assert!(
+                (-1.0..=1.0).contains(&s),
+                "[{lang}] clipping at sample {i}: {s} (sentence: {:?})",
+                sentence
+            );
+        }
+
+        // 4. Non-silent: RMS > 0.01.
+        let r = rms(&samples);
+        assert!(
+            r > 0.01,
+            "[{lang}] audio is near-silent (RMS={r:.4}) for {:?}",
+            sentence
+        );
+
+        // 5. Plausible length: duration in [0.3, 1.5] × (grapheme_count / 12).
+        //    Loose band — catches near-zero or catastrophically long output only.
+        let sample_count = samples.len();
+        let duration_secs = sample_count as f32 / sample_rate as f32;
+        let reference = grapheme_count / 12.0; // ~12 graphemes/sec as baseline
+        let lo = reference * 0.3;
+        let hi = reference * 1.5;
+        assert!(
+            duration_secs >= lo && duration_secs <= hi,
+            "[{lang}] duration {duration_secs:.2}s outside [{lo:.2}, {hi:.2}]s \
+             for {grapheme_count:.0}-grapheme sentence {:?}",
+            sentence
+        );
+    }
+}
+
+#[test]
+fn multilang_audio_regression_es() {
+    let corpus = load_corpus();
+    let sentences = corpus.get("es").map(Vec::as_slice).unwrap_or(&[]);
+    run_corpus_for_lang("es", sentences);
+}
+
+#[test]
+fn multilang_audio_regression_fr() {
+    let corpus = load_corpus();
+    let sentences = corpus.get("fr").map(Vec::as_slice).unwrap_or(&[]);
+    run_corpus_for_lang("fr", sentences);
+}
+
+#[test]
+fn multilang_audio_regression_it() {
+    let corpus = load_corpus();
+    let sentences = corpus.get("it").map(Vec::as_slice).unwrap_or(&[]);
+    run_corpus_for_lang("it", sentences);
+}
+
+#[test]
+fn multilang_audio_regression_pt() {
+    let corpus = load_corpus();
+    let sentences = corpus.get("pt").map(Vec::as_slice).unwrap_or(&[]);
+    run_corpus_for_lang("pt", sentences);
+}
+
+fn load_corpus() -> HashMap<String, Vec<String>> {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/fixtures/tts/multilang_corpus.json"
+    );
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("failed to read corpus fixture {path}: {e}"));
+    serde_json::from_str(&raw).expect("corpus JSON must be a map of lang → [sentence]")
+}

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -62,9 +62,24 @@ const VAD_FILES: PlanFile[] = [
   { relPath: "models/silero-vad/silero_vad.onnx", sizeBytes: 2_327_524 },
 ];
 
+// klebster CharsiuG2P byt5-tiny ONNX export (CC-BY 4.0 — see NOTICES.md).
+// 3 files enabling multilingual G2P for es/fr/it/pt Kokoro voices (#212).
+const G2P_CHARSIU_FILES: PlanFile[] = [
+  { relPath: "models/g2p/byt5-tiny/encoder_model.onnx", sizeBytes: 12_478_704 },
+  { relPath: "models/g2p/byt5-tiny/decoder_model.onnx", sizeBytes: 11_983_268 },
+  { relPath: "models/g2p/byt5-tiny/decoder_with_past_model.onnx", sizeBytes: 5_427_260 },
+];
+
 const KOKORO_FILES: PlanFile[] = [
   { relPath: "models/kokoro-82m/model.onnx", sizeBytes: 325_532_387 },
   { relPath: "models/kokoro-82m/voices/am_michael.bin", sizeBytes: 522_240 },
+  // Multilingual voice packs for es/fr/it/pt (#212).
+  // em_alex (es, male), ff_siwis (fr, female — only French voice in Kokoro v1.0),
+  // im_nicola (it, male), pm_alex (pt, male).
+  { relPath: "models/kokoro-82m/voices/em_alex.bin", sizeBytes: 522_240 },
+  { relPath: "models/kokoro-82m/voices/ff_siwis.bin", sizeBytes: 522_240 },
+  { relPath: "models/kokoro-82m/voices/im_nicola.bin", sizeBytes: 522_240 },
+  { relPath: "models/kokoro-82m/voices/pm_alex.bin", sizeBytes: 522_240 },
 ];
 
 const VOSK_RU_FILES: PlanFile[] = [
@@ -245,11 +260,21 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
       components.push(
         bundleComponent(
           cacheRoot,
-          "TTS Kokoro EN",
+          "TTS Kokoro EN/ES/FR/IT/PT",
           "model cache",
           KOKORO_FILES,
           noCache,
-          "English en-* voices",
+          "English en-* voices + multilingual es-*/fr-*/it-*/pt-* voices",
+        ),
+      );
+      components.push(
+        bundleComponent(
+          cacheRoot,
+          "G2P CharsiuG2P byt5-tiny",
+          "model cache",
+          G2P_CHARSIU_FILES,
+          noCache,
+          "multilingual grapheme-to-phoneme for es/fr/it/pt Kokoro voices (CC-BY 4.0)",
         ),
       );
       components.push(

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -14,6 +14,19 @@ const DARWIN_KOKORO_DEFAULTS: Record<string, string> = {
   zh: "zh-zm_yunjian",
 };
 
+/**
+ * ONNX-platform (Linux / Windows / Intel macOS) multilingual defaults.
+ * These mirror the Rust `default_voice_for_lang` in the engine.
+ * es/it/pt are male; fr is the documented brand-rule exception
+ * (Kokoro v1.0 ships no male French voice).
+ */
+const ONNX_KOKORO_DEFAULTS: Record<string, string> = {
+  es: "es-em_alex",
+  fr: "fr-ff_siwis",
+  it: "it-im_nicola",
+  pt: "pt-pm_alex",
+};
+
 /** Map a detected language code to a default voice id. Unknown / low-confidence → undefined. */
 export function pickVoiceForLang(
   code: string | undefined,
@@ -30,10 +43,11 @@ export function pickVoiceForLang(
       // AVSpeech Milena is a macOS system voice (any arch); Vosk elsewhere.
       return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-vosk-m02";
     default:
-      // Multilingual Kokoro voices ship only on darwin-arm64 (FluidAudio ANE).
-      // Intel Macs have no such voice pack, so don't auto-route to ids the
-      // engine can't honour — fall through to the engine default instead.
+      // darwin-arm64: FluidAudio ANE voice pack (full multilingual set).
       if (platform === "darwin" && arch === "arm64") return DARWIN_KOKORO_DEFAULTS[baseCode];
-      return undefined;
+      // ONNX platforms (Linux, Windows, Intel macOS): es/fr/it/pt are supported
+      // via CharsiuG2P + ONNX Kokoro. Other languages (hi, ja, zh, …) have no
+      // ONNX voice pack, so fall through to the engine default (undefined).
+      return ONNX_KOKORO_DEFAULTS[baseCode];
   }
 }

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -66,6 +66,31 @@ describe("renderInstallPlan", () => {
     }
   });
 
+  test("--tts plan on non-darwin includes G2P + multilingual voice packs", async () => {
+    if (process.platform === "darwin" && process.arch === "arm64") {
+      // darwin-arm64 uses FluidAudio Kokoro warmup path, not the ONNX manifest
+      return;
+    }
+    const dir = mkdtempSync(join(tmpdir(), "kesha-install-plan-multilang-test-"));
+    try {
+      process.env.HOME = dir;
+      process.env.KESHA_CACHE_DIR = join(dir, "cache");
+      process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+
+      const output = await renderInstallPlan({ tts: true });
+
+      // G2P CharsiuG2P component present in plan
+      expect(output).toContain("G2P CharsiuG2P byt5-tiny");
+      expect(output).toContain("multilingual grapheme-to-phoneme for es/fr/it/pt");
+
+      // Kokoro component covers multilingual voices
+      expect(output).toContain("TTS Kokoro EN/ES/FR/IT/PT");
+      expect(output).toContain("multilingual es-*/fr-*/it-*/pt-*");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("darwin sidecar cache state follows installed filenames", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-install-plan-sidecar-test-"));
     try {

--- a/tests/unit/say-routing.test.ts
+++ b/tests/unit/say-routing.test.ts
@@ -18,8 +18,8 @@ describe("resolveSayVoice precedence", () => {
   });
 
   test("--lang with no mapped voice → undefined (engine default), no re-detection", async () => {
-    // French has no male Kokoro voice → unmapped on every platform.
-    expect(await resolveSayVoice(undefined, "fr", "Bonjour")).toBeUndefined();
+    // German has no Kokoro voice on any platform → unmapped everywhere.
+    expect(await resolveSayVoice(undefined, "de", "Hallo Welt")).toBeUndefined();
     // Unknown language code → unmapped.
     expect(await resolveSayVoice(undefined, "xx", "whatever")).toBeUndefined();
   });

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -27,14 +27,35 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("zh-Hans", 0.95, "darwin", "arm64")).toBe("zh-zm_yunjian");
   });
 
-  it("does not auto-route Kokoro-only languages on non-darwin", () => {
-    expect(pickVoiceForLang("es", 0.95, "linux")).toBeUndefined();
-    expect(pickVoiceForLang("ja", 0.95, "win32")).toBeUndefined();
+  it("does not auto-route languages without an ONNX voice pack on non-darwin", () => {
+    // hi/ja/zh have no ONNX voice pack; they should not be auto-routed.
+    expect(pickVoiceForLang("ja", 0.95, "linux")).toBeUndefined();
+    expect(pickVoiceForLang("hi", 0.95, "win32")).toBeUndefined();
+    expect(pickVoiceForLang("zh", 0.95, "linux")).toBeUndefined();
   });
 
-  it("does not auto-route multilingual Kokoro on Intel macOS (no FluidAudio voice pack)", () => {
-    expect(pickVoiceForLang("es", 0.95, "darwin", "x64")).toBeUndefined();
+  it("routes es/fr/it/pt to multilingual ONNX voices on non-darwin-arm64 (Track B)", () => {
+    // Linux and Windows use ONNX Kokoro with CharsiuG2P for these four languages.
+    for (const platform of ["linux", "win32"] as const) {
+      expect(pickVoiceForLang("es", 0.95, platform)).toBe("es-em_alex");
+      expect(pickVoiceForLang("fr", 0.95, platform)).toBe("fr-ff_siwis");
+      expect(pickVoiceForLang("it", 0.95, platform)).toBe("it-im_nicola");
+      expect(pickVoiceForLang("pt", 0.95, platform)).toBe("pt-pm_alex");
+    }
+    // Intel macOS also uses ONNX path (no FluidAudio arm64 voice pack).
+    expect(pickVoiceForLang("es", 0.95, "darwin", "x64")).toBe("es-em_alex");
+    expect(pickVoiceForLang("fr", 0.95, "darwin", "x64")).toBe("fr-ff_siwis");
+    expect(pickVoiceForLang("it", 0.95, "darwin", "x64")).toBe("it-im_nicola");
+    expect(pickVoiceForLang("pt", 0.95, "darwin", "x64")).toBe("pt-pm_alex");
+  });
+
+  it("routes ONNX-supported langs on Intel macOS; ja/hi/zh without ONNX pack return undefined", () => {
+    // es/fr/it/pt now route via ONNX on Intel macOS too (Track B, #212).
+    expect(pickVoiceForLang("es", 0.95, "darwin", "x64")).toBe("es-em_alex");
+    expect(pickVoiceForLang("fr", 0.95, "darwin", "x64")).toBe("fr-ff_siwis");
+    // ja/hi/zh have no ONNX voice pack — still undefined on Intel macOS.
     expect(pickVoiceForLang("ja", 0.95, "darwin", "x64")).toBeUndefined();
+    expect(pickVoiceForLang("hi", 0.95, "darwin", "x64")).toBeUndefined();
     // en (ONNX Kokoro) and ru (AVSpeech Milena) still route on Intel Macs.
     expect(pickVoiceForLang("en", 0.95, "darwin", "x64")).toBe("en-am_michael");
     expect(pickVoiceForLang("ru", 0.95, "darwin", "x64")).toBe(

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -68,8 +68,11 @@ describe("pickVoiceForLang (auto-routing)", () => {
   });
 
   it("returns undefined for unsupported languages", () => {
-    expect(pickVoiceForLang("fr", 0.95)).toBeUndefined();
-    expect(pickVoiceForLang("de", 0.95)).toBeUndefined();
+    // de/ko have no Kokoro voice on either the ONNX or the darwin path.
+    expect(pickVoiceForLang("de", 0.95, "linux", "x64")).toBeUndefined();
+    expect(pickVoiceForLang("ko", 0.95, "darwin", "arm64")).toBeUndefined();
+    // fr maps on the ONNX path (ff_siwis) but NOT on darwin/FluidAudio — no fr voice there.
+    expect(pickVoiceForLang("fr", 0.95, "darwin", "arm64")).toBeUndefined();
   });
 
   it("returns undefined when code is missing", () => {


### PR DESCRIPTION
**Draft — implementation in progress.** Design + plan for real per-language G2P on the ONNX TTS path (es/fr/it/pt), so `kesha say --voice {es,fr,it,pt}-*` produces natural speech instead of CoreML's English-accented Latin.

## Approach (Track B, from spike #507)
CharsiuG2P ByT5 → ONNX (the pre-converted **klebster** export, **CC-BY 4.0**) on the existing `ort`, KV-cache decode, + a per-language numbers/acronym normalizer ahead of G2P. Builds directly on the prior **#185** G2P-ONNX spike (on `main`), which already pinned klebster's SHA-256 hashes and verified byte-identical Rust↔Python IPA.

## Validated by ear (2026-06-01)
CharsiuG2P→Kokoro output for **all four languages** (es/fr/it/pt) confirmed natural-sounding.

## In this PR so far
- Design spec + implementation plan (spike-free: feasibility established by #185).

## Landing next (per the plan)
`charsiu` engine (byte tokenizer + KV-cache decode + remap) → numbers/acronym normalizer → g2p routing + `kokoro.rs` clamp/`phonemeCount-1` fixes → voices/models wiring + `kesha install --tts` → CI audio-regression gate.

## Notes
- Spanish defaults LatAm; **French defaults `ff_siwis` (female)** — documented brand-rule exception (no male fr voice in Kokoro v1.0), needs sign-off.
- CC-BY 4.0 → NOTICES attribution (Kleber Noel + Zhu et al.) lands with the model pin.

Refs #212.