### PR TITLE
fix(cli): year-only manpage date — stop monthly shell-artifacts CI drift

### DIFF
--- a/man/kesha.1
+++ b/man/kesha.1
@@ -1,4 +1,4 @@
-.TH KESHA 1 "May 2026" "kesha" "User Commands"
+.TH KESHA 1 "2026" "kesha" "User Commands"
 .SH NAME
 kesha \- open-source local voice toolkit
 .SH SYNOPSIS

--- a/src/shell-artifacts.ts
+++ b/src/shell-artifacts.ts
@@ -257,9 +257,11 @@ function roff(value: string): string {
 }
 
 function manpageDate(): string {
-  const now = new Date();
-  const month = now.toLocaleString("en-US", { month: "long" });
-  return `${month} ${now.getFullYear()}`;
+  // Year only — the man `.TH` date drove a monthly drift failure in the
+  // shell-artifacts test (committed "May 2026" vs regenerated "June 2026").
+  // Year granularity is plenty for a manpage revision date and stays stable
+  // across the year.
+  return `${new Date().getFullYear()}`;
 }
 
 function renderManpage(model: ArtifactModel): string {


### PR DESCRIPTION
The manpage `.TH` date was generated as `Month Year` (`src/shell-artifacts.ts::manpageDate`) but the result is committed as a fixture (`man/kesha.1`). The `shell-artifacts` drift test regenerates and compares, so it **fails on every month rollover** — right now committed "May 2026" vs regenerated "June 2026" — turning CI red on every open PR.

Fix: drop the month, keep the year (`.TH KESHA 1 "2026"`). Year granularity is plenty for a manpage revision date and is stable within the year. Regenerated `man/kesha.1` to match.

`bun test tests/unit/shell-artifacts.test.ts` → 3/3 pass; `tsc --noEmit` clean.