### PR TITLE
chore(ci): single 70% total coverage gate, drop per-file floors

### DIFF
--- a/.github/scripts/check-coverage.ts
+++ b/.github/scripts/check-coverage.ts
@@ -24,39 +24,22 @@ type FileCoverage = {
   linePct: number;
 };
 
+// Coverage policy: a single total-lines gate per language, no per-file floors.
+// The per-file map was an auto-ratchet pinned just below each file's current
+// coverage (with brittle 98%/100% outliers) — high friction (every feature that
+// touched a high-floor file had to add coverage-padding tests), low signal
+// (concentrated regressions are caught by review + the total gate). Dropped in
+// favour of one honest total floor.
 const presets: Record<PresetName, CoveragePreset> = {
   ts: {
     title: "TypeScript Coverage",
-    minTotalLines: 62,
-    minFileLines: {
-      "src/cli/main.ts": 40,
-      "src/doctor.ts": 92,
-      "src/engine.ts": 44,
-      "src/install-plan.ts": 79,
-      "src/star.ts": 97,
-      "src/stats.ts": 94,
-      "src/status.ts": 83,
-      "src/support-bundle.ts": 94,
-      "src/toon.ts": 100,
-      "src/transcribe.ts": 65,
-    },
+    minTotalLines: 70,
+    minFileLines: {},
   },
   rust: {
     title: "Rust Coverage",
-    minTotalLines: 65,
-    minFileLines: {
-      "src/cli/say.rs": 70,
-      "src/main.rs": 68,
-      "src/models.rs": 67,
-      "src/say_loop.rs": 64,
-      "src/transcribe/mod.rs": 70,
-      "src/transcribe/options.rs": 100,
-      "src/tts/encode.rs": 88,
-      "src/tts/say.rs": 23,
-      "src/tts/ssml/mod.rs": 83,
-      "src/tts/voices.rs": 98,
-      "src/vad.rs": 70,
-    },
+    minTotalLines: 70,
+    minFileLines: {},
   },
 };
 

--- a/.github/scripts/check-coverage.ts
+++ b/.github/scripts/check-coverage.ts
@@ -126,11 +126,18 @@ function renderSummary(title: string, total: FileCoverage, checked: Array<FileCo
     "",
     `Total line coverage: **${pct(total.linePct)}%** (${total.linesHit}/${total.linesFound})`,
     "",
-    "| File | Lines | Minimum |",
-    "| --- | ---: | ---: |",
-    ...checked.map((file) => `| \`${file.path}\` | ${pct(file.linePct)}% | ${file.min}% |`),
-    "",
   ];
+  // Only render the per-file table when floors are configured; with an empty
+  // minFileLines map `checked` is empty, so skip the header to avoid an
+  // orphaned table in the CI summary.
+  if (checked.length > 0) {
+    rows.push(
+      "| File | Lines | Minimum |",
+      "| --- | ---: | ---: |",
+      ...checked.map((file) => `| \`${file.path}\` | ${pct(file.linePct)}% | ${file.min}% |`),
+      "",
+    );
+  }
   return rows.join("\n");
 }
 


### PR DESCRIPTION
## What
Replace the per-file `minFileLines` coverage gates with a single **total-lines floor of 70%** per language (ts + rust). `minFileLines` is now `{}`.

## Why
The per-file map was an **auto-ratchet** — each floor pinned a few points under whatever coverage a file happened to have, with brittle `98%`/`100%` outliers (`voices.rs`, `transcribe/options.rs`, `toon.ts`). That's high friction / low signal:
- **Friction:** every feature that touched a high-floor file had to add coverage-padding tests. Concrete example: a routing change dropped `voices.rs` to 92.79% and the 98% floor rejected it, forcing tests for a trivial getter arm + test-helper restructuring just to satisfy the line counter.
- **Low signal:** the one thing per-file gates catch that a total gate doesn't — a *concentrated* regression in one file — is already caught by code review + the total floor.

A single total gate is honest and low-maintenance. Bar raised from 65→**70%** (ts currently 70.96%, rust 73.6%).

## Note
ts headroom is tight (70.96% vs 70%). If a near-term TS change dips it, the gate will flag — easy to nudge or add a test then. Rust has ~3.6% headroom.

No production code touched; CI-policy only.