### PR TITLE
feat(tts): multilingual G2P polish — PT/FR number connectors, acronym stop-lists, Castilian es-ES (#511)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,5 +424,12 @@ Spanish, French, Italian, and Portuguese are supported via CharsiuG2P (klebster 
 Kokoro v1.0 ships no male French voice; revisit when one exists). macOS CoreML (`system_kokoro`/FluidAudio)
 multilingual is a follow-up — those voices currently route through the English G2P.
 
+**Castilian Spanish:** select with `--lang es-ES`; `es` / `es-419` / `es-MX` use
+Latin-American (*seseo*). The upstream CharsiuG2P export has no Castilian θ tag (#511
+spike), so `es-ES` currently synthesizes Latin-American phonology and prints a one-time
+stderr note. Per-language acronym stop-lists (`ES/FR/IT/PT_STOP_LIST` in
+`rust/src/tts/normalize/acronyms.rs`) keep word-acronyms (OTAN, OVNI, FIFA…) from being
+letter-spelled; they are curated seeds, not exhaustive.
+
 **Engine internals, Kokoro/Vosk ONNX I/O shapes, G2P split, SSML handling, `KESHA_*` env vars,
 macOS dev/build env:** `docs/runbooks/tts-internals.md`.

--- a/docs/runbooks/tts-internals.md
+++ b/docs/runbooks/tts-internals.md
@@ -60,6 +60,17 @@ the normalizer runs first so digit sentences produce longer, correctly-paced aud
 **IO contract and latency reference:** `docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md`
 (PR #185) — verified ~36 ms/word on M2, byte-identical Rust↔Python IPA for es/fr/it/pt.
 
+### Multilingual G2P (#511)
+
+`--lang es-ES` selects Castilian Spanish via `charsiu::is_castilian_region` / `base_lang`
+resolution. Because the upstream CharsiuG2P klebster export contains no Castilian θ tag
+(confirmed in the #511 Phase-0 spike), the `CASTILIAN` decision constant is set to
+`Degrade`: the synthesizer falls back to Latin-American phonology (`<spa>` tag) and emits
+a one-time stderr note. `es` / `es-419` / `es-MX` continue to use Latin-American directly
+with no warning. Per-language acronym stop-lists (`ES/FR/IT/PT_STOP_LIST` in
+`rust/src/tts/normalize/acronyms.rs`) are curated seeds that prevent word-acronyms
+(OTAN, OVNI, FIFA…) from being letter-spelled; they are not exhaustive.
+
 ## History
 
 Original spec assumed Silero TTS; pivoted to Piper during M3 spike (Silero ships PyTorch-only, no public ONNX). See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.

--- a/docs/superpowers/plans/2026-06-01-multilingual-g2p-polish.md
+++ b/docs/superpowers/plans/2026-06-01-multilingual-g2p-polish.md
@@ -61,9 +61,23 @@ Expected θ-bearing IPA for Castilian (e.g. `zapato → θaˈpato`, `cielo → �
 
 Fill in **one** of the two outcomes below, commit this plan edit, then `rm -rf /tmp/castilian-spike /tmp/castilian-spike-venv`.
 
-> **SPIKE FINDING (2026-06-01): _[FILL IN]_**
-> - **Outcome A — native Castilian tag exists:** record the exact tag string (e.g. `<spa-es>`) and a sample θ output. Task 4 uses `CASTILIAN: Castilian = Castilian::Tag("<…>")`.
-> - **Outcome B — no native tag (only `<spa>` → seseo):** record the candidate tags tried and that all produced `s`. Task 4 uses `CASTILIAN: Castilian = Castilian::Degrade`.
+> **SPIKE FINDING (2026-06-01): Outcome B — no native Castilian tag.**
+> Probed `zapato / cielo / gracias / zorro / cinco` through the cached klebster export
+> (reusing the real `decode::greedy` path) under candidate tags `<spa>`, `<spa-es>`,
+> `<spa-me>`, `<spa-latin>`, `<spa-castilian>`, `<spa-ib>`:
+> - `<spa>` / `<spa-es>` / `<spa-me>` → **seseo /s/** (`zapato→sapato`, `cielo→sjelo`,
+>   `zorro→soro`) — identical to LatAm, no θ.
+> - `<spa-latin>` → /s/ with trailing-char hallucination.
+> - `<spa-castilian>` → garbage (`cielo→silian`) — tag unrecognized.
+> - `<spa-ib>` → literal /z/ + French-like ʁ (`zorro→zoʁo`) — also garbage, not θ.
+>
+> **No tag yields θ.** Decision: **`CASTILIAN: Castilian = Castilian::Degrade`** — `es-ES`
+> synthesizes LatAm `<spa>` with a one-time stderr note. Castilian θ deferred (would need
+> a grapheme-driven θ-injection layer — out of scope here, see spec Non-goals). Probe was a
+> throwaway gated unit test, reverted (not committed).
+>
+> _(For reference if a future tag appears — Outcome A would have used
+> `CASTILIAN: Castilian = Castilian::Tag("<…>")`.)_
 
 **Decision gate:** Tasks 4–6 reference `CASTILIAN`. Implement the matching branch; both branches are fully specified in Task 4 so the engineer codes only the one the spike selected, but the other compiles too (no dead code — see Task 4 Step 6).
 

--- a/docs/superpowers/plans/2026-06-01-multilingual-g2p-polish.md
+++ b/docs/superpowers/plans/2026-06-01-multilingual-g2p-polish.md
@@ -1,0 +1,593 @@
+# Multilingual G2P Polish Implementation Plan (#511)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Portuguese/French number connectors, stop word-acronyms from being letter-spelled in es/fr/it/pt, and add Castilian Spanish (θ) via `--lang es-ES` with a spike gate and Latin-American fallback.
+
+**Architecture:** Three deterministic fixes live in `rust/src/tts/normalize/{numbers,acronyms}.rs` (pure functions, exhaustive unit tests, no upstream dependency). Castilian threads a BCP-47 region subtag from the existing `--lang` override through `say_loop`/`say`/`g2p`/`charsiu`, choosing a Castilian G2P tag if the spike (Phase 0) finds one upstream, else degrading to Latin-American with a one-time stderr note.
+
+**Tech Stack:** Rust (`rust/src/tts/**`), `ort` (CharsiuG2P ONNX sessions), `cargo nextest`, a throwaway Python venv for the Phase-0 spike.
+
+**Design doc:** `docs/superpowers/specs/2026-06-01-multilingual-g2p-polish-design.md`
+
+**Working directory:** `.worktrees/mlang-g2p-polish` (branch `feat/mlang-g2p-polish`, off fresh `origin/main`).
+
+**Independence:** Tasks 1–3 are independent of Phase 0 and of each other — they may be implemented and committed in any order. Tasks 4–6 depend on the Phase-0 decision.
+
+**Verification (run before every push, per CLAUDE.md):**
+```bash
+cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts
+```
+Use `cargo nextest run`, never plain `cargo test`. If CI-only clippy flags `manual_is_multiple_of`, the repo prefers `x.is_multiple_of(n)` (#224).
+
+---
+
+## Phase 0: Castilian G2P spike (decision gate — blocks Tasks 4–6 only)
+
+**Goal:** Determine whether klebster's CharsiuG2P ByT5-tiny export emits a Castilian θ via a dedicated language tag, or only generic `<spa>` (Latin-American seseo). Records the decision that Tasks 4–6 consume. **No production code in this phase.**
+
+**Files:** none committed. Spike artifacts in `/tmp/castilian-spike/`, deleted after the finding is recorded here.
+
+- [ ] **Step 1: Stage the ONNX export (reuse the existing cache if present)**
+
+The three CharsiuG2P files are already pinned in `rust/src/models.rs` and cached at `~/.cache/kesha/models/g2p/byt5-tiny/` after any `kesha install --tts`. Confirm they exist; if not, the spike can pull them from the klebster HF repo `klebster/g2p_multilingual_byT5_tiny_onnx`.
+
+```bash
+ls -la ~/.cache/kesha/models/g2p/byt5-tiny/
+# expect: encoder_model.onnx, decoder_model.onnx, decoder_with_past_model.onnx
+```
+
+- [ ] **Step 2: Create a throwaway venv and probe the tag vocabulary**
+
+Per CLAUDE.md "PYTHON DEPENDENCIES GO IN A VENV":
+```bash
+python3 -m venv /tmp/castilian-spike-venv
+/tmp/castilian-spike-venv/bin/pip install --quiet onnxruntime transformers
+```
+
+The CharsiuG2P training tags are documented in the upstream `charsiu/g2p` README and the ByT5 tokenizer is pure byte-level (no tag is "unknown" — any `<tag>:` string is just bytes). So the real question is **empirical**: does any plausible Castilian tag (`<spa-es>`, `<spa-ib>`, `<spa-eu>`, `<spa-castilian>`) yield θ for θ-words while `<spa>` does not? Run the model end-to-end on a θ corpus and compare.
+
+- [ ] **Step 3: Run the θ probe end-to-end**
+
+Write `/tmp/castilian-spike/probe.py` that loads the three ONNX sessions (mirror `rust/src/tts/charsiu/decode.rs`: encoder once, decoder step 0, decoder_with_past steps 1..N, byte-id encode = `byte + 3`, EOS=1) and phonemizes the corpus `["zapato","cielo","gracias","zorro","cinco"]` under each candidate tag plus baseline `<spa>`.
+
+Expected θ-bearing IPA for Castilian (e.g. `zapato → θaˈpato`, `cielo → ˈθjelo`); LatAm gives `s` (`saˈpato`, `ˈsjelo`).
+
+```bash
+/tmp/castilian-spike-venv/bin/python3 /tmp/castilian-spike/probe.py
+```
+
+- [ ] **Step 4: Record the decision in this file and clean up**
+
+Fill in **one** of the two outcomes below, commit this plan edit, then `rm -rf /tmp/castilian-spike /tmp/castilian-spike-venv`.
+
+> **SPIKE FINDING (2026-06-01): _[FILL IN]_**
+> - **Outcome A — native Castilian tag exists:** record the exact tag string (e.g. `<spa-es>`) and a sample θ output. Task 4 uses `CASTILIAN: Castilian = Castilian::Tag("<…>")`.
+> - **Outcome B — no native tag (only `<spa>` → seseo):** record the candidate tags tried and that all produced `s`. Task 4 uses `CASTILIAN: Castilian = Castilian::Degrade`.
+
+**Decision gate:** Tasks 4–6 reference `CASTILIAN`. Implement the matching branch; both branches are fully specified in Task 4 so the engineer codes only the one the spike selected, but the other compiles too (no dead code — see Task 4 Step 6).
+
+---
+
+## Task 1: Portuguese number connectors
+
+**Files:**
+- Modify: `rust/src/tts/normalize/numbers.rs:420-437` (`pt_words`)
+- Test: `rust/src/tts/normalize/numbers.rs` (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `numbers.rs`:
+```rust
+#[test]
+fn portuguese_thousands_connector() {
+    // "e" joins thousands↔remainder only when remainder < 100 or a multiple of 100.
+    assert_eq!(to_words(1024, "pt"), "mil e vinte e quatro");        // rem 24  < 100
+    assert_eq!(to_words(1500, "pt"), "mil e quinhentos");           // rem 500 multiple of 100
+    assert_eq!(to_words(1100, "pt"), "mil e cem");                  // rem 100 multiple of 100
+    assert_eq!(to_words(1524, "pt"), "mil quinhentos e vinte e quatro"); // rem 524 non-round hundreds
+    assert_eq!(to_words(2350, "pt"), "dois mil trezentos e cinquenta"); // rem 350 non-round hundreds
+    assert_eq!(to_words(2000, "pt"), "dois mil");                   // no remainder
+    assert_eq!(to_words(24, "pt"), "vinte e quatro");               // no thousands group
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts numbers::tests::portuguese_thousands_connector`
+Expected: FAIL — `to_words(1524, "pt")` returns `"mil e quinhentos e vinte e quatro"` (extra "e").
+
+- [ ] **Step 3: Implement the conditional connector**
+
+Replace the body of `pt_words` (currently ending in `parts.join(" e ")`) with:
+```rust
+fn pt_words(n: u32) -> String {
+    if n == 0 {
+        return "zero".into();
+    }
+    let (thousands, rem) = (n / 1000, n % 1000);
+    let mut parts: Vec<String> = Vec::new();
+    if thousands > 0 {
+        if thousands == 1 {
+            parts.push("mil".into());
+        } else {
+            parts.push(format!("{} mil", pt_under_1000(thousands)));
+        }
+    }
+    if rem > 0 {
+        parts.push(pt_under_1000(rem));
+    }
+    // Portuguese inserts "e" between the thousands group and the remainder only
+    // when the remainder is < 100 OR an exact multiple of 100; otherwise the
+    // groups are joined with a plain space.
+    //   1024 -> "mil e vinte e quatro"             (rem 24, < 100)
+    //   1500 -> "mil e quinhentos"                 (rem 500, multiple of 100)
+    //   1524 -> "mil quinhentos e vinte e quatro"  (rem 524, non-round hundreds)
+    if parts.len() == 2 {
+        let connector = if rem < 100 || rem.is_multiple_of(100) {
+            " e "
+        } else {
+            " "
+        };
+        format!("{}{}{}", parts[0], connector, parts[1])
+    } else {
+        // 0 or 1 part: nothing to connect.
+        parts.join(" ")
+    }
+}
+```
+Note: `rem.is_multiple_of(100)` is the repo-preferred form (#224). If the local toolchain rejects it, use `rem % 100 == 0` and expect CI clippy to ask for the change.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd rust && cargo nextest run --features tts numbers::tests::portuguese_thousands_connector`
+Expected: PASS. Also run the existing `numbers::tests::large_numbers_do_not_panic` to confirm no regression.
+
+- [ ] **Step 5: Commit**
+```bash
+git add rust/src/tts/normalize/numbers.rs
+git commit -m "fix(tts): correct Portuguese thousands connector (#511)"
+```
+
+---
+
+## Task 2: French 71 connector ("soixante-et-onze")
+
+**Files:**
+- Modify: `rust/src/tts/normalize/numbers.rs:135-138` (the `70..=79` arm of `fr_under_100`)
+- Test: `rust/src/tts/normalize/numbers.rs` (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module:
+```rust
+#[test]
+fn french_seventy_one_takes_et() {
+    // 71 is the one value in 70-79 that takes the "et" connector (like 21/31/.../61).
+    assert_eq!(to_words(71, "fr"), "soixante-et-onze");
+    // Controls: the rest of 70-79 stay hyphenated without "et".
+    assert_eq!(to_words(72, "fr"), "soixante-douze");
+    assert_eq!(to_words(79, "fr"), "soixante-dix-neuf");
+    // 80s/90s never take "et".
+    assert_eq!(to_words(81, "fr"), "quatre-vingt-un");
+    assert_eq!(to_words(91, "fr"), "quatre-vingt-onze");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts numbers::tests::french_seventy_one_takes_et`
+Expected: FAIL — `to_words(71, "fr")` returns `"soixante-onze"` (no "et").
+
+- [ ] **Step 3: Special-case 71 in the 70..=79 arm**
+
+In `fr_under_100`, replace the `70..=79` arm:
+```rust
+        // 70-79 = soixante + 10..19
+        70..=79 => {
+            let sub = FR_UNITS[(n - 60) as usize];
+            // 71 takes the "et" connector (soixante-et-onze), mirroring
+            // vingt-et-un/.../soixante-et-un. 72-79 stay plain-hyphenated.
+            if n == 71 {
+                "soixante-et-onze".to_string()
+            } else {
+                format!("soixante-{sub}")
+            }
+        }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd rust && cargo nextest run --features tts numbers::tests::french_seventy_one_takes_et`
+Expected: PASS. Run the existing `french_integers` test to confirm no regression.
+
+- [ ] **Step 5: Commit**
+```bash
+git add rust/src/tts/normalize/numbers.rs
+git commit -m "fix(tts): French 71 takes the 'et' connector (#511)"
+```
+
+---
+
+## Task 3: Per-language acronym stop-lists
+
+**Files:**
+- Modify: `rust/src/tts/normalize/acronyms.rs` (add stop-list consts + consult them in `spell`/the spell path)
+- Test: `rust/src/tts/normalize/acronyms.rs` (`#[cfg(test)] mod tests`)
+
+Mirrors the English path (`rust/src/tts/en/acronym.rs:24` `STOP_LIST` + its `every_stop_list_entry_round_trips` test).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `acronyms.rs`:
+```rust
+#[test]
+fn stop_listed_word_acronyms_pass_through_unspelled() {
+    // Word-acronyms read as words must NOT be letter-spelled.
+    assert_eq!(spell("OTAN", "es"), "OTAN");
+    assert_eq!(spell("OVNI", "es"), "OVNI");
+    assert_eq!(spell("FIFA", "fr"), "FIFA");
+    assert_eq!(spell("FIAT", "it"), "FIAT");
+    assert_eq!(spell("SIDA", "pt"), "SIDA");
+    // True initialisms still spell letter-by-letter.
+    assert_eq!(spell("DNI", "es"), "de ene i");
+    // Cross-language isolation: an es-only entry does not suppress under it.
+    // "OEA" is es/pt-list only; under "it" it letter-spells.
+    assert_eq!(spell("OEA", "it"), "o e a");
+}
+
+#[test]
+fn every_stop_list_entry_passes_through() {
+    for (lang, list) in [
+        ("es", ES_STOP_LIST),
+        ("fr", FR_STOP_LIST),
+        ("it", IT_STOP_LIST),
+        ("pt", PT_STOP_LIST),
+    ] {
+        for w in list {
+            assert_eq!(spell(w, lang), *w, "stop-list entry was spelled: {w} ({lang})");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts acronyms::tests`
+Expected: FAIL — `spell("OTAN","es")` returns `"o te a ene"` (letter-spelled); `ES_STOP_LIST` is undefined (compile error is acceptable as the failing state).
+
+- [ ] **Step 3: Add the stop-list consts**
+
+Add near the top of `acronyms.rs` (after the letter-name tables):
+```rust
+// ── Stop-lists: all-caps tokens that are read as WORDS, not spelled out ──────
+// Hand-curated seeds, case-sensitive ALL-CAPS keys. NOT exhaustive — extend by
+// ear. Mirrors `tts/en/acronym.rs::STOP_LIST`. Initialisms that SHOULD spell
+// (DNI, ADN, RAI, EUA) are deliberately absent.
+pub(crate) const ES_STOP_LIST: &[&str] =
+    &["OTAN", "OVNI", "SIDA", "OPEP", "OEA", "ONU", "UNESCO", "FIFA", "OMS"];
+pub(crate) const FR_STOP_LIST: &[&str] =
+    &["OTAN", "OVNI", "SIDA", "UNESCO", "FIFA", "OPEP", "ONU", "OMS"];
+pub(crate) const IT_STOP_LIST: &[&str] =
+    &["FIAT", "NATO", "FIFA", "AIDS", "UNESCO", "ONU"];
+pub(crate) const PT_STOP_LIST: &[&str] =
+    &["OTAN", "OVNI", "SIDA", "AIDS", "FIFA", "UNESCO", "ONU", "OMS"];
+
+/// True if `token` is in `lang`'s stop-list (read as a word, not letter-spelled).
+fn is_stop_listed(token: &str, lang: &str) -> bool {
+    let list: &[&str] = match lang {
+        "es" => ES_STOP_LIST,
+        "fr" => FR_STOP_LIST,
+        "it" => IT_STOP_LIST,
+        "pt" => PT_STOP_LIST,
+        _ => &[],
+    };
+    list.iter().any(|w| w.eq_ignore_ascii_case(token))
+}
+```
+
+- [ ] **Step 4: Consult the stop-list in `spell`**
+
+At the very top of the existing `pub fn spell(token: &str, lang: &str) -> String` body, before the per-language letter-name match, add:
+```rust
+    // Word-acronyms (read as words) pass through unspelled.
+    if is_stop_listed(token, lang) {
+        return token.to_string();
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd rust && cargo nextest run --features tts acronyms::tests`
+Expected: PASS (all, including the existing `spells_acronyms_with_spanish_letter_names` and `spells_italian_acronyms_including_jkwxy`).
+
+- [ ] **Step 6: Commit**
+```bash
+git add rust/src/tts/normalize/acronyms.rs
+git commit -m "feat(tts): per-language acronym stop-lists for es/fr/it/pt (#511)"
+```
+
+---
+
+## Task 4: Castilian dialect — region parsing + G2P tag selection
+
+**Files:**
+- Modify: `rust/src/tts/charsiu/mod.rs:43-74` (`Charsiu::to_ipa` tag selection)
+- Create: a small `castilian` helper (region parsing + the spike decision) inside `rust/src/tts/charsiu/mod.rs` or `rust/src/tts/normalize/mod.rs`
+- Test: `rust/src/tts/charsiu/mod.rs` (`#[cfg(test)] mod tests`)
+
+**Depends on:** Phase 0 `CASTILIAN` decision.
+
+- [ ] **Step 1: Write the failing test for region parsing**
+
+Add to the `charsiu` tests module:
+```rust
+#[test]
+fn castilian_region_detection() {
+    // Region subtag drives Castilian; base/LatAm regions do not.
+    assert!(is_castilian_region("es-ES"));
+    assert!(is_castilian_region("es-es"));      // case-insensitive
+    assert!(!is_castilian_region("es"));
+    assert!(!is_castilian_region("es-419"));
+    assert!(!is_castilian_region("es-MX"));
+    assert!(!is_castilian_region("fr"));        // non-Spanish never Castilian
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts charsiu::tests::castilian_region_detection`
+Expected: FAIL — `is_castilian_region` undefined.
+
+- [ ] **Step 3: Implement region parsing + base-lang split**
+
+Add to `charsiu/mod.rs`:
+```rust
+/// True when an espeak-style lang code selects Castilian Spanish (e.g. "es-ES").
+/// LatAm regions ("es", "es-419", "es-MX", …) and non-Spanish codes are false.
+pub(crate) fn is_castilian_region(lang: &str) -> bool {
+    let lower = lang.to_ascii_lowercase();
+    matches!(lower.as_str(), "es-es") || lower.starts_with("es-es-")
+}
+
+/// Reduce a (possibly region-tagged) code to the base lang Charsiu understands:
+/// "es-ES"/"es-419"/"es-MX" → "es"; "pt-br" → "pt"; passthrough otherwise.
+pub(crate) fn base_lang(lang: &str) -> &str {
+    match lang.split('-').next() {
+        Some(b) if matches!(b.to_ascii_lowercase().as_str(), "es" | "fr" | "it" | "pt") => b,
+        _ => lang,
+    }
+}
+```
+
+- [ ] **Step 4: Add the spike-derived Castilian decision**
+
+Add the `CASTILIAN` constant per the Phase-0 finding:
+```rust
+/// Spike-derived (#511 Phase 0): how to realize Castilian θ.
+enum Castilian {
+    /// Native CharsiuG2P tag that emits θ (Outcome A). Holds the tag string.
+    Tag(&'static str),
+    /// No upstream Castilian tag (Outcome B). `es-ES` degrades to LatAm `<spa>`
+    /// with a one-time stderr note.
+    Degrade,
+}
+
+// FILL IN from the Phase-0 finding (exactly one):
+//   const CASTILIAN: Castilian = Castilian::Tag("<spa-es>");   // Outcome A
+//   const CASTILIAN: Castilian = Castilian::Degrade;           // Outcome B
+const CASTILIAN: Castilian = Castilian::Degrade;
+```
+
+- [ ] **Step 5: Thread the dialect into `to_ipa`**
+
+Change `Charsiu::to_ipa` to accept the full (region-tagged) lang and pick the tag:
+```rust
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_ipa(&mut self, text: &str, lang: &str) -> Result<String> {
+        let castilian = is_castilian_region(lang);
+        let tag = match base_lang(lang) {
+            "es" => match (&CASTILIAN, castilian) {
+                (Castilian::Tag(t), true) => t,
+                (Castilian::Degrade, true) => {
+                    // User-facing, one-time per process (survives --stdin-loop).
+                    use std::sync::Once;
+                    static NOTE: Once = Once::new();
+                    NOTE.call_once(|| {
+                        eprintln!(
+                            "note: Castilian (θ) pronunciation is unavailable; \
+                             using Latin-American Spanish."
+                        );
+                    });
+                    "<spa>"
+                }
+                _ => "<spa>",
+            },
+            "fr" => "<fra>",
+            "it" => "<ita>",
+            "pt" => "<por-bz>",
+            other => anyhow::bail!("CharsiuG2P: unsupported language {other:?}"),
+        };
+        // … unchanged per-word decode loop using `tag` …
+    }
+```
+
+- [ ] **Step 6: Avoid dead-code lint on the unused `Castilian` variant**
+
+Because only one `CASTILIAN` value ships, the other enum variant is unreferenced and `-D warnings` will fail (`dead_code`). Annotate the enum with a justification (allowed per CLAUDE.md "NO SPECULATIVE FIELDS"):
+```rust
+/// Spike-derived (#511 Phase 0): how to realize Castilian θ. Both variants are
+/// part of the documented decision surface; only one is selected per build.
+#[allow(dead_code)] // the non-selected variant is the documented alternative outcome
+enum Castilian { /* … */ }
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd rust && cargo nextest run --features tts charsiu::tests`
+Expected: PASS. The existing gated `to_ipa_phonemizes_when_model_available` still passes (it calls `to_ipa("…","fr")` etc., unaffected).
+
+- [ ] **Step 8: Commit**
+```bash
+git add rust/src/tts/charsiu/mod.rs
+git commit -m "feat(tts): Castilian region parsing + G2P tag selection (#511)"
+```
+
+---
+
+## Task 5: Wire `--lang es-ES` through the synth paths
+
+**Files:**
+- Modify: `rust/src/tts/g2p.rs:24` (Romance routing match — accept region-tagged es)
+- Modify: `rust/src/tts/g2p.rs:71-78` (`charsiu_ipa` passes the full lang through)
+- Modify: `rust/src/say_loop.rs:271` (CharsiuCache branch match — accept region-tagged es)
+- Modify: `rust/src/tts/sessions.rs:200-207` (`CharsiuCache::to_ipa` keeps the region tag)
+- Test: `rust/src/tts/g2p.rs` (`#[cfg(test)] mod tests`)
+
+**Depends on:** Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `g2p.rs` tests:
+```rust
+#[test]
+fn castilian_region_routes_to_charsiu() {
+    // "es-ES" must route to CharsiuG2P (not bail to the misaki/#212 path).
+    match text_to_ipa("cielo", "es-ES") {
+        Ok(ipa) => assert!(!ipa.is_empty(), "es-ES: empty IPA"),
+        Err(e) => {
+            let m = e.to_string();
+            assert!(m.contains("install") || m.contains("G2P"), "es-ES unexpected: {m}");
+            assert!(!m.contains("not supported in this build"), "es-ES bailed to #212: {m}");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts g2p::tests::castilian_region_routes_to_charsiu`
+Expected: FAIL — "es-es" misses the `matches!(lower, "es"|"fr"|"it"|"pt")` guard and bails with the #212 message.
+
+- [ ] **Step 3: Accept region-tagged Romance codes in `text_to_ipa`**
+
+In `g2p.rs`, replace the Romance guard (line ~24) to test the **base** language and pass the full code to Charsiu:
+```rust
+    // Romance languages: normalize then CharsiuG2P (ONNX ByT5-tiny, #212).
+    // Region subtags (e.g. "es-ES" for Castilian) are preserved for tag choice.
+    let base = crate::tts::charsiu::base_lang(&lower);
+    if matches!(base, "es" | "fr" | "it" | "pt") {
+        crate::dtrace!("g2p::route lang={lang} backend=charsiu text_chars={text_chars}");
+        let dir = crate::models::cache_dir().join("models/g2p/byt5-tiny");
+        check_charsiu_files(&dir)?;
+        let mut g = crate::tts::charsiu::Charsiu::load(&dir)?;
+        let ipa = charsiu_ipa(&mut g, text, &lower)?; // pass full code (region-aware)
+        crate::dtrace!("g2p::result ipa_chars={}", ipa.chars().count());
+        return Ok(ipa);
+    }
+```
+And in `charsiu_ipa`, normalize with the **base** lang but phonemize with the **full** code:
+```rust
+pub(crate) fn charsiu_ipa(
+    g: &mut crate::tts::charsiu::Charsiu,
+    text: &str,
+    lang: &str,
+) -> Result<String> {
+    let base = crate::tts::charsiu::base_lang(lang);
+    let normalized = crate::tts::normalize::normalize(text, base);
+    g.to_ipa(&normalized, lang) // full code so to_ipa sees the region subtag
+}
+```
+(`normalize` only matches bare `"es"|"fr"|"it"|"pt"`, so it must receive `base`, not `"es-ES"`.)
+
+- [ ] **Step 4: Accept region-tagged es in the cached loop path**
+
+In `say_loop.rs:271`, change the CharsiuCache guard to test the base language:
+```rust
+                let ipa = if matches!(
+                    crate::tts::charsiu::base_lang(espeak_lang),
+                    "es" | "fr" | "it" | "pt"
+                ) {
+                    state
+                        .charsiu
+                        .to_ipa(&state.cache_dir, &req.text, espeak_lang) // full code
+                        // … unchanged …
+```
+Confirm `CharsiuCache::to_ipa` (`sessions.rs:200-207`) forwards `lang` unchanged to `charsiu_ipa` (it already does: `super::g2p::charsiu_ipa(g, text, lang)`), so no change there beyond passing the region-tagged `espeak_lang`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd rust && cargo nextest run --features tts g2p::tests::castilian_region_routes_to_charsiu`
+Expected: PASS. Also run `g2p::tests::romance_langs_route_to_charsiu_not_212_bail` and the full `cargo nextest run --features tts` to confirm no regression.
+
+- [ ] **Step 6: Commit**
+```bash
+git add rust/src/tts/g2p.rs rust/src/say_loop.rs rust/src/tts/sessions.rs
+git commit -m "feat(tts): route --lang es-ES through CharsiuG2P (#511)"
+```
+
+---
+
+## Task 6: Docs + audio regression fixture
+
+**Files:**
+- Modify: `rust/fixtures/tts/multilang_corpus.json` (add es-ES θ, PT 4-digit, FR-71 lines)
+- Modify: `CLAUDE.md` (TTS section — `es-ES` lever + degrade note)
+- Modify: `docs/runbooks/tts-internals.md` (Castilian + stop-list seeds)
+
+- [ ] **Step 1: Add regression lines to the corpus fixture**
+
+`rust/fixtures/tts/multilang_corpus.json` is a `{ lang: [sentences] }` map, and the
+harness (`rust/tests/tts_multilang_audio.rs`) keys on the lang via `default_voice(lang)`,
+which `panic!`s on unknown keys. So **do not** add an `"es-ES"` key — append the new
+sentences to the existing `"pt"` and `"fr"` arrays (exercises the PT connector + FR-71 fixes
+through the unchanged harness). Castilian θ is covered by the audio-quality-check agent in
+Step 4, not here — the structural test (RMS/silence/rate/length) cannot distinguish θ from
+s anyway.
+
+Edit the file to:
+```json
+{
+  "es": ["El veloz murciélago hindú comía feliz cardillo y kiwi.", "Compré 27 libros y el código ISBN empezaba por X."],
+  "fr": ["Un bon vin blanc, un grand pont, enfin les enfants chantent.", "Il a soixante-et-onze ans et lit le journal."],
+  "it": ["Ma la volpe col suo balzo ha raggiunto il quieto Fido."],
+  "pt": ["Um pequeno jabuti xereta viu dez cegonhas felizes.", "O documento data do ano de mil quinhentos e vinte e quatro."]
+}
+```
+
+- [ ] **Step 2: Run the gated audio-regression test**
+
+Run: `cd rust && CHARSIU_ONNX=~/.cache/kesha/models/g2p/byt5-tiny cargo nextest run --features tts tts_multilang_audio`
+Expected: PASS (no-clip / 24 kHz / RMS / length within bounds) for all four langs incl. the
+two new sentences. If models are absent the test self-skips with an `eprintln!` (Gate 1/2);
+in that case note the skip in the commit message and rely on the agent in Step 4.
+
+- [ ] **Step 3: Update docs**
+
+In `CLAUDE.md` TTS section, add after the multilingual paragraph:
+```markdown
+Castilian Spanish (θ / *distinción*) is selectable with `--lang es-ES`; `es` /
+`es-419` / `es-MX` use Latin-American (*seseo*). [If Outcome B shipped:] When the
+upstream G2P lacks a Castilian tag, `es-ES` synthesizes Latin-American phonology
+and prints a one-time stderr note.
+```
+In `docs/runbooks/tts-internals.md`, document `is_castilian_region`/`base_lang`, the `CASTILIAN` decision, and that the acronym stop-lists (`ES/FR/IT/PT_STOP_LIST`) are curated seeds, not exhaustive.
+
+- [ ] **Step 4: Generate samples and run the audio-quality-check agent**
+
+Build the debug engine and synthesize the three new lines plus an es-ES vs es contrast (`zapato`, `cielo`), then dispatch the `audio-quality-check` agent over the WAVs (RMS/silence/clip/rate/length). Record the verdict in the PR body.
+
+- [ ] **Step 5: Commit**
+```bash
+git add rust/fixtures/tts/multilang_corpus.json CLAUDE.md docs/runbooks/tts-internals.md
+git commit -m "docs(tts): document es-ES dialect + add regression fixtures (#511)"
+```
+
+---
+
+## Final steps (after all tasks)
+
+- [ ] **Full gate:** `cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts`
+- [ ] **CoreML guard** (Task 4/5 touch `tts` modules, not `backend`, but `charsiu`/`g2p` compile under both feature sets): `cd rust && cargo check --features coreml --no-default-features`
+- [ ] **Open PR:** `gh pr create --base main --head feat/mlang-g2p-polish` with body `Closes #511, Refs #212`, the Phase-0 spike finding (Outcome A/B), and the audio-quality-check verdict. Add the `WIP` label when starting (`gh issue edit 511 --add-label WIP`).
+- [ ] **Greptile gate:** wait for CI + Greptile on the head SHA; address P1/P2; re-wait after each push (per CLAUDE.md "GREPTILE PR REVIEW IS A GATE").

--- a/docs/superpowers/specs/2026-06-01-multilingual-g2p-polish-design.md
+++ b/docs/superpowers/specs/2026-06-01-multilingual-g2p-polish-design.md
@@ -1,0 +1,168 @@
+# Multilingual G2P Polish — Design (#511)
+
+**Status:** approved (brainstorm), pending implementation plan
+**Refs:** #511, #212, follow-up to #509
+
+## Problem
+
+#509 shipped multilingual TTS (es/fr/it/pt) on the ONNX Kokoro path via CharsiuG2P plus
+a per-language numbers/acronym normalizer. Its review surfaced three non-blocking P3
+follow-ups, plus one related number-connector finding. This spec covers all four as a
+single cohesive "normalizer + dialect polish" effort.
+
+Three of the four items are **pure deterministic normalizer logic** (no upstream
+dependency, exhaustively unit-testable). The fourth — Castilian Spanish — touches G2P
+routing and `say` plumbing and is **gated on a spike** of the upstream G2P artifact.
+
+## Goal
+
+- Correct Portuguese number connectors for 4-digit values.
+- Correct the French 71 connector ("soixante-et-onze").
+- Stop natural word-acronyms (OTAN, OVNI, FIFA, …) from being letter-spelled in es/fr/it/pt.
+- Add Castilian Spanish (θ / *distinción*) as a selectable dialect via `--lang es-ES`,
+  gated on whether the upstream G2P supports it, with a safe Latin-American fallback.
+
+### Non-goals
+
+- No new voices, no new CLI flags (Castilian reuses the existing `--lang` BCP-47 override).
+- No exhaustive acronym dictionaries — curated, extensible seed lists only.
+- macOS CoreML (`system_kokoro`) multilingual remains out of scope (closed: #510).
+- No change to the English path (`tts/en/*`), which already has its own stop-list.
+
+## Architecture & boundaries
+
+| Component | Files | Nature | Risk |
+|---|---|---|---|
+| 1. Number connectors | `rust/src/tts/normalize/numbers.rs` | Pure fn | None — deterministic |
+| 2. Acronym stop-lists | `rust/src/tts/normalize/acronyms.rs` | Pure fn | None — deterministic |
+| 3. Castilian dialect | `rust/src/tts/charsiu/*`, `voices.rs`, `g2p.rs`, `say` plumbing | G2P routing | Spike-gated |
+| 4. Wiring/docs/tests | fixtures, runbooks, CLAUDE.md | Glue | None |
+
+Components 1, 2, 4 ship regardless of the spike outcome in Component 3.
+
+## Component 1 — Number connector fixes (`numbers.rs`)
+
+### Portuguese
+
+Replace the unconditional `parts.join(" e ")` in `pt_words` (`numbers.rs:436`) with the
+standard rule: insert **"e"** between the thousands group and the remainder **iff** the
+remainder is `< 100` **or** an exact multiple of 100; otherwise join with a space.
+
+The existing intra-group connector (hundreds → tens/units, e.g. `cento e vinte e quatro`)
+is already correct and stays.
+
+| n | before (wrong) | after (correct) |
+|---|---|---|
+| 1024 | mil e vinte e quatro | mil e vinte e quatro *(unchanged — was already right)* |
+| 1500 | mil e quinhentos | mil e quinhentos *(unchanged)* |
+| 1524 | mil **e** quinhentos e vinte e quatro | mil quinhentos e vinte e quatro |
+| 2350 | dois mil **e** trezentos e cinquenta | dois mil trezentos e cinquenta |
+| 2000 | dois mil | dois mil *(unchanged)* |
+| 1100 | mil e cem | mil e cem *(rem 100, round → e)* |
+
+Rule applies only to the thousands↔remainder seam; values ≥ 1,000,000 remain guarded
+(return the digit string) as today.
+
+### French
+
+Special-case **71 → "soixante-et-onze"** inside the `70..=79` arm of `fr_under_100`
+(`numbers.rs:135`), matching the existing hyphenated `vingt-et-un` style produced by the
+`u == 1 && t < 8` branch. 72–79 stay `soixante-douze … soixante-dix-neuf`; 81/91 stay
+`quatre-vingt-un` / `quatre-vingt-onze` (no "et") — already correct, covered by a
+regression assertion.
+
+## Component 2 — Per-language acronym stop-lists (`acronyms.rs`)
+
+Today `acronyms.rs` letter-spells every all-caps 2–5-char token via the structural
+`is_acronym_token` + `spell`. Word-acronyms (read as words, not letters) are spelled
+incorrectly.
+
+Mirror the English path (`tts/en/acronym.rs:24`, `STOP_LIST` + the
+`every_stop_list_entry_round_trips` test): add `ES_STOP_LIST`, `FR_STOP_LIST`,
+`IT_STOP_LIST`, `PT_STOP_LIST` const arrays. The spell path consults the active
+language's list case-insensitively; a match passes the token through **unspelled** (no
+letter expansion). Unknown languages keep today's behavior.
+
+Seed contents (hand-curated, extensible, explicitly non-exhaustive):
+
+- **es:** OTAN, OVNI, SIDA, OPEP, OEA, ONU, UNESCO, FIFA, OMS
+- **fr:** OTAN, OVNI, SIDA, UNESCO, FIFA, OPEP, ONU, OMS
+- **it:** FIAT, NATO, FIFA, AIDS, UNESCO, ONU
+- **pt:** OTAN, OVNI, SIDA, AIDS, FIFA, UNESCO, ONU, OMS
+
+(Final per-language membership validated by ear during implementation; the list is a
+seed, not a contract.)
+
+Initialisms that *should* spell (DNI, ADN, RAI, EUA) are deliberately absent and keep
+letter-spelling. No logging.
+
+## Component 3 — Castilian Spanish (spike-gated)
+
+### Selection lever
+
+Reuse the existing `say --lang <LANG>` BCP-47 override (already used for `en-gb`):
+
+- `--lang es-ES` (any `es-ES*` region subtag) → **Castilian** (*distinción*, θ).
+- `--lang es`, `es-419`, `es-MX`, `es-AR`, … → **Latin-American** (*seseo*, default).
+
+Thread the BCP-47 region subtag from `--lang` through to the es branch of the G2P path so
+it can pick the Castilian tag/behavior. No new voices, no new flags.
+
+### θ background (why a spike is required)
+
+The Castilian θ/s split is 100% predictable from spelling: /θ/ ⇔ every `z` and every `c`
+before `e`/`i`; all other /s/ comes from `s`/`x`. But CharsiuG2P output is not aligned to
+source graphemes, so a naive post-G2P "/s/→/θ/" remap would wrongly convert /s/ from `s`.
+Producing θ correctly therefore needs either a native Castilian G2P tag or careful
+grapheme-position tracking — hence the decision gate.
+
+### Phase-1 spike (hard decision gate)
+
+Per the repo's "verify third-party model formats with a spike" rule: download/run klebster
+CharsiuG2P end-to-end on a θ-bearing corpus (*zapato, cielo, gracias, zorro, cinco*) and
+determine whether it exposes a native Castilian/Iberian Spanish tag (e.g. some `<spa-*>`
+variant) that emits θ. Spike artifacts live in `/tmp/castilian-spike/` and are deleted
+after the finding is recorded here.
+
+- **Native tag exists →** route `es-ES` to that tag. θ produced natively. Add a regression
+  asserting θ appears for *zapato/cielo* and not for *sopa/casa*.
+- **No native tag →** **graceful degrade**: `es-ES` still synthesizes, but via the generic
+  `<spa>` (LatAm seseo) phonology, and emits a **one-time stderr note**: "Castilian (θ)
+  pronunciation is unavailable; using Latin-American Spanish." Castilian θ is deferred to a
+  separate later effort (re-open the relevant item). No silent mis-pronunciation, no failure.
+
+stderr-only note keeps stdout pipe-clean per the repo's output contract.
+
+## Component 4 — Wiring, docs, tests
+
+- **Unit tests** (deterministic, in-module):
+  - PT connector table (the rows above) + edge cases (1000, 1100, 999_999).
+  - FR 71 = "soixante-et-onze"; 72/79/81/91 control assertions.
+  - Stop-lists: every seed entry round-trips unspelled per language; a control initialism
+    (DNI/RAI) still spells; cross-language isolation (an es entry doesn't suppress spelling
+    under `it`).
+- **Audio regression:** add to `rust/fixtures/tts/multilang_corpus.json` a PT 4-digit
+  sentence, a FR-71 sentence, and an `es-ES` θ sentence; run the audio-quality-check agent
+  (no-clip / 24 kHz / RMS / length) as the pre-merge gate.
+- **Docs:** CLAUDE.md TTS section and `docs/runbooks/tts-internals.md` document the
+  `es-ES` lever and the degrade behavior; note the stop-lists are seed lists.
+
+## Error handling
+
+- Components 1 & 2 are pure functions over already-validated input; no new failure modes.
+- Component 3 never hard-fails on dialect: unknown/unsupported region degrades to LatAm
+  with a stderr note. Missing models still fail loudly with the existing
+  `kesha install --tts` hint (unchanged).
+
+## Testing strategy
+
+- Deterministic logic: exhaustive small-case unit tests (fast, no models).
+- Castilian: spike validates the upstream contract before any routing code commits to it;
+  end-to-end audio regression validates the chosen path.
+- Full Rust gate per CLAUDE.md: `cargo fmt && cargo clippy --all-targets -- -D warnings &&
+  cargo nextest run --features tts`.
+
+## Rollout / linkage
+
+Single PR, `Refs #212`, `Closes #511`. The PR body records the spike finding (native tag
+vs degrade). If Castilian degrades, note in the PR that θ is deferred.

--- a/rust/fixtures/tts/multilang_corpus.json
+++ b/rust/fixtures/tts/multilang_corpus.json
@@ -1,6 +1,6 @@
 {
   "es": ["El veloz murciélago hindú comía feliz cardillo y kiwi.", "Compré 27 libros y el código ISBN empezaba por X."],
-  "fr": ["Un bon vin blanc, un grand pont, enfin les enfants chantent."],
+  "fr": ["Un bon vin blanc, un grand pont, enfin les enfants chantent.", "Il a soixante-et-onze ans et lit le journal."],
   "it": ["Ma la volpe col suo balzo ha raggiunto il quieto Fido."],
-  "pt": ["Um pequeno jabuti xereta viu dez cegonhas felizes."]
+  "pt": ["Um pequeno jabuti xereta viu dez cegonhas felizes.", "O documento data do ano de mil quinhentos e vinte e quatro."]
 }

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -268,7 +268,10 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
                 // session to avoid reloading ~100 MB of ONNX models per request.
                 // All other languages fall through to the one-shot text_to_ipa
                 // path (which will error with a lang-specific hint for ru etc.).
-                let ipa = if matches!(espeak_lang, "es" | "fr" | "it" | "pt") {
+                let ipa = if matches!(
+                    crate::tts::charsiu::base_lang(espeak_lang),
+                    "es" | "fr" | "it" | "pt"
+                ) {
                     state
                         .charsiu
                         .to_ipa(

--- a/rust/src/tts/charsiu/mod.rs
+++ b/rust/src/tts/charsiu/mod.rs
@@ -25,8 +25,20 @@ pub(crate) fn is_castilian_region(lang: &str) -> bool {
 /// Reduce a (possibly region-tagged) code to the base lang Charsiu understands:
 /// "es-ES"/"es-419"/"es-MX" → "es"; "pt-br" → "pt"; passthrough otherwise.
 pub(crate) fn base_lang(lang: &str) -> &str {
-    match lang.split('-').next() {
-        Some(b) if matches!(b.to_ascii_lowercase().as_str(), "es" | "fr" | "it" | "pt") => b,
+    // Return a canonical lowercase literal for the four supported bases so the
+    // result matches case-insensitively at every call site (routing guards) and
+    // feeds `normalize` (which only matches bare lowercase codes) correctly even
+    // for an uppercase region tag like "ES-ES". Unsupported codes pass through.
+    match lang
+        .split('-')
+        .next()
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("es") => "es",
+        Some("fr") => "fr",
+        Some("it") => "it",
+        Some("pt") => "pt",
         _ => lang,
     }
 }
@@ -131,6 +143,21 @@ mod tests {
         assert!(!is_castilian_region("es-419"));
         assert!(!is_castilian_region("es-MX"));
         assert!(!is_castilian_region("fr"));
+    }
+
+    #[test]
+    fn base_lang_canonicalizes_case_and_region() {
+        // Region tags reduce to the bare base; the base is canonical lowercase
+        // even when the input lang subtag is uppercase (so routing guards and
+        // `normalize` see "es", not "ES").
+        assert_eq!(base_lang("es-ES"), "es");
+        assert_eq!(base_lang("ES-ES"), "es");
+        assert_eq!(base_lang("es-419"), "es");
+        assert_eq!(base_lang("pt-BR"), "pt");
+        assert_eq!(base_lang("FR"), "fr");
+        // Unsupported codes pass through unchanged.
+        assert_eq!(base_lang("de"), "de");
+        assert_eq!(base_lang("en-us"), "en-us");
     }
 
     /// Gated on CHARSIU_ONNX env var. Skipped when unset so default CI stays fast.

--- a/rust/src/tts/charsiu/mod.rs
+++ b/rust/src/tts/charsiu/mod.rs
@@ -15,6 +15,35 @@ pub(crate) mod decode;
 pub(crate) mod remap;
 pub(crate) mod tokenizer;
 
+/// True when an espeak-style lang code selects Castilian Spanish (e.g. "es-ES").
+/// LatAm regions ("es", "es-419", "es-MX", …) and non-Spanish codes are false.
+pub(crate) fn is_castilian_region(lang: &str) -> bool {
+    let lower = lang.to_ascii_lowercase();
+    lower == "es-es" || lower.starts_with("es-es-")
+}
+
+/// Reduce a (possibly region-tagged) code to the base lang Charsiu understands:
+/// "es-ES"/"es-419"/"es-MX" → "es"; "pt-br" → "pt"; passthrough otherwise.
+pub(crate) fn base_lang(lang: &str) -> &str {
+    match lang.split('-').next() {
+        Some(b) if matches!(b.to_ascii_lowercase().as_str(), "es" | "fr" | "it" | "pt") => b,
+        _ => lang,
+    }
+}
+
+/// Spike-derived (#511 Phase 0): how to realize Castilian θ. Both variants are
+/// part of the documented decision surface; only one is selected per build.
+#[allow(dead_code)] // the non-selected variant is the documented alternative outcome
+enum Castilian {
+    /// Native CharsiuG2P tag that emits θ (Outcome A). Holds the tag string.
+    Tag(&'static str),
+    /// No upstream Castilian tag (Outcome B, what shipped): degrade to LatAm <spa>.
+    Degrade,
+}
+
+/// #511 Phase-0 spike found no Castilian tag (every candidate gave seseo /s/ or garbage).
+const CASTILIAN: Castilian = Castilian::Degrade;
+
 /// CharsiuG2P phonemizer holding the three decode sessions.
 pub struct Charsiu {
     encoder: Session,
@@ -50,8 +79,24 @@ impl Charsiu {
     // name reflects the conversion semantics, so silence wrong_self_convention.
     #[allow(clippy::wrong_self_convention)]
     pub fn to_ipa(&mut self, text: &str, lang: &str) -> Result<String> {
-        let tag = match lang {
-            "es" => "<spa>",
+        let castilian = is_castilian_region(lang);
+        let tag = match base_lang(lang) {
+            "es" => match (&CASTILIAN, castilian) {
+                (Castilian::Tag(t), true) => t,
+                (Castilian::Degrade, true) => {
+                    // User-facing, one-time per process (survives --stdin-loop).
+                    use std::sync::Once;
+                    static NOTE: Once = Once::new();
+                    NOTE.call_once(|| {
+                        eprintln!(
+                            "note: Castilian (θ) pronunciation is unavailable; \
+                             using Latin-American Spanish."
+                        );
+                    });
+                    "<spa>"
+                }
+                _ => "<spa>",
+            },
             "fr" => "<fra>",
             "it" => "<ita>",
             "pt" => "<por-bz>",
@@ -77,6 +122,16 @@ impl Charsiu {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn castilian_region_detection() {
+        assert!(is_castilian_region("es-ES"));
+        assert!(is_castilian_region("es-es"));
+        assert!(!is_castilian_region("es"));
+        assert!(!is_castilian_region("es-419"));
+        assert!(!is_castilian_region("es-MX"));
+        assert!(!is_castilian_region("fr"));
+    }
 
     /// Gated on CHARSIU_ONNX env var. Skipped when unset so default CI stays fast.
     #[test]

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -21,7 +21,8 @@ pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
     let lower = lang.to_ascii_lowercase();
 
     // Romance languages: normalize then CharsiuG2P (ONNX ByT5-tiny, #212).
-    if matches!(lower.as_str(), "es" | "fr" | "it" | "pt") {
+    let base = crate::tts::charsiu::base_lang(&lower);
+    if matches!(base, "es" | "fr" | "it" | "pt") {
         crate::dtrace!("g2p::route lang={lang} backend=charsiu text_chars={text_chars}");
         let dir = crate::models::cache_dir().join("models/g2p/byt5-tiny");
         check_charsiu_files(&dir)?;
@@ -73,7 +74,8 @@ pub(crate) fn charsiu_ipa(
     text: &str,
     lang: &str,
 ) -> Result<String> {
-    let normalized = crate::tts::normalize::normalize(text, lang);
+    let base = crate::tts::charsiu::base_lang(lang);
+    let normalized = crate::tts::normalize::normalize(text, base);
     g.to_ipa(&normalized, lang)
 }
 
@@ -152,6 +154,24 @@ mod tests {
                         "{lang}: still bails to #212: {m}"
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn castilian_region_routes_to_charsiu() {
+        match text_to_ipa("cielo", "es-ES") {
+            Ok(ipa) => assert!(!ipa.is_empty(), "es-ES: empty IPA"),
+            Err(e) => {
+                let m = e.to_string();
+                assert!(
+                    m.contains("install") || m.contains("G2P"),
+                    "es-ES unexpected: {m}"
+                );
+                assert!(
+                    !m.contains("not supported in this build"),
+                    "es-ES bailed to #212: {m}"
+                );
             }
         }
     }

--- a/rust/src/tts/normalize/acronyms.rs
+++ b/rust/src/tts/normalize/acronyms.rs
@@ -130,6 +130,33 @@ const PT_LETTERS: [(&str, &str); 26] = [
     ("Z", "zê"),
 ];
 
+// ── Stop-lists: all-caps tokens read as WORDS, not spelled out ───────────────
+// Hand-curated seeds, ALL-CAPS keys. NOT exhaustive — extend by ear. Mirrors
+// `tts/en/acronym.rs::STOP_LIST`. Initialisms that SHOULD spell (DNI, ADN, RAI,
+// EUA) are deliberately absent.
+pub(crate) const ES_STOP_LIST: &[&str] = &[
+    "OTAN", "OVNI", "SIDA", "OPEP", "OEA", "ONU", "UNESCO", "FIFA", "OMS",
+];
+pub(crate) const FR_STOP_LIST: &[&str] = &[
+    "OTAN", "OVNI", "SIDA", "UNESCO", "FIFA", "OPEP", "ONU", "OMS",
+];
+pub(crate) const IT_STOP_LIST: &[&str] = &["FIAT", "NATO", "FIFA", "AIDS", "UNESCO", "ONU"];
+pub(crate) const PT_STOP_LIST: &[&str] = &[
+    "OTAN", "OVNI", "SIDA", "AIDS", "FIFA", "UNESCO", "ONU", "OMS",
+];
+
+/// True if `token` is in `lang`'s stop-list (read as a word, not letter-spelled).
+fn is_stop_listed(token: &str, lang: &str) -> bool {
+    let list: &[&str] = match lang {
+        "es" => ES_STOP_LIST,
+        "fr" => FR_STOP_LIST,
+        "it" => IT_STOP_LIST,
+        "pt" => PT_STOP_LIST,
+        _ => &[],
+    };
+    list.iter().any(|w| w.eq_ignore_ascii_case(token))
+}
+
 fn lookup_letter(ch: char, table: &[(&str, &str)]) -> String {
     let s = ch.to_string();
     table
@@ -155,6 +182,10 @@ pub fn is_acronym_token(token: &str) -> bool {
 /// Letter names are joined with spaces. Unknown languages fall back to lowercased
 /// individual characters joined with spaces.
 pub fn spell(token: &str, lang: &str) -> String {
+    // Word-acronyms (read as words) pass through unspelled.
+    if is_stop_listed(token, lang) {
+        return token.to_string();
+    }
     let names: Vec<String> = match lang {
         "es" => token
             .chars()
@@ -196,5 +227,36 @@ mod tests {
         // J/K/W/X/Y now resolve to standard Italian names, not raw-lowercase fallback.
         assert_eq!(spell("WC", "it"), "doppia vu ci");
         assert_eq!(spell("OK", "it"), "o cappa");
+    }
+
+    #[test]
+    fn stop_listed_word_acronyms_pass_through_unspelled() {
+        assert_eq!(spell("OTAN", "es"), "OTAN");
+        assert_eq!(spell("OVNI", "es"), "OVNI");
+        assert_eq!(spell("FIFA", "fr"), "FIFA");
+        assert_eq!(spell("FIAT", "it"), "FIAT");
+        assert_eq!(spell("SIDA", "pt"), "SIDA");
+        // True initialisms still spell letter-by-letter.
+        assert_eq!(spell("DNI", "es"), "de ene i");
+        // Cross-language isolation: "OEA" is es/pt-list only; under "it" it letter-spells.
+        assert_eq!(spell("OEA", "it"), "o e a");
+    }
+
+    #[test]
+    fn every_stop_list_entry_passes_through() {
+        for (lang, list) in [
+            ("es", ES_STOP_LIST),
+            ("fr", FR_STOP_LIST),
+            ("it", IT_STOP_LIST),
+            ("pt", PT_STOP_LIST),
+        ] {
+            for w in list {
+                assert_eq!(
+                    spell(w, lang),
+                    *w,
+                    "stop-list entry was spelled: {w} ({lang})"
+                );
+            }
+        }
     }
 }

--- a/rust/src/tts/normalize/acronyms.rs
+++ b/rust/src/tts/normalize/acronyms.rs
@@ -237,7 +237,8 @@ mod tests {
         assert_eq!(spell("SIDA", "pt"), "SIDA");
         // True initialisms still spell letter-by-letter.
         assert_eq!(spell("DNI", "es"), "de ene i");
-        // Cross-language isolation: "OEA" is es/pt-list only; under "it" it letter-spells.
+        // Cross-language isolation: "OEA" is in ES_STOP_LIST only; under "it"
+        // (not in IT_STOP_LIST) it letter-spells.
         assert_eq!(spell("OEA", "it"), "o e a");
     }
 

--- a/rust/src/tts/normalize/acronyms.rs
+++ b/rust/src/tts/normalize/acronyms.rs
@@ -134,16 +134,15 @@ const PT_LETTERS: [(&str, &str); 26] = [
 // Hand-curated seeds, ALL-CAPS keys. NOT exhaustive — extend by ear. Mirrors
 // `tts/en/acronym.rs::STOP_LIST`. Initialisms that SHOULD spell (DNI, ADN, RAI,
 // EUA) are deliberately absent.
-pub(crate) const ES_STOP_LIST: &[&str] = &[
-    "OTAN", "OVNI", "SIDA", "OPEP", "OEA", "ONU", "UNESCO", "FIFA", "OMS",
-];
-pub(crate) const FR_STOP_LIST: &[&str] = &[
-    "OTAN", "OVNI", "SIDA", "UNESCO", "FIFA", "OPEP", "ONU", "OMS",
-];
-pub(crate) const IT_STOP_LIST: &[&str] = &["FIAT", "NATO", "FIFA", "AIDS", "UNESCO", "ONU"];
-pub(crate) const PT_STOP_LIST: &[&str] = &[
-    "OTAN", "OVNI", "SIDA", "AIDS", "FIFA", "UNESCO", "ONU", "OMS",
-];
+//
+// Entries must be 2..=5 chars: `normalize` only routes a token through `spell`
+// when `is_acronym_token` (length 2..=5) matches, so a 6+-char all-caps word
+// (e.g. "UNESCO") already passes through verbatim and needs no entry here.
+pub(crate) const ES_STOP_LIST: &[&str] =
+    &["OTAN", "OVNI", "SIDA", "OPEP", "OEA", "ONU", "FIFA", "OMS"];
+pub(crate) const FR_STOP_LIST: &[&str] = &["OTAN", "OVNI", "SIDA", "FIFA", "OPEP", "ONU", "OMS"];
+pub(crate) const IT_STOP_LIST: &[&str] = &["FIAT", "NATO", "FIFA", "AIDS", "ONU"];
+pub(crate) const PT_STOP_LIST: &[&str] = &["OTAN", "OVNI", "SIDA", "AIDS", "FIFA", "ONU", "OMS"];
 
 /// True if `token` is in `lang`'s stop-list (read as a word, not letter-spelled).
 fn is_stop_listed(token: &str, lang: &str) -> bool {

--- a/rust/src/tts/normalize/mod.rs
+++ b/rust/src/tts/normalize/mod.rs
@@ -110,6 +110,20 @@ mod tests {
     }
 
     #[test]
+    fn normalize_via_base_lang_handles_region_tagged_es() {
+        // The region subtag (es-ES) is reduced to the base lang upstream before
+        // `normalize` is called; this locks that numbers/acronyms still expand
+        // identically to bare "es" (i.e. the region tag never silently disables
+        // expansion). Passing the raw "es-ES" tag would NOT match and skip it.
+        let base = crate::tts::charsiu::base_lang("es-ES");
+        assert_eq!(base, "es");
+        assert_eq!(normalize("27 OTAN", base), normalize("27 OTAN", "es"));
+        assert!(normalize("27 OTAN", base).contains("veintisiete"));
+        // The raw region tag is intentionally inert in `normalize` itself.
+        assert_eq!(normalize("27 OTAN", "es-ES"), "27 OTAN");
+    }
+
+    #[test]
     fn normalize_large_number_does_not_panic() {
         // Numbers >= 1_000_000 are outside the word-table range; they must pass
         // through verbatim rather than panicking.

--- a/rust/src/tts/normalize/numbers.rs
+++ b/rust/src/tts/normalize/numbers.rs
@@ -134,7 +134,13 @@ fn fr_under_100(n: u32) -> String {
         // 70-79 = soixante + 10..19
         70..=79 => {
             let sub = FR_UNITS[(n - 60) as usize];
-            format!("soixante-{sub}")
+            // 71 takes the "et" connector (soixante-et-onze), mirroring
+            // vingt-et-un/.../soixante-et-un. 72-79 stay plain-hyphenated.
+            if n == 71 {
+                "soixante-et-onze".to_string()
+            } else {
+                format!("soixante-{sub}")
+            }
         }
         // 90-99 = quatre-vingt + 10..19
         90..=99 => {
@@ -433,7 +439,22 @@ fn pt_words(n: u32) -> String {
     if rem > 0 {
         parts.push(pt_under_1000(rem));
     }
-    parts.join(" e ")
+    // Portuguese inserts "e" between the thousands group and the remainder only
+    // when the remainder is < 100 OR an exact multiple of 100; otherwise the
+    // groups are joined with a plain space.
+    //   1024 -> "mil e vinte e quatro"             (rem 24, < 100)
+    //   1500 -> "mil e quinhentos"                 (rem 500, multiple of 100)
+    //   1524 -> "mil quinhentos e vinte e quatro"  (rem 524, non-round hundreds)
+    if parts.len() == 2 {
+        let connector = if rem < 100 || rem % 100 == 0 {
+            " e "
+        } else {
+            " "
+        };
+        format!("{}{}{}", parts[0], connector, parts[1])
+    } else {
+        parts.join(" ")
+    }
 }
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -493,5 +514,26 @@ mod tests {
     fn french_integers() {
         assert_eq!(to_words(348, "fr"), "trois cent quarante-huit");
         assert_eq!(to_words(80, "fr"), "quatre-vingts");
+    }
+
+    #[test]
+    fn portuguese_thousands_connector() {
+        // "e" joins thousands↔remainder only when remainder < 100 or a multiple of 100.
+        assert_eq!(to_words(1024, "pt"), "mil e vinte e quatro"); // rem 24  < 100
+        assert_eq!(to_words(1500, "pt"), "mil e quinhentos"); // rem 500 multiple of 100
+        assert_eq!(to_words(1100, "pt"), "mil e cem"); // rem 100 multiple of 100
+        assert_eq!(to_words(1524, "pt"), "mil quinhentos e vinte e quatro"); // rem 524 non-round hundreds
+        assert_eq!(to_words(2350, "pt"), "dois mil trezentos e cinquenta"); // rem 350 non-round hundreds
+        assert_eq!(to_words(2000, "pt"), "dois mil"); // no remainder
+        assert_eq!(to_words(24, "pt"), "vinte e quatro"); // no thousands group
+    }
+
+    #[test]
+    fn french_seventy_one_takes_et() {
+        assert_eq!(to_words(71, "fr"), "soixante-et-onze");
+        assert_eq!(to_words(72, "fr"), "soixante-douze");
+        assert_eq!(to_words(79, "fr"), "soixante-dix-neuf");
+        assert_eq!(to_words(81, "fr"), "quatre-vingt-un");
+        assert_eq!(to_words(91, "fr"), "quatre-vingt-onze");
     }
 }


### PR DESCRIPTION
Closes #511. Refs #212. Follow-up to #509.

Polish for the ONNX multilingual TTS path (es/fr/it/pt). Spec + plan + Phase-0 spike finding in `docs/superpowers/{specs,plans}/2026-06-01-multilingual-g2p-polish*`.

## What changed

1. **Portuguese number connectors** (`normalize/numbers.rs`) — `pt_words` now inserts "e" between the thousands group and the remainder only when the remainder is `< 100` or a multiple of 100, else a space. Fixes over-connection like `1524 → "mil e quinhentos e vinte e quatro"` → `"mil quinhentos e vinte e quatro"`. `1024 → "mil e vinte e quatro"` stays correct.
2. **French 71** (`normalize/numbers.rs`) — `71 → "soixante-et-onze"` (was `"soixante-onze"`); 72–79, 81, 91 unchanged.
3. **Per-language acronym stop-lists** (`normalize/acronyms.rs`) — `ES/FR/IT/PT_STOP_LIST` + `is_stop_listed`; word-acronyms (OTAN, OVNI, FIFA, SIDA, FIAT…) pass through unspelled instead of being letter-spelled. True initialisms (DNI, ADN, RAI) still spell. Mirrors the English `STOP_LIST` path.
4. **Castilian Spanish** — selectable with `--lang es-ES` (`es` / `es-419` / `es-MX` → Latin-American). Threaded the BCP-47 region subtag through `g2p`/`say_loop`/`charsiu` via `is_castilian_region` + `base_lang`.

## Castilian spike (Phase 0 — Outcome B)

Per the "verify model formats with a spike" rule, I probed the cached klebster CharsiuG2P export (reusing the real `decode::greedy` path) on a θ corpus (`zapato/cielo/gracias/zorro/cinco`) under candidate tags `<spa>`, `<spa-es>`, `<spa-me>`, `<spa-latin>`, `<spa-castilian>`, `<spa-ib>`. **No tag yields θ** — every candidate gives seseo /s/ (identical to LatAm) or garbage. So `es-ES` **gracefully degrades** to Latin-American `<spa>` with a **one-time stderr note**; Castilian θ is deferred (would need a grapheme-driven θ-injection layer — out of scope). The throwaway probe was reverted, not committed.

## Verification

- `cargo fmt` ✅ · `cargo clippy --all-targets --features tts -D warnings` ✅
- `cargo nextest run --features tts` → **335 passed, 0 skipped** ✅
- `cargo check --features coreml --no-default-features` ✅
- Gated audio-regression (`tts_multilang_audio`) PASS incl. the new PT-connector + FR-71 lines.
- **audio-quality-check agent: 4/4 PASS** on `es` / `es-ES` / `pt` / `fr` samples (mono 24 kHz f32, no clip, RMS/length sane).
- End-to-end: `es-ES` degrade note fires **exactly once** (incl. across `--stdin-loop`); `es` vs `es-ES` output **byte-identical** (degrade confirmed, no spurious θ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)