### PR TITLE
feat(tts): native Chinese (zh) TTS via FluidAudio 0.14.8 KokoroAne Mandarin variant (#492)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,8 +421,15 @@ stderr is progress/errors only. Auto-routing for an omitted `--voice` is in `src
 Spanish, French, Italian, and Portuguese are supported via CharsiuG2P (klebster ONNX export, CC-BY 4.0)
 + a per-language numbers/acronym normalizer (#212). Default voices: `es-em_alex` (LatAm Spanish, male),
 `it-im_nicola` (male), `pt-pm_alex` (male), `fr-ff_siwis` (female — **documented brand-rule exception**:
-Kokoro v1.0 ships no male French voice; revisit when one exists). macOS CoreML (`system_kokoro`/FluidAudio)
-multilingual is a follow-up — those voices currently route through the English G2P.
+Kokoro v1.0 ships no male French voice; revisit when one exists).
+
+**macOS CoreML (`system_kokoro`/FluidAudio) multilingual:** `init_kokoro` selects the
+KokoroAne variant by language (FluidAudio 0.14.8 ships `.english` + `.mandarin`). **Chinese
+(`zh`) is supported natively** (`zh-zm_050`, male; tone-aware Mandarin G2P) — #492. The
+Latin-script langs (es/fr/it/pt) route through the English G2P, which is adequate for them.
+**Hindi (`hi`) and Japanese (`ja`) still fail fast** with `E_SCRIPT_UNSUPPORTED` (no FluidAudio
+KokoroAne variant yet; ja/hi are a future ONNX-CharsiuG2P effort). zh voices are fetched by
+FluidAudio's own `ANE-zh/` bundle, not staged in `models.rs`.
 
 **Castilian Spanish:** select with `--lang es-ES`; `es` / `es-419` / `es-MX` use
 Latin-American (*seseo*). The upstream CharsiuG2P export has no Castilian θ tag (#511

--- a/docs/runbooks/tts-internals.md
+++ b/docs/runbooks/tts-internals.md
@@ -71,6 +71,22 @@ with no warning. Per-language acronym stop-lists (`ES/FR/IT/PT_STOP_LIST` in
 `rust/src/tts/normalize/acronyms.rs`) are curated seeds that prevent word-acronyms
 (OTAN, OVNI, FIFA…) from being letter-spelled; they are not exhaustive.
 
+## FluidAudio KokoroAne variants — macOS Chinese (#492)
+
+On `system_kokoro` (darwin/ANE), `tts::fluid_kokoro::with_kokoro` resolves the voice's
+language (`lang_for_fluid_id`) and passes it to `init_kokoro(voice, lang)`. The fork's
+Swift bridge (`fluidaudio-rs`, FluidAudio 0.14.8) maps it to a `KokoroAneVariant`:
+`zh` → `.mandarin` (tone-aware G2P: jieba + g2pw + bopomofo + tone sandhi), everything
+else → `.english` (en plus Latin-script es/fr/it/pt, which the English G2P handles
+acceptably). The `.mandarin` variant fetches its own `ANE-zh/` bundle (nested
+`voices/<id>.bin`) on first synth — zh voices are therefore **not** staged in
+`models.rs::ANE_KOKORO_VOICES` and are exempt from the staging-coverage test (like
+`af_heart`). Default zh voice: `zh-zm_050` (male). Native-script `hi`/`ja` still fail fast
+(`E_SCRIPT_UNSUPPORTED`) — no FluidAudio KokoroAne variant for them yet. The
+`-Wl,-rpath,/usr/lib/swift` link arg in `build.rs` is emitted under
+`coreml`/`system_kokoro`/`system_diarize` so the Swift runtime loads without
+`MACOSX_DEPLOYMENT_TARGET=14.0` locally.
+
 ## History
 
 Original spec assumed Silero TTS; pivoted to Piper during M3 spike (Silero ships PyTorch-only, no public ONNX). See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.

--- a/docs/superpowers/plans/2026-06-01-ja-fluidaudio-kokoro.md
+++ b/docs/superpowers/plans/2026-06-01-ja-fluidaudio-kokoro.md
@@ -1,0 +1,388 @@
+# Japanese TTS via FluidAudio 0.14.8 KokoroAne — Implementation Plan (#492)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Native Japanese TTS on the darwin FluidAudio Kokoro path by bumping the fork to FluidAudio 0.14.8 and selecting the `KokoroAne` variant by language (en/es/ja).
+
+**Architecture:** Two repos, sequenced. Phase A edits the `drakulavich/fluidaudio-rs` fork (Swift bridge + FFI) so `init_kokoro` picks the `KokoroAneVariant` from a `lang` argument; publishes a new rev. Phase B bumps kesha's rev, threads the voice's language into the bridge init, and unblocks `ja` native script. `hi`/`zh` stay fail-fast.
+
+**Tech Stack:** Swift 6 / SwiftPM (FluidAudio 0.14.8), Rust FFI (`fluidaudio-rs`), Rust (kesha `tts::fluid_kokoro`), `cargo nextest`. **macOS arm64 only** (`system_kokoro` / Xcode).
+
+**Design doc:** `docs/superpowers/specs/2026-06-01-ja-fluidaudio-kokoro-design.md`
+
+**Spec refinement (intentional):** the spec proposed threading `lang` through `synthesizeKokoro`; this plan threads it through **`init_kokoro`** instead, because `KokoroAneManager`'s variant is fixed at construction (bridge `FluidAudioBridge.swift:140`) and kesha's `with_kokoro` re-inits the bridge per call. Same outcome ("variant selected by language"), correct lever.
+
+**Repos & working dirs:**
+- Fork: `/Users/anton/Personal/repos/fluidaudio-rs` — base branch `feat/fluidaudio-0.14.7-kokoro-ane-speed` (has the KokoroAneManager migration + `--rate`); work on a new branch `feat/fluidaudio-0.14.8-multilingual-variants`.
+- kesha: `.worktrees/ja-fluidaudio` (branch `feat/ja-fluidaudio-kokoro`).
+
+**Build-loop caveat:** Phase A is iterative Swift work against a real API. Steps A1/A2 are "edit → `swift build` → read errors → adapt" — the exact `KokoroAneManager` init signature and `KokoroAneVariant` case spellings in 0.14.8 must be confirmed from the compiler/source, not assumed. The variant cases were observed as `.english` / `.spanish` / `.japanese` (raw values `"en"`/`"es"`/`"ja"`) in the FluidAudio 0.14.8 source.
+
+---
+
+## PHASE A — fork: `drakulavich/fluidaudio-rs`
+
+### Task A1: Bump FluidAudio to 0.14.8 and establish the build baseline
+
+**Files:** `Package.swift` (FluidAudio pin)
+
+- [ ] **Step 1: Branch off the KokoroAne base**
+```bash
+cd /Users/anton/Personal/repos/fluidaudio-rs
+git fetch origin
+git switch feat/fluidaudio-0.14.7-kokoro-ane-speed
+git switch -c feat/fluidaudio-0.14.8-multilingual-variants
+```
+
+- [ ] **Step 2: Bump the FluidAudio pin**
+
+In `Package.swift`, change the FluidAudio dependency:
+```swift
+.package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "0.14.8"),
+```
+(from `exact: "0.14.7"`).
+
+- [ ] **Step 3: Resolve + build to surface the API delta**
+```bash
+swift package resolve
+swift build 2>&1 | tee /tmp/fa-build.log
+```
+Expected: either a clean build (0.14.7→0.14.8 is API-compatible for the paths we use) **or** compile errors in `swift/FluidAudioBridge.swift` around `KokoroAneManager`. **Read the errors** — they define exactly what Task A2 must adapt. Do not guess; if `KokoroAneManager(variant:defaultVoice:)` changed, note the new signature from the error/source before proceeding.
+
+- [ ] **Step 4: Commit the bump (even if the bridge still hardcodes English)**
+```bash
+git add Package.swift Package.resolved
+git commit -m "build: bump FluidAudio 0.14.7 -> 0.14.8"
+```
+
+### Task A2: Select the KokoroAne variant by language in the bridge
+
+**Files:** `swift/FluidAudioBridge.swift` (`initializeKokoro`, ~lines 132-155, and the stored `kokoroManager`)
+
+- [ ] **Step 1: Add a lang→variant mapping helper**
+
+Add to `FluidAudioBridge` (near `initializeKokoro`). Confirm the exact `KokoroAneVariant` case names compile (observed: `.english`, `.spanish`, `.japanese`):
+```swift
+/// Map a kesha/espeak-style language tag to a KokoroAne variant. FluidAudio
+/// 0.14.8 ships english/spanish/japanese variants; anything else (incl. empty)
+/// falls back to English so existing en voices are unaffected.
+private static func kokoroVariant(for lang: String) -> KokoroAneVariant {
+    let base = lang.lowercased().split(separator: "-").first.map(String.init) ?? ""
+    switch base {
+    case "ja": return .japanese
+    case "es": return .spanish
+    default:   return .english
+    }
+}
+```
+
+- [ ] **Step 2: Thread `lang` into `initializeKokoro` and pick the variant**
+
+Change the signature and the hardcoded `.english`:
+```swift
+func initializeKokoro(defaultVoice: String, lang: String) throws {
+    let semaphore = DispatchSemaphore(value: 0)
+    var initError: Error?
+    Task {
+        do {
+            let variant = Self.kokoroVariant(for: lang)
+            let manager = KokoroAneManager(variant: variant, defaultVoice: defaultVoice)
+            try await manager.initialize(preloadVoices: [defaultVoice])
+            self.kokoroManager = manager
+        } catch {
+            initError = error
+        }
+        semaphore.signal()
+    }
+    semaphore.wait()
+    if let error = initError { throw error }
+}
+```
+(`synthesizeKokoro` is unchanged — it uses the now variant-correct `kokoroManager`.)
+
+- [ ] **Step 3: Build**
+```bash
+swift build 2>&1 | tail -20
+```
+Expected: clean. If `KokoroAneManager.initialize(preloadVoices:)` rejects a Japanese voice id at init, adjust `preloadVoices` (e.g. preload nothing or the variant's default) per the error — record what you changed.
+
+### Task A3: Thread `lang` through the FFI (Swift FFI → Rust binding)
+
+**Files:** `swift/Kokoro_ffi.swift` (`fluidaudio_initialize_kokoro`), `src/ffi/bridge.rs` (extern + `initialize_kokoro`), `src/lib.rs` (`init_kokoro`)
+
+- [ ] **Step 1: Add `lang` to the Swift FFI init**
+
+In `swift/Kokoro_ffi.swift`, `fluidaudio_initialize_kokoro` currently takes `(ptr, defaultVoice)`. Add a `lang` C-string param and pass it through:
+```swift
+@_cdecl("fluidaudio_initialize_kokoro")
+public func fluidaudio_initialize_kokoro(
+    _ ptr: UnsafeMutableRawPointer?,
+    _ defaultVoice: UnsafePointer<CChar>?,
+    _ lang: UnsafePointer<CChar>?
+) -> Int32 {
+    guard let ptr = ptr, let defaultVoice = defaultVoice else { return -1 }
+    let bridge = Unmanaged<FluidAudioBridge>.fromOpaque(ptr).takeUnretainedValue()
+    let voiceString = String(cString: defaultVoice)
+    let langString = lang.map { String(cString: $0) } ?? ""
+    do {
+        try bridge.initializeKokoro(defaultVoice: voiceString, lang: langString)
+        return 0
+    } catch {
+        print("Kokoro init error: \(error)")
+        return -1
+    }
+}
+```
+(Match the existing function's exact error/return style — copy its current body and add the `lang` decode + pass-through.)
+
+- [ ] **Step 2: Update the Rust extern + wrapper in `src/ffi/bridge.rs`**
+
+Update the `extern "C"` declaration for `fluidaudio_initialize_kokoro` to add `lang: *const c_char`, and update `initialize_kokoro`:
+```rust
+pub fn initialize_kokoro(&self, default_voice: &str, lang: &str) -> Result<(), String> {
+    let c_voice = CString::new(default_voice).map_err(|e| e.to_string())?;
+    let c_lang = CString::new(lang).map_err(|e| e.to_string())?;
+    let rc = unsafe {
+        fluidaudio_initialize_kokoro(self.ptr, c_voice.as_ptr(), c_lang.as_ptr())
+    };
+    if rc == 0 { Ok(()) } else { Err("kokoro init failed".into()) }
+}
+```
+(Adapt to the file's existing CString/error idioms — keep them.)
+
+- [ ] **Step 3: Update `src/lib.rs` `init_kokoro`**
+```rust
+pub fn init_kokoro(&self, default_voice: &str, lang: &str) -> Result<(), FluidAudioError> {
+    self.bridge
+        .initialize_kokoro(default_voice, lang)
+        .map_err(FluidAudioError::Kokoro)
+}
+```
+(Match the existing error-wrapping; only the added `lang` param is new.)
+
+- [ ] **Step 4: Build the Rust binding**
+```bash
+cargo build 2>&1 | tail -15
+```
+Expected: clean.
+
+### Task A4: Validate Japanese synthesis + publish the rev
+
+- [ ] **Step 1: Smoke-test Japanese end-to-end**
+
+Write a throwaway example `examples/ja_smoke.rs` (do not keep) that inits Kokoro with a Japanese voice + `lang="ja"` and synthesizes こんにちは, asserting a non-empty WAV:
+```rust
+fn main() {
+    let a = fluidaudio_rs::FluidAudio::new().unwrap();
+    a.init_kokoro("jm_kumo", "ja").unwrap();
+    let wav = a.synthesize_kokoro("こんにちは", "jm_kumo", 1.0).unwrap();
+    assert!(wav.len() > 1000, "empty/short WAV: {}", wav.len());
+    eprintln!("ja WAV bytes: {}", wav.len());
+}
+```
+```bash
+cargo run --example ja_smoke 2>&1 | tail -5
+rm examples/ja_smoke.rs
+```
+Expected: non-empty WAV, no error. (If the JA model/assets download on first init, allow it — note the size.) Also re-run with `init_kokoro("am_michael","en-us")` to confirm English is unregressed.
+
+- [ ] **Step 2: Verify `--rate` still feeds the model across variants**
+
+Synthesize the same JA text at `speed: 0.7` and `1.3`; confirm the WAV durations differ (rate applied). Record the observation.
+
+- [ ] **Step 3: Commit + push**
+```bash
+git add -A
+git commit -m "feat: select KokoroAne variant by language (en/es/ja) on FluidAudio 0.14.8"
+git push -u origin feat/fluidaudio-0.14.8-multilingual-variants
+git rev-parse HEAD   # record this SHA for Phase B
+```
+
+- [ ] **Step 4: Open the fork PR**
+```bash
+gh pr create -R drakulavich/fluidaudio-rs --base forked-main \
+  --head feat/fluidaudio-0.14.8-multilingual-variants \
+  --title "feat: FluidAudio 0.14.8 + KokoroAne variant selection (en/es/ja)" \
+  --body "Bumps FluidAudio 0.14.7→0.14.8 and selects the KokoroAne variant by language in initializeKokoro (threaded via a new lang FFI arg). Unblocks Japanese (and Spanish) native synthesis on the ANE Kokoro path; English unchanged. Preserves the --rate model-native speed input. For kesha-voice-kit #492."
+```
+
+---
+
+## PHASE B — kesha-voice-kit (`feat/ja-fluidaudio-kokoro`)
+
+> Prerequisite: Phase A rev SHA (call it `<FORK_SHA>`). Phase B does not build green on darwin until the fork rev is pushed.
+
+### Task B1: Bump the fluidaudio-rs rev
+
+**Files:** `rust/Cargo.toml:72-78`
+
+- [ ] **Step 1: Point at the new fork commit**
+
+Update the `fluidaudio-rs` dep `rev` to `<FORK_SHA>` and refresh the comment to note FluidAudio 0.14.8 + per-language KokoroAne variant selection. Then:
+```bash
+cd rust && cargo update -p fluidaudio-rs 2>&1 | tail -5
+```
+
+- [ ] **Step 2: Commit**
+```bash
+git add rust/Cargo.toml rust/Cargo.lock
+git commit -m "build(tts): bump fluidaudio-rs to FluidAudio 0.14.8 multilingual variants (#492)"
+```
+
+### Task B2: Thread the voice's language into `init_kokoro`
+
+**Files:** `rust/src/tts/fluid_kokoro.rs` (`with_kokoro`, ~line 249)
+
+- [ ] **Step 1: Resolve the lang in `with_kokoro` and pass it to init**
+
+`lang_for_fluid_id(fluid_id)` (defined ~line 188) returns the voice's lang. Update `with_kokoro`:
+```rust
+fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> Result<R> {
+    let lang = lang_for_fluid_id(voice_id).unwrap_or("en-us");
+    crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
+        let audio = FluidAudio::new().context("init FluidAudio bridge")?;
+        audio
+            .init_kokoro(voice_id, lang)
+            .context("init FluidAudio Kokoro (downloads the model on first run)")?;
+        f(&audio)
+    })
+}
+```
+
+- [ ] **Step 2: Build (darwin, system_kokoro)**
+```bash
+cd rust && cargo build --features system_kokoro --no-default-features 2>&1 | tail -10
+```
+Expected: clean (the binding's `init_kokoro` now takes 2 args).
+
+- [ ] **Step 3: Commit**
+```bash
+git add rust/src/tts/fluid_kokoro.rs
+git commit -m "feat(tts): pass voice language to FluidAudio Kokoro init for variant selection (#492)"
+```
+
+### Task B3: Unblock `ja` native script (keep hi/zh fail-fast)
+
+**Files:** `rust/src/tts/fluid_kokoro.rs` (`unsupported_native_script`, ~line 214) + its test
+
+- [ ] **Step 1: Update the gate test first (TDD)**
+
+Find the existing `flags_native_script_for_non_latin_voices` test (~line 362). Change its expectations so `ja` (kana/kanji) is now **allowed** while `hi`/`zh` still flag. Concretely, assert:
+```rust
+// ja native script now synthesizes (FluidAudio 0.14.8 Japanese KokoroAne variant).
+assert_eq!(unsupported_native_script("こんにちは", "jm_kumo"), None);
+// hi/zh remain unsupported until their variants ship in a FluidAudio release.
+assert_eq!(unsupported_native_script("नमस्ते", "hm_omega"), Some("Devanagari"));
+assert_eq!(unsupported_native_script("你好", "zm_yunjian"), Some("Chinese (Han)"));
+```
+(Keep any existing Latin-passes-through assertions.)
+
+- [ ] **Step 2: Run the test → expect FAIL**
+```bash
+cd rust && cargo nextest run --features system_kokoro --no-default-features fluid_kokoro 2>&1 | tail -8
+```
+Expected: FAIL — `ja` still returns `Some("Japanese (kana/kanji)")`.
+
+- [ ] **Step 3: Drop the `ja` arm from `unsupported_native_script`**
+```rust
+fn unsupported_native_script(text: &str, fluid_id: &str) -> Option<&'static str> {
+    let any = |f: fn(char) -> bool| text.chars().any(f);
+    match lang_for_fluid_id(fluid_id)? {
+        "hi" => any(|c| ('\u{0900}'..='\u{097F}').contains(&c)).then_some("Devanagari"),
+        // ja (kana/kanji) is supported via FluidAudio 0.14.8's Japanese KokoroAne
+        // variant (#492). zh remains noise until a release ships the mandarin variant.
+        "zh" => any(is_han).then_some("Chinese (Han)"),
+        _ => None,
+    }
+}
+```
+Update the doc comment above it to say hi/zh (not hi/ja/zh).
+
+- [ ] **Step 4: Run the test → PASS**
+```bash
+cd rust && cargo nextest run --features system_kokoro --no-default-features fluid_kokoro 2>&1 | tail -8
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add rust/src/tts/fluid_kokoro.rs
+git commit -m "feat(tts): allow Japanese native script on FluidAudio Kokoro; keep hi/zh fail-fast (#492)"
+```
+
+### Task B4: Confirm the Japanese default voice is male
+
+**Files:** `rust/src/tts/voices.rs` (`resolve_fluid_kokoro` / default for `ja`)
+
+- [ ] **Step 1: Verify `--voice` resolution + the auto-default for `ja`**
+
+`ja-jm_kumo` (lang `ja`, `jm_` = male) already exists in the `fluid_kokoro` VOICES table. Confirm `resolve_voice("ja-jm_kumo")` resolves and that the `ja` auto-route default (when `--voice` omitted) is a `jm_*` male voice, per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE". Add/adjust a small unit test if a default mapping exists:
+```rust
+#[test]
+fn japanese_default_voice_is_male() {
+    // brand rule: ja default must be a male (jm_*) voice
+    let v = super::resolve_voice("ja-jm_kumo").expect("ja-jm_kumo present");
+    assert!(v.fluid_id.starts_with("jm_"), "ja default not male: {}", v.fluid_id);
+}
+```
+If `pickVoiceForLang`/`default_voice_for_lang` has a `ja` entry, assert it points at a `jm_*` voice; if it's missing, add it pointing at `jm_kumo`.
+
+- [ ] **Step 2: Run + commit**
+```bash
+cd rust && cargo nextest run --features system_kokoro --no-default-features japanese_default 2>&1 | tail -5
+git add rust/src/tts/voices.rs rust/src/tts/fluid_kokoro.rs
+git commit -m "test(tts): assert Japanese default voice is male (#492)"
+```
+
+### Task B5: Japanese round-trip + audio QC + docs
+
+**Files:** a darwin-gated test (e.g. `rust/tests/`), `CLAUDE.md`, `docs/runbooks/tts-internals.md`
+
+- [ ] **Step 1: Build the engine + synthesize Japanese**
+```bash
+cd rust && cargo build --features system_kokoro --no-default-features --bin kesha-engine
+./target/debug/kesha-engine say --voice ja-jm_kumo "こんにちは。私の名前はケシャです。" --out /tmp/ja.wav 2>/tmp/ja.err
+cat /tmp/ja.err   # should be progress only, no ScriptUnsupported error
+afinfo /tmp/ja.wav | grep -i 'duration\|format'
+```
+Expected: a real WAV, no `E_SCRIPT_UNSUPPORTED`.
+
+- [ ] **Step 2: Round-trip via ASR + audio-quality-check**
+
+Transcribe the synth output and confirm recognizable Japanese (the #492 evidence method), and run the `audio-quality-check` agent on `/tmp/ja.wav` (rate/RMS/clip/length). Record both in the PR body. (This is a manual/controller verification step, not a committed test, because it needs the ANE + models.)
+
+- [ ] **Step 3: Update docs**
+
+In `CLAUDE.md` TTS section, update the FluidAudio multilingual note: Japanese (kana/kanji) now synthesizes natively via FluidAudio 0.14.8's KokoroAne Japanese variant; hi/zh still fail-fast (`E_SCRIPT_UNSUPPORTED`) pending a FluidAudio release with those variants. In `docs/runbooks/tts-internals.md`, document the `init_kokoro(voice, lang)` → variant-selection flow and the en/es/ja variant map.
+
+- [ ] **Step 4: Commit**
+```bash
+git add CLAUDE.md docs/runbooks/tts-internals.md
+git commit -m "docs(tts): document Japanese FluidAudio Kokoro support (#492)"
+```
+
+### Task B6: Final gate + PR
+
+- [ ] **Step 1: Full verification (darwin)**
+```bash
+cd rust && cargo fmt && cargo clippy --all-targets --features system_kokoro --no-default-features -- -D warnings
+cargo nextest run --features system_kokoro --no-default-features
+# default ONNX build must also stay green:
+cargo nextest run --features tts
+```
+All pass.
+
+- [ ] **Step 2: Open the kesha PR**
+```bash
+gh pr create --base main --head feat/ja-fluidaudio-kokoro \
+  --title "feat(tts): native Japanese TTS via FluidAudio 0.14.8 KokoroAne (#492)" \
+  --body "Refs #492 (ships ja; hi/zh remain tracked). Bumps the fluidaudio-rs fork to FluidAudio 0.14.8 + per-language KokoroAne variant selection (fork PR: <link>), threads the voice language into init, and unblocks ja native script. hi/zh keep the #495 fail-fast. Includes ja round-trip + audio-quality-check evidence."
+```
+Use `Refs #492` (NOT `Closes` — hi/zh remain). Add the `WIP` label on start; after merge, comment on #492 that ja is supported.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** fork bump (A1) ✓, variant-by-language (A2) ✓, FFI thread (A3) ✓, `--rate` preserved (A2/A4 Step 2) ✓, rev bump (B1) ✓, lang→init (B2) ✓, relax gate keep hi/zh (B3) ✓, male ja default (B4) ✓, assets via install (B5 Step 1 note) ✓, tests/docs (B5) ✓, Refs-not-Closes (B6) ✓.
+- **Build-discovery steps** (A1 Step 3, A2 Step 3) are explicitly "build → read errors → adapt" because the exact 0.14.8 `KokoroAneManager` API can only be confirmed against the compiler; the variant case names (`.english`/`.spanish`/`.japanese`) were observed in the 0.14.8 source but must compile.
+- **hi/zh** intentionally untouched (still fail-fast) — out of scope per spec.

--- a/docs/superpowers/plans/2026-06-01-ja-fluidaudio-kokoro.md
+++ b/docs/superpowers/plans/2026-06-01-ja-fluidaudio-kokoro.md
@@ -386,3 +386,34 @@ Use `Refs #492` (NOT `Closes` — hi/zh remain). Add the `WIP` label on start; a
 - **Spec coverage:** fork bump (A1) ✓, variant-by-language (A2) ✓, FFI thread (A3) ✓, `--rate` preserved (A2/A4 Step 2) ✓, rev bump (B1) ✓, lang→init (B2) ✓, relax gate keep hi/zh (B3) ✓, male ja default (B4) ✓, assets via install (B5 Step 1 note) ✓, tests/docs (B5) ✓, Refs-not-Closes (B6) ✓.
 - **Build-discovery steps** (A1 Step 3, A2 Step 3) are explicitly "build → read errors → adapt" because the exact 0.14.8 `KokoroAneManager` API can only be confirmed against the compiler; the variant case names (`.english`/`.spanish`/`.japanese`) were observed in the 0.14.8 source but must compile.
 - **hi/zh** intentionally untouched (still fail-fast) — out of scope per spec.
+
+---
+
+## REVISION (2026-06-01): pivoted ja → zh (spike misread corrected)
+
+FluidAudio 0.14.8 `KokoroAneVariant` is **`english` + `mandarin` only** (verified in the
+resolved checkout) — there is no `japanese`/`spanish` variant. This effort therefore ships
+**Chinese (zh)**, not Japanese. The task structure below is unchanged; the *specifics* change:
+
+- **A1** — done (0.14.8 bump committed; builds clean, API-compatible — no bridge break).
+- **A2 (corrected)** — bridge variant map is simply:
+  ```swift
+  private static func kokoroVariant(for lang: String) -> KokoroAneVariant {
+      switch lang.lowercased().split(separator: "-").first.map(String.init) ?? "" {
+      case "zh": return .mandarin
+      default:   return .english   // en + Latin-script es/fr/it/pt (already work)
+      }
+  }
+  ```
+  (No `.spanish`/`.japanese` — they don't exist in 0.14.8.)
+- **A3** — unchanged (thread `lang` through `init_kokoro` FFI).
+- **A4** — smoke-test **Mandarin** (你好) with a zh voice + `lang="zh"`, not Japanese.
+- **B2** — unchanged (pass voice lang to `init_kokoro`).
+- **B3 (corrected)** — drop the **`zh`** arm from `unsupported_native_script`; **keep `hi`
+  AND `ja`** fail-fast (neither has a 0.14.8 variant).
+- **B4 (corrected)** — zh default voice **`zh-zm_yunjian`** (male; the `.mandarin` variant's
+  own default `zf_001` is female — override per brand rule). Verify `zm_yunjian` ships in the
+  `ANE-zh/` pack.
+- **B5/B6** — Mandarin round-trip + audio QC; docs say zh supported, hi/ja still fail-fast.
+
+`ja`/`hi` are deferred to a separate ONNX CharsiuG2P effort. Linkage `Refs #492`.

--- a/docs/superpowers/specs/2026-06-01-ja-fluidaudio-kokoro-design.md
+++ b/docs/superpowers/specs/2026-06-01-ja-fluidaudio-kokoro-design.md
@@ -1,0 +1,126 @@
+# Japanese TTS via FluidAudio 0.14.8 KokoroAne — Design (#492)
+
+**Status:** approved (brainstorm), pending implementation plan
+**Refs:** #492 (partial — ships `ja`; `hi`/`zh` remain open follow-ups)
+
+## Problem
+
+The darwin `system_kokoro` (FluidAudio) TTS path emits **noise** for non-Latin native-script
+input (hi/ja/zh): the fork's Swift bridge hardcodes `KokoroAneManager(variant: .english, …)`,
+so FluidAudio's English G2P is applied to Devanagari / kana-kanji / Han. #495 added a
+fail-fast gate (`E_SCRIPT_UNSUPPORTED`) so this is a loud error today, not silent noise.
+
+Spikes (recorded in #492 and the prior session) established:
+- FluidAudio **v0.14.8** (latest *release*) exposes `KokoroAneVariant` cases
+  **`english` / `spanish` / `japanese`** with per-variant G2P. So **Japanese is achievable
+  on a released version** by selecting the variant by language.
+- `hi`/`zh` KokoroAne variants exist only on FluidAudio's **unreleased dev HEAD** — pinning a
+  shipped dependency to that is too fragile. They are deferred (hi is also reachable via the
+  ONNX CharsiuG2P path with one remap rule; zh needs Kokoro-specific tone encoding — hard).
+
+## Goal
+
+Native Japanese TTS on the darwin FluidAudio Kokoro path: bump the fork to FluidAudio
+0.14.8, select the `KokoroAne` variant by language (en/es/ja), preserve the `--rate`
+patch, and unblock `ja` native script in kesha. `hi`/`zh` stay fail-fast.
+
+### Non-goals
+- `hi` and `zh` native-script synthesis (separate follow-ups; keep the #495 gate for them).
+- Pinning FluidAudio to an unreleased dev commit.
+- Changing the ONNX (Linux/Windows) TTS path. This is darwin `system_kokoro` only.
+- Re-architecting the fork beyond what variant selection requires.
+
+## Architecture — two repos, sequenced
+
+Repo A (the fork) is a hard prerequisite: kesha can't bump its rev until the fork publishes
+one. ~80% of the effort is in the fork's Swift bridge.
+
+### Repo A — `drakulavich/fluidaudio-rs` (`/Users/anton/Personal/repos/fluidaudio-rs`)
+
+Base branch: **`feat/fluidaudio-0.14.7-kokoro-ane-speed`** (rev `9ce32cc` — already carries the
+`KokoroAneManager` migration + the `--rate` model-native-speed patch). NOT `forked-main`
+(which lags at FluidAudio 0.14.5 and lacks the migration). Work on a new branch off it, e.g.
+`feat/fluidaudio-0.14.8-multilingual-variants`.
+
+1. **`Package.swift`** — `FluidAudio` `exact: "0.14.7"` → `exact: "0.14.8"`.
+2. **`swift/FluidAudioBridge.swift`** — replace the hardcoded
+   `KokoroAneManager(variant: .english, defaultVoice:)` (≈line 143) with **variant selection
+   by language**:
+   - Map language → `KokoroAneVariant`: `en → .english`, `es → .spanish`, `ja → .japanese`.
+   - Cache one `KokoroAneManager` per variant (lazily created on first use); do not tear down
+     the English manager when a Japanese request arrives. A small `[KokoroAneVariant: KokoroAneManager]`
+     dictionary keyed by variant.
+   - The language signal reaches the bridge via an explicit FFI parameter (preferred — see
+     §FFI) rather than guessing from the voice id, so kesha stays the source of truth for
+     language routing.
+3. **FFI surface** (`swift/Kokoro_ffi.swift` + `src/ffi/bridge.rs` + `src/lib.rs`) — thread a
+   `lang` argument through `fluidaudio_kokoro_synthesize` / `synthesize_kokoro` so the bridge
+   picks the variant. Backward-compatible default: empty/unknown lang → `.english` (preserves
+   today's behavior for en voices).
+4. **Preserve `--rate`** — the model-native `speed` input must still feed the model for every
+   variant, not just English. Verify against the 0.14.8 `KokoroAneManager.synthesize` signature
+   (the patch may need re-applying if the API shifted between 0.14.7 and 0.14.8).
+5. **Build + smoke** — `swift build`; a throwaway harness synthesizes one Japanese sentence
+   (e.g. こんにちは) and confirms non-empty WAV. Spike-validate the 0.14.7→0.14.8
+   `KokoroAneManager` API delta before finalizing the bridge.
+6. Commit on the new branch, push to `origin`, record the new rev SHA.
+
+### Repo B — kesha-voice-kit (`feat/ja-fluidaudio-kokoro` worktree)
+
+1. **`rust/Cargo.toml`** — bump the `fluidaudio-rs` `rev` to the new fork commit; update the
+   pinning comment (now FluidAudio 0.14.8, multilingual variant selection).
+2. **`rust/src/tts/fluid_kokoro.rs`** — pass the resolved language to the binding's
+   `synthesize_kokoro`/`synthesize_pcm` calls so the bridge selects the variant. The
+   `ResolvedVoice::FluidKokoro` already carries `espeak_lang`; thread it through.
+3. **Script gate** (`unsupported_native_script` / `ensure_script_supported`, #495) — remove the
+   `ja` (kana/kanji) arm so Japanese native script is allowed; **keep `hi` (Devanagari) and
+   `zh` (Han) blocked** with the existing `E_SCRIPT_UNSUPPORTED` fail-fast.
+4. **Voices** (`rust/src/tts/voices.rs`, FluidKokoro catalog) — ensure a **male** Japanese
+   voice is the default for `ja` (brand rule "DEFAULT TTS VOICES MUST BE MALE" — pick a `jm_*`
+   voice, e.g. `jm_kumo`, validated by ear). Wire `default_voice_for_lang`/voice resolution on
+   the `system_kokoro` path.
+5. **Model assets** — KokoroAne fetches the Japanese variant's CoreML/G2P assets via
+   FluidAudio's own downloader (HF `FluidInference/kokoro-82m-coreml`). Ensure this happens
+   under the explicit `kesha install --tts` flow and never as a surprise download at synth time
+   (the "NEVER AUTO-DOWNLOAD" rule). Document any new asset/size in the install path.
+
+## Data flow (after)
+
+```
+kesha say --voice ja-jm_kumo "こんにちは"
+  → fluid_kokoro::synthesize(text, "ja-jm_kumo", speed)
+      → ensure_script_supported: ja now allowed
+      → fluidaudio-rs synthesize_kokoro(text, voice="jm_kumo", lang="ja", speed)
+          → FluidAudioBridge: KokoroAneManager(variant: .japanese) (cached)
+              → FluidAudio 0.14.8 Japanese G2P → Kokoro → WAV
+```
+
+## Error handling
+
+- `hi`/`zh` native script: unchanged fail-fast (`E_SCRIPT_UNSUPPORTED`) with the romanize/other-voice hint.
+- Unknown/empty lang into the FFI: defaults to `.english` (no regression for en).
+- Missing ja assets: the existing `kesha install --tts` hint path; never silently synthesize noise.
+
+## Testing strategy
+
+- **Fork:** `swift build` + a Japanese synth smoke (non-empty WAV) on the new branch before publishing the rev.
+- **kesha (darwin only):**
+  - ja round-trip: synthesize a Japanese sentence, transcribe with Parakeet, assert recognizable Japanese (the #492 evidence methodology) — gated to darwin `system_kokoro`.
+  - audio-quality-check agent on the ja WAV (rate/RMS/clip/length).
+  - script-gate test: `ja` native script now succeeds; `hi`/`zh` still error with `E_SCRIPT_UNSUPPORTED`.
+- Full gate per CLAUDE.md: `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts`, plus the build is `system_kokoro` (darwin) — validate with `cargo check --features system_kokoro` / a real darwin build.
+
+## Rollout / linkage
+
+Two PRs:
+1. Fork PR in `drakulavich/fluidaudio-rs` (FluidAudio 0.14.8 + multilingual variant selection).
+2. kesha-voice-kit PR: `Refs #492` (partial — ships ja; do NOT `Closes`, since hi/zh remain).
+   After it lands, comment on #492 that `ja` is supported and hi/zh stay tracked.
+
+## Open risks (validate during implementation)
+
+- Exact `KokoroAneManager` init/`synthesize` API delta between 0.14.7 and 0.14.8 (drives the
+  bridge edit + `--rate` re-apply).
+- Whether multiple per-variant `KokoroAneManager` instances coexist cleanly (memory/ANE), or a
+  single manager must be re-initialized on variant switch.
+- Japanese asset download size/source and how it fits `kesha install --tts`.

--- a/docs/superpowers/specs/2026-06-01-ja-fluidaudio-kokoro-design.md
+++ b/docs/superpowers/specs/2026-06-01-ja-fluidaudio-kokoro-design.md
@@ -124,3 +124,30 @@ Two PRs:
 - Whether multiple per-variant `KokoroAneManager` instances coexist cleanly (memory/ANE), or a
   single manager must be re-initialized on variant switch.
 - Japanese asset download size/source and how it fits `kesha install --tts`.
+
+---
+
+## REVISION (2026-06-01): pivoted ja → zh
+
+**Correction:** the brainstorm spike misread the FluidAudio source — it conflated
+`KokoroAneVariant` with unrelated ASR/G2P language enums. The **resolved FluidAudio
+0.14.8** `KokoroAneVariant` has exactly two cases: **`english` and `mandarin` (zh)** —
+**no `japanese`, no `spanish`**. Verified against `.build/checkouts/FluidAudio/.../KokoroAne/KokoroAneConstants.swift`.
+
+**Impact:** this FluidAudio-0.14.8 effort ships **Chinese (zh)**, not Japanese. The
+`.mandarin` variant is fully functional (jieba + g2pw + bopomofo + erhua + tone sandhi +
+pinyin dict; `ANE-zh/` bundle; default voice `zf_001`). FluidAudio handles Mandarin tones
+in-engine — the part that was hard on the ONNX CharsiuG2P path (tone letters were OOV).
+
+**Corrected design (supersedes the ja-specific details above):**
+- Bridge variant map: **`zh → .mandarin`, everything else → `.english`** (en plus the
+  Latin-script es/fr/it/pt, which already synthesize acceptably through the English G2P).
+  No spanish/japanese variant exists to select.
+- kesha script gate: **drop the `zh` (Han) arm**; **keep `hi` (Devanagari) AND `ja`
+  (kana/kanji) fail-fast** — neither has a FluidAudio 0.14.8 KokoroAne variant.
+- zh default voice: **`zh-zm_yunjian`** (male, per brand rule) — overrides the variant's
+  `zf_001` (female) default. Verify `zm_yunjian` ships in the `ANE-zh/` pack during impl.
+- `ja` and `hi` are deferred to a separate **ONNX CharsiuG2P** effort (spike: ja OOV=0
+  clean, hi 1 remap rule) — they are not reachable via FluidAudio 0.14.8.
+
+Linkage stays `Refs #492` (ships zh; ja/hi remain).

--- a/docs/superpowers/specs/2026-06-01-ja-fluidaudio-kokoro-design.md
+++ b/docs/superpowers/specs/2026-06-01-ja-fluidaudio-kokoro-design.md
@@ -151,3 +151,16 @@ in-engine — the part that was hard on the ONNX CharsiuG2P path (tone letters w
   clean, hi 1 remap rule) — they are not reachable via FluidAudio 0.14.8.
 
 Linkage stays `Refs #492` (ships zh; ja/hi remain).
+
+## Correction (2026-06-01): zh model staging — first-synth download is the norm
+
+The B5 "Model assets" item above aspired to pre-fetch under `kesha install --tts` and
+"never a surprise download at synth time." Implementation reality: the FluidAudio
+`system_kokoro` path **already** leaves its model graph + `af_heart` to a first-synth,
+FluidAudio-owned download (`models.rs::download_tts` notes `kokoro_manifest()` is empty for
+this path). The Mandarin `.mandarin` variant fetches its **nested** `ANE-zh/` bundle the same
+way; kesha cannot pre-stage it (FluidAudio owns that layout), and pre-fetching a large
+Mandarin bundle at install for users who never use zh would be worse. So zh is **consistent
+with the existing first-synth model download** for this path, not a new rule violation
+(Greptile #516 P1). A general "warm all TTS models at install" is a separate possible
+enhancement (would also pre-fetch the en model graph), out of scope here.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -687,8 +687,8 @@ dependencies = [
 
 [[package]]
 name = "fluidaudio-rs"
-version = "0.14.1"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=832d74b3d0057ad2f1fec5bf3b20ea94e253b703#832d74b3d0057ad2f1fec5bf3b20ea94e253b703"
+version = "0.14.8"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=1a20fb37e5f402f6809986b727475a89bf896da2#1a20fb37e5f402f6809986b727475a89bf896da2"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.8"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=1a20fb37e5f402f6809986b727475a89bf896da2#1a20fb37e5f402f6809986b727475a89bf896da2"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=dd9387f1ae79ad355e5197ee1bb880e7dc782409#dd9387f1ae79ad355e5197ee1bb880e7dc782409"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.8"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=dd9387f1ae79ad355e5197ee1bb880e7dc782409#dd9387f1ae79ad355e5197ee1bb880e7dc782409"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?branch=forked-main#8081ac65aa8d1efc906a4aed43884afa4b61a8b1"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.1"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=ddcb14d9519232fbf01111cd31292680adaa1fcf#ddcb14d9519232fbf01111cd31292680adaa1fcf"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=832d74b3d0057ad2f1fec5bf3b20ea94e253b703#832d74b3d0057ad2f1fec5bf3b20ea94e253b703"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -70,13 +70,11 @@ ndarray = { version = "0.17" }
 # FluidAudio (macOS): ASR (CoreML/ANE), native Kokoro TTS, and model-path
 # diarization. Forked to add the Kokoro binding + `diarize_file_with_models`
 # (upstream PR pending; retire the fork once merged).
-# Pinned to FluidAudio 0.14.8 + per-language KokoroAne variant selection on the
-# `feat/fluidaudio-0.14.8-multilingual-variants` branch (fork PR #3): `init_kokoro`
-# takes a `lang` arg → `zh` selects the `.mandarin` variant (tone-aware Mandarin
-# G2P), else `.english` (#492). Retains the `--rate` model-native speed (#475).
-# Cargo forbids `branch` + `rev` together, so we pin by `rev`; re-point to
-# `branch = "forked-main"` once fork PR #3 merges to the fork's main.
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "dd9387f1ae79ad355e5197ee1bb880e7dc782409", optional = true }
+# Tracks `forked-main`, which carries FluidAudio 0.14.8 + per-language KokoroAne
+# variant selection (fork PRs #2 + #3, both merged): `init_kokoro` takes a `lang`
+# arg → `zh` selects the `.mandarin` variant (tone-aware Mandarin G2P), else
+# `.english` (#492). Retains the `--rate` model-native speed (#475).
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", branch = "forked-main", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -76,7 +76,7 @@ ndarray = { version = "0.17" }
 # G2P), else `.english` (#492). Retains the `--rate` model-native speed (#475).
 # Cargo forbids `branch` + `rev` together, so we pin by `rev`; re-point to
 # `branch = "forked-main"` once fork PR #3 merges to the fork's main.
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "1a20fb37e5f402f6809986b727475a89bf896da2", optional = true }
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "dd9387f1ae79ad355e5197ee1bb880e7dc782409", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -76,7 +76,7 @@ ndarray = { version = "0.17" }
 # G2P), else `.english` (#492). Retains the `--rate` model-native speed (#475).
 # Cargo forbids `branch` + `rev` together, so we pin by `rev`; re-point to
 # `branch = "forked-main"` once fork PR #3 merges to the fork's main.
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "832d74b3d0057ad2f1fec5bf3b20ea94e253b703", optional = true }
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "1a20fb37e5f402f6809986b727475a89bf896da2", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -70,12 +70,13 @@ ndarray = { version = "0.17" }
 # FluidAudio (macOS): ASR (CoreML/ANE), native Kokoro TTS, and model-path
 # diarization. Forked to add the Kokoro binding + `diarize_file_with_models`
 # (upstream PR pending; retire the fork once merged).
-# Pinned to the FluidAudio 0.14.7 KokoroAneManager migration on the
-# `feat/fluidaudio-0.14.7-kokoro-ane-speed` branch (fork PR #2) so `--rate`
-# actually feeds the model `speed` input on the CoreML Kokoro path (#475).
+# Pinned to FluidAudio 0.14.8 + per-language KokoroAne variant selection on the
+# `feat/fluidaudio-0.14.8-multilingual-variants` branch (fork PR #3): `init_kokoro`
+# takes a `lang` arg → `zh` selects the `.mandarin` variant (tone-aware Mandarin
+# G2P), else `.english` (#492). Retains the `--rate` model-native speed (#475).
 # Cargo forbids `branch` + `rev` together, so we pin by `rev`; re-point to
-# `branch = "forked-main"` once fork PR #2 merges to the fork's main.
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "ddcb14d9519232fbf01111cd31292680adaa1fcf", optional = true }
+# `branch = "forked-main"` once fork PR #3 merges to the fork's main.
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "832d74b3d0057ad2f1fec5bf3b20ea94e253b703", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,10 +1,17 @@
 fn main() {
-    // The `coreml` feature pulls in fluidaudio-rs, which links against the
-    // macOS Swift runtime (libswift_Concurrency.dylib and friends). Without
-    // an explicit rpath the dynamic linker fails at startup with
-    // `Library not loaded: @rpath/libswift_Concurrency.dylib`. /usr/lib/swift
-    // is the standard location on macOS 13+.
-    #[cfg(feature = "coreml")]
+    // The `coreml`, `system_kokoro`, and `system_diarize` features all pull in
+    // fluidaudio-rs, which links against the macOS Swift runtime
+    // (libswift_Concurrency.dylib and friends). Without an explicit rpath the
+    // dynamic linker fails at startup with
+    // `Library not loaded: @rpath/libswift_Concurrency.dylib`. /usr/lib/swift is
+    // the standard location on macOS 13+. CI also sets MACOSX_DEPLOYMENT_TARGET=14.0
+    // to elide the dep, but this rpath keeps local `system_kokoro`/`system_diarize`
+    // builds runnable without that env var.
+    #[cfg(any(
+        feature = "coreml",
+        feature = "system_kokoro",
+        feature = "system_diarize"
+    ))]
     {
         println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
     }

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -355,11 +355,13 @@ const ANE_KOKORO_VOICES: &[ModelFile] = &[
         url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_alex.bin",
         sha256: "0175c753f59c54e7fd5a995bedef0c5ff2fb67e0043dd3dcb2ae74ec2acbeb2a",
     },
-    ModelFile {
-        rel_path: "zm_yunjian.bin",
-        url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/zm_yunjian.bin",
-        sha256: "de48a00bdbf3649f07162269a2b6e0513604389bfac8a2e6c75cb34b323ad6fa",
-    },
+    // re-pinned (#492): removed the flat `zm_yunjian.bin`
+    // (was sha de48a00bdbf3649f07162269a2b6e0513604389bfac8a2e6c75cb34b323ad6fa).
+    // zh (Mandarin) voices are NOT staged here — the FluidAudio 0.14.8 `.mandarin`
+    // KokoroAne variant fetches its own `ANE-zh/` bundle (nested `voices/<id>.bin`)
+    // on first synth, and those ids are numbered (e.g. zm_050), not the
+    // onnx-community names. A flat kesha-staged pack would be unused. See
+    // `tts::fluid_kokoro` zh-* voices.
 ];
 
 /// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
@@ -985,7 +987,10 @@ mod tts_tests {
                 .split_once('-')
                 .map(|(_, bare)| bare)
                 .unwrap_or(v.as_str());
-            if bare == "af_heart" {
+            // af_heart: FluidAudio auto-provides it into the English ANE dir.
+            // zh-*: the Mandarin KokoroAne variant fetches its own ANE-zh bundle
+            // (nested voices/) on first synth, so kesha does not stage it (#492).
+            if bare == "af_heart" || v.starts_with("zh-") {
                 continue;
             }
             assert!(

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -990,6 +990,12 @@ mod tts_tests {
             // af_heart: FluidAudio auto-provides it into the English ANE dir.
             // zh-*: the Mandarin KokoroAne variant fetches its own ANE-zh bundle
             // (nested voices/) on first synth, so kesha does not stage it (#492).
+            // Both are first-synth FluidAudio-owned downloads — the SAME class as
+            // the English Kokoro model graph + af_heart, which `download_tts`
+            // deliberately leaves to FluidAudio (see the `kokoro_manifest()` is
+            // empty note in `download_tts`). Pre-staging zh here is impossible
+            // (FluidAudio owns the nested ANE-zh layout) and would be inconsistent
+            // with how the en model graph already loads.
             if bare == "af_heart" || v.starts_with("zh-") {
                 continue;
             }

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -204,20 +204,20 @@ fn is_han(c: char) -> bool {
     )
 }
 
-/// FluidAudio's Kokoro G2P only phonemizes **Latin** input; for the non-Latin
-/// languages it ships voices for (hi/ja/zh) native-script text is not converted
-/// to phonemes and synthesizes as noise rather than speech (#492). Returns the
-/// human-facing script name when `text` actually contains characters of the
-/// script `fluid_id`'s language is written in — romanized (Latin) input for the
-/// same voice returns `None` because it works. Latin-script Kokoro languages
-/// (en/es/fr/it/pt) always return `None`.
+/// FluidAudio's Kokoro G2P handles Latin (en/es/fr/it/pt) and, since the
+/// FluidAudio 0.14.8 `.mandarin` KokoroAne variant, Chinese (Han). For the other
+/// non-Latin languages it ships voices for (hi/ja) native-script text is not
+/// converted to phonemes and synthesizes as noise rather than speech (#492).
+/// Returns the human-facing script name when `text` actually contains characters
+/// of the script `fluid_id`'s language is written in — romanized (Latin) input
+/// for the same voice returns `None` because it works.
 fn unsupported_native_script(text: &str, fluid_id: &str) -> Option<&'static str> {
     let any = |f: fn(char) -> bool| text.chars().any(f);
     match lang_for_fluid_id(fluid_id)? {
         "hi" => any(|c| ('\u{0900}'..='\u{097F}').contains(&c)).then_some("Devanagari"),
         "ja" => any(|c| matches!(c, '\u{3040}'..='\u{30FF}') || is_han(c))
             .then_some("Japanese (kana/kanji)"),
-        "zh" => any(is_han).then_some("Chinese (Han)"),
+        // zh (Han) is supported via FluidAudio 0.14.8's Mandarin KokoroAne variant.
         _ => None,
     }
 }
@@ -247,10 +247,13 @@ fn ensure_script_supported(fluid_id: &str, text: &str) -> Result<()> {
 /// would corrupt `kesha say`'s WAV byte stream; the oneshot guard restores fd 1
 /// on return (#259, mirrors the diarize/ASR guard).
 fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> Result<R> {
+    // The voice's language selects the KokoroAne variant in the bridge
+    // (`zh` → Mandarin, else English). Unknown voices default to English.
+    let lang = lang_for_fluid_id(voice_id).unwrap_or("en-us");
     crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
         let audio = FluidAudio::new().context("init FluidAudio bridge")?;
         audio
-            .init_kokoro(voice_id)
+            .init_kokoro(voice_id, lang)
             .context("init FluidAudio Kokoro (downloads the model on first run)")?;
         f(&audio)
     })
@@ -374,15 +377,13 @@ mod tests {
             unsupported_native_script("日本語", "jm_kumo"),
             Some("Japanese (kana/kanji)")
         );
+        // zh (Han) is now SUPPORTED via FluidAudio 0.14.8's Mandarin KokoroAne
+        // variant (#492) — native-script Chinese must NOT be flagged.
         assert_eq!(
             unsupported_native_script("你好我叫凯沙", "zm_yunjian"),
-            Some("Chinese (Han)")
+            None
         );
-        // Supplementary-plane CJK (Extension B, U+20000) must also be detected.
-        assert_eq!(
-            unsupported_native_script("\u{20000}", "zm_yunjian"),
-            Some("Chinese (Han)")
-        );
+        assert_eq!(unsupported_native_script("\u{20000}", "zm_yunjian"), None);
     }
 
     #[test]
@@ -421,11 +422,8 @@ mod tests {
 
     #[test]
     fn ensure_script_supported_bails_with_code_on_native_script() {
-        for (text, voice) in [
-            ("नमस्ते", "hm_omega"),
-            ("こんにちは", "jm_kumo"),
-            ("你好", "zm_yunjian"),
-        ] {
+        // hi/ja native script still bails (no FluidAudio 0.14.8 KokoroAne variant).
+        for (text, voice) in [("नमस्ते", "hm_omega"), ("こんにちは", "jm_kumo")] {
             let err =
                 ensure_script_supported(voice, text).expect_err("should reject native script");
             assert_eq!(
@@ -434,6 +432,8 @@ mod tests {
                 "voice {voice} text {text:?} -> {err}"
             );
         }
+        // zh (Han) now passes — supported via the Mandarin KokoroAne variant (#492).
+        ensure_script_supported("zm_yunjian", "你好").expect("zh native ok");
         // Romanized + Latin-script voices pass.
         ensure_script_supported("hm_omega", "Namaste").expect("romanized hi ok");
         ensure_script_supported("em_alex", "¡Hola!").expect("latin es ok");

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -166,8 +166,8 @@ const VOICES: &[VoiceSpec] = &[
         lang: "pt-br",
     },
     VoiceSpec {
-        public_id: "zh-zm_yunjian",
-        fluid_id: "zm_yunjian",
+        public_id: "zh-zm_050",
+        fluid_id: "zm_050",
         lang: "zh",
     },
     VoiceSpec {
@@ -343,7 +343,7 @@ mod tests {
         assert!(voices.contains(&"en-af_heart".to_string()));
         assert!(voices.contains(&"es-em_alex".to_string()));
         assert!(voices.contains(&"ja-jm_kumo".to_string()));
-        assert!(voices.contains(&"zh-zm_yunjian".to_string()));
+        assert!(voices.contains(&"zh-zm_050".to_string()));
     }
 
     #[test]
@@ -379,11 +379,8 @@ mod tests {
         );
         // zh (Han) is now SUPPORTED via FluidAudio 0.14.8's Mandarin KokoroAne
         // variant (#492) — native-script Chinese must NOT be flagged.
-        assert_eq!(
-            unsupported_native_script("你好我叫凯沙", "zm_yunjian"),
-            None
-        );
-        assert_eq!(unsupported_native_script("\u{20000}", "zm_yunjian"), None);
+        assert_eq!(unsupported_native_script("你好我叫凯沙", "zm_050"), None);
+        assert_eq!(unsupported_native_script("\u{20000}", "zm_050"), None);
     }
 
     #[test]
@@ -398,7 +395,7 @@ mod tests {
             None
         );
         assert_eq!(
-            unsupported_native_script("Ni hao! Wo jiao Kesha.", "zm_yunjian"),
+            unsupported_native_script("Ni hao! Wo jiao Kesha.", "zm_050"),
             None
         );
     }
@@ -433,7 +430,7 @@ mod tests {
             );
         }
         // zh (Han) now passes — supported via the Mandarin KokoroAne variant (#492).
-        ensure_script_supported("zm_yunjian", "你好").expect("zh native ok");
+        ensure_script_supported("zm_050", "你好").expect("zh native ok");
         // Romanized + Latin-script voices pass.
         ensure_script_supported("hm_omega", "Namaste").expect("romanized hi ok");
         ensure_script_supported("em_alex", "¡Hola!").expect("latin es ok");


### PR DESCRIPTION
Refs #492 (ships **zh**; `hi`/`ja` remain tracked). Design/plan + spike trail in `docs/superpowers/{specs,plans}/2026-06-01-ja-fluidaudio-kokoro*` (note: brainstorm targeted `ja`, but a spike of the resolved FluidAudio 0.14.8 source found its `KokoroAneVariant` is `english` + `mandarin` only — so this ships Chinese; the docs carry the ja→zh correction).

**Depends on fork PR:** drakulavich/fluidaudio-rs#3 (FluidAudio 0.14.8 + per-language KokoroAne variant selection). `Cargo.toml` pins that rev (`832d74b`); re-point to a tag/`forked-main` once the fork PR merges.

## What changed (kesha)
- bump `fluidaudio-rs` rev → FluidAudio 0.14.8 multilingual-variant fork
- `with_kokoro` resolves the voice language and passes it to `init_kokoro(voice, lang)` → the Swift bridge selects `.mandarin` for `zh`, else `.english`
- drop `zh` from the native-script fail-fast gate (now supported); **`hi`/`ja` still fail fast** (`E_SCRIPT_UNSUPPORTED`)
- zh default voice **`zh-zm_050`** (male, per brand rule); the variant's own default `zf_001` is female
- remove the stale flat `zm_yunjian.bin` staging — zh voices are fetched by FluidAudio's own `ANE-zh/` bundle (nested), so they're exempt from kesha staging (like `af_heart`)
- `build.rs`: emit the `/usr/lib/swift` rpath under `system_kokoro`/`system_diarize` too (not just `coreml`), so local builds load `libswift_Concurrency` without `MACOSX_DEPLOYMENT_TARGET=14.0`

## Verification (darwin)
- `cargo nextest --features system_kokoro` → **341/341**; default `--features tts` (ONNX) → **335/335**; clippy `-D warnings` + fmt clean; `cargo check --features coreml` compiles.
- End-to-end: `kesha say --voice zh-zm_050 "你好，我叫凯沙。…"` → 230 KB / 24 kHz / 4.8 s, clean stderr. `hi-hm_omega` native → exits 4 with `E_SCRIPT_UNSUPPORTED` (still gated).
- audio-quality-check agent: **PASS** (advisory: one Int16-ceiling sample — upstream float→int16 quantization artifact in FluidAudio, inaudible).
- zh default voice `zm_050` chosen by ear from 5 male `ANE-zh` candidates.

**Known upstream warning (non-fatal):** FluidAudio's `jieba_hmm_start.bin` asset 404s → Mandarin HMM segmentation disabled; synthesis still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)