### PR TITLE
chore(release): 1.23.0 — multilingual TTS (es/fr/it/pt + zh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.22.0"
+    "version": "1.23.0"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.22.0"
+version = "1.23.0"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Engine release **1.23.0** — ships the multilingual TTS work merged to `main` since the `v1.22.0` engine build (which predates all of it, so users can't use any of this until the engine is re-released).

## Shipped since v1.22.0
- **#509** — multilingual Kokoro on the ONNX build (es/fr/it/pt) via CharsiuG2P (klebster ONNX, CC-BY 4.0) + per-language numbers/acronym normalizer.
- **#511** — G2P polish: Portuguese thousands connector, French 71 ("soixante-et-onze"), per-language acronym stop-lists, Castilian Spanish via `--lang es-ES`.
- **#516** — native **Chinese (zh)** on the darwin `system_kokoro` path via FluidAudio 0.14.8's `.mandarin` KokoroAne variant (default `zh-zm_050`, male). Fork bindings: drakulavich/fluidaudio-rs#3.

## Version bump (engine release)
`package.json#version`, `package.json#keshaEngine.version`, `rust/Cargo.toml`, `rust/Cargo.lock` → **1.23.0**. Version-drift gate (`bun run check:versions`) passes.

## After merge
Tag `v1.23.0` → `build-engine.yml` builds the 3 platform binaries (darwin row includes `system_kokoro` for zh) + draft release → validate draft assets → un-draft fires npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)