### PR TITLE
Language-scoped TTS install: `kesha install --tts <langs>` + init multi-select

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,9 +411,13 @@ const text = await transcribe("audio.ogg");
 
 Text-to-speech via three engines selected by voice id prefix:
 `en-*` → Kokoro-82M (24 kHz), `ru-*` → Vosk-TTS (22.05 kHz), `macos-*` → AVSpeech Swift sidecar.
-Install Kokoro + Vosk explicitly with `kesha install --tts` (~990 MB); `macos-*` voices need no
-model download. Models are NEVER auto-downloaded — `kesha say` fails loudly with a
-`kesha install --tts` hint when models are missing. Default voices MUST be male (see DEFAULT TTS
+Install TTS models explicitly with `kesha install --tts [<langs>...]` — bare `--tts` installs
+English only (~326 MB); `kesha install --tts en ru` adds Russian (~937 MB); `es/fr/it/pt` are
+available on all platforms, `hi/ja/zh` are darwin-arm64 only (FluidAudio ANE). `macos-*` voices
+need no model download. Re-running is additive (never prunes). `kesha init` presents a
+multi-select of available TTS languages with English pre-checked. Models are NEVER
+auto-downloaded — `kesha say` fails loudly with a `kesha install --tts` hint when models are
+missing. Default voices MUST be male (see DEFAULT TTS
 VOICES MUST BE MALE above). `kesha say` writes WAV mono f32 to stdout unless `--out` is given;
 stderr is progress/errors only. Auto-routing for an omitted `--voice` is in `src/cli/say.ts::pickVoiceForLang`.
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@drakulavich/kesha-voice-kit",
       "dependencies": {
+        "@clack/prompts": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@toon-format/toon": "^2.1.0",
         "citty": "^0.2.2",
@@ -23,6 +24,10 @@
     },
   },
   "packages": {
+    "@clack/core": ["@clack/core@1.4.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw=="],
+
+    "@clack/prompts": ["@clack/prompts@1.5.0", "", { "dependencies": { "@clack/core": "1.4.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
@@ -111,7 +116,13 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
 
@@ -224,6 +235,8 @@
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -40,6 +40,16 @@ NVIDIA Parakeet TDT 0.6B v3. Language is auto-detected; `--lang <code>` warns if
 
 Voice auto-picks from the text's language; pass `--voice <id>` to choose. Run `kesha say --list-voices` to see what's installed. Full voice catalogue and SSML details: [tts.md](tts.md).
 
+TTS models are installed per-language via `kesha install --tts <codes>`. Bare `--tts` defaults to English only. Re-running is additive. `kesha init` presents a multi-select of available languages.
+
+```bash
+kesha install --tts              # English only (~326 MB)
+kesha install --tts en ru        # add Russian (~937 MB)
+kesha install --tts es fr it pt  # Romance languages (all platforms)
+```
+
+Languages marked **darwin-arm64** below require a darwin-arm64 engine build (FluidAudio ANE); requesting them on other platforms is a hard error.
+
 | # | Language | Code | | Engine (voice prefix) | Platform | Notes |
 |---:|----------|------|---|------------------------|----------|-------|
 | 1 | English | `en` | 🇬🇧 | Kokoro (`en-*`) | all | default `en-am_michael` |
@@ -53,7 +63,7 @@ Voice auto-picks from the text's language; pass `--voice <id>` to choose. Run `k
 | 9 | Chinese | `zh` | 🇨🇳 | Kokoro (`zh-*`) | darwin-arm64 | **pinyin (Latin) input only** — native Han is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
 | — | *(system voices)* | — | 🍎 | AVSpeech (`macos-*`) | macOS | any of the 180+ voices already installed on your Mac; zero model download |
 
-On Linux/Windows, text-to-speech covers English (Kokoro ONNX) and Russian (Vosk-TTS); the FluidAudio Kokoro multilingual voices above are darwin-arm64 only.
+On Linux/Windows, text-to-speech covers English (Kokoro ONNX), Russian (Vosk-TTS), and the Romance languages es/fr/it/pt (CharsiuG2P ONNX). The FluidAudio Kokoro voices for hi/ja/zh are darwin-arm64 only. `macos-*` AVSpeech voices need no install.
 
 ## Audio language detection (107)
 

--- a/docs/superpowers/plans/2026-06-01-tts-install-languages.md
+++ b/docs/superpowers/plans/2026-06-01-tts-install-languages.md
@@ -1,0 +1,1337 @@
+# Language-scoped TTS Install — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `kesha install --tts <langs>` and `kesha init` download only the TTS models the requested languages need (Playwright-style), instead of always pulling the full ~990 MB.
+
+**Architecture:** Three layers. The Rust engine owns the language↔engine↔platform registry and exposes it via `--capabilities-json` (single source of truth). The engine `install --tts` accepts language codes and builds a per-language download manifest. The TS CLI parses positional language codes, validates them against capabilities before forwarding, and drives a `@clack/prompts` multi-select in `kesha init`.
+
+**Tech Stack:** Rust (clap, anyhow, serde), Bun + TypeScript (citty), `@clack/prompts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-tts-install-languages-design.md`
+**Issue:** [#517](https://github.com/drakulavich/kesha-voice-kit/issues/517) — PR must say `Closes #517`.
+
+**Key facts the implementer must keep straight:**
+- Availability differs by build. **ONNX build** (Linux/Windows/macOS-without-`system_kokoro`): `en es fr it pt ru`. **`system_kokoro` build** (darwin-arm64): `en es fr hi it ja pt zh ru`. `hi ja zh` are darwin-arm64-only.
+- On the ONNX path the Kokoro graph (`model.onnx`, ~326 MB) is shared by `en es fr it pt`. CharsiuG2P (3 files, ~30 MB) is needed only for `es fr it pt` (not `en`). Vosk RU is ~937 MB.
+- On the `system_kokoro` path `kokoro_manifest()` is empty; per-language voices are staged into FluidAudio's ANE cache by `stage_ane_kokoro_voices`.
+- `macos-*` AVSpeech is **never installed** — it is ambient on macOS and excluded from `install --tts` entirely.
+- Re-runs are **additive**: `download_verified` already short-circuits cached, hash-matching files, so no pruning logic is needed.
+- The `<lang>:<engine>` override syntax is **deferred** — model the data as `{ code, engines[] }` but do not build the override parser (every list is length 1 today). Adding a second engine to a list later must NOT require unused code now (clippy `-D warnings` forbids dead code).
+
+**Verification commands (run as indicated per task):**
+- TS: `bun test` and `bunx tsc --noEmit`
+- Rust: `cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts`
+- Backend/capabilities changed: also `cd rust && cargo check --features coreml --no-default-features`
+
+---
+
+## File Structure
+
+**Rust (`rust/src/`):**
+- `models.rs` — add `tts_languages()` (cfg-gated registry), `validate_tts_langs()`, refactor `kokoro_manifest()` into addressable consts + `kokoro_manifest_for(langs)`, partition `ANE_KOKORO_VOICES` by language + `ane_voices_for(langs)`, change `download_tts(no_cache)` → `download_tts(langs, no_cache)` and `stage_ane_kokoro_voices(no_cache)` → `stage_ane_kokoro_voices(langs, no_cache)`.
+- `capabilities.rs` — add structured `tts` field (`TtsCapabilities { languages: Vec<TtsLanguage> }`), bump `protocol_version` 2→3.
+- `cli/install.rs` — `run` takes `tts_langs: Vec<String>`; validate + forward to `download_tts`.
+- `main.rs` — `Install.tts` from `bool` → `Vec<String>` (`num_args(0..)`); dispatch.
+
+**TypeScript (`src/`):**
+- `engine.ts` — extend `EngineCapabilities` with `tts?: { languages: { code: string; engines: string[] }[] }`.
+- `cli/install.ts` — parse positional langs, validate against capabilities, forward.
+- `engine-install.ts` — `InstallOptions.tts: boolean` → `ttsLangs?: string[]`; build engine args; gate Kokoro warm-up on a Kokoro language being present.
+- `cli/init.ts` — `@clack/prompts` multi-select; thread `string[]` through `InitSelection`.
+- `install-plan.ts` — per-language pack groups; `renderInstallPlan` takes the lang list.
+
+**Tests:** alongside each (`rust/src/*.rs` `#[cfg(test)]` modules; `tests/unit/*.test.ts`, `src/__tests__/*.test.ts`).
+
+**Docs:** `CLAUDE.md` (TTS section), `docs/tts.md`, `docs/languages.md`.
+
+---
+
+## Task 0: Add the `@clack/prompts` dependency
+
+**Files:**
+- Modify: `package.json` (dependencies)
+
+- [ ] **Step 1: Add the dependency**
+
+Run:
+```bash
+bun add @clack/prompts
+```
+Expected: `package.json` gains `"@clack/prompts": "^<version>"` under `dependencies`; `bun.lock` updates.
+
+- [ ] **Step 2: Verify it imports under Bun**
+
+Run:
+```bash
+bun -e "import { multiselect, isCancel } from '@clack/prompts'; console.log(typeof multiselect, typeof isCancel)"
+```
+Expected: `function function`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json bun.lock
+git commit -m "build: add @clack/prompts for init language multi-select (#517)"
+```
+
+---
+
+## Task 1: Rust — TTS language registry + capabilities field
+
+**Files:**
+- Modify: `rust/src/models.rs` (add `tts_languages`)
+- Modify: `rust/src/capabilities.rs` (add structured `tts`, bump protocol)
+- Test: `rust/src/models.rs` `#[cfg(all(test, feature = "tts"))] mod tts_tests`, `rust/src/capabilities.rs` tests
+
+- [ ] **Step 1: Write the failing test for `tts_languages()`**
+
+Add to `rust/src/models.rs` inside `mod tts_tests`:
+```rust
+    #[test]
+    fn tts_languages_includes_en_and_ru_everywhere() {
+        let langs = tts_languages();
+        assert!(langs.contains(&"en"), "en missing: {langs:?}");
+        assert!(langs.contains(&"ru"), "ru missing: {langs:?}");
+        // es/fr/it/pt are available on every TTS build.
+        for l in ["es", "fr", "it", "pt"] {
+            assert!(langs.contains(&l), "{l} missing: {langs:?}");
+        }
+    }
+
+    #[test]
+    fn tts_languages_gates_ane_only_langs() {
+        let langs = tts_languages();
+        let ane_only = ["hi", "ja", "zh"];
+        #[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]
+        for l in ane_only {
+            assert!(langs.contains(&l), "{l} should be present on system_kokoro build");
+        }
+        #[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+        for l in ane_only {
+            assert!(!langs.contains(&l), "{l} must NOT be present on the ONNX build");
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts tts_languages`
+Expected: FAIL — `cannot find function tts_languages`
+
+- [ ] **Step 3: Implement `tts_languages()`**
+
+Add to `rust/src/models.rs` (near `kokoro_manifest`, under `#[cfg(feature = "tts")]`):
+```rust
+/// TTS languages installable on THIS build, in maintainer-curated order.
+/// Source of truth for `kesha-engine install --tts <lang>` validation and the
+/// `tts.languages` capabilities rows. `es/fr/it/pt` exist on both the ONNX
+/// (CharsiuG2P) and darwin ANE builds; `hi/ja/zh` exist only on the ANE build.
+/// `macos-*` AVSpeech is NOT listed — it needs no install.
+#[cfg(feature = "tts")]
+pub fn tts_languages() -> Vec<&'static str> {
+    #[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]
+    {
+        vec!["en", "es", "fr", "hi", "it", "ja", "pt", "zh", "ru"]
+    }
+    #[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+    {
+        vec!["en", "es", "fr", "it", "pt", "ru"]
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify the models test passes**
+
+Run: `cd rust && cargo nextest run --features tts tts_languages`
+Expected: PASS (both tests)
+
+- [ ] **Step 5: Write the failing capabilities test**
+
+Add to `rust/src/capabilities.rs` (create a `#[cfg(test)] mod tests` if absent):
+```rust
+#[cfg(all(test, feature = "tts"))]
+mod tts_caps_tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_expose_tts_languages() {
+        let caps = get_capabilities();
+        let tts = caps.tts.expect("tts field present on a tts build");
+        let codes: Vec<&str> = tts.languages.iter().map(|l| l.code).collect();
+        assert!(codes.contains(&"en"));
+        assert!(codes.contains(&"ru"));
+        // every language advertises at least one downloadable engine
+        for lang in &tts.languages {
+            assert!(!lang.engines.is_empty(), "{} has no engines", lang.code);
+        }
+    }
+
+    #[test]
+    fn protocol_version_is_3() {
+        assert_eq!(get_capabilities().protocol_version, 3);
+    }
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts capabilities_expose_tts_languages`
+Expected: FAIL — no field `tts` on `Capabilities`
+
+- [ ] **Step 7: Implement the capabilities field**
+
+In `rust/src/capabilities.rs`, add the types and populate them. The engine for each language is its default downloadable engine (`engines[0]`); the list shape anticipates future multi-engine languages without building override syntax now:
+```rust
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TtsLanguage {
+    pub code: &'static str,
+    /// Downloadable engines for this language, default first. One entry today.
+    pub engines: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TtsCapabilities {
+    pub languages: Vec<TtsLanguage>,
+}
+```
+Add to `Capabilities`:
+```rust
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tts: Option<TtsCapabilities>,
+```
+Change `protocol_version: 2` → `protocol_version: 3`. In `get_capabilities()`, after the `features` block, build the field:
+```rust
+    #[cfg(feature = "tts")]
+    let tts = Some(TtsCapabilities {
+        languages: crate::models::tts_languages()
+            .into_iter()
+            .map(|code| TtsLanguage {
+                code,
+                engines: vec![if code == "ru" { "vosk" } else { "kokoro" }],
+            })
+            .collect(),
+    });
+    #[cfg(not(feature = "tts"))]
+    let tts = None;
+```
+and include `tts` in the returned `Capabilities { ... }`.
+
+- [ ] **Step 8: Run all capabilities + models tts tests**
+
+Run: `cd rust && cargo nextest run --features tts capabilities tts_languages`
+Expected: PASS
+
+- [ ] **Step 9: Verify the non-tts build still compiles (tts is Optional)**
+
+Run: `cd rust && cargo check --no-default-features --features onnx`
+Expected: compiles (the `#[cfg(not(feature="tts"))] let tts = None;` arm covers it)
+
+- [ ] **Step 10: fmt + clippy + commit**
+
+```bash
+cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings
+cd .. && git add rust/src/models.rs rust/src/capabilities.rs
+git commit -m "feat(engine): expose installable TTS languages via capabilities (proto v3) (#517)"
+```
+Expected: clippy clean.
+
+---
+
+## Task 2: Rust — language-aware ONNX Kokoro manifest
+
+**Files:**
+- Modify: `rust/src/models.rs` (refactor `kokoro_manifest`, add `kokoro_manifest_for`)
+- Test: `rust/src/models.rs` `mod tts_tests`
+
+This task only touches the **ONNX path** (`not(all(system_kokoro, macos, aarch64))`). The darwin ANE path is Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tts_tests` (guard for the ONNX path, since the helper is cfg'd there):
+```rust
+    #[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+    #[test]
+    fn kokoro_manifest_for_selects_per_language() {
+        let ends = |m: &[ModelFile], suffix: &str| m.iter().any(|f| f.rel_path.ends_with(suffix));
+
+        // en: graph + am_michael, NO g2p
+        let en = kokoro_manifest_for(&["en"]);
+        assert!(ends(&en, "model.onnx"));
+        assert!(ends(&en, "am_michael.bin"));
+        assert!(!en.iter().any(|f| f.rel_path.contains("g2p")), "en must not pull g2p");
+
+        // es: graph + em_alex + g2p, NO am_michael
+        let es = kokoro_manifest_for(&["es"]);
+        assert!(ends(&es, "model.onnx"));
+        assert!(ends(&es, "em_alex.bin"));
+        assert!(es.iter().any(|f| f.rel_path.contains("g2p")), "es needs g2p");
+        assert!(!ends(&es, "am_michael.bin"));
+
+        // en + es: graph once, both voices, g2p present
+        let both = kokoro_manifest_for(&["en", "es"]);
+        assert_eq!(both.iter().filter(|f| f.rel_path.ends_with("model.onnx")).count(), 1);
+        assert!(ends(&both, "am_michael.bin") && ends(&both, "em_alex.bin"));
+
+        // ru only: no kokoro graph at all
+        assert!(kokoro_manifest_for(&["ru"]).is_empty());
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts kokoro_manifest_for`
+Expected: FAIL — `cannot find function kokoro_manifest_for`
+
+- [ ] **Step 3: Refactor `kokoro_manifest` into addressable consts + add `kokoro_manifest_for`**
+
+In `rust/src/models.rs`, under the existing `#[cfg(not(all(system_kokoro, macos, aarch64)))]` ONNX region, replace the inline literals of `kokoro_manifest()` with named consts and a lang-keyed voice table. Keep `kokoro_manifest()` returning the full set (its existing test depends on it). Use the EXACT urls/sha256 already in the file — copy them verbatim, do not invent hashes.
+
+```rust
+#[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+const KOKORO_GRAPH: ModelFile = ModelFile {
+    rel_path: "models/kokoro-82m/model.onnx",
+    url: "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx",
+    sha256: "7d5df8ecf7d4b1878015a32686053fd0eebe2bc377234608764cc0ef3636a6c5",
+};
+
+#[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+const KOKORO_EN_VOICE: ModelFile = ModelFile {
+    rel_path: "models/kokoro-82m/voices/am_michael.bin",
+    url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin",
+    sha256: "1d1f21dd8da39c30705cd4c75d039d265e9bc4a2a93ed09bc9e1b1225eb95ba1",
+};
+
+// CharsiuG2P byt5-tiny (CC-BY 4.0, #185) — shared by es/fr/it/pt only.
+#[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+const G2P_CHARSIU_FILES: &[ModelFile] = &[
+    ModelFile {
+        rel_path: "models/g2p/byt5-tiny/encoder_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/encoder_model.onnx",
+        sha256: "1ac7aca11845527873f9e0e870fbe1e3c3ac2cb009d8852230332d10541aab04",
+    },
+    ModelFile {
+        rel_path: "models/g2p/byt5-tiny/decoder_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_model.onnx",
+        sha256: "de32477aae14e254d4a7dee4b2c324fb39f93a0dc254181c5bfdd8fc67492919",
+    },
+    ModelFile {
+        rel_path: "models/g2p/byt5-tiny/decoder_with_past_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_with_past_model.onnx",
+        sha256: "fae30b9f3a8d935be01b32af851bae6d54f330813167073e84caf6d0a1890fcb",
+    },
+];
+
+// es/fr/it/pt → that language's Kokoro voice pack (ONNX path).
+#[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+fn multilang_voice(lang: &str) -> Option<ModelFile> {
+    let (rel, url, sha) = match lang {
+        "es" => ("models/kokoro-82m/voices/em_alex.bin",
+                 "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/em_alex.bin",
+                 "27809e9eafdcbcfff90a3016c697568676531de2a2c39cee29c96c7bd6b83e95"),
+        "fr" => ("models/kokoro-82m/voices/ff_siwis.bin",
+                 "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/ff_siwis.bin",
+                 "a35f5675ad08948e326ae75fd0ea16ba5d0042e4f76b5f3d1df77d0a48c54861"),
+        "it" => ("models/kokoro-82m/voices/im_nicola.bin",
+                 "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/im_nicola.bin",
+                 "bc578e510d52a96d6940d46f12e96d7b3df00905dbea075113226d100e6e1ab0"),
+        "pt" => ("models/kokoro-82m/voices/pm_alex.bin",
+                 "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_alex.bin",
+                 "0175c753f59c54e7fd5a995bedef0c5ff2fb67e0043dd3dcb2ae74ec2acbeb2a"),
+        _ => return None,
+    };
+    Some(ModelFile { rel_path: rel, url, sha256: sha })
+}
+
+/// ONNX-path Kokoro files needed for `langs`. Graph included if any kokoro
+/// language is selected; G2P included only if a multilingual language is
+/// selected; per-language voices added individually. Empty if no kokoro lang.
+#[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
+    const KOKORO_LANGS: [&str; 5] = ["en", "es", "fr", "it", "pt"];
+    const MULTILANG: [&str; 4] = ["es", "fr", "it", "pt"];
+    let mut out = Vec::new();
+    if langs.iter().any(|l| KOKORO_LANGS.contains(l)) {
+        out.push(KOKORO_GRAPH.clone());
+    }
+    if langs.contains(&"en") {
+        out.push(KOKORO_EN_VOICE.clone());
+    }
+    if langs.iter().any(|l| MULTILANG.contains(l)) {
+        out.extend(G2P_CHARSIU_FILES.iter().cloned());
+    }
+    for l in langs {
+        if let Some(v) = multilang_voice(l) {
+            out.push(v);
+        }
+    }
+    out
+}
+```
+Then rewrite `kokoro_manifest()`'s non-empty arm to reuse the consts so there is ONE copy of each literal:
+```rust
+    #[allow(unreachable_code)]
+    {
+        let mut v = vec![KOKORO_GRAPH.clone(), KOKORO_EN_VOICE.clone()];
+        v.extend(G2P_CHARSIU_FILES.iter().cloned());
+        for l in ["es", "fr", "it", "pt"] {
+            v.push(multilang_voice(l).expect("multilang voice"));
+        }
+        v
+    }
+```
+
+- [ ] **Step 4: Run the new + existing manifest tests**
+
+Run: `cd rust && cargo nextest run --features tts kokoro_manifest`
+Expected: PASS (`kokoro_manifest_for_selects_per_language` and `kokoro_manifest_has_expected_files`)
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings
+cd .. && git add rust/src/models.rs
+git commit -m "refactor(engine): addressable Kokoro manifest + kokoro_manifest_for(langs) (#517)"
+```
+
+---
+
+## Task 3: Rust — language-aware ANE voice staging (darwin path)
+
+**Files:**
+- Modify: `rust/src/models.rs` (partition `ANE_KOKORO_VOICES`, add `ane_voices_for`, change `stage_ane_kokoro_voices` signature)
+- Test: `rust/src/models.rs` `mod tts_tests`
+
+This task only touches the **`system_kokoro` darwin-arm64 path**. Its tests are cfg-gated and only run on that build (CI runs them via the `cargo check --features coreml` job and on macos-14). Implement carefully even though local non-darwin runs skip them.
+
+- [ ] **Step 1: Write the failing test (darwin-gated)**
+
+Add to `mod tts_tests`:
+```rust
+    #[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    fn ane_voices_for_filters_by_language_prefix() {
+        let names = |langs: &[&str]| {
+            ane_voices_for(langs)
+                .iter()
+                .map(|f| f.rel_path.to_string())
+                .collect::<Vec<_>>()
+        };
+        // en → only a*/b* voices (am_*, bm_*); never es/it/etc
+        let en = names(&["en"]);
+        assert!(en.iter().any(|n| n.starts_with("am_")));
+        assert!(en.iter().all(|n| n.starts_with("am_") || n.starts_with("af_") || n.starts_with("bm_")));
+        // es → only e* voices
+        let es = names(&["es"]);
+        assert!(!es.is_empty() && es.iter().all(|n| n.starts_with("e")));
+        // af_heart never staged
+        assert!(!names(&["en"]).iter().any(|n| n == "af_heart.bin"));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails (on a darwin-arm64 machine / CI)**
+
+Run: `cd rust && cargo nextest run --features tts,system_kokoro ane_voices_for` (darwin-arm64 only)
+Expected: FAIL — `cannot find function ane_voices_for`
+
+- [ ] **Step 3: Add `ane_voices_for` and rewire `stage_ane_kokoro_voices`**
+
+The flat `ANE_KOKORO_VOICES` const stays as the catalogue. Add a prefix→language classifier and filter. Add near `ANE_KOKORO_VOICES`:
+```rust
+#[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]
+fn ane_voice_lang(rel_path: &str) -> Option<&'static str> {
+    // Kokoro voice files are `<x><gender>_name.bin`; first char picks language.
+    match rel_path.chars().next() {
+        Some('a') | Some('b') => Some("en"),
+        Some('e') => Some("es"),
+        Some('f') => Some("fr"),
+        Some('h') => Some("hi"),
+        Some('i') => Some("it"),
+        Some('j') => Some("ja"),
+        Some('p') => Some("pt"),
+        Some('z') => Some("zh"),
+        _ => None,
+    }
+}
+
+#[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]
+fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
+    ANE_KOKORO_VOICES
+        .iter()
+        .filter(|f| ane_voice_lang(f.rel_path).is_some_and(|l| langs.contains(&l)))
+        .collect()
+}
+```
+Change the staging fn signature and body:
+```rust
+#[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]
+pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
+    let manifest = ane_voices_for(langs);
+    if manifest.is_empty() {
+        return Ok(());
+    }
+    let ane_dir = fluidaudio_ane_kokoro_dir();
+    fs::create_dir_all(&ane_dir)
+        .with_context(|| format!("create FluidAudio ANE dir {}", ane_dir.display()))?;
+    parallel_download(&ane_dir, &manifest, no_cache)
+}
+```
+
+- [ ] **Step 4: Run the test (darwin-arm64 / CI)**
+
+Run: `cd rust && cargo nextest run --features tts,system_kokoro ane_voices_for`
+Expected: PASS. (On non-darwin dev machines this test is cfg'd out — that's expected; CI's macos-14 job covers it.)
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings
+cd .. && git add rust/src/models.rs
+git commit -m "refactor(engine): stage only requested languages' ANE Kokoro voices (#517)"
+```
+
+---
+
+## Task 4: Rust — `download_tts(langs)` + validation
+
+**Files:**
+- Modify: `rust/src/models.rs` (`download_tts` signature + `validate_tts_langs`)
+- Test: `rust/src/models.rs` `mod tts_tests`
+
+- [ ] **Step 1: Write the failing validation test**
+
+Add to `mod tts_tests`:
+```rust
+    #[test]
+    fn validate_tts_langs_accepts_known_rejects_unknown() {
+        assert!(validate_tts_langs(&["en"]).is_ok());
+        let err = validate_tts_langs(&["en", "klingon"]).unwrap_err().to_string();
+        assert!(err.contains("klingon"), "err names the bad code: {err}");
+        // a known-but-unavailable-on-this-build code is rejected too
+        #[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+        {
+            let err = validate_tts_langs(&["ja"]).unwrap_err().to_string();
+            assert!(err.contains("ja"), "ja unavailable on ONNX build: {err}");
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd rust && cargo nextest run --features tts validate_tts_langs`
+Expected: FAIL — `cannot find function validate_tts_langs`
+
+- [ ] **Step 3: Implement validation**
+
+Add to `rust/src/models.rs`:
+```rust
+/// Validate requested TTS language codes against what THIS build supports.
+/// Hard error (download nothing) naming the offending code and the supported set.
+#[cfg(feature = "tts")]
+pub fn validate_tts_langs(langs: &[&str]) -> Result<()> {
+    let supported = tts_languages();
+    for l in langs {
+        if !supported.contains(l) {
+            coded_bail!(
+                ErrorCode::VoiceUnknown,
+                "TTS language '{l}' is not available on this build (supported: {})",
+                supported.join(", ")
+            );
+        }
+    }
+    Ok(())
+}
+```
+(`ErrorCode::VoiceUnknown` and `coded_bail!` are already imported in this module — confirm the `use` at the top; if `coded_bail!`/`ErrorCode` are not in scope here, add `use crate::errors::ErrorCode;` and `use crate::coded_bail;` matching how `download_verified` references them.)
+
+- [ ] **Step 4: Write the failing `download_tts(langs)` shape test**
+
+`download_tts` hits the network, so test only the no-op early-return shape (empty langs downloads nothing and returns Ok):
+```rust
+    #[test]
+    fn download_tts_empty_langs_is_noop() {
+        // No languages selected → nothing to download, Ok.
+        assert!(download_tts(&[], false).is_ok());
+    }
+```
+
+- [ ] **Step 5: Run to verify it fails (signature mismatch)**
+
+Run: `cd rust && cargo nextest run --features tts download_tts_empty`
+Expected: FAIL — `download_tts` takes 1 argument / type mismatch.
+
+- [ ] **Step 6: Change `download_tts` to take languages**
+
+Replace the existing `download_tts`:
+```rust
+#[cfg(feature = "tts")]
+pub fn download_tts(langs: &[&str], no_cache: bool) -> Result<()> {
+    if langs.is_empty() {
+        return Ok(());
+    }
+    let cache = cache_dir();
+
+    // ONNX path: assemble the per-language Kokoro/G2P manifest + Vosk for ru.
+    #[cfg(not(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64")))]
+    {
+        let mut manifest = kokoro_manifest_for(langs);
+        if langs.contains(&"ru") {
+            manifest.extend(vosk_ru_manifest());
+        }
+        let refs: Vec<&ModelFile> = manifest.iter().collect();
+        parallel_download(&cache, &refs, no_cache)?;
+    }
+
+    // system_kokoro (darwin-arm64): Vosk for ru via the normal cache, Kokoro
+    // langs staged into FluidAudio's ANE cache (graph auto-downloads on synth).
+    #[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]
+    {
+        if langs.contains(&"ru") {
+            let manifest = vosk_ru_manifest();
+            let refs: Vec<&ModelFile> = manifest.iter().collect();
+            parallel_download(&cache, &refs, no_cache)?;
+        }
+        stage_ane_kokoro_voices(langs, no_cache)?;
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 7: Run the tts tests**
+
+Run: `cd rust && cargo nextest run --features tts download_tts_empty validate_tts_langs`
+Expected: PASS
+
+- [ ] **Step 8: fmt + clippy (callers still broken — that's Task 5)**
+
+Run: `cd rust && cargo fmt` then `cargo clippy --features tts -- -D warnings 2>&1 | head`
+Expected: the only remaining error is `cli/install.rs` calling `download_tts(no_cache)` with the old signature. That is fixed in Task 5 — do NOT commit until it compiles. Proceed directly to Task 5 in the same working tree.
+
+---
+
+## Task 5: Rust — wire `install` CLI + `main.rs`
+
+**Files:**
+- Modify: `rust/src/cli/install.rs` (`run` signature, validate + forward)
+- Modify: `rust/src/main.rs` (`Install.tts` arg + dispatch)
+- Test: `rust/src/cli/install.rs` (small unit test on a pure helper if added) — primary coverage is Task 1/4 + the TS layer.
+
+- [ ] **Step 1: Change `cli::install::run` to take language codes**
+
+In `rust/src/cli/install.rs`, change the `tts: bool` parameter to `tts_langs: Vec<String>` and replace the TTS block:
+```rust
+pub fn run(
+    no_cache: bool,
+    #[cfg(feature = "tts")] tts_langs: Vec<String>,
+    vad: bool,
+    #[cfg(feature = "system_diarize")] diarize: bool,
+    no_warmup: bool,
+) -> Result<()> {
+    models::init_mirror_logging();
+    models::install(no_cache)?;
+    #[cfg(feature = "tts")]
+    if !tts_langs.is_empty() {
+        let refs: Vec<&str> = tts_langs.iter().map(String::as_str).collect();
+        models::validate_tts_langs(&refs)?;
+        models::download_tts(&refs, no_cache)?;
+        eprintln!("TTS models installed ({}).", tts_langs.join(", "));
+    }
+    // ... (vad / diarize / warm-up blocks unchanged) ...
+```
+Leave the ASR/diarize warm-up blocks exactly as they are.
+
+- [ ] **Step 2: Change the `Install` subcommand in `main.rs`**
+
+Replace the `tts: bool` arg:
+```rust
+        /// Install TTS models for these languages (space-separated, e.g.
+        /// `--tts en ru`). Bare `--tts` installs English only. Codes are
+        /// validated against this build's supported set.
+        #[cfg(feature = "tts")]
+        #[arg(long, num_args = 0.., value_name = "LANG", default_missing_value = "en")]
+        tts: Vec<String>,
+```
+And in the dispatch arm, forward `tts` to the renamed parameter:
+```rust
+        Some(Commands::Install {
+            no_cache,
+            #[cfg(feature = "tts")]
+            tts,
+            vad,
+            #[cfg(feature = "system_diarize")]
+            diarize,
+            no_warmup,
+        }) => cli::install::run(
+            no_cache,
+            #[cfg(feature = "tts")]
+            tts,
+            vad,
+            #[cfg(feature = "system_diarize")]
+            diarize,
+            no_warmup,
+        )?,
+```
+
+Note on clap semantics: `num_args = 0..` + `default_missing_value = "en"` means bare `--tts` yields `vec!["en"]`, `--tts en ru` yields `vec!["en","ru"]`, and omitting `--tts` yields `vec![]`. Verify this in Step 4.
+
+- [ ] **Step 3: Build the engine**
+
+Run: `cd rust && cargo build --features tts`
+Expected: compiles.
+
+- [ ] **Step 4: Manually verify clap parsing of the new arg**
+
+Run:
+```bash
+cd rust
+./target/debug/kesha-engine install --tts --plan 2>/dev/null || true   # if --plan unsupported, skip
+./target/debug/kesha-engine install --help | grep -A3 -- '--tts'
+```
+Then confirm validation rejects a bad code without downloading the engine models (point at an empty temp cache so `install` is cheap, and expect the bad-code error before any large download — interrupt if it starts fetching ASR):
+```bash
+KESHA_CACHE_DIR=$(mktemp -d) ./target/debug/kesha-engine install --tts klingon 2>&1 | grep -i klingon
+```
+Expected: an error line naming `klingon`. (ASR install runs first; if that is too slow locally, trust the Task 4 `validate_tts_langs` unit test and the TS-layer pre-validation in Task 7 instead.)
+
+- [ ] **Step 5: Run the full rust suite + clippy**
+
+Run: `cd rust && cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts`
+Expected: clippy clean, tests PASS.
+
+- [ ] **Step 6: Verify the coreml/system_kokoro build compiles**
+
+Run: `cd rust && cargo check --features coreml --no-default-features`
+Expected: compiles. (This exercises the `system_kokoro` cfg arms in `download_tts` and `stage_ane_kokoro_voices`.)
+
+- [ ] **Step 7: Commit (Rust engine now fully language-aware)**
+
+```bash
+cd .. && git add rust/src/models.rs rust/src/cli/install.rs rust/src/main.rs
+git commit -m "feat(engine): kesha-engine install --tts <langs> with validation (#517)"
+```
+
+---
+
+## Task 6: TS — mirror the capabilities `tts` field
+
+**Files:**
+- Modify: `src/engine.ts` (`EngineCapabilities`)
+- Test: `src/__tests__/engine.test.ts` (create if needed) or `tests/unit/engine.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that parses a capabilities JSON with the new field. In `tests/unit/engine.test.ts` (new file if absent):
+```typescript
+import { describe, expect, test } from "bun:test";
+import type { EngineCapabilities } from "../../src/engine";
+
+describe("EngineCapabilities tts field", () => {
+  test("typed tts.languages round-trips from JSON", () => {
+    const json = `{"protocolVersion":3,"backend":"onnx","features":["tts"],"tts":{"languages":[{"code":"en","engines":["kokoro"]},{"code":"ru","engines":["vosk"]}]}}`;
+    const caps = JSON.parse(json) as EngineCapabilities;
+    expect(caps.tts?.languages.map((l) => l.code)).toEqual(["en", "ru"]);
+    expect(caps.tts?.languages[0].engines).toEqual(["kokoro"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bunx tsc --noEmit`
+Expected: FAIL — `Property 'tts' does not exist on type 'EngineCapabilities'`.
+
+- [ ] **Step 3: Extend the interface**
+
+In `src/engine.ts`, update:
+```typescript
+export interface TtsLanguageCapability {
+  code: string;
+  engines: string[];
+}
+
+export interface EngineCapabilities {
+  protocolVersion: number;
+  backend: string;
+  features: string[];
+  tts?: { languages: TtsLanguageCapability[] };
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `bunx tsc --noEmit && bun test tests/unit/engine.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine.ts tests/unit/engine.test.ts
+git commit -m "feat(cli): type the capabilities tts.languages field (#517)"
+```
+
+---
+
+## Task 7: TS — `install` positional language parsing + validation
+
+**Files:**
+- Modify: `src/cli/install.ts` (arg shape, parse positionals, validate, forward)
+- Modify: `src/engine-install.ts` (consumed in Task 8 — declare the new option here only if needed; otherwise keep Task 8 separate)
+- Test: `tests/unit/install.test.ts` (new)
+
+Add a pure, exported helper so parsing/validation is unit-testable without spawning the engine.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/install.test.ts`:
+```typescript
+import { describe, expect, test } from "bun:test";
+import { resolveTtsLangs } from "../../src/cli/install";
+
+const caps = ["en", "es", "fr", "it", "pt", "ru"];
+
+describe("resolveTtsLangs", () => {
+  test("bare --tts defaults to en", () => {
+    expect(resolveTtsLangs({ tts: true, positionals: [] }, caps)).toEqual(["en"]);
+  });
+  test("explicit languages pass through", () => {
+    expect(resolveTtsLangs({ tts: true, positionals: ["en", "ru"] }, caps)).toEqual(["en", "ru"]);
+  });
+  test("no --tts means no tts even with positionals -> error", () => {
+    expect(() => resolveTtsLangs({ tts: false, positionals: ["en"] }, caps)).toThrow(/require .*--tts/i);
+  });
+  test("unsupported language is a hard error naming the code and supported set", () => {
+    expect(() => resolveTtsLangs({ tts: true, positionals: ["ja"] }, caps)).toThrow(/ja/);
+  });
+  test("tts disabled and no positionals -> empty", () => {
+    expect(resolveTtsLangs({ tts: false, positionals: [] }, caps)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test tests/unit/install.test.ts`
+Expected: FAIL — `resolveTtsLangs` is not exported.
+
+- [ ] **Step 3: Implement `resolveTtsLangs`**
+
+Add to `src/cli/install.ts`:
+```typescript
+export interface TtsArgInput {
+  /** Whether --tts was passed. */
+  tts: boolean;
+  /** Positional args after the install command (candidate language codes). */
+  positionals: string[];
+}
+
+/**
+ * Resolve the requested TTS language list. Bare `--tts` defaults to English.
+ * Positionals without `--tts` are an error. Unsupported codes (per the engine's
+ * advertised capabilities) are a hard error so nothing downloads.
+ */
+export function resolveTtsLangs(input: TtsArgInput, supported: string[]): string[] {
+  if (!input.tts) {
+    if (input.positionals.length > 0) {
+      throw new Error(
+        `Language codes (${input.positionals.join(", ")}) require the --tts flag, ` +
+          `e.g. \`kesha install --tts ${input.positionals.join(" ")}\`.`,
+      );
+    }
+    return [];
+  }
+  const langs = input.positionals.length > 0 ? input.positionals : ["en"];
+  const bad = langs.filter((l) => !supported.includes(l));
+  if (bad.length > 0) {
+    throw new Error(
+      `Unsupported TTS language(s): ${bad.join(", ")}. ` +
+        `Supported on this platform: ${supported.join(", ")}.`,
+    );
+  }
+  return langs;
+}
+```
+
+- [ ] **Step 4: Wire it into the `install` command**
+
+In `src/cli/install.ts`, the citty command currently declares `tts` as a boolean. Keep `tts: { type: "boolean" }`; citty exposes positionals as `args._`. In `run`, after the engine is present, fetch capabilities and resolve:
+```typescript
+  async run({ args, rawArgs }: { args: InstallCommandArgs; rawArgs: string[] }) {
+    const backend = resolveBackendFlag(args.coreml, args.onnx);
+    const positionals = (args._ ?? []).map(String);
+    // Engine must exist to read capabilities; performInstall downloads it first
+    // when missing, then validates TTS langs before the TTS model step.
+    await performInstall(
+      resolveNoCacheFlag(args, rawArgs),
+      backend,
+      { tts: args.tts === true, positionals },
+      args.vad,
+      args.diarize,
+      args.plan,
+    );
+  },
+```
+Update `performInstall` to accept the TTS input, fetch capabilities, resolve+validate, and pass `ttsLangs` down (the engine-install change is Task 8). For this task, thread the resolved `string[]` into the existing `downloadEngine` call site; capabilities fetch:
+```typescript
+import { getEngineCapabilities } from "../engine";
+// inside performInstall, after the engine binary is guaranteed present:
+const caps = await getEngineCapabilities();
+const supported = caps?.tts?.languages.map((l) => l.code) ?? ["en", "ru"];
+const ttsLangs = resolveTtsLangs(ttsInput, supported);
+```
+(Keep the `["en","ru"]` fallback minimal — it only applies if the capability probe fails on an older engine; the engine re-validates authoritatively.)
+
+- [ ] **Step 5: Run the unit test**
+
+Run: `bun test tests/unit/install.test.ts && bunx tsc --noEmit`
+Expected: PASS / no type errors. (Some `performInstall` call sites in `init.ts` will not yet compile against the new signature — Task 9 fixes them. If `tsc` fails ONLY on `init.ts`, proceed to Tasks 8–9 before committing; otherwise fix here.)
+
+- [ ] **Step 6: Commit once `tsc` is clean across the tree (after Task 8/9 if needed)**
+
+```bash
+git add src/cli/install.ts tests/unit/install.test.ts
+git commit -m "feat(cli): parse + validate positional --tts languages (#517)"
+```
+
+---
+
+## Task 8: TS — `engine-install.ts` forwards language list
+
+**Files:**
+- Modify: `src/engine-install.ts` (`InstallOptions`, args, warm-up gating)
+- Test: `src/__tests__/engine-install.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing test for arg construction**
+
+Add an exported pure helper for the engine install args and test it. In `src/engine-install.ts` add:
+```typescript
+/** Build the `kesha-engine install` argv from options. Exported for testing. */
+export function buildEngineInstallArgs(opts: {
+  noCache: boolean;
+  ttsLangs?: string[];
+  vad?: boolean;
+  diarize?: boolean;
+}): string[] {
+  return [
+    "install",
+    ...(opts.noCache ? ["--no-cache"] : []),
+    ...(opts.ttsLangs && opts.ttsLangs.length > 0 ? ["--tts", ...opts.ttsLangs] : []),
+    ...(opts.vad ? ["--vad"] : []),
+    ...(opts.diarize ? ["--diarize"] : []),
+  ];
+}
+```
+Test in `src/__tests__/engine-install.test.ts`:
+```typescript
+import { buildEngineInstallArgs } from "../engine-install";
+// ...
+test("tts languages become positional args after --tts", () => {
+  expect(buildEngineInstallArgs({ noCache: false, ttsLangs: ["en", "ru"] }))
+    .toEqual(["install", "--tts", "en", "ru"]);
+});
+test("no tts langs omits --tts", () => {
+  expect(buildEngineInstallArgs({ noCache: true, ttsLangs: [] }))
+    .toEqual(["install", "--no-cache"]);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test src/__tests__/engine-install.test.ts`
+Expected: FAIL — `buildEngineInstallArgs` not exported (after adding the test before the impl, or import error).
+
+- [ ] **Step 3: Implement — change `InstallOptions` and use the helper**
+
+In `src/engine-install.ts`:
+```typescript
+export interface InstallOptions {
+  /** TTS languages to install (empty/undefined = no TTS). */
+  ttsLangs?: string[];
+  vad?: boolean;
+  diarize?: boolean;
+}
+```
+Replace the inline `installArgs` construction in `downloadEngine` with:
+```typescript
+  const installArgs = buildEngineInstallArgs({
+    noCache,
+    ttsLangs: options.ttsLangs,
+    vad: options.vad,
+    diarize: options.diarize,
+  });
+```
+Gate the Kokoro warm-up on a Kokoro language being requested (en/es/fr/hi/it/ja/pt — i.e. any non-`ru`):
+```typescript
+  const wantsKokoro = (options.ttsLangs ?? []).some((l) => l !== "ru");
+  if (wantsKokoro) {
+    await warmDarwinKokoro(binPath);
+  }
+```
+(Previously gated on `options.tts`; Vosk-only installs no longer trigger the Kokoro warm-up.)
+
+- [ ] **Step 4: Update `performInstall` (install.ts) to pass `ttsLangs`**
+
+In `src/cli/install.ts`, change the `downloadEngine` call inside `performInstall`:
+```typescript
+    await downloadEngine(noCache, backend, { ttsLangs, vad, diarize });
+```
+and update the `--plan` branch to pass langs to `renderInstallPlan` (Task 10 changes the signature; for now pass `{ ttsLangs, ... }`).
+
+- [ ] **Step 5: Run tests + types**
+
+Run: `bun test src/__tests__/engine-install.test.ts && bunx tsc --noEmit`
+Expected: PASS (init.ts may still be pending Task 9 — see note in Task 7 Step 6).
+
+- [ ] **Step 6: Commit (after init compiles — Task 9)**
+
+```bash
+git add src/engine-install.ts src/__tests__/engine-install.test.ts src/cli/install.ts
+git commit -m "feat(cli): forward --tts language list to the engine; gate Kokoro warm-up (#517)"
+```
+
+---
+
+## Task 9: TS — `init` multi-select language picker
+
+**Files:**
+- Modify: `src/cli/init.ts` (`InitSelection`, prompt, args, suggestions)
+- Test: `tests/unit/init.test.ts` (update)
+
+`InitSelection.tts: boolean` becomes `ttsLangs: string[]`. `initInstallArgs` emits `--tts <langs>`. The interactive selection uses `@clack/prompts` `multiselect`; the non-TTY path keeps printing suggested commands.
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `tests/unit/init.test.ts`, update the expectations to the new shape:
+```typescript
+  test("defaults to base install only", () => {
+    const selection = resolveInitSelection(initArgs(), undefined);
+    expect(selection).toEqual({
+      noCache: false,
+      backend: undefined,
+      ttsLangs: [],
+      vad: false,
+      diarize: false,
+    });
+    expect(initInstallArgs(selection)).toEqual(["kesha", "install"]);
+  });
+
+  test("preselected feature flags map to install flags", () => {
+    const selection = resolveInitSelection(
+      initArgs({ "no-cache": true, tts: true, vad: true, diarize: true }),
+      "coreml",
+    );
+    expect(initInstallArgs(selection)).toEqual([
+      "kesha", "install", "--no-cache", "--coreml", "--tts", "en", "--vad", "--diarize",
+    ]);
+  });
+```
+Add:
+```typescript
+  test("tts languages render as positional args", () => {
+    const args = initInstallArgs({
+      noCache: false, backend: undefined, ttsLangs: ["en", "ru"], vad: false, diarize: false,
+    });
+    expect(args).toEqual(["kesha", "install", "--tts", "en", "ru"]);
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test tests/unit/init.test.ts`
+Expected: FAIL — shape mismatch (`tts` vs `ttsLangs`).
+
+- [ ] **Step 3: Update `InitSelection`, `resolveInitSelection`, `initInstallArgs`**
+
+In `src/cli/init.ts`:
+```typescript
+export interface InitSelection {
+  noCache: boolean;
+  backend?: string;
+  ttsLangs: string[];
+  vad: boolean;
+  diarize: boolean;
+}
+```
+`resolveInitSelection` maps the preselect `args.tts` boolean to `["en"]` (the default) when set:
+```typescript
+    ttsLangs: args.tts ? ["en"] : [],
+```
+`initInstallArgs`:
+```typescript
+export function initInstallArgs(selection: InitSelection): string[] {
+  return [
+    "kesha",
+    "install",
+    selection.noCache ? "--no-cache" : "",
+    selection.backend === "coreml" ? "--coreml" : "",
+    selection.backend === "onnx" ? "--onnx" : "",
+    ...(selection.ttsLangs.length > 0 ? ["--tts", ...selection.ttsLangs] : []),
+    selection.vad ? "--vad" : "",
+    selection.diarize ? "--diarize" : "",
+  ].filter(Boolean);
+}
+```
+Update `initSuggestionCommands`, `omitUnsupportedDiarize`, and `printPlan`/`performInstall` call sites to use `ttsLangs` instead of `tts`. In the variants list in `initSuggestionCommands`, replace `tts: false`/`tts: true` with `ttsLangs: []`/`ttsLangs: ["en"]`.
+
+- [ ] **Step 4: Replace the interactive TTS prompt with `@clack/prompts` multiselect**
+
+In `promptInitSelection`, replace the `askYesNo(... "Install text-to-speech ...")` call. Fetch the supported languages from capabilities (fall back to `["en","ru"]` if unavailable), then:
+```typescript
+import { multiselect, isCancel } from "@clack/prompts";
+import { getEngineCapabilities } from "../engine";
+
+const TTS_LANG_LABELS: Record<string, string> = {
+  en: "English (Kokoro)",
+  es: "Spanish (Kokoro)",
+  fr: "French (Kokoro)",
+  hi: "Hindi (Kokoro ANE)",
+  it: "Italian (Kokoro)",
+  ja: "Japanese (Kokoro ANE)",
+  pt: "Portuguese (Kokoro)",
+  zh: "Chinese (Kokoro ANE)",
+  ru: "Russian (Vosk-TTS)",
+};
+
+async function promptTtsLangs(preselect: string[]): Promise<string[]> {
+  const caps = await getEngineCapabilities();
+  const supported = caps?.tts?.languages.map((l) => l.code) ?? ["en", "ru"];
+  const selected = await multiselect({
+    message: "Select TTS languages to install (space to toggle, enter to confirm; none = skip TTS):",
+    options: supported.map((code) => ({
+      value: code,
+      label: TTS_LANG_LABELS[code] ?? code,
+    })),
+    initialValues: preselect.filter((l) => supported.includes(l)),
+    required: false,
+  });
+  if (isCancel(selected)) return [];
+  return selected as string[];
+}
+```
+Call it in `promptInitSelection`:
+```typescript
+  const ttsLangs = await promptTtsLangs(args.tts ? ["en"] : []);
+```
+and return `ttsLangs` in the `InitSelection`. Keep the VAD/diarize `askYesNo` prompts unchanged.
+
+Note: `getEngineCapabilities` requires the engine to be installed. `init` runs before install in the cold case; if capabilities is null, the `["en","ru"]` fallback keeps the picker usable, and the engine re-validates at download time.
+
+- [ ] **Step 5: Update `performInstall` calls in `init.ts`**
+
+`init.ts` calls `performInstall(...)` in the `--yes` and confirmed-interactive branches. Update them to the new `performInstall` signature from Task 7/8 (passing `{ tts: prompted.ttsLangs.length > 0, positionals: prompted.ttsLangs }` or, simpler, give `performInstall` a path that accepts an already-resolved `ttsLangs` — choose ONE: extend `performInstall` to accept resolved `ttsLangs: string[]` directly and have the `install` command call `resolveTtsLangs` before it). Recommended: `performInstall(noCache, backend, ttsLangs, vad, diarize, plan)` taking the resolved list; `install`'s `run` resolves via `resolveTtsLangs`, `init` passes `prompted.ttsLangs` directly. Update Task 7 Step 4/Task 8 Step 4 call shapes to match this resolved-list signature.
+
+- [ ] **Step 6: Run init tests + full TS suite + types**
+
+Run: `bun test && bunx tsc --noEmit`
+Expected: PASS, no type errors across the tree.
+
+- [ ] **Step 7: Commit the TS install/init/engine-install set together**
+
+```bash
+git add src/cli/init.ts src/cli/install.ts src/engine-install.ts tests/unit/init.test.ts tests/unit/install.test.ts src/__tests__/engine-install.test.ts
+git commit -m "feat(cli): init multi-select TTS languages via @clack/prompts (#517)"
+```
+
+---
+
+## Task 10: TS — per-language install plan
+
+**Files:**
+- Modify: `src/install-plan.ts` (`InstallPlanOptions`, per-language groups, command line)
+- Test: `tests/unit/install-plan.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/unit/install-plan.test.ts`:
+```typescript
+test("plan with --tts en omits Vosk RU", async () => {
+  const out = await renderInstallPlan({ ttsLangs: ["en"] });
+  expect(out).toContain("Kokoro");
+  expect(out).not.toContain("Vosk RU");
+  expect(out).toContain("--tts en");
+});
+test("plan with --tts ru omits Kokoro graph component", async () => {
+  const out = await renderInstallPlan({ ttsLangs: ["ru"] });
+  expect(out).toContain("Vosk RU");
+  expect(out).toContain("--tts ru");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test tests/unit/install-plan.test.ts`
+Expected: FAIL — `ttsLangs` not on `InstallPlanOptions` / Vosk still present for en.
+
+- [ ] **Step 3: Make the plan language-aware**
+
+In `src/install-plan.ts`:
+```typescript
+export interface InstallPlanOptions {
+  noCache?: boolean;
+  backend?: string;
+  ttsLangs?: string[];
+  vad?: boolean;
+  diarize?: boolean;
+}
+```
+Replace the `if (options.tts) { ... }` block with per-language logic. Define which languages map to which packs and add components conditionally:
+```typescript
+  const ttsLangs = options.ttsLangs ?? [];
+  const wantsKokoro = ttsLangs.some((l) => ["en", "es", "fr", "it", "pt"].includes(l));
+  const wantsG2p = ttsLangs.some((l) => ["es", "fr", "it", "pt"].includes(l));
+  const wantsRu = ttsLangs.includes("ru");
+
+  if (ttsLangs.length > 0) {
+    if (isDarwinArm64()) {
+      // ANE path: graph auto-downloads (warm-up note); Vosk only if ru.
+      if (wantsKokoro) {
+        warmups.push({
+          name: "TTS Kokoro (ANE)",
+          note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoroCachePath()})`,
+        });
+      }
+      if (wantsRu) {
+        components.push(bundleComponent(cacheRoot, "TTS Vosk RU", "model cache", VOSK_RU_FILES, noCache, "Russian ru-vosk-* voices"));
+      }
+    } else {
+      if (wantsKokoro) {
+        components.push(bundleComponent(cacheRoot, "TTS Kokoro graph + voices", "model cache", kokoroPlanFiles(ttsLangs), noCache, `voices for ${ttsLangs.filter((l) => l !== "ru").join(", ")}`));
+      }
+      if (wantsG2p) {
+        components.push(bundleComponent(cacheRoot, "G2P CharsiuG2P byt5-tiny", "model cache", G2P_CHARSIU_FILES, noCache, "multilingual G2P for es/fr/it/pt (CC-BY 4.0)"));
+      }
+      if (wantsRu) {
+        components.push(bundleComponent(cacheRoot, "TTS Vosk RU", "model cache", VOSK_RU_FILES, noCache, "Russian ru-vosk-* voices"));
+      }
+    }
+  }
+```
+Add a helper that selects the graph + per-language voice plan files (split `KOKORO_FILES` into the graph and named voices):
+```typescript
+const KOKORO_GRAPH_FILE: PlanFile = { relPath: "models/kokoro-82m/model.onnx", sizeBytes: 325_532_387 };
+const KOKORO_VOICE_FILES: Record<string, PlanFile> = {
+  en: { relPath: "models/kokoro-82m/voices/am_michael.bin", sizeBytes: 522_240 },
+  es: { relPath: "models/kokoro-82m/voices/em_alex.bin", sizeBytes: 522_240 },
+  fr: { relPath: "models/kokoro-82m/voices/ff_siwis.bin", sizeBytes: 522_240 },
+  it: { relPath: "models/kokoro-82m/voices/im_nicola.bin", sizeBytes: 522_240 },
+  pt: { relPath: "models/kokoro-82m/voices/pm_alex.bin", sizeBytes: 522_240 },
+};
+function kokoroPlanFiles(langs: string[]): PlanFile[] {
+  const files: PlanFile[] = [KOKORO_GRAPH_FILE];
+  for (const l of langs) {
+    const v = KOKORO_VOICE_FILES[l];
+    if (v) files.push(v);
+  }
+  return files;
+}
+```
+Update the final `command` array builder to emit `--tts <langs>`:
+```typescript
+  const command = [
+    "kesha",
+    "install",
+    options.noCache ? "--no-cache" : "",
+    options.backend === "coreml" ? "--coreml" : "",
+    options.backend === "onnx" ? "--onnx" : "",
+    ...(ttsLangs.length > 0 ? ["--tts", ...ttsLangs] : []),
+    options.vad ? "--vad" : "",
+    options.diarize ? "--diarize" : "",
+  ].filter(Boolean);
+```
+Keep the old `KOKORO_FILES` const only if still referenced; otherwise remove it to avoid an unused-variable lint. Update the `--tts && isDarwinArm64()` warm-up note line to check `ttsLangs.length > 0 && wantsKokoro`.
+
+- [ ] **Step 4: Run the plan tests + full suite**
+
+Run: `bun test tests/unit/install-plan.test.ts && bun test && bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/install-plan.ts tests/unit/install-plan.test.ts
+git commit -m "feat(cli): per-language install plan for --tts <langs> (#517)"
+```
+
+---
+
+## Task 11: Docs + end-to-end verification
+
+**Files:**
+- Modify: `CLAUDE.md` (TTS section), `docs/tts.md`, `docs/languages.md`
+
+- [ ] **Step 1: Update the docs**
+
+- `CLAUDE.md` TTS section: change "`kesha install --tts` (~990 MB)" guidance to describe language scoping: bare `--tts` = English (~326 MB); `--tts en ru` etc.; note `es/fr/it/pt` on all builds, `hi/ja/zh` darwin-arm64-only, `ru` ~937 MB.
+- `docs/tts.md` and `docs/languages.md`: document `kesha install --tts <langs>`, the default (English-only), the platform availability matrix, and that `kesha init` offers a multi-select. Keep all install/upgrade examples in **bun** form (never npm).
+
+- [ ] **Step 2: Full verification sweep**
+
+Run:
+```bash
+bun test && bunx tsc --noEmit
+cd rust && cargo fmt --check && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts && cargo check --features coreml --no-default-features
+cd ..
+```
+Expected: all green.
+
+- [ ] **Step 3: Manual smoke (engine built in Task 5)**
+
+Run (English-only install into a temp cache; confirm NO Vosk files appear):
+```bash
+CACHE=$(mktemp -d)
+KESHA_CACHE_DIR="$CACHE" rust/target/debug/kesha-engine install --tts en --no-warmup 2>&1 | tail -5
+test ! -d "$CACHE/models/vosk-ru" && echo "OK: no vosk-ru for --tts en"
+ls "$CACHE/models/kokoro-82m/voices/" 2>/dev/null
+```
+Expected: `OK: no vosk-ru for --tts en`; `am_michael.bin` present, no `em_alex.bin`/etc.
+
+- [ ] **Step 4: audio-quality-check gate (rust/src/tts changed)**
+
+Dispatch the `audio-quality-check` agent against a fixed Russian + English corpus to confirm `kesha say` still produces sane audio for `en-am_michael` and `ru-vosk-m02` after the TTS download refactor.
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add CLAUDE.md docs/tts.md docs/languages.md
+git commit -m "docs: document language-scoped TTS install (#517)"
+```
+
+- [ ] **Step 6: Push + open PR**
+
+```bash
+git push -u origin feat/tts-install-languages
+gh pr create --base main --head feat/tts-install-languages \
+  --title "Language-scoped TTS install: \`kesha install --tts <langs>\` + init multi-select" \
+  --body "Closes #517
+
+Implements the spec at docs/superpowers/specs/2026-06-01-tts-install-languages-design.md.
+- \`kesha install --tts en ru\` (Playwright-style positionals); bare \`--tts\` = English only.
+- Unsupported-on-platform language → hard error, nothing downloaded.
+- \`kesha init\` multi-select via @clack/prompts.
+- AVSpeech excluded from install; additive re-runs.
+- Engine capabilities (proto v3) advertise installable TTS languages; TS validates against them."
+```
+Then follow the CLAUDE.md gate: wait for CI + Greptile, address P1/P2, re-push, merge only after both cover the latest head SHA. Remove the `WIP` label when the PR merges.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Positional syntax → Task 5 (engine clap `num_args`), Task 7 (TS parsing). ✓
+- Bare `--tts` = English → Task 5 (`default_missing_value = "en"`), Task 7 (`["en"]`), Task 9 (init preselect). ✓
+- Hard error on unsupported lang → Task 4 (`validate_tts_langs`), Task 7 (`resolveTtsLangs`). ✓
+- init multi-select → Task 9. ✓
+- Additive re-runs → inherent (`download_verified` short-circuit); no task needed; noted. ✓
+- AVSpeech excluded → `tts_languages()` omits `macos`; documented Task 11. ✓
+- Many-to-many data model, override deferred → Task 1 (`engines: Vec`), no override parser built. ✓
+- Capabilities source of truth, proto bump → Task 1, Task 6. ✓
+- ONNX es/fr/it/pt + G2P dependency → Task 2, Task 10. ✓
+- darwin hi/ja/zh + ANE per-language staging → Task 1, Task 3. ✓
+- Plan rendering per language → Task 10. ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases" — every code step shows code. The one judgment call (final `performInstall` signature) is resolved explicitly in Task 9 Step 5 (resolved-list signature) and referenced back to Tasks 7/8.
+
+**Type consistency:** `InitSelection.ttsLangs: string[]` (Tasks 9), `InstallOptions.ttsLangs?: string[]` (Task 8), `InstallPlanOptions.ttsLangs?: string[]` (Task 10), `EngineCapabilities.tts?.languages[].code/engines` (Task 6) — consistent. Rust `download_tts(&[&str], bool)` / `stage_ane_kokoro_voices(&[&str], bool)` / `validate_tts_langs(&[&str])` / `tts_languages() -> Vec<&'static str>` — consistent across Tasks 1–5.

--- a/docs/superpowers/specs/2026-06-01-tts-install-languages-design.md
+++ b/docs/superpowers/specs/2026-06-01-tts-install-languages-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-01
 **Status:** Approved (brainstorm) — ready for implementation plan
-**Issue:** TBD (open before implementation)
+**Issue:** [#517](https://github.com/drakulavich/kesha-voice-kit/issues/517)
 
 ## Problem
 
@@ -220,7 +220,7 @@ back-compat; the new structured field is additive.
 
 ## Open items before implementation
 
-- Open a GitHub issue and tag it `WIP`; fill the issue number into the header and use
-  `Closes #N` in the PR.
+- Issue [#517](https://github.com/drakulavich/kesha-voice-kit/issues/517) opened and
+  tagged `WIP`; use `Closes #517` in the PR.
 - `@clack/prompts` is the only new runtime dependency; verify it installs cleanly under
   Bun during the first implementation step.

--- a/docs/superpowers/specs/2026-06-01-tts-install-languages-design.md
+++ b/docs/superpowers/specs/2026-06-01-tts-install-languages-design.md
@@ -1,0 +1,226 @@
+# Language-scoped TTS install — design
+
+**Date:** 2026-06-01
+**Status:** Approved (brainstorm) — ready for implementation plan
+**Issue:** TBD (open before implementation)
+
+## Problem
+
+`kesha install --tts` and the `kesha init` TTS step are a single boolean. They
+unconditionally download **every** TTS model: Kokoro (English + the multilingual
+graph) **and** Vosk-TTS Russian — roughly 990 MB. A user who only wants English
+still pays Vosk's ~937 MB; a Russian-only user still pays Kokoro's ~326 MB.
+
+We want the install to take **language codes**, downloading only the models those
+languages need — modelled on `npx playwright install chromium firefox`, where the
+caller names what they want.
+
+## Goals
+
+- `kesha install --tts en ru` downloads only the packs those languages need.
+- Bare `kesha install --tts` downloads **English only** (the smallest useful default).
+- `kesha init` collects languages through a multi-select checkbox TUI.
+- Requesting a language unavailable on the current platform is a **hard error** that
+  downloads nothing.
+- Re-running install is **additive** — it adds the new language's packs and never
+  prunes existing ones.
+
+## Non-goals (YAGNI)
+
+- Pruning / uninstalling languages. Install is additive only.
+- `macos-*` AVSpeech voices. They need no download and are never "installed"
+  (see "AVSpeech is ambient" below).
+- A `--tts <lang>:<engine>` override syntax. The data model anticipates multiple
+  downloadable models per language, but the override parser is **deferred** until a
+  language actually has two downloadable models (today none do).
+- `kesha status` reporting which languages are installed. Possible follow-up.
+
+## Decisions (from brainstorm)
+
+| Decision | Choice |
+|---|---|
+| CLI syntax | Positional, Playwright-style: `kesha install --tts en ru` |
+| Bare `--tts` | English only (~326 MB) |
+| Unsupported language on platform | Hard error, download nothing |
+| `init` collection | `@clack/prompts` multi-select TUI, platform-aware, `en` pre-checked |
+| Re-run semantics | Additive (downloads only missing packs; never prunes) |
+| AVSpeech / `macos-*` | Excluded from install entirely (ambient on macOS) |
+| Multiple models per language | Many-to-many data model now; override syntax deferred |
+| Language↔platform source of truth | Rust engine, exposed via `--capabilities-json` |
+
+## The language ↔ model relationship
+
+Two distinct shapes, handled differently:
+
+**Many languages → one model.** The Kokoro graph (`model.onnx`) serves `en`, `es`,
+`fr`, `hi`, `it`, `ja`, `pt`, `zh` from one shared file plus per-language voice
+`.bin`s. Selecting multiple Kokoro languages must download the graph **once** and
+stage each language's voices. The download layer dedups the shared graph.
+
+**One language → multiple models.** Today every language is served by a downloadable
+neural model *and* (on macOS) by AVSpeech system voices. The forward-looking case is
+two *downloadable* models for one language (e.g. if Kokoro ever ships Russian, `ru`
+would have both Kokoro and Vosk).
+
+### AVSpeech is ambient, not installed
+
+`install --tts` manages **downloadable model packs only**. AVSpeech / `macos-*`
+voices are part of macOS, need no download, and are therefore never resolved by
+install. This kills the present-day ambiguity:
+
+- `kesha install --tts ru` on macOS **always downloads Vosk** (~937 MB), regardless
+  of whether Milena (AVSpeech) is present.
+- Milena and other `macos-*` voices remain usable at synth time via
+  `--voice macos-...` with zero install.
+
+### Resolution model
+
+The registry is **many-to-many (language ↔ engine)**, even though every language's
+engine list is currently a singleton:
+
+```jsonc
+"tts": { "languages": [
+  { "code": "en", "engines": ["kokoro"] },
+  { "code": "ru", "engines": ["vosk"] },
+  { "code": "es", "engines": ["kokoro"] }   // darwin-arm64 only
+]}
+```
+
+- `--tts <lang>` resolves to the language's **default engine** = `engines[0]`
+  (maintainer-curated order). Today every list has length 1, so it is always
+  unambiguous.
+- When a list gains a second entry, the override token `--tts <lang>:<engine>` is
+  introduced. The parser is not built until then — but capabilities and the registry
+  already express the many-to-many shape, so the later addition is a registry edit,
+  not a re-architecture.
+
+### Language → pack table (today)
+
+| code | engine | packs downloaded | platform | approx |
+|---|---|---|---|---|
+| `en` | Kokoro | shared graph + EN voice(s) | all | ~326 MB |
+| `ru` | Vosk-TTS | model + dictionary + BERT + vocab | all | ~937 MB |
+| `es fr hi it ja pt zh` | FluidKokoro (ANE) | shared graph (auto) + that language's voice `.bin` | **darwin-arm64 only** | small per-language |
+
+## Architecture
+
+Three layers. The language↔platform↔engine table lives in **one place** — the Rust
+engine — and is exposed via `--capabilities-json`. The TS layer consumes it and never
+hardcodes a parallel table (per the CLAUDE.md "validate against `--capabilities-json`"
+rule).
+
+### Layer 1 — Capabilities (Rust, source of truth)
+
+`rust/src/capabilities.rs`:
+
+- Add a structured `tts` field carrying the language rows shown above
+  (`{ code, engines }` per language), populated by `#[cfg]`:
+  - `en`, `ru` whenever `feature = "tts"`.
+  - `es`, `fr`, `hi`, `it`, `ja`, `pt`, `zh` added under
+    `system_kokoro + macos + aarch64`.
+- Bump `protocolVersion` `2 → 3`.
+- `EngineCapabilities` (TS, `src/engine.ts`) mirrors the new field.
+
+The flat `features` array keeps its existing `tts*` entries unchanged for
+back-compat; the new structured field is additive.
+
+### Layer 2 — Engine install CLI (Rust)
+
+`rust/src/main.rs` + `rust/src/cli/install.rs`:
+
+- `kesha-engine install --tts` changes from `bool` to accept zero-or-more language
+  codes (`clap` `num_args(0..)`). Present with no values → `["en"]`; absent → no TTS.
+- Validate each requested code against `get_capabilities()` TTS languages. Unknown or
+  platform-unavailable code → hard error listing the supported codes, **download
+  nothing**.
+- `models::download_tts(no_cache)` → `download_tts(langs, no_cache)`:
+  - Refactor the flat `ANE_KOKORO_VOICES` const into a language-prefix lookup
+    (`a`/`b` → en, `e` → es, `f` → fr, `h` → hi, `i` → it, `j` → ja, `p` → pt,
+    `z` → zh) so each language stages only its own voices.
+  - If any Kokoro language is selected: download the shared graph once on the ONNX
+    path (rely on FluidAudio auto-download on the darwin `system_kokoro` path), and
+    stage only the selected languages' voices.
+  - If `ru` is selected: `vosk_ru_manifest()`.
+- **Additive** is free: `download_verified` already short-circuits cached files that
+  match their pinned SHA, so re-runs fetch only missing packs. No pruning logic.
+
+### Layer 3 — TS CLI
+
+`src/cli/install.ts`:
+
+- `kesha install --tts en ru`: `--tts` enables TTS; the positional args (`args._`)
+  are the language list. Bare `--tts` → `["en"]`. Positionals present without `--tts`
+  → error ("language codes require `--tts`").
+- Validate the requested languages against `getEngineCapabilities()` TTS languages
+  **before** forwarding to the engine (hard error, nothing downloaded).
+- Forward the language list verbatim to `kesha-engine install --tts en ru`.
+
+`src/engine-install.ts`:
+
+- `InstallOptions.tts: boolean` → `ttsLangs?: string[]`.
+- Build the engine `install` args from the language list.
+- TTS warm-up (`warmDarwinKokoro`) runs when the selected set includes a Kokoro
+  language; otherwise skip it.
+
+`src/cli/init.ts`:
+
+- The TTS step becomes a `@clack/prompts` **multi-select** over the capabilities'
+  TTS languages (platform-aware — only installable codes are shown), with `en`
+  pre-checked. An empty selection skips TTS.
+- The existing non-TTY branch (`runNonInteractive`) keeps printing suggested commands
+  (now `kesha install --tts en …`); no TUI is attempted without a TTY.
+- `InitSelection` carries the selected language list through to `performInstall`.
+
+### Plan rendering
+
+`src/install-plan.ts`:
+
+- `KOKORO_FILES` / `VOSK_FILES` become per-language groups.
+- `renderInstallPlan` takes the language list and sums only the selected packs (with
+  the shared Kokoro graph counted once), showing a per-language size breakdown.
+
+## Dependencies
+
+- Add `@clack/prompts` (runs under Bun) for the `init` multi-select TUI.
+
+## Error handling
+
+- Unknown / platform-unavailable language → hard error naming the bad code and listing
+  supported codes; nothing downloads. Enforced in the engine (authoritative) and
+  surfaced earlier in TS via capabilities for a faster, friendlier message.
+- Positionals without `--tts` → actionable usage error.
+- Engine/model download failures keep the existing contextual messages.
+
+## Testing
+
+**Rust:**
+- `download_tts` language → manifest partition: `en` → Kokoro packs only, `ru` → Vosk
+  only, `es` → ANE es voices only; multiple Kokoro languages share one graph.
+- Capabilities lists the expected TTS language rows per `#[cfg]` (en/ru everywhere;
+  es…zh only under `system_kokoro + macos + aarch64`).
+- Install validation rejects unknown and platform-unavailable codes, downloading
+  nothing.
+- Run the `audio-quality-check` agent after the `rust/src/tts/**` changes.
+
+**TS:**
+- `install` arg parsing: positionals → languages; bare `--tts` → `["en"]`; positionals
+  without `--tts` → error.
+- Validation against capabilities (mock `getEngineCapabilities`).
+- `init` multi-select selection → correct `install` args; empty selection → skip TTS;
+  non-TTY → printed suggestions.
+
+## Verification
+
+- `bun test && bunx tsc --noEmit`
+- `cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts`
+- `cargo check --features coreml --no-default-features` (backend module + capabilities changed)
+- Confirm the build-engine feature matrix still mirrors cargo defaults (no new default
+  feature added, so no matrix change expected — verify with the
+  `ci-feature-matrix-auditor` before any release).
+
+## Open items before implementation
+
+- Open a GitHub issue and tag it `WIP`; fill the issue number into the header and use
+  `Closes #N` in the PR.
+- `@clack/prompts` is the only new runtime dependency; verify it installs cleanly under
+  Bun during the first implementation step.

--- a/docs/superpowers/specs/2026-06-01-tts-install-languages-design.md
+++ b/docs/superpowers/specs/2026-06-01-tts-install-languages-design.md
@@ -79,10 +79,12 @@ The registry is **many-to-many (language ↔ engine)**, even though every langua
 engine list is currently a singleton:
 
 ```jsonc
+// example on the ONNX build (Linux/Windows/macOS-without-system_kokoro)
 "tts": { "languages": [
   { "code": "en", "engines": ["kokoro"] },
-  { "code": "ru", "engines": ["vosk"] },
-  { "code": "es", "engines": ["kokoro"] }   // darwin-arm64 only
+  { "code": "es", "engines": ["kokoro"] },  // also fr, it, pt
+  { "code": "ru", "engines": ["vosk"] }
+  // hi, ja, zh appear only on the darwin-arm64 system_kokoro build
 ]}
 ```
 
@@ -96,11 +98,29 @@ engine list is currently a singleton:
 
 ### Language → pack table (today)
 
-| code | engine | packs downloaded | platform | approx |
+Availability differs by build. The **ONNX build** (Linux, Windows, macOS without
+`system_kokoro`) covers `en es fr it pt ru`. The **`system_kokoro` build**
+(darwin-arm64) covers `en es fr hi it ja pt zh ru`. `hi ja zh` exist **only** on the
+darwin ANE path; `es fr it pt` exist on **both** (via CharsiuG2P on ONNX, ANE on darwin).
+
+| code | engine | packs downloaded | available on | approx |
 |---|---|---|---|---|
-| `en` | Kokoro | shared graph + EN voice(s) | all | ~326 MB |
-| `ru` | Vosk-TTS | model + dictionary + BERT + vocab | all | ~937 MB |
-| `es fr hi it ja pt zh` | FluidKokoro (ANE) | shared graph (auto) + that language's voice `.bin` | **darwin-arm64 only** | small per-language |
+| `en` | Kokoro | shared graph + `am_michael` | all builds | ~326 MB |
+| `es fr it pt` | Kokoro (ONNX) / FluidKokoro (ANE) | shared graph + that language's voice `.bin`; **+ CharsiuG2P (3 files, ~30 MB, shared) on the ONNX path** | all builds | ~30 MB (G2P, once) + tiny per-voice; graph shared |
+| `hi ja zh` | FluidKokoro (ANE) | shared graph (auto) + that language's ANE voice `.bin` | **darwin-arm64 only** | tiny per-language |
+| `ru` | Vosk-TTS | model + dictionary + BERT + vocab | all builds | ~937 MB |
+
+Pack dependencies on the **ONNX build** (`kokoro_manifest()`):
+- The Kokoro graph `model.onnx` (~326 MB) is shared by `en es fr it pt` — download once
+  if *any* of them is selected.
+- `en` needs no G2P (English uses the embedded `misaki-rs` lexicon).
+- `es fr it pt` each need their voice `.bin` **and** the shared CharsiuG2P byt5-tiny pack
+  (3 files). Download G2P once if any of `es fr it pt` is selected.
+
+Pack dependencies on the **`system_kokoro` build** (darwin-arm64):
+- `kokoro_manifest()` is empty — the graph auto-downloads into FluidAudio's cache on
+  first synth. Each Kokoro language stages only its own voice `.bin`(s) from
+  `ANE_KOKORO_VOICES` (today `stage_ane_kokoro_voices` stages the entire catalog).
 
 ## Architecture
 
@@ -116,8 +136,10 @@ rule).
 - Add a structured `tts` field carrying the language rows shown above
   (`{ code, engines }` per language), populated by `#[cfg]`:
   - `en`, `ru` whenever `feature = "tts"`.
-  - `es`, `fr`, `hi`, `it`, `ja`, `pt`, `zh` added under
-    `system_kokoro + macos + aarch64`.
+  - `es`, `fr`, `it`, `pt` added on **both** TTS builds — under
+    `not(all(system_kokoro, macos, aarch64))` (ONNX/CharsiuG2P) **and** under
+    `all(system_kokoro, macos, aarch64)` (ANE).
+  - `hi`, `ja`, `zh` added **only** under `all(system_kokoro, macos, aarch64)`.
 - Bump `protocolVersion` `2 → 3`.
 - `EngineCapabilities` (TS, `src/engine.ts`) mirrors the new field.
 
@@ -133,13 +155,17 @@ back-compat; the new structured field is additive.
 - Validate each requested code against `get_capabilities()` TTS languages. Unknown or
   platform-unavailable code → hard error listing the supported codes, **download
   nothing**.
-- `models::download_tts(no_cache)` → `download_tts(langs, no_cache)`:
-  - Refactor the flat `ANE_KOKORO_VOICES` const into a language-prefix lookup
-    (`a`/`b` → en, `e` → es, `f` → fr, `h` → hi, `i` → it, `j` → ja, `p` → pt,
-    `z` → zh) so each language stages only its own voices.
-  - If any Kokoro language is selected: download the shared graph once on the ONNX
-    path (rely on FluidAudio auto-download on the darwin `system_kokoro` path), and
-    stage only the selected languages' voices.
+- `models::download_tts(no_cache)` → `download_tts(langs, no_cache)`. Build the
+  manifest from the selected languages:
+  - **ONNX path** (`kokoro_manifest()` non-empty): split `kokoro_manifest()` into
+    addressable pieces — the shared graph, `en`'s `am_michael`, the shared CharsiuG2P
+    pack, and each multilingual voice (`es`→`em_alex`, `fr`→`ff_siwis`, `it`→`im_nicola`,
+    `pt`→`pm_alex`). Include the graph if any of `en es fr it pt` is selected; include
+    G2P if any of `es fr it pt` is selected; include each selected language's voice.
+  - **`system_kokoro` path** (darwin-arm64): refactor the flat `ANE_KOKORO_VOICES` const
+    into a language-prefix lookup (`a`/`b` → en, `e` → es, `f` → fr, `h` → hi, `i` → it,
+    `j` → ja, `p` → pt, `z` → zh) so `stage_ane_kokoro_voices` stages only the selected
+    languages' voices. (`af_heart` stays excluded.)
   - If `ru` is selected: `vosk_ru_manifest()`.
 - **Additive** is free: `download_verified` already short-circuits cached files that
   match their pinned SHA, so re-runs fetch only missing packs. No pruning logic.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -3,7 +3,9 @@
 Kesha speaks back via Kokoro-82M (English plus selected multilingual voices on Apple Silicon) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path. FluidAudio keeps its CoreML Kokoro cache at `~/.cache/fluidaudio/Models/kokoro`; those files are managed by FluidAudio, not Kesha's pinned model downloader.
 
 ```bash
-kesha install --tts                 # TTS models, opt-in (Darwin Kokoro uses FluidAudio cache)
+kesha install --tts                 # English only (~326 MB); Darwin Kokoro uses FluidAudio cache
+kesha install --tts en ru           # English + Russian (~326 MB + ~937 MB)
+kesha install --tts es fr it pt     # Romance languages (all platforms)
 kesha say "Hello, world" > hello.wav
 kesha say "Привет, мир" > privet.wav    # auto-routes (Milena on darwin, ru-vosk-m02 elsewhere)
 echo "long text" | kesha say > reply.wav
@@ -16,6 +18,36 @@ kesha say --list-voices
 Voice selection precedence: `--voice <id>` (explicit) → `--lang <code>` (route to that language's default voice, skipping detection — also the way to route on Linux/Windows, where text-language detection is macOS-only) → macOS text-language auto-detection → engine default (`en-am_michael`). A `--lang` whose language has no mapped male voice (e.g. French) falls to the engine default rather than re-detecting.
 
 Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Vosk). OGG/Opus and MP3 are tracked in follow-up issues.
+
+## Installing TTS languages
+
+`kesha install --tts [<lang>...]` installs TTS model packs for the requested languages. Bare `--tts` defaults to English only. Re-running is additive — already-cached packs are skipped, nothing is pruned.
+
+```bash
+kesha install --tts              # English only (~326 MB)
+kesha install --tts en ru        # English + Russian (~326 MB + ~937 MB)
+kesha install --tts es fr it pt  # Romance languages (shared ~30 MB CharsiuG2P ONNX pack + voice files)
+```
+
+**Platform availability:**
+
+| Language | Code | All builds | darwin-arm64 only |
+|----------|------|:----------:|:-----------------:|
+| English | `en` | ✅ | |
+| Spanish | `es` | ✅ | |
+| French | `fr` | ✅ | |
+| Italian | `it` | ✅ | |
+| Portuguese | `pt` | ✅ | |
+| Russian | `ru` | ✅ | |
+| Hindi | `hi` | | ✅ |
+| Japanese | `ja` | | ✅ |
+| Chinese | `zh` | | ✅ |
+
+`macos-*` AVSpeech voices require no install and are not listed here — they use voices already on your Mac.
+
+Requesting a language unavailable on the current platform (e.g. `hi` on Linux) is a hard error — nothing is downloaded.
+
+`kesha init` presents a multi-select checkbox of the languages available on your platform, with English pre-checked. Selecting none skips TTS entirely; Ctrl-C aborts init.
 
 Grapheme-to-phoneme:
 - **Kokoro on darwin-arm64** uses FluidAudio CoreML/ANE for English, Spanish, Hindi, Italian, Japanese, Mandarin Chinese, Brazilian Portuguese, and the single native French Kokoro voice.

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "yaml": "^2.9.0"
   },
   "dependencies": {
+    "@clack/prompts": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@toon-format/toon": "^2.1.0",
     "citty": "^0.2.2",

--- a/rust/src/capabilities.rs
+++ b/rust/src/capabilities.rs
@@ -12,10 +12,26 @@ use crate::transcribe::TRANSCRIBE_SEGMENTS_FEATURE;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TtsLanguage {
+    pub code: &'static str,
+    /// Downloadable engines for this language, default first. One entry today.
+    pub engines: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TtsCapabilities {
+    pub languages: Vec<TtsLanguage>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Capabilities {
     pub protocol_version: u32,
     pub backend: &'static str,
     pub features: Vec<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tts: Option<TtsCapabilities>,
 }
 
 pub fn get_capabilities() -> Capabilities {
@@ -55,10 +71,24 @@ pub fn get_capabilities() -> Capabilities {
     #[cfg(all(feature = "system_diarize", target_os = "macos"))]
     features.push(TRANSCRIBE_DIARIZE_FEATURE);
 
+    #[cfg(feature = "tts")]
+    let tts = Some(TtsCapabilities {
+        languages: crate::models::tts_languages()
+            .into_iter()
+            .map(|code| TtsLanguage {
+                code,
+                engines: vec![if code == "ru" { "vosk" } else { "kokoro" }],
+            })
+            .collect(),
+    });
+    #[cfg(not(feature = "tts"))]
+    let tts = None;
+
     Capabilities {
-        protocol_version: 2,
+        protocol_version: 3,
         backend: backend_name(),
         features,
+        tts,
     }
 }
 
@@ -70,5 +100,27 @@ fn backend_name() -> &'static str {
     #[cfg(not(feature = "coreml"))]
     {
         "onnx"
+    }
+}
+
+#[cfg(all(test, feature = "tts"))]
+mod tts_caps_tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_expose_tts_languages() {
+        let caps = get_capabilities();
+        let tts = caps.tts.expect("tts field present on a tts build");
+        let codes: Vec<&str> = tts.languages.iter().map(|l| l.code).collect();
+        assert!(codes.contains(&"en"));
+        assert!(codes.contains(&"ru"));
+        for lang in &tts.languages {
+            assert!(!lang.engines.is_empty(), "{} has no engines", lang.code);
+        }
+    }
+
+    #[test]
+    fn protocol_version_is_3() {
+        assert_eq!(get_capabilities().protocol_version, 3);
     }
 }

--- a/rust/src/capabilities.rs
+++ b/rust/src/capabilities.rs
@@ -77,7 +77,7 @@ pub fn get_capabilities() -> Capabilities {
             .into_iter()
             .map(|code| TtsLanguage {
                 code,
-                engines: vec![if code == "ru" { "vosk" } else { "kokoro" }],
+                engines: vec![crate::models::tts_engine_for(code)],
             })
             .collect(),
     });
@@ -117,6 +117,10 @@ mod tts_caps_tests {
         for lang in &tts.languages {
             assert!(!lang.engines.is_empty(), "{} has no engines", lang.code);
         }
+        let ru = tts.languages.iter().find(|l| l.code == "ru").unwrap();
+        assert_eq!(ru.engines, vec!["vosk"]);
+        let en = tts.languages.iter().find(|l| l.code == "en").unwrap();
+        assert_eq!(en.engines, vec!["kokoro"]);
     }
 
     #[test]

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -4,7 +4,7 @@ use crate::{backend, models};
 
 pub fn run(
     no_cache: bool,
-    #[cfg(feature = "tts")] tts: bool,
+    #[cfg(feature = "tts")] tts_langs: Vec<String>,
     vad: bool,
     #[cfg(feature = "system_diarize")] diarize: bool,
     no_warmup: bool,
@@ -16,9 +16,11 @@ pub fn run(
     models::init_mirror_logging();
     models::install(no_cache)?;
     #[cfg(feature = "tts")]
-    if tts {
-        models::download_tts(no_cache)?;
-        eprintln!("TTS models installed.");
+    if !tts_langs.is_empty() {
+        let refs: Vec<&str> = tts_langs.iter().map(String::as_str).collect();
+        models::validate_tts_langs(&refs)?;
+        models::download_tts(&refs, no_cache)?;
+        eprintln!("TTS models installed ({}).", tts_langs.join(", "));
     }
     if vad {
         models::download_vad(no_cache)?;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -91,10 +91,12 @@ enum Commands {
         /// Re-download even if cached
         #[arg(long)]
         no_cache: bool,
-        /// Also install TTS models (Kokoro EN + Vosk RU, ~990MB).
+        /// Install TTS models for these languages (space-separated, e.g.
+        /// `--tts en ru`). Bare `--tts` installs English only. Codes are
+        /// validated against this build's supported set.
         #[cfg(feature = "tts")]
-        #[arg(long)]
-        tts: bool,
+        #[arg(long, num_args = 0.., value_name = "LANG", default_missing_value = "en")]
+        tts: Vec<String>,
         /// Also install Silero VAD (~2.3MB) for long-audio preprocessing.
         #[arg(long)]
         vad: bool,

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -119,6 +119,31 @@ const LANG_ID_FILES: &[ModelFile] = &[
     },
 ];
 
+/// TTS languages installable on THIS build, in maintainer-curated order.
+/// Source of truth for `kesha-engine install --tts <lang>` validation and the
+/// `tts.languages` capabilities rows. `es/fr/it/pt` exist on both the ONNX
+/// (CharsiuG2P) and darwin ANE builds; `hi/ja/zh` exist only on the ANE build.
+/// `macos-*` AVSpeech is NOT listed — it needs no install.
+#[cfg(feature = "tts")]
+pub fn tts_languages() -> Vec<&'static str> {
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    {
+        vec!["en", "es", "fr", "hi", "it", "ja", "pt", "zh", "ru"]
+    }
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    {
+        vec!["en", "es", "fr", "it", "pt", "ru"]
+    }
+}
+
 #[cfg(feature = "tts")]
 pub fn kokoro_manifest() -> Vec<ModelFile> {
     #[cfg(all(
@@ -1039,6 +1064,44 @@ mod tts_tests {
                     std::env::remove_var(self.key);
                 },
             }
+        }
+    }
+
+    #[test]
+    fn tts_languages_includes_en_and_ru_everywhere() {
+        let langs = tts_languages();
+        assert!(langs.contains(&"en"), "en missing: {langs:?}");
+        assert!(langs.contains(&"ru"), "ru missing: {langs:?}");
+        for l in ["es", "fr", "it", "pt"] {
+            assert!(langs.contains(&l), "{l} missing: {langs:?}");
+        }
+    }
+
+    #[test]
+    fn tts_languages_gates_ane_only_langs() {
+        let langs = tts_languages();
+        let ane_only = ["hi", "ja", "zh"];
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        for l in ane_only {
+            assert!(
+                langs.contains(&l),
+                "{l} should be present on system_kokoro build"
+            );
+        }
+        #[cfg(not(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        )))]
+        for l in ane_only {
+            assert!(
+                !langs.contains(&l),
+                "{l} must NOT be present on the ONNX build"
+            );
         }
     }
 }

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -122,7 +122,8 @@ const LANG_ID_FILES: &[ModelFile] = &[
 /// TTS languages installable on THIS build, in maintainer-curated order.
 /// Source of truth for `kesha-engine install --tts <lang>` validation and the
 /// `tts.languages` capabilities rows. `es/fr/it/pt` exist on both the ONNX
-/// (CharsiuG2P) and darwin ANE builds; `hi/ja/zh` exist only on the ANE build.
+/// (CharsiuG2P) and darwin ANE builds; `hi/ja/zh` exist only on the
+/// `system_kokoro` feature (darwin arm64 ANE).
 /// `macos-*` AVSpeech is NOT listed — it needs no install.
 #[cfg(feature = "tts")]
 pub fn tts_languages() -> Vec<&'static str> {
@@ -141,6 +142,16 @@ pub fn tts_languages() -> Vec<&'static str> {
     )))]
     {
         vec!["en", "es", "fr", "it", "pt", "ru"]
+    }
+}
+
+/// Default downloadable engine for a TTS language code. One engine per
+/// language today; the capabilities `engines` list is a Vec to allow more later.
+#[cfg(feature = "tts")]
+pub fn tts_engine_for(lang: &str) -> &'static str {
+    match lang {
+        "ru" => "vosk",
+        _ => "kokoro",
     }
 }
 

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -160,8 +160,8 @@ pub fn tts_engine_for(lang: &str) -> &'static str {
 #[cfg(feature = "tts")]
 pub fn validate_tts_langs(langs: &[&str]) -> Result<()> {
     let supported = tts_languages();
-    for l in langs {
-        if !supported.contains(l) {
+    for &l in langs {
+        if !supported.contains(&l) {
             coded_bail!(
                 ErrorCode::VoiceUnknown,
                 "TTS language '{l}' is not available on this build (supported: {})",
@@ -1279,7 +1279,8 @@ mod tts_tests {
             .all(|n| n.starts_with("am_") || n.starts_with("af_") || n.starts_with("bm_")));
         let es = names(&["es"]);
         assert!(!es.is_empty() && es.iter().all(|n| n.starts_with("e")));
-        assert!(!names(&["en"]).iter().any(|n| n == "af_heart.bin"));
+        // af_alloy IS in ANE_KOKORO_VOICES and is en-prefixed — the filter must return it for "en".
+        assert!(names(&["en"]).iter().any(|n| n == "af_alloy.bin"));
     }
 
     #[test]
@@ -1420,6 +1421,8 @@ pub fn download_tts(langs: &[&str], no_cache: bool) -> Result<()> {
     {
         if langs.contains(&"ru") {
             let cache = cache_dir();
+            // `manifest` must outlive `refs` (the borrows point into it), so it
+            // stays a named binding rather than an inlined temporary.
             let manifest = vosk_ru_manifest();
             let refs: Vec<&ModelFile> = manifest.iter().collect();
             parallel_download(&cache, &refs, no_cache)?;

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -155,10 +155,27 @@ pub fn tts_engine_for(lang: &str) -> &'static str {
     }
 }
 
+/// Validate requested TTS language codes against what THIS build supports.
+/// Hard error (download nothing) naming the offending code and supported set.
+#[cfg(feature = "tts")]
+pub fn validate_tts_langs(langs: &[&str]) -> Result<()> {
+    let supported = tts_languages();
+    for l in langs {
+        if !supported.contains(l) {
+            coded_bail!(
+                ErrorCode::VoiceUnknown,
+                "TTS language '{l}' is not available on this build (supported: {})",
+                supported.join(", ")
+            );
+        }
+    }
+    Ok(())
+}
+
 // ── ONNX-path Kokoro shared consts ──────────────────────────────────────────
 // These are gated to the ONNX (non-ANE) build. Each literal appears exactly
-// once; both `kokoro_manifest()` and `kokoro_manifest_for(langs)` build their
-// outputs by cloning from these consts.
+// once; `kokoro_manifest_for(langs)` builds its output by cloning from these
+// consts.
 
 /// The Kokoro-82M ONNX graph (~326 MB). Single copy regardless of how many
 /// Kokoro languages are installed — all voices share this graph.
@@ -168,11 +185,14 @@ pub fn tts_engine_for(lang: &str) -> &'static str {
 /// official kokoro-onnx project release, which uses different IO
 /// tensor names (`tokens`/`audio` vs `input_ids`/`waveform`) but
 /// same dtypes/shapes — handled in `kokoro::Kokoro::infer`.
-#[cfg(not(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-)))]
+#[cfg(all(
+    feature = "tts",
+    not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))
+))]
 const KOKORO_GRAPH: ModelFile = ModelFile {
     rel_path: "models/kokoro-82m/model.onnx",
     url: "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx",
@@ -181,11 +201,14 @@ const KOKORO_GRAPH: ModelFile = ModelFile {
 
 /// Default English male voice pack (Кеша is a male name — CLAUDE.md brand rule).
 /// Switched from `af_heart` (female) in #210.
-#[cfg(not(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-)))]
+#[cfg(all(
+    feature = "tts",
+    not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))
+))]
 const KOKORO_EN_VOICE: ModelFile = ModelFile {
     rel_path: "models/kokoro-82m/voices/am_michael.bin",
     url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin",
@@ -195,11 +218,14 @@ const KOKORO_EN_VOICE: ModelFile = ModelFile {
 /// klebster CharsiuG2P byt5-tiny ONNX export (CC-BY 4.0).
 /// Pinned hashes from #185 (see NOTICES.md for attribution).
 /// These 3 files enable multilingual G2P for es/fr/it/pt voices.
-#[cfg(not(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-)))]
+#[cfg(all(
+    feature = "tts",
+    not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))
+))]
 const G2P_CHARSIU_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/g2p/byt5-tiny/encoder_model.onnx",
@@ -223,11 +249,14 @@ const G2P_CHARSIU_FILES: &[ModelFile] = &[
 /// em_alex (es, male), im_nicola (it, male), pm_alex (pt, male)
 /// satisfy the brand male-default rule. ff_siwis (fr, female) is
 /// the sole French voice Kokoro v1.0 ships — see voices.rs comment.
-#[cfg(not(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-)))]
+#[cfg(all(
+    feature = "tts",
+    not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))
+))]
 fn multilang_voice(lang: &str) -> Option<ModelFile> {
     let (rel, url, sha) = match lang {
         "es" => (
@@ -263,15 +292,16 @@ fn multilang_voice(lang: &str) -> Option<ModelFile> {
 /// language is selected; G2P only if a multilingual lang (es/fr/it/pt) is
 /// selected; per-language voices added individually.
 ///
-/// Groundwork for `download_tts(langs)` so an English-only install skips the
-/// ~30 MB CharsiuG2P pack and a Russian-only install skips Kokoro entirely.
-/// Wired to the install handler in the next task; `#[allow(dead_code)]` until then.
-#[cfg(not(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-)))]
-#[allow(dead_code)]
+/// An English-only install skips the ~30 MB CharsiuG2P pack and a Russian-only
+/// install skips Kokoro entirely. Consumed by [`download_tts`].
+#[cfg(all(
+    feature = "tts",
+    not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))
+))]
 fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
     const KOKORO_LANGS: [&str; 5] = ["en", "es", "fr", "it", "pt"];
     const MULTILANG: [&str; 4] = ["es", "fr", "it", "pt"];
@@ -291,27 +321,6 @@ fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
         }
     }
     out
-}
-
-#[cfg(feature = "tts")]
-pub fn kokoro_manifest() -> Vec<ModelFile> {
-    #[cfg(all(
-        feature = "system_kokoro",
-        target_os = "macos",
-        target_arch = "aarch64"
-    ))]
-    {
-        return Vec::new();
-    }
-    #[allow(unreachable_code)]
-    {
-        let mut v = vec![KOKORO_GRAPH.clone(), KOKORO_EN_VOICE.clone()];
-        v.extend(G2P_CHARSIU_FILES.iter().cloned());
-        for l in ["es", "fr", "it", "pt"] {
-            v.push(multilang_voice(l).expect("multilang voice"));
-        }
-        v
-    }
 }
 
 /// FluidAudio ANE Kokoro voice packs (`system_kokoro` darwin path, #475).
@@ -480,6 +489,44 @@ const ANE_KOKORO_VOICES: &[ModelFile] = &[
     // `tts::fluid_kokoro` zh-* voices.
 ];
 
+/// Map a flat ANE voice-pack basename (`<x><gender>_name.bin`) to its Kokoro
+/// language code. The first character of a Kokoro voice id selects language
+/// (`a`/`b` = English, `e` = Spanish, etc.); the second is the gender prefix.
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn ane_voice_lang(rel_path: &str) -> Option<&'static str> {
+    // Kokoro voice files are `<x><gender>_name.bin`; first char picks language.
+    match rel_path.chars().next() {
+        Some('a') | Some('b') => Some("en"),
+        Some('e') => Some("es"),
+        Some('f') => Some("fr"),
+        Some('h') => Some("hi"),
+        Some('i') => Some("it"),
+        Some('j') => Some("ja"),
+        Some('p') => Some("pt"),
+        Some('z') => Some("zh"),
+        _ => None,
+    }
+}
+
+/// Subset of [`ANE_KOKORO_VOICES`] whose language is in `langs`. Drives the
+/// language-aware ANE staging so an English-only install skips the es/it/pt/…
+/// packs (and a Russian-only install stages nothing here).
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
+    ANE_KOKORO_VOICES
+        .iter()
+        .filter(|f| ane_voice_lang(f.rel_path).is_some_and(|l| langs.contains(&l)))
+        .collect()
+}
+
 /// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
 /// `KESHA_CACHE_DIR` — FluidAudio 0.14.7 owns this path and reads voice packs
 /// from here local-first. We pre-stage onnx-community packs here so the full
@@ -506,18 +553,21 @@ pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
 /// local-first (#475). Idempotent: an existing pack that already matches its
 /// pinned hash short-circuits the network round-trip, identical to
 /// [`download_verified`]. Runs only on the `system_kokoro` darwin path; the
-/// ONNX Kokoro path keeps using `kokoro_manifest()` under `KESHA_CACHE_DIR`.
+/// ONNX Kokoro path keeps using `kokoro_manifest_for()` under `KESHA_CACHE_DIR`.
 #[cfg(all(
     feature = "system_kokoro",
     target_os = "macos",
     target_arch = "aarch64"
 ))]
-pub fn stage_ane_kokoro_voices(no_cache: bool) -> Result<()> {
+pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
+    // `rel_path = "<voice>.bin"` + `cache = ane_dir` → flat ANE dir.
+    let manifest = ane_voices_for(langs);
+    if manifest.is_empty() {
+        return Ok(());
+    }
     let ane_dir = fluidaudio_ane_kokoro_dir();
     fs::create_dir_all(&ane_dir)
         .with_context(|| format!("create FluidAudio ANE dir {}", ane_dir.display()))?;
-    // `rel_path = "<voice>.bin"` + `cache = ane_dir` → flat ANE dir.
-    let manifest: Vec<&ModelFile> = ANE_KOKORO_VOICES.iter().collect();
     parallel_download(&ane_dir, &manifest, no_cache)
 }
 
@@ -1018,32 +1068,6 @@ mod tts_tests {
     use super::*;
 
     #[test]
-    fn kokoro_manifest_has_expected_files() {
-        let m = kokoro_manifest();
-        #[cfg(all(
-            feature = "system_kokoro",
-            target_os = "macos",
-            target_arch = "aarch64"
-        ))]
-        {
-            assert!(m.is_empty());
-        }
-        #[cfg(not(all(
-            feature = "system_kokoro",
-            target_os = "macos",
-            target_arch = "aarch64"
-        )))]
-        {
-            assert!(m.iter().any(|f| f.rel_path.ends_with("model.onnx")));
-            assert!(m.iter().any(|f| f.rel_path.ends_with("am_michael.bin")));
-            for f in &m {
-                assert_eq!(f.sha256.len(), 64, "{:?} sha256 not 64 hex chars", f);
-                assert!(f.url.starts_with("https://"), "{f:?} url not https");
-            }
-        }
-    }
-
-    #[test]
     fn vosk_ru_manifest_has_expected_files() {
         let m = vosk_ru_manifest();
         assert_eq!(m.len(), 5);
@@ -1234,6 +1258,52 @@ mod tts_tests {
 
         assert!(kokoro_manifest_for(&["ru"]).is_empty());
     }
+
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    #[test]
+    fn ane_voices_for_filters_by_language_prefix() {
+        let names = |langs: &[&str]| {
+            ane_voices_for(langs)
+                .iter()
+                .map(|f| f.rel_path.to_string())
+                .collect::<Vec<_>>()
+        };
+        let en = names(&["en"]);
+        assert!(en.iter().any(|n| n.starts_with("am_")));
+        assert!(en
+            .iter()
+            .all(|n| n.starts_with("am_") || n.starts_with("af_") || n.starts_with("bm_")));
+        let es = names(&["es"]);
+        assert!(!es.is_empty() && es.iter().all(|n| n.starts_with("e")));
+        assert!(!names(&["en"]).iter().any(|n| n == "af_heart.bin"));
+    }
+
+    #[test]
+    fn validate_tts_langs_accepts_known_rejects_unknown() {
+        assert!(validate_tts_langs(&["en"]).is_ok());
+        let err = validate_tts_langs(&["en", "klingon"])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("klingon"), "err names the bad code: {err}");
+        #[cfg(not(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        )))]
+        {
+            let err = validate_tts_langs(&["ja"]).unwrap_err().to_string();
+            assert!(err.contains("ja"), "ja unavailable on ONNX build: {err}");
+        }
+    }
+
+    #[test]
+    fn download_tts_empty_langs_is_noop() {
+        assert!(download_tts(&[], false).is_ok());
+    }
 }
 
 /// Download the Sortformer `.mlpackage`. Opt-in via `kesha install --diarize`
@@ -1311,27 +1381,52 @@ pub fn download_vad(no_cache: bool) -> Result<()> {
     parallel_download(&cache, &refs, no_cache)
 }
 
-/// Download every TTS model file: Kokoro English + Vosk Russian.
-/// Each file is streamed to disk, then SHA256-verified. 4 concurrent
-/// downloads (#178).
+/// Download the TTS model files needed for `langs` only. Each file is streamed
+/// to disk, then SHA256-verified, 4 concurrent (#178). An English-only install
+/// skips the CharsiuG2P pack; a Russian-only install skips Kokoro entirely.
+/// Empty `langs` is a no-op so the install handler can short-circuit a bare run.
 #[cfg(feature = "tts")]
-pub fn download_tts(no_cache: bool) -> Result<()> {
-    let cache = cache_dir();
-    let mut manifest = kokoro_manifest();
-    manifest.extend(vosk_ru_manifest());
-    let refs: Vec<&ModelFile> = manifest.iter().collect();
-    parallel_download(&cache, &refs, no_cache)?;
-    // On the FluidAudio ANE Kokoro path `kokoro_manifest()` is empty (the model
-    // graph + `af_heart` auto-download into FluidAudio's own cache on first
-    // synth). Stage the rest of the en-* catalog — including the male
-    // `am_michael` default — into FluidAudio's ANE voice-pack cache so they
-    // resolve local-first instead of 404ing against the ANE bundle (#475).
+pub fn download_tts(langs: &[&str], no_cache: bool) -> Result<()> {
+    if langs.is_empty() {
+        return Ok(());
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    {
+        let cache = cache_dir();
+        let mut manifest = kokoro_manifest_for(langs);
+        if langs.contains(&"ru") {
+            manifest.extend(vosk_ru_manifest());
+        }
+        let refs: Vec<&ModelFile> = manifest.iter().collect();
+        parallel_download(&cache, &refs, no_cache)?;
+    }
+
+    // On the FluidAudio ANE Kokoro path the model graph + `af_heart`
+    // auto-download into FluidAudio's own cache on first synth. Stage only the
+    // requested en/es/it/… catalog — including the male `am_michael` default —
+    // into FluidAudio's ANE voice-pack cache so they resolve local-first
+    // instead of 404ing against the ANE bundle (#475). Vosk-RU still lands
+    // under KESHA_CACHE_DIR.
     #[cfg(all(
         feature = "system_kokoro",
         target_os = "macos",
         target_arch = "aarch64"
     ))]
-    stage_ane_kokoro_voices(no_cache)?;
+    {
+        if langs.contains(&"ru") {
+            let cache = cache_dir();
+            let manifest = vosk_ru_manifest();
+            let refs: Vec<&ModelFile> = manifest.iter().collect();
+            parallel_download(&cache, &refs, no_cache)?;
+        }
+        stage_ane_kokoro_voices(langs, no_cache)?;
+    }
+
     Ok(())
 }
 

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -155,6 +155,144 @@ pub fn tts_engine_for(lang: &str) -> &'static str {
     }
 }
 
+// ── ONNX-path Kokoro shared consts ──────────────────────────────────────────
+// These are gated to the ONNX (non-ANE) build. Each literal appears exactly
+// once; both `kokoro_manifest()` and `kokoro_manifest_for(langs)` build their
+// outputs by cloning from these consts.
+
+/// The Kokoro-82M ONNX graph (~326 MB). Single copy regardless of how many
+/// Kokoro languages are installed — all voices share this graph.
+///
+/// The HF onnx-community variant produces unintelligible audio with
+/// `af_heart` — confirmed by audio bisection, see #207. Use the
+/// official kokoro-onnx project release, which uses different IO
+/// tensor names (`tokens`/`audio` vs `input_ids`/`waveform`) but
+/// same dtypes/shapes — handled in `kokoro::Kokoro::infer`.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+const KOKORO_GRAPH: ModelFile = ModelFile {
+    rel_path: "models/kokoro-82m/model.onnx",
+    url: "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx",
+    sha256: "7d5df8ecf7d4b1878015a32686053fd0eebe2bc377234608764cc0ef3636a6c5",
+};
+
+/// Default English male voice pack (Кеша is a male name — CLAUDE.md brand rule).
+/// Switched from `af_heart` (female) in #210.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+const KOKORO_EN_VOICE: ModelFile = ModelFile {
+    rel_path: "models/kokoro-82m/voices/am_michael.bin",
+    url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin",
+    sha256: "1d1f21dd8da39c30705cd4c75d039d265e9bc4a2a93ed09bc9e1b1225eb95ba1",
+};
+
+/// klebster CharsiuG2P byt5-tiny ONNX export (CC-BY 4.0).
+/// Pinned hashes from #185 (see NOTICES.md for attribution).
+/// These 3 files enable multilingual G2P for es/fr/it/pt voices.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+const G2P_CHARSIU_FILES: &[ModelFile] = &[
+    ModelFile {
+        rel_path: "models/g2p/byt5-tiny/encoder_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/encoder_model.onnx",
+        sha256: "1ac7aca11845527873f9e0e870fbe1e3c3ac2cb009d8852230332d10541aab04",
+    },
+    ModelFile {
+        rel_path: "models/g2p/byt5-tiny/decoder_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_model.onnx",
+        sha256: "de32477aae14e254d4a7dee4b2c324fb39f93a0dc254181c5bfdd8fc67492919",
+    },
+    ModelFile {
+        rel_path: "models/g2p/byt5-tiny/decoder_with_past_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_with_past_model.onnx",
+        sha256: "fae30b9f3a8d935be01b32af851bae6d54f330813167073e84caf6d0a1890fcb",
+    },
+];
+
+/// Multilingual Kokoro voice packs (es/fr/it/pt). All from
+/// onnx-community/Kokoro-82M-v1.0-ONNX on HuggingFace.
+/// em_alex (es, male), im_nicola (it, male), pm_alex (pt, male)
+/// satisfy the brand male-default rule. ff_siwis (fr, female) is
+/// the sole French voice Kokoro v1.0 ships — see voices.rs comment.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+fn multilang_voice(lang: &str) -> Option<ModelFile> {
+    let (rel, url, sha) = match lang {
+        "es" => (
+            "models/kokoro-82m/voices/em_alex.bin",
+            "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/em_alex.bin",
+            "27809e9eafdcbcfff90a3016c697568676531de2a2c39cee29c96c7bd6b83e95",
+        ),
+        "fr" => (
+            "models/kokoro-82m/voices/ff_siwis.bin",
+            "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/ff_siwis.bin",
+            "a35f5675ad08948e326ae75fd0ea16ba5d0042e4f76b5f3d1df77d0a48c54861",
+        ),
+        "it" => (
+            "models/kokoro-82m/voices/im_nicola.bin",
+            "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/im_nicola.bin",
+            "bc578e510d52a96d6940d46f12e96d7b3df00905dbea075113226d100e6e1ab0",
+        ),
+        "pt" => (
+            "models/kokoro-82m/voices/pm_alex.bin",
+            "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_alex.bin",
+            "0175c753f59c54e7fd5a995bedef0c5ff2fb67e0043dd3dcb2ae74ec2acbeb2a",
+        ),
+        _ => return None,
+    };
+    Some(ModelFile {
+        rel_path: rel,
+        url,
+        sha256: sha,
+    })
+}
+
+/// ONNX-path Kokoro files needed for `langs`. Graph included if any Kokoro
+/// language is selected; G2P only if a multilingual lang (es/fr/it/pt) is
+/// selected; per-language voices added individually.
+///
+/// Groundwork for `download_tts(langs)` so an English-only install skips the
+/// ~30 MB CharsiuG2P pack and a Russian-only install skips Kokoro entirely.
+/// Wired to the install handler in the next task; `#[allow(dead_code)]` until then.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+#[allow(dead_code)]
+fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
+    const KOKORO_LANGS: [&str; 5] = ["en", "es", "fr", "it", "pt"];
+    const MULTILANG: [&str; 4] = ["es", "fr", "it", "pt"];
+    let mut out = Vec::new();
+    if langs.iter().any(|l| KOKORO_LANGS.contains(l)) {
+        out.push(KOKORO_GRAPH.clone());
+    }
+    if langs.contains(&"en") {
+        out.push(KOKORO_EN_VOICE.clone());
+    }
+    if langs.iter().any(|l| MULTILANG.contains(l)) {
+        out.extend(G2P_CHARSIU_FILES.iter().cloned());
+    }
+    for l in langs {
+        if let Some(v) = multilang_voice(l) {
+            out.push(v);
+        }
+    }
+    out
+}
+
 #[cfg(feature = "tts")]
 pub fn kokoro_manifest() -> Vec<ModelFile> {
     #[cfg(all(
@@ -167,70 +305,12 @@ pub fn kokoro_manifest() -> Vec<ModelFile> {
     }
     #[allow(unreachable_code)]
     {
-        vec![
-        ModelFile {
-            // The HF onnx-community variant produces unintelligible audio with
-            // `af_heart` — confirmed by audio bisection, see #207. Use the
-            // official kokoro-onnx project release, which uses different IO
-            // tensor names (`tokens`/`audio` vs `input_ids`/`waveform`) but
-            // same dtypes/shapes — handled in `kokoro::Kokoro::infer`.
-            rel_path: "models/kokoro-82m/model.onnx",
-            url: "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx",
-            sha256: "7d5df8ecf7d4b1878015a32686053fd0eebe2bc377234608764cc0ef3636a6c5",
-        },
-        ModelFile {
-            // Kesha (Кеша) is a male name — default to a male voice.
-            // Switched from `af_heart` (female) in #210; per-CLAUDE.md
-            // "DEFAULT TTS VOICES MUST BE MALE". Other voices download on
-            // demand via explicit `--voice` after `kesha install --tts`.
-            rel_path: "models/kokoro-82m/voices/am_michael.bin",
-            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin",
-            sha256: "1d1f21dd8da39c30705cd4c75d039d265e9bc4a2a93ed09bc9e1b1225eb95ba1",
-        },
-        // klebster CharsiuG2P byt5-tiny ONNX export (CC-BY 4.0).
-        // Pinned hashes from #185 (see NOTICES.md for attribution).
-        // These 3 files enable multilingual G2P for es/fr/it/pt voices.
-        ModelFile {
-            rel_path: "models/g2p/byt5-tiny/encoder_model.onnx",
-            url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/encoder_model.onnx",
-            sha256: "1ac7aca11845527873f9e0e870fbe1e3c3ac2cb009d8852230332d10541aab04",
-        },
-        ModelFile {
-            rel_path: "models/g2p/byt5-tiny/decoder_model.onnx",
-            url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_model.onnx",
-            sha256: "de32477aae14e254d4a7dee4b2c324fb39f93a0dc254181c5bfdd8fc67492919",
-        },
-        ModelFile {
-            rel_path: "models/g2p/byt5-tiny/decoder_with_past_model.onnx",
-            url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_with_past_model.onnx",
-            sha256: "fae30b9f3a8d935be01b32af851bae6d54f330813167073e84caf6d0a1890fcb",
-        },
-        // Multilingual Kokoro voice packs (es/fr/it/pt). All from
-        // onnx-community/Kokoro-82M-v1.0-ONNX on HuggingFace.
-        // em_alex (es, male), im_nicola (it, male), pm_alex (pt, male)
-        // satisfy the brand male-default rule. ff_siwis (fr, female) is
-        // the sole French voice Kokoro v1.0 ships — see voices.rs comment.
-        ModelFile {
-            rel_path: "models/kokoro-82m/voices/em_alex.bin",
-            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/em_alex.bin",
-            sha256: "27809e9eafdcbcfff90a3016c697568676531de2a2c39cee29c96c7bd6b83e95",
-        },
-        ModelFile {
-            rel_path: "models/kokoro-82m/voices/ff_siwis.bin",
-            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/ff_siwis.bin",
-            sha256: "a35f5675ad08948e326ae75fd0ea16ba5d0042e4f76b5f3d1df77d0a48c54861",
-        },
-        ModelFile {
-            rel_path: "models/kokoro-82m/voices/im_nicola.bin",
-            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/im_nicola.bin",
-            sha256: "bc578e510d52a96d6940d46f12e96d7b3df00905dbea075113226d100e6e1ab0",
-        },
-        ModelFile {
-            rel_path: "models/kokoro-82m/voices/pm_alex.bin",
-            url: "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/pm_alex.bin",
-            sha256: "0175c753f59c54e7fd5a995bedef0c5ff2fb67e0043dd3dcb2ae74ec2acbeb2a",
-        },
-    ]
+        let mut v = vec![KOKORO_GRAPH.clone(), KOKORO_EN_VOICE.clone()];
+        v.extend(G2P_CHARSIU_FILES.iter().cloned());
+        for l in ["es", "fr", "it", "pt"] {
+            v.push(multilang_voice(l).expect("multilang voice"));
+        }
+        v
     }
 }
 
@@ -1114,6 +1194,45 @@ mod tts_tests {
                 "{l} must NOT be present on the ONNX build"
             );
         }
+    }
+
+    #[cfg(not(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn kokoro_manifest_for_selects_per_language() {
+        let ends = |m: &[ModelFile], suffix: &str| m.iter().any(|f| f.rel_path.ends_with(suffix));
+
+        let en = kokoro_manifest_for(&["en"]);
+        assert!(ends(&en, "model.onnx"));
+        assert!(ends(&en, "am_michael.bin"));
+        assert!(
+            !en.iter().any(|f| f.rel_path.contains("g2p")),
+            "en must not pull g2p"
+        );
+
+        let es = kokoro_manifest_for(&["es"]);
+        assert!(ends(&es, "model.onnx"));
+        assert!(ends(&es, "em_alex.bin"));
+        assert!(
+            es.iter().any(|f| f.rel_path.contains("g2p")),
+            "es needs g2p"
+        );
+        assert!(!ends(&es, "am_michael.bin"));
+
+        let both = kokoro_manifest_for(&["en", "es"]);
+        assert_eq!(
+            both.iter()
+                .filter(|f| f.rel_path.ends_with("kokoro-82m/model.onnx"))
+                .count(),
+            1,
+            "Kokoro graph must appear exactly once even when both en and es are selected"
+        );
+        assert!(ends(&both, "am_michael.bin") && ends(&both, "em_alex.bin"));
+
+        assert!(kokoro_manifest_for(&["ru"]).is_empty());
     }
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -193,7 +193,6 @@ async function printPlan(selection: InitSelection): Promise<void> {
     await renderInstallPlan({
       noCache: selection.noCache,
       backend: selection.backend,
-      tts: selection.ttsLangs.length > 0,
       ttsLangs: selection.ttsLangs,
       vad: selection.vad,
       diarize: selection.diarize,

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import { multiselect, isCancel } from "@clack/prompts";
+import { multiselect, isCancel, cancel } from "@clack/prompts";
 import { renderInstallPlan } from "../install-plan";
 import { log } from "../log";
 import { getEngineCapabilities } from "../engine";
@@ -37,7 +37,10 @@ async function promptTtsLangs(preselect: string[]): Promise<string[]> {
     initialValues: preselect.filter((l) => supported.includes(l)),
     required: false,
   });
-  if (isCancel(selected)) return [];
+  if (isCancel(selected)) {
+    cancel("Init cancelled.");
+    process.exit(0);
+  }
   return selected as string[];
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,9 +1,45 @@
 import { defineCommand } from "citty";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
+import { multiselect, isCancel } from "@clack/prompts";
 import { renderInstallPlan } from "../install-plan";
 import { log } from "../log";
-import { performInstall, resolveBackendFlag, resolveNoCacheFlag } from "./install";
+import { getEngineCapabilities } from "../engine";
+import {
+  performInstall,
+  resolveBackendFlag,
+  resolveNoCacheFlag,
+  TTS_LANG_FALLBACK,
+} from "./install";
+
+const TTS_LANG_LABELS: Record<string, string> = {
+  en: "English (Kokoro)",
+  es: "Spanish (Kokoro)",
+  fr: "French (Kokoro)",
+  hi: "Hindi (Kokoro ANE)",
+  it: "Italian (Kokoro)",
+  ja: "Japanese (Kokoro ANE)",
+  pt: "Portuguese (Kokoro)",
+  zh: "Chinese (Kokoro ANE)",
+  ru: "Russian (Vosk-TTS)",
+};
+
+/** Signature of the interactive TTS-language picker (injectable for tests). */
+export type TtsLangPrompt = (preselect: string[]) => Promise<string[]>;
+
+async function promptTtsLangs(preselect: string[]): Promise<string[]> {
+  const caps = await getEngineCapabilities();
+  const supported = caps?.tts?.languages.map((l) => l.code) ?? TTS_LANG_FALLBACK;
+  const selected = await multiselect({
+    message:
+      "Select TTS languages to install (space to toggle, enter to confirm; none = skip TTS):",
+    options: supported.map((code) => ({ value: code, label: TTS_LANG_LABELS[code] ?? code })),
+    initialValues: preselect.filter((l) => supported.includes(l)),
+    required: false,
+  });
+  if (isCancel(selected)) return [];
+  return selected as string[];
+}
 
 export interface InitCommandArgs {
   coreml: boolean;
@@ -21,7 +57,7 @@ export interface InitCommandArgs {
 export interface InitSelection {
   noCache: boolean;
   backend?: string;
-  tts: boolean;
+  ttsLangs: string[];
   vad: boolean;
   diarize: boolean;
 }
@@ -45,7 +81,7 @@ export function resolveInitSelection(
   return {
     noCache,
     backend,
-    tts: args.tts,
+    ttsLangs: args.tts ? ["en"] : [],
     vad: args.vad,
     diarize: args.diarize,
   };
@@ -58,7 +94,7 @@ export function initInstallArgs(selection: InitSelection): string[] {
     selection.noCache ? "--no-cache" : "",
     selection.backend === "coreml" ? "--coreml" : "",
     selection.backend === "onnx" ? "--onnx" : "",
-    selection.tts ? "--tts" : "",
+    ...(selection.ttsLangs.length > 0 ? ["--tts", ...selection.ttsLangs] : []),
     selection.vad ? "--vad" : "",
     selection.diarize ? "--diarize" : "",
   ].filter(Boolean);
@@ -70,12 +106,12 @@ export function initSuggestionCommands(
 ): string[][] {
   const variants: InitSelection[] = [
     selection,
-    { ...selection, tts: false, vad: true, diarize: false },
-    { ...selection, tts: true, vad: true, diarize: false },
+    { ...selection, ttsLangs: [], vad: true, diarize: false },
+    { ...selection, ttsLangs: ["en"], vad: true, diarize: false },
   ];
 
   if (canDiarize) {
-    variants.push({ ...selection, tts: false, vad: true, diarize: true });
+    variants.push({ ...selection, ttsLangs: [], vad: true, diarize: true });
   }
 
   const seen = new Set<string>();
@@ -118,8 +154,9 @@ export async function promptInitSelection(
   backend = resolveBackendFlag(args.coreml, args.onnx),
   canDiarize = canInstallDiarizeOnPlatform(),
   noCache = resolveNoCacheFlag(args),
+  promptTts: TtsLangPrompt = promptTtsLangs,
 ): Promise<InitSelection> {
-  const tts = await askYesNo(prompt, "Install text-to-speech models for `kesha say`?", args.tts);
+  const ttsLangs = await promptTts(args.tts ? ["en"] : []);
   const vad = await askYesNo(prompt, "Install VAD for long or silence-heavy audio?", args.vad);
   let diarize = false;
   if (canDiarize) {
@@ -131,7 +168,7 @@ export async function promptInitSelection(
   return {
     noCache,
     backend,
-    tts,
+    ttsLangs,
     vad,
     diarize,
   };
@@ -153,7 +190,8 @@ async function printPlan(selection: InitSelection): Promise<void> {
     await renderInstallPlan({
       noCache: selection.noCache,
       backend: selection.backend,
-      tts: selection.tts,
+      tts: selection.ttsLangs.length > 0,
+      ttsLangs: selection.ttsLangs,
       vad: selection.vad,
       diarize: selection.diarize,
     }),
@@ -240,7 +278,7 @@ export const initCommand = defineCommand({
       await performInstall(
         installSelection.noCache,
         installSelection.backend,
-        installSelection.tts,
+        installSelection.ttsLangs,
         installSelection.vad,
         installSelection.diarize,
       );
@@ -265,7 +303,13 @@ export const initCommand = defineCommand({
         log.info(`Skipped install. Run later: ${initInstallArgs(prompted).join(" ")}`);
         return;
       }
-      await performInstall(prompted.noCache, prompted.backend, prompted.tts, prompted.vad, prompted.diarize);
+      await performInstall(
+        prompted.noCache,
+        prompted.backend,
+        prompted.ttsLangs,
+        prompted.vad,
+        prompted.diarize,
+      );
     } finally {
       rl.close();
     }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -215,7 +215,7 @@ export const installCommand = defineCommand({
     const backend = resolveBackendFlag(args.coreml, args.onnx);
     const positionals = (args._ ?? []).map(String);
     const caps = await getEngineCapabilities();
-    const supported = caps?.tts?.languages.map((l) => l.code) ?? undefined;
+    const supported = caps?.tts?.languages.map((l) => l.code);
     let ttsLangs: string[];
     try {
       ttsLangs = resolveTtsLangs({ tts: args.tts === true, positionals }, supported);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -123,9 +123,8 @@ export async function performInstall(
   diarize = false,
   plan = false,
 ) {
-  const tts = ttsLangs.length > 0;
   if (plan) {
-    log.info(await renderInstallPlan({ noCache, backend, tts, ttsLangs, vad, diarize }));
+    log.info(await renderInstallPlan({ noCache, backend, ttsLangs, vad, diarize }));
     return;
   }
 
@@ -138,7 +137,7 @@ export async function performInstall(
       command: "install",
       backend: backend ?? "auto",
       noCache,
-      tts,
+      tts: ttsLangs.length > 0,
       vad,
       diarize,
     });

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "citty";
 import { downloadEngine } from "../engine-install";
-import { getEngineBinPath } from "../engine";
+import { getEngineBinPath, getEngineCapabilities } from "../engine";
 import { renderInstallPlan } from "../install-plan";
 import { maybeAskForStar } from "../star";
 import { log } from "../log";
@@ -8,6 +8,8 @@ import { packageVersion } from "../package-info";
 import { createDiagnosticLogSession, type DiagnosticLogSession } from "../diagnostic-log";
 
 export interface InstallCommandArgs {
+  /** Positional args after `install` — candidate TTS language codes. */
+  _?: string[];
   coreml: boolean;
   onnx: boolean;
   "no-cache": boolean;
@@ -17,6 +19,50 @@ export interface InstallCommandArgs {
   vad: boolean;
   diarize: boolean;
   plan: boolean;
+}
+
+/**
+ * TTS languages installable on EVERY build, used when the engine binary isn't
+ * installed yet (capabilities unavailable). hi/ja/zh are darwin-arm64-only and
+ * can't be assumed without capabilities, so they're excluded here.
+ */
+export const TTS_LANG_FALLBACK = ["en", "es", "fr", "it", "pt", "ru"];
+
+export interface TtsArgInput {
+  /** Whether --tts was passed. */
+  tts: boolean;
+  /** Positional args after the install command (candidate language codes). */
+  positionals: string[];
+}
+
+/**
+ * Resolve the requested TTS language list. Bare `--tts` defaults to English.
+ * Positionals without `--tts` are an error. When `supported` is provided,
+ * unsupported codes are a hard error (nothing downloads); when it's undefined
+ * (engine not yet installed, capabilities unavailable) the check is skipped and
+ * the engine validates authoritatively at download time.
+ */
+export function resolveTtsLangs(input: TtsArgInput, supported: string[] | undefined): string[] {
+  if (!input.tts) {
+    if (input.positionals.length > 0) {
+      throw new Error(
+        `Language codes (${input.positionals.join(", ")}) require the --tts flag, ` +
+          `e.g. \`kesha install --tts ${input.positionals.join(" ")}\`.`,
+      );
+    }
+    return [];
+  }
+  const langs = input.positionals.length > 0 ? input.positionals : ["en"];
+  if (supported) {
+    const bad = langs.filter((l) => !supported.includes(l));
+    if (bad.length > 0) {
+      throw new Error(
+        `Unsupported TTS language(s): ${bad.join(", ")}. ` +
+          `Supported on this platform: ${supported.join(", ")}.`,
+      );
+    }
+  }
+  return langs;
 }
 
 export function resolveNoCacheFlag(
@@ -71,14 +117,15 @@ function finishInstallDiagnostic(
 
 export async function performInstall(
   noCache: boolean,
-  backend?: string,
-  tts = false,
+  backend: string | undefined,
+  ttsLangs: string[],
   vad = false,
   diarize = false,
   plan = false,
 ) {
+  const tts = ttsLangs.length > 0;
   if (plan) {
-    log.info(await renderInstallPlan({ noCache, backend, tts, vad, diarize }));
+    log.info(await renderInstallPlan({ noCache, backend, tts, ttsLangs, vad, diarize }));
     return;
   }
 
@@ -111,7 +158,7 @@ export async function performInstall(
           `the release engine uses "${platformBackend}".`,
       );
     }
-    await downloadEngine(noCache, backend, { tts, vad, diarize });
+    await downloadEngine(noCache, backend, { ttsLangs, vad, diarize });
     await maybeAskForStar(getEngineBinPath(), packageVersion, log);
     finishInstallDiagnostic(diagnosticLog, startedAt, "success");
   } catch (err: unknown) {
@@ -166,6 +213,23 @@ export const installCommand = defineCommand({
   },
   async run({ args, rawArgs }: { args: InstallCommandArgs; rawArgs: string[] }) {
     const backend = resolveBackendFlag(args.coreml, args.onnx);
-    await performInstall(resolveNoCacheFlag(args, rawArgs), backend, args.tts, args.vad, args.diarize, args.plan);
+    const positionals = (args._ ?? []).map(String);
+    const caps = await getEngineCapabilities();
+    const supported = caps?.tts?.languages.map((l) => l.code) ?? undefined;
+    let ttsLangs: string[];
+    try {
+      ttsLangs = resolveTtsLangs({ tts: args.tts === true, positionals }, supported);
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    await performInstall(
+      resolveNoCacheFlag(args, rawArgs),
+      backend,
+      ttsLangs,
+      args.vad,
+      args.diarize,
+      args.plan,
+    );
   },
 });

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -325,9 +325,25 @@ async function warmDarwinKokoro(binPath: string): Promise<void> {
   }
 }
 
+/** Build the `kesha-engine install` argv from options. Exported for testing. */
+export function buildEngineInstallArgs(opts: {
+  noCache: boolean;
+  ttsLangs?: string[];
+  vad?: boolean;
+  diarize?: boolean;
+}): string[] {
+  return [
+    "install",
+    ...(opts.noCache ? ["--no-cache"] : []),
+    ...(opts.ttsLangs && opts.ttsLangs.length > 0 ? ["--tts", ...opts.ttsLangs] : []),
+    ...(opts.vad ? ["--vad"] : []),
+    ...(opts.diarize ? ["--diarize"] : []),
+  ];
+}
+
 export interface InstallOptions {
-  /** Also install Kokoro + Vosk-TTS models. */
-  tts?: boolean;
+  /** TTS languages to install (empty/undefined = no TTS). */
+  ttsLangs?: string[];
   /** Also install Silero VAD model for long-audio preprocessing. */
   vad?: boolean;
   /** Also install the Sortformer streaming-diarization model (~245MB,
@@ -498,13 +514,12 @@ export async function downloadEngine(
   }
 
   log.progress("Installing models...");
-  const installArgs = [
-    "install",
-    ...(noCache ? ["--no-cache"] : []),
-    ...(options.tts ? ["--tts"] : []),
-    ...(options.vad ? ["--vad"] : []),
-    ...(options.diarize ? ["--diarize"] : []),
-  ];
+  const installArgs = buildEngineInstallArgs({
+    noCache,
+    ttsLangs: options.ttsLangs,
+    vad: options.vad,
+    diarize: options.diarize,
+  });
   const proc = Bun.spawnSync([binPath, ...installArgs], {
     stdout: "pipe",
     stderr: "pipe",
@@ -520,7 +535,11 @@ export async function downloadEngine(
     throw new Error(detail ? `Failed to install models: ${detail}` : "Failed to install models");
   }
 
-  if (options.tts) {
+  // Warm the FluidAudio Kokoro CoreML cache only when a Kokoro language is
+  // requested. Russian (`ru`) routes through Vosk-TTS, not Kokoro, so a
+  // Russian-only install has nothing to warm.
+  const wantsKokoro = (options.ttsLangs ?? []).some((l) => l !== "ru");
+  if (wantsKokoro) {
     await warmDarwinKokoro(binPath);
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -340,10 +340,16 @@ export async function detectTextLanguageEngine(
   return parseLangResult(stdout);
 }
 
+export interface TtsLanguageCapability {
+  code: string;
+  engines: string[];
+}
+
 export interface EngineCapabilities {
   protocolVersion: number;
   backend: string;
   features: string[];
+  tts?: { languages: TtsLanguageCapability[] };
 }
 
 let cachedEngineCapabilities:

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -14,6 +14,8 @@ export interface InstallPlanOptions {
   noCache?: boolean;
   backend?: string;
   tts?: boolean;
+  /** Resolved TTS language codes (consumed by per-language plan in #517 Task 10). */
+  ttsLangs?: string[];
   vad?: boolean;
   diarize?: boolean;
 }

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -13,8 +13,7 @@ import {
 export interface InstallPlanOptions {
   noCache?: boolean;
   backend?: string;
-  tts?: boolean;
-  /** Resolved TTS language codes (consumed by per-language plan in #517 Task 10). */
+  /** Resolved TTS language codes, e.g. ["en", "ru"]. */
   ttsLangs?: string[];
   vad?: boolean;
   diarize?: boolean;
@@ -72,17 +71,29 @@ const G2P_CHARSIU_FILES: PlanFile[] = [
   { relPath: "models/g2p/byt5-tiny/decoder_with_past_model.onnx", sizeBytes: 5_427_260 },
 ];
 
-const KOKORO_FILES: PlanFile[] = [
-  { relPath: "models/kokoro-82m/model.onnx", sizeBytes: 325_532_387 },
-  { relPath: "models/kokoro-82m/voices/am_michael.bin", sizeBytes: 522_240 },
-  // Multilingual voice packs for es/fr/it/pt (#212).
-  // em_alex (es, male), ff_siwis (fr, female — only French voice in Kokoro v1.0),
-  // im_nicola (it, male), pm_alex (pt, male).
-  { relPath: "models/kokoro-82m/voices/em_alex.bin", sizeBytes: 522_240 },
-  { relPath: "models/kokoro-82m/voices/ff_siwis.bin", sizeBytes: 522_240 },
-  { relPath: "models/kokoro-82m/voices/im_nicola.bin", sizeBytes: 522_240 },
-  { relPath: "models/kokoro-82m/voices/pm_alex.bin", sizeBytes: 522_240 },
-];
+// Kokoro ONNX graph (shared by all Kokoro languages on non-darwin builds).
+const KOKORO_GRAPH_FILE: PlanFile = { relPath: "models/kokoro-82m/model.onnx", sizeBytes: 325_532_387 };
+
+// Per-language default voice files.
+// Multilingual voice packs for es/fr/it/pt (#212).
+// em_alex (es, male), ff_siwis (fr, female — only French voice in Kokoro v1.0),
+// im_nicola (it, male), pm_alex (pt, male).
+const KOKORO_VOICE_FILES: Record<string, PlanFile> = {
+  en: { relPath: "models/kokoro-82m/voices/am_michael.bin", sizeBytes: 522_240 },
+  es: { relPath: "models/kokoro-82m/voices/em_alex.bin", sizeBytes: 522_240 },
+  fr: { relPath: "models/kokoro-82m/voices/ff_siwis.bin", sizeBytes: 522_240 },
+  it: { relPath: "models/kokoro-82m/voices/im_nicola.bin", sizeBytes: 522_240 },
+  pt: { relPath: "models/kokoro-82m/voices/pm_alex.bin", sizeBytes: 522_240 },
+};
+
+function kokoroPlanFiles(langs: string[]): PlanFile[] {
+  const files: PlanFile[] = [KOKORO_GRAPH_FILE];
+  for (const l of langs) {
+    const v = KOKORO_VOICE_FILES[l];
+    if (v) files.push(v);
+  }
+  return files;
+}
 
 const VOSK_RU_FILES: PlanFile[] = [
   { relPath: "models/vosk-ru/model.onnx", sizeBytes: 179_314_533 },
@@ -242,53 +253,54 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     ),
   );
 
-  if (options.tts) {
+  const ttsLangs = options.ttsLangs ?? [];
+  const wantsKokoro = ttsLangs.some((l) => ["en", "es", "fr", "it", "pt"].includes(l));
+  const wantsG2p = ttsLangs.some((l) => ["es", "fr", "it", "pt"].includes(l));
+  const wantsRu = ttsLangs.includes("ru");
+
+  if (ttsLangs.length > 0) {
     if (isDarwinArm64()) {
-      components.push(
-        bundleComponent(
-          cacheRoot,
-          "TTS Vosk RU",
-          "model cache",
-          VOSK_RU_FILES,
-          noCache,
-          "Russian ru-vosk-* voices",
-        ),
-      );
-      warmups.push({
-        name: "TTS Kokoro EN",
-        note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoroCachePath()})`,
-      });
+      if (wantsKokoro) {
+        warmups.push({
+          name: "TTS Kokoro (ANE)",
+          note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoroCachePath()})`,
+        });
+      }
+      if (wantsRu) {
+        components.push(
+          bundleComponent(cacheRoot, "TTS Vosk RU", "model cache", VOSK_RU_FILES, noCache, "Russian ru-vosk-* voices"),
+        );
+      }
     } else {
-      components.push(
-        bundleComponent(
-          cacheRoot,
-          "TTS Kokoro EN/ES/FR/IT/PT",
-          "model cache",
-          KOKORO_FILES,
-          noCache,
-          "English en-* voices + multilingual es-*/fr-*/it-*/pt-* voices",
-        ),
-      );
-      components.push(
-        bundleComponent(
-          cacheRoot,
-          "G2P CharsiuG2P byt5-tiny",
-          "model cache",
-          G2P_CHARSIU_FILES,
-          noCache,
-          "multilingual grapheme-to-phoneme for es/fr/it/pt Kokoro voices (CC-BY 4.0)",
-        ),
-      );
-      components.push(
-        bundleComponent(
-          cacheRoot,
-          "TTS Vosk RU",
-          "model cache",
-          VOSK_RU_FILES,
-          noCache,
-          "Russian ru-vosk-* voices",
-        ),
-      );
+      if (wantsKokoro) {
+        components.push(
+          bundleComponent(
+            cacheRoot,
+            "TTS Kokoro graph + voices",
+            "model cache",
+            kokoroPlanFiles(ttsLangs),
+            noCache,
+            `voices for ${ttsLangs.filter((l) => l !== "ru").join(", ")}`,
+          ),
+        );
+      }
+      if (wantsG2p) {
+        components.push(
+          bundleComponent(
+            cacheRoot,
+            "G2P CharsiuG2P byt5-tiny",
+            "model cache",
+            G2P_CHARSIU_FILES,
+            noCache,
+            "multilingual G2P for es/fr/it/pt (CC-BY 4.0)",
+          ),
+        );
+      }
+      if (wantsRu) {
+        components.push(
+          bundleComponent(cacheRoot, "TTS Vosk RU", "model cache", VOSK_RU_FILES, noCache, "Russian ru-vosk-* voices"),
+        );
+      }
     }
   }
 
@@ -372,7 +384,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     "  - install warms the ASR backend after downloads; CoreML warm-up is typically 20-30 s, ONNX warm-up is about 500 ms.",
   );
 
-  if (options.tts && isDarwinArm64()) {
+  if (ttsLangs.length > 0 && wantsKokoro && isDarwinArm64()) {
     lines.push(
       "  - --tts also warms FluidAudio Kokoro CoreML; FluidAudio may download/compile its own Kokoro cache on first use.",
     );
@@ -384,7 +396,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     options.noCache ? "--no-cache" : "",
     options.backend === "coreml" ? "--coreml" : "",
     options.backend === "onnx" ? "--onnx" : "",
-    options.tts ? "--tts" : "",
+    ...(ttsLangs.length > 0 ? ["--tts", ...ttsLangs] : []),
     options.vad ? "--vad" : "",
     options.diarize ? "--diarize" : "",
   ].filter(Boolean);

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -254,13 +254,18 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
   );
 
   const ttsLangs = options.ttsLangs ?? [];
-  const wantsKokoro = ttsLangs.some((l) => ["en", "es", "fr", "it", "pt"].includes(l));
+  // Darwin ANE serves every non-ru language through Kokoro (en/es/fr/it/pt + the
+  // ANE-only hi/ja/zh), so the warm-up gate mirrors engine-install.ts's
+  // `some((l) => l !== "ru")`. The ONNX component, by contrast, only covers the
+  // graph-backed en/es/fr/it/pt set (hi/ja/zh are darwin-only and rejected on ONNX).
+  const wantsAnyKokoro = ttsLangs.some((l) => l !== "ru");
+  const wantsOnnxKokoro = ttsLangs.some((l) => ["en", "es", "fr", "it", "pt"].includes(l));
   const wantsG2p = ttsLangs.some((l) => ["es", "fr", "it", "pt"].includes(l));
   const wantsRu = ttsLangs.includes("ru");
 
   if (ttsLangs.length > 0) {
     if (isDarwinArm64()) {
-      if (wantsKokoro) {
+      if (wantsAnyKokoro) {
         warmups.push({
           name: "TTS Kokoro (ANE)",
           note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoroCachePath()})`,
@@ -272,7 +277,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
         );
       }
     } else {
-      if (wantsKokoro) {
+      if (wantsOnnxKokoro) {
         components.push(
           bundleComponent(
             cacheRoot,
@@ -384,7 +389,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     "  - install warms the ASR backend after downloads; CoreML warm-up is typically 20-30 s, ONNX warm-up is about 500 ms.",
   );
 
-  if (ttsLangs.length > 0 && wantsKokoro && isDarwinArm64()) {
+  if (ttsLangs.length > 0 && wantsAnyKokoro && isDarwinArm64()) {
     lines.push(
       "  - --tts also warms FluidAudio Kokoro CoreML; FluidAudio may download/compile its own Kokoro cache on first use.",
     );

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -29,9 +29,13 @@ export type {
   TranscribeResult,
 } from "./types";
 
-/** Install Kokoro (EN) + Vosk-TTS (RU) models. Shorthand for the default TTS set. */
-export async function downloadTts(noCache = false): Promise<void> {
-  await downloadEngine(noCache, undefined, { ttsLangs: ["en", "ru"] });
+/**
+ * Install TTS models for the given languages (default: English only, matching
+ * `kesha install --tts`). Pass e.g. `["en", "ru"]` for more. Unsupported-on-platform
+ * codes are rejected by the engine.
+ */
+export async function downloadTts(noCache = false, langs: string[] = ["en"]): Promise<void> {
+  await downloadEngine(noCache, undefined, { ttsLangs: langs });
 }
 
 /** @deprecated Use `downloadModel` instead. */

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -29,9 +29,9 @@ export type {
   TranscribeResult,
 } from "./types";
 
-/** Install Kokoro TTS models. Shorthand for `downloadModel({ tts: true })`. */
+/** Install Kokoro (EN) + Vosk-TTS (RU) models. Shorthand for the default TTS set. */
 export async function downloadTts(noCache = false): Promise<void> {
-  await downloadEngine(noCache, undefined, { tts: true });
+  await downloadEngine(noCache, undefined, { ttsLangs: ["en", "ru"] });
 }
 
 /** @deprecated Use `downloadModel` instead. */

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -782,7 +782,7 @@ describe("CLI contracts", () => {
       stdoutContains: [
         "Kesha install plan",
         "Expected Kesha-managed network for this run:",
-        "Run: kesha install --tts",
+        "Run: kesha install --tts en",
       ],
       stderrNotContains: ["fake engine should not have been invoked"],
     });
@@ -793,7 +793,7 @@ describe("CLI contracts", () => {
         "Kesha init",
         "Nothing downloads until you confirm",
         "Kesha install plan",
-        "Run: kesha install --tts --vad",
+        "Run: kesha install --tts en --vad",
       ],
       stderrNotContains: ["fake engine should not have been invoked"],
     });

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -210,7 +210,7 @@ describe("e2e-cli", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("kesha install --no-cache --coreml");
     expect(stdout).toContain("kesha install --no-cache --coreml --vad");
-    expect(stdout).toContain("kesha install --no-cache --coreml --tts --vad");
+    expect(stdout).toContain("kesha install --no-cache --coreml --tts en --vad");
     expect(stderr).not.toContain("fake engine should not have been invoked");
   });
 

--- a/tests/integration/e2e-cli.test.ts
+++ b/tests/integration/e2e-cli.test.ts
@@ -169,7 +169,7 @@ describe("e2e-cli", () => {
     expect(stdout).toContain("Kesha init");
     expect(stdout).toContain("Text-to-speech");
     expect(stdout).toContain("Kesha install plan");
-    expect(stdout).toContain("Run: kesha install --tts --vad");
+    expect(stdout).toContain("Run: kesha install --tts en --vad");
     expect(stderr).not.toContain("fake engine should not have been invoked");
   });
 

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import {
+  buildEngineInstallArgs,
   cleanupRetiredSidecars,
   getVersionMarkerPath,
   readInstalledEngineVersion,
@@ -62,6 +63,17 @@ describe("engine-install version marker (#151)", () => {
     writeInstalledEngineVersion(binPath, "1.2.0");
     expect(readInstalledEngineVersion(binPath)).toBe("1.2.0");
     rmSync(binPath + ".version");
+  });
+});
+
+describe("buildEngineInstallArgs (#517)", () => {
+  test("tts languages become positional args after --tts", () => {
+    expect(buildEngineInstallArgs({ noCache: false, ttsLangs: ["en", "ru"] }))
+      .toEqual(["install", "--tts", "en", "ru"]);
+  });
+  test("no tts langs omits --tts", () => {
+    expect(buildEngineInstallArgs({ noCache: true, ttsLangs: [] }))
+      .toEqual(["install", "--no-cache"]);
   });
 });
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -11,6 +11,7 @@ import {
   transcribeEngine,
   transcribeEngineWithSegments,
 } from "../../src/engine";
+import type { EngineCapabilities } from "../../src/engine";
 
 function fakeEngine(features: string[]): string {
   const dir = mkdtempSync(join(tmpdir(), "kesha-engine-test-"));
@@ -250,5 +251,14 @@ describe("spawnStdioWithDebugFd", () => {
     // padding array. Legitimate users never have an fd this high.
     process.env.KESHA_DEBUG_FD = "1000000";
     expect(spawnStdioWithDebugFd(["ignore", "pipe", "pipe"])).toEqual(["ignore", "pipe", "pipe"]);
+  });
+});
+
+describe("EngineCapabilities tts field", () => {
+  test("typed tts.languages round-trips from JSON", () => {
+    const json = `{"protocolVersion":3,"backend":"onnx","features":["tts"],"tts":{"languages":[{"code":"en","engines":["kokoro"]},{"code":"ru","engines":["vosk"]}]}}`;
+    const caps = JSON.parse(json) as EngineCapabilities;
+    expect(caps.tts?.languages.map((l) => l.code)).toEqual(["en", "ru"]);
+    expect(caps.tts?.languages[0].engines).toEqual(["kokoro"]);
   });
 });

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -32,7 +32,7 @@ describe("init onboarding", () => {
     expect(selection).toEqual({
       noCache: false,
       backend: undefined,
-      tts: false,
+      ttsLangs: [],
       vad: false,
       diarize: false,
     });
@@ -50,13 +50,27 @@ describe("init onboarding", () => {
       "--no-cache",
       "--coreml",
       "--tts",
+      "en",
       "--vad",
       "--diarize",
     ]);
   });
 
+  test("multiple tts languages emit positional codes after --tts", () => {
+    expect(
+      initInstallArgs({
+        noCache: false,
+        backend: undefined,
+        ttsLangs: ["en", "ru"],
+        vad: false,
+        diarize: false,
+      }),
+    ).toEqual(["kesha", "install", "--tts", "en", "ru"]);
+  });
+
   test("interactive selection drops unsupported diarize preselection before confirmation", async () => {
     const prompts: string[] = [];
+    const ttsPreselects: string[][] = [];
     const savedError = console.error;
     console.error = () => {};
     try {
@@ -70,12 +84,44 @@ describe("init onboarding", () => {
         },
         undefined,
         false,
+        false,
+        async (preselect) => {
+          ttsPreselects.push(preselect);
+          return [];
+        },
       );
 
       expect(selection.diarize).toBe(false);
+      expect(selection.ttsLangs).toEqual([]);
       expect(initInstallArgs(selection)).toEqual(["kesha", "install"]);
-      expect(prompts).toHaveLength(2);
+      // TTS is now a multiselect handled outside the yes/no PromptApi, so only
+      // the VAD question flows through `question` (diarize skipped off darwin).
+      expect(prompts).toHaveLength(1);
       expect(prompts.join("\n")).not.toContain("diarization");
+      expect(ttsPreselects).toEqual([[]]);
+    } finally {
+      console.error = savedError;
+    }
+  });
+
+  test("interactive TTS multiselect result flows into the selection", async () => {
+    const savedError = console.error;
+    console.error = () => {};
+    try {
+      const selection = await promptInitSelection(
+        initArgs({ tts: true }),
+        {
+          async question() {
+            return "";
+          },
+        },
+        undefined,
+        false,
+        false,
+        async () => ["en", "ru"],
+      );
+      expect(selection.ttsLangs).toEqual(["en", "ru"]);
+      expect(initInstallArgs(selection)).toEqual(["kesha", "install", "--tts", "en", "ru"]);
     } finally {
       console.error = savedError;
     }
@@ -83,13 +129,13 @@ describe("init onboarding", () => {
 
   test("non-interactive suggestions preserve backend and cache flags", () => {
     const commands = initSuggestionCommands(
-      { noCache: true, backend: "coreml", tts: false, vad: false, diarize: false },
+      { noCache: true, backend: "coreml", ttsLangs: [], vad: false, diarize: false },
       true,
     ).map((command) => command.join(" "));
 
     expect(commands).toContain("kesha install --no-cache --coreml");
     expect(commands).toContain("kesha install --no-cache --coreml --vad");
-    expect(commands).toContain("kesha install --no-cache --coreml --tts --vad");
+    expect(commands).toContain("kesha install --no-cache --coreml --tts en --vad");
     expect(commands).toContain("kesha install --no-cache --coreml --vad --diarize");
   });
 
@@ -97,7 +143,7 @@ describe("init onboarding", () => {
     const selection = {
       noCache: true,
       backend: "onnx",
-      tts: true,
+      ttsLangs: ["en"],
       vad: true,
       diarize: true,
     };
@@ -105,7 +151,7 @@ describe("init onboarding", () => {
     expect(omitUnsupportedDiarize(selection, false)).toEqual({
       noCache: true,
       backend: "onnx",
-      tts: true,
+      ttsLangs: ["en"],
       vad: true,
       diarize: false,
     });
@@ -115,6 +161,7 @@ describe("init onboarding", () => {
       "--no-cache",
       "--onnx",
       "--tts",
+      "en",
       "--vad",
     ]);
   });

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -27,7 +27,7 @@ describe("renderInstallPlan", () => {
       process.env.KESHA_CACHE_DIR = join(dir, "cache");
       process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
 
-      const output = await renderInstallPlan({ tts: true });
+      const output = await renderInstallPlan({ ttsLangs: ["en", "ru"] });
 
       expect(output).toContain("Kesha install plan");
       expect(output).toContain("ASR Parakeet TDT v3");
@@ -36,13 +36,13 @@ describe("renderInstallPlan", () => {
       expect(output).toContain("Cold-cache Kesha-managed download:");
       expect(output).toContain("Expected Kesha-managed network for this run:");
       expect(output).toContain("No files are downloaded or changed by --plan.");
-      expect(output).toContain("Run: kesha install --tts");
+      expect(output).toContain("Run: kesha install --tts en ru");
       if (process.platform === "darwin" && process.arch === "arm64") {
         expect(output).toContain("Warm-ups:");
-        expect(output).toContain("TTS Kokoro EN: FluidAudio CoreML in-engine");
+        expect(output).toContain("TTS Kokoro (ANE): FluidAudio CoreML in-engine");
         expect(output).toContain(".cache/fluidaudio/Models/kokoro");
         expect(output).toContain("outside Kesha's pinned model cache");
-        expect(output).not.toContain("TTS Kokoro EN: 0 B");
+        expect(output).not.toContain("TTS Kokoro (ANE): 0 B");
       }
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -77,15 +77,47 @@ describe("renderInstallPlan", () => {
       process.env.KESHA_CACHE_DIR = join(dir, "cache");
       process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
 
-      const output = await renderInstallPlan({ tts: true });
+      const output = await renderInstallPlan({ ttsLangs: ["en", "es", "fr", "it", "pt"] });
 
       // G2P CharsiuG2P component present in plan
       expect(output).toContain("G2P CharsiuG2P byt5-tiny");
-      expect(output).toContain("multilingual grapheme-to-phoneme for es/fr/it/pt");
+      expect(output).toContain("multilingual G2P for es/fr/it/pt");
 
       // Kokoro component covers multilingual voices
-      expect(output).toContain("TTS Kokoro EN/ES/FR/IT/PT");
-      expect(output).toContain("multilingual es-*/fr-*/it-*/pt-*");
+      expect(output).toContain("TTS Kokoro graph + voices");
+      expect(output).toContain("voices for en, es, fr, it, pt");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("plan with --tts en omits Vosk RU", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-install-plan-tts-en-test-"));
+    try {
+      process.env.HOME = dir;
+      process.env.KESHA_CACHE_DIR = join(dir, "cache");
+      process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+
+      const out = await renderInstallPlan({ ttsLangs: ["en"] });
+      expect(out).toContain("Kokoro");
+      expect(out).not.toContain("Vosk RU");
+      expect(out).toContain("--tts en");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("plan with --tts ru omits Kokoro graph component", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-install-plan-tts-ru-test-"));
+    try {
+      process.env.HOME = dir;
+      process.env.KESHA_CACHE_DIR = join(dir, "cache");
+      process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+
+      const out = await renderInstallPlan({ ttsLangs: ["ru"] });
+      expect(out).toContain("Vosk RU");
+      expect(out).not.toContain("Kokoro");
+      expect(out).toContain("--tts ru");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTtsLangs } from "../../src/cli/install";
+
+const caps = ["en", "es", "fr", "it", "pt", "ru"];
+
+describe("resolveTtsLangs", () => {
+  test("bare --tts defaults to en", () => {
+    expect(resolveTtsLangs({ tts: true, positionals: [] }, caps)).toEqual(["en"]);
+  });
+  test("explicit languages pass through", () => {
+    expect(resolveTtsLangs({ tts: true, positionals: ["en", "ru"] }, caps)).toEqual(["en", "ru"]);
+  });
+  test("no --tts with positionals -> error", () => {
+    expect(() => resolveTtsLangs({ tts: false, positionals: ["en"] }, caps)).toThrow(/require .*--tts/i);
+  });
+  test("unsupported language is a hard error naming the code", () => {
+    expect(() => resolveTtsLangs({ tts: true, positionals: ["ja"] }, caps)).toThrow(/ja/);
+  });
+  test("tts disabled and no positionals -> empty", () => {
+    expect(resolveTtsLangs({ tts: false, positionals: [] }, caps)).toEqual([]);
+  });
+  test("undefined supported set skips the unsupported check (engine validates)", () => {
+    expect(resolveTtsLangs({ tts: true, positionals: ["ja"] }, undefined)).toEqual(["ja"]);
+  });
+});


### PR DESCRIPTION
Closes #517

Installs only the TTS models the requested languages need, instead of always pulling the full ~990 MB — modelled on `npx playwright install`.

## Behaviour
- `kesha install --tts en ru` — positional, Playwright-style.
- Bare `kesha install --tts` → **English only** (~326 MB). Omitting `--tts` → no TTS.
- Requesting a language unavailable on the platform → **hard error, nothing downloaded** (validated in TS against `--capabilities-json` and authoritatively in the engine).
- Re-running is **additive** (downloads only missing packs; never prunes — `download_verified` already short-circuits cached, hash-matching files).
- `kesha init` presents a **multi-select** of available TTS languages (English pre-checked; empty = skip TTS; Ctrl-C aborts init) via `@clack/prompts`.
- `macos-*` AVSpeech is **excluded** from install (ambient on macOS) — `kesha install --tts ru` on mac still downloads Vosk; Milena stays usable via `--voice macos-…`.
- Public `./core` `downloadTts(noCache?, langs = ["en"])` now takes a language list, defaulting to English (documented behaviour change — previously installed the full set).

## Platform availability
`en es fr it pt ru` on every build; `hi ja zh` darwin-arm64-only (FluidAudio ANE). On the ONNX path the shared Kokoro graph (~326 MB) downloads once for any of en/es/fr/it/pt, CharsiuG2P (~30 MB) only for es/fr/it/pt, Vosk (~937 MB) for ru.

## Design
Many-to-many language↔engine data model now (capabilities expose `{code, engines[]}` rows; `protocolVersion` 2→3); the `--tts <lang>:<engine>` override syntax is **deferred** until a language actually has two downloadable models. The Rust engine is the single source of truth, validated via `--capabilities-json` — no hardcoded parallel table in TS.

Spec: `docs/superpowers/specs/2026-06-01-tts-install-languages-design.md`
Plan: `docs/superpowers/plans/2026-06-01-tts-install-languages.md`

## Verification
- `bun test` (379 pass) + `bunx tsc --noEmit` clean.
- `cargo fmt` + `cargo clippy --all-targets --features tts -- -D warnings` clean; `cargo nextest run --features tts` (341 pass); `cargo check --features coreml --no-default-features` clean.
- No `rust/src/tts/**` synthesis code changed (download/install path only), so audio output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)