### PR TITLE
chore(deps): refresh Rust dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2308,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"


### PR DESCRIPTION
Closes #514

Monthly Rust dependency upkeep for 2026-06.

`cd rust && cargo update` produced a single transitive bump:
- **unicode-segmentation 1.13.2 → 1.13.3** — patch release, pure-Rust grapheme/word segmentation. No major, security-sensitive, native, or backend/platform crate changes.

## Checklist
- [x] Branch from current `main`
- [x] `cargo update`
- [x] Reviewed `Cargo.lock` diff — one patch bump, no risky transitive changes
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --features tts` — 341 passed
- [x] Backend/platform crates unchanged → `coreml` check not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)