### PR TITLE
chore(dx): .editorconfig, PR template, test:watch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig — consistent formatting across editors for this polyglot tree.
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Rust uses 4-space indentation (rustfmt default).
+[*.rs]
+indent_size = 4
+
+# Makefiles require real tabs.
+[Makefile]
+indent_style = tab
+
+# Markdown: keep trailing whitespace (it can be a hard line break).
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!-- Thanks for contributing! Keep this short — delete sections that don't apply. -->
+
+## What
+
+<!-- What does this PR change? -->
+
+## Why
+
+<!-- Motivation / linked issue. Use "Closes #123" to auto-close. -->
+
+Closes #
+
+## Testing
+
+<!-- How did you verify this? Commands run, manual checks, new tests. -->
+
+## Checklist
+
+- [ ] `bun run check` passes (lint + version drift + fast tests)
+- [ ] Tests added/updated for the change
+- [ ] Rust changes: `cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings`
+- [ ] Docs/CHANGELOG updated if user-facing
+
+<!-- See CONTRIBUTING.md for the full workflow and release process. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,6 @@
 
 <!-- Motivation / linked issue. Use "Closes #123" to auto-close. -->
 
-Closes #
-
 ## Testing
 
 <!-- How did you verify this? Commands run, manual checks, new tests. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,12 @@ kesha-voice-kit/
 - `audio-quality-check` agent runs after every commit touching
   `rust/src/tts/**` (see `.claude/agents/audio-quality-check.md`).
 
+Handy loops:
+
+- `bun run test:watch` — re-run tests on save during development.
+- `bun test -t "<pattern>"` — run only tests whose name matches `<pattern>`
+  (e.g. `bun test -t "say"`).
+
 ## CI workflows
 
 - `ci.yml` — runs on PRs: `changes` filter → unit-tests (3 OSes) +

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "scripts": {
     "test": "bun test",
+    "test:watch": "bun test --watch",
     "test:unit": "bun test tests/unit/",
     "test:cli-fast": "bun test tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts tests/integration/say.test.ts",
     "test:integration": "bun test tests/integration/",


### PR DESCRIPTION
## What

Three small developer-experience additions (Pareto polish set):

- **`.editorconfig`** — cross-editor formatting consistency for the polyglot tree (2-space TS/shell, 4-space Rust, tabs for `Makefile`, preserve trailing whitespace in Markdown).
- **`.github/pull_request_template.md`** — structured What / Why / Testing / Checklist so PRs open pre-filled.
- **`test:watch`** script (`bun test --watch`) + a CONTRIBUTING note documenting `bun test -t "<pattern>"` for single-test filtering.

## Why

Closes #528, #529, #530. Each is a low-effort, high-leverage smoothing of contributor onboarding identified during a UX/DX audit.

## Testing

- `package.json` validated as JSON; `test:watch` present.
- Config/docs only — no code paths touched, no behavior change.

## Checklist

- [x] No source/behavior changes (config + docs)
- [x] `package.json` valid

Closes #528
Closes #529
Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)