### PR TITLE
ci: run rust-test + security on every PR (unblock unrelated PRs)

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,13 +1,12 @@
 name: "🧪 Rust Tests"
 
 on:
+  # Run on EVERY PR (no top-level path filter). A path-filtered workflow is
+  # skipped on unrelated PRs, so its required status check never reports and
+  # permanently blocks the PR (e.g. a docs-only change). Instead a cheap
+  # `changes` job always runs and the expensive rust jobs gate on its output —
+  # skipped jobs report success, satisfying branch protection.
   pull_request:
-    paths:
-      - "rust/**"
-      - ".github/workflows/rust-test.yml"
-      - ".github/scripts/check-coverage.ts"
-      - "package.json"
-      - "bun.lock"
   push:
     branches: [main]
     paths:
@@ -18,8 +17,28 @@ permissions:
   contents: read
 
 jobs:
+  # Always runs (even on docs PRs) so the workflow concludes successfully and
+  # its required check reports; outputs gate the heavy rust jobs below.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'rust/**'
+              - '.github/workflows/rust-test.yml'
+              - '.github/scripts/check-coverage.ts'
+              - 'package.json'
+              - 'bun.lock'
+
   lint-ubuntu:
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -40,7 +59,8 @@ jobs:
         run: bash rust/ci/run-clippy.sh Linux
 
   test:
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     permissions:
       contents: read
       # Flakiness.io CLI authenticates via GitHub OIDC; scope the
@@ -184,7 +204,8 @@ jobs:
             --category rust --flakiness-project Laputa/kesha-voice-kit
 
   coverage:
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,12 @@
 name: "🛡️ Security Audit"
 
 on:
+  # Run on EVERY PR (no top-level path filter). A path-filtered workflow is
+  # skipped on unrelated PRs, so its required status checks never report and
+  # permanently block the PR. A cheap `changes` job always runs; the audit jobs
+  # gate on its output (skipped jobs report success, satisfying branch
+  # protection) so docs-only PRs aren't blocked.
   pull_request:
-    paths:
-      - "rust/Cargo.toml"
-      - "rust/Cargo.lock"
-      - "rust/deny.toml"
-      - "package.json"
-      - "bun.lock"
-      - ".github/workflows/security.yml"
   schedule:
     # Weekly advisory-DB re-check against unchanged deps (RUSTSEC/npm
     # advisories update independently of our code). Offset from the
@@ -24,7 +22,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Always runs so the required checks always report; outputs gate the audits.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            deps:
+              - 'rust/Cargo.toml'
+              - 'rust/Cargo.lock'
+              - 'rust/deny.toml'
+              - 'package.json'
+              - 'bun.lock'
+              - '.github/workflows/security.yml'
+
   cargo-deny:
+    needs: changes
+    # Run for scheduled/manual audits, or on PRs that touch dependencies. On a
+    # PR that doesn't, this skips → reports success → satisfies branch protection.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,6 +80,8 @@ jobs:
           exit 1
 
   bun-audit:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

A docs-only PR (#533) couldn't be merged except via **admin override**. Branch protection requires `🧪 Rust Tests` and `🛡️ Security Audit / cargo-deny|bun-audit`, but those workflows are **path-filtered at the workflow level** — on a PR that touches no `rust/` or dependency files they're skipped entirely, their required checks **never report**, and the PR is blocked forever.

The root cause is a GitHub asymmetry:

| Skip kind | Status | Blocks required check? |
|---|---|---|
| whole workflow via `on.…paths` | **pending** forever | **yes** |
| a job via `if:` | **success** | no |

## Fix

Adopt the exact pattern `ci.yml` already uses (which is why `🧪 CI` never had this problem):

- Drop the top-level `on.pull_request.paths` filter from `rust-test.yml` and `security.yml` so they run on every PR.
- Add an always-running **`changes`** job (`dorny/paths-filter@v4`).
- Gate the expensive jobs on its output:
  - rust: `lint-ubuntu` / `test` / `coverage` → `if: … && needs.changes.outputs.rust == 'true'`
  - security: `cargo-deny` / `bun-audit` → `if: github.event_name != 'pull_request' || needs.changes.outputs.deps == 'true'`

On an unrelated PR the heavy jobs **skip → report success**, and the cheap `changes` job keeps each workflow's run green, so the required checks report and the PR merges normally. rust/dependency PRs and the weekly scheduled audit behave exactly as before.

## Test Plan

- [x] `bun run check:workflows` passes; both files are valid YAML
- [x] This PR touches both workflow files, so the `changes` filters match → the **full** rust matrix + audits run here (end-to-end proof the gating lets real work through)
- [ ] A follow-up docs-only PR should now show `rust-test`/`security` jobs **skipped (success)** and be mergeable without admin

Once merged, no branch-protection settings change is needed — the same required contexts now always report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)