### PR TITLE
ci: add aggregator gate jobs as the single required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,3 +686,28 @@ jobs:
 
       - name: 🚬 Smoke
         run: ./result/bin/kesha-engine --version
+
+  # Aggregator gate = the single required status check for branch protection.
+  # Always runs so 🧪 CI reports on every PR; the path-gated jobs above skip on
+  # unrelated PRs (→ success). The step fails the gate only if a real job failed.
+  ci:
+    name: 🧪 CI
+    if: always()
+    needs:
+      - changes
+      - workflow-lint
+      - homebrew-formula
+      - unit-tests
+      - ts-coverage
+      - integration-tests
+      - integration-tests-full
+      - published-engine-smoke
+      - release-branch-engine-smoke
+      - tts-e2e
+      - raycast-lint
+      - nix-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -332,3 +332,16 @@ jobs:
         run: bash rust/ci/run-clippy.sh Linux
       - name: Tests
         run: cd rust && cargo nextest run --features tts
+
+  # Aggregator gate = the single required status check for branch protection.
+  # Always runs so the context reports on every PR (the heavy jobs above skip on
+  # non-rust PRs → success); the step fails the gate only if a real job failed.
+  rust-tests:
+    name: 🧪 Rust Tests
+    if: always()
+    needs: [changes, lint-ubuntu, test, coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -117,3 +117,16 @@ jobs:
         run: |
           echo "::warning::bun audit reported findings (non-blocking until promotion PR)"
           exit 1
+
+  # Aggregator gate = the single required status check for branch protection.
+  # Always runs so the context reports on every PR (the audits skip on PRs that
+  # don't touch dependencies → success); fails only if a real job failed.
+  security-audit:
+    name: 🛡️ Security Audit
+    if: always()
+    needs: [changes, cargo-deny, bun-audit]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## What

Adds an always-running **aggregator "gate" job** to each required workflow, whose job name is exactly the required branch-protection context:

- `ci.yml` → **🧪 CI**
- `rust-test.yml` → **🧪 Rust Tests**
- `security.yml` → **🛡️ Security Audit**

Each `needs` its workflow's real jobs with `if: always()`, and its single step runs **only** if a needed job `failure`/`cancelled` — so passing/skipped jobs leave the gate green.

## Why

Even after #535 made these workflows run on every PR, the branch-protection contexts `🧪 CI` and `🧪 Rust Tests` are **bare names that no job ever produced** (every check-run is a bare job name like `unit-tests`, `lint-ubuntu`). So those two required checks were unmatched on **every** PR — which is why admin override was always required, not just for docs PRs (a green-but-`BLOCKED` PR like #534 is the tell).

These gate jobs produce check-runs named exactly `🧪 CI` / `🧪 Rust Tests` / `🛡️ Security Audit`, giving branch protection a single, rename-proof required check per workflow that resolves on every PR.

## Follow-up (repo settings, not in this PR)

After merge, branch protection on `main` should require exactly these three gate contexts and drop the per-job `🛡️ Security Audit / cargo-deny|bun-audit` entries (now subsumed). I'll confirm the exact context strings from this PR's run.

## Test Plan

- [x] `bun run check:workflows` passes (incl. the "no inline scripts > 3 lines" rule — the gate uses a single conditional `exit 1` step); all three YAML files valid
- [ ] This PR's run produces check-runs named `🧪 CI`, `🧪 Rust Tests`, `🛡️ Security Audit`
- [ ] A later docs-only PR shows all three gates green with the heavy jobs skipped → mergeable without admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)