### PR TITLE
refactor: Tidy First — top-10 Pareto tidyings across TS CLI and Rust engine

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -577,39 +577,38 @@ pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
 /// SHA-256 pins computed from the HF mirror — see CLAUDE.md MODEL HASHES
 /// ARE PINNED rule.
 #[cfg(feature = "tts")]
-pub fn vosk_ru_manifest() -> Vec<ModelFile> {
-    vec![
-        ModelFile {
-            rel_path: "models/vosk-ru/model.onnx",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/model.onnx",
-            sha256: "0fa5a36b22a8bf7fe7179a3882c6371d2c01e5317019e717516f892d329c24b9",
-        },
-        ModelFile {
-            rel_path: "models/vosk-ru/dictionary",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/dictionary",
-            sha256: "2939e72c170bb41ac8e256828cca1c5fac4db1e36717f9f53fde843b00a220ba",
-        },
-        ModelFile {
-            rel_path: "models/vosk-ru/config.json",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/config.json",
-            sha256: "e155fb266a730e1858a2420442b465acf08a3236dffad7d1a507bf155b213d50",
-        },
-        ModelFile {
-            rel_path: "models/vosk-ru/bert/model.onnx",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/model.onnx",
-            sha256: "2e2f1740eaae5e29c2b4844625cbb01ff644b2b5fb0560bd34374c35d8a092c1",
-        },
-        ModelFile {
-            rel_path: "models/vosk-ru/bert/vocab.txt",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/vocab.txt",
-            sha256: "bbe5063cc3d7a314effd90e9c5099cf493b81f2b9552c155264e16eeab074237",
-        },
-        // removed: README.md (drakulavich/vosk-tts-ru-0.9-multi) — not opened at
-        // runtime; pinning its SHA forced a manifest bump on every upstream
-        // doc copy-edit. CharsiuG2P entries (3 byt5-tiny ONNX) were also
-        // removed in PR #213 — Russian uses vosk-tts internal G2P now.
-    ]
-}
+pub const VOSK_RU_FILES: &[ModelFile] = &[
+    ModelFile {
+        rel_path: "models/vosk-ru/model.onnx",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/model.onnx",
+        sha256: "0fa5a36b22a8bf7fe7179a3882c6371d2c01e5317019e717516f892d329c24b9",
+    },
+    ModelFile {
+        rel_path: "models/vosk-ru/dictionary",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/dictionary",
+        sha256: "2939e72c170bb41ac8e256828cca1c5fac4db1e36717f9f53fde843b00a220ba",
+    },
+    ModelFile {
+        rel_path: "models/vosk-ru/config.json",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/config.json",
+        sha256: "e155fb266a730e1858a2420442b465acf08a3236dffad7d1a507bf155b213d50",
+    },
+    ModelFile {
+        rel_path: "models/vosk-ru/bert/model.onnx",
+        url:
+            "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/model.onnx",
+        sha256: "2e2f1740eaae5e29c2b4844625cbb01ff644b2b5fb0560bd34374c35d8a092c1",
+    },
+    ModelFile {
+        rel_path: "models/vosk-ru/bert/vocab.txt",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/vocab.txt",
+        sha256: "bbe5063cc3d7a314effd90e9c5099cf493b81f2b9552c155264e16eeab074237",
+    },
+    // removed: README.md (drakulavich/vosk-tts-ru-0.9-multi) — not opened at
+    // runtime; pinning its SHA forced a manifest bump on every upstream
+    // doc copy-edit. CharsiuG2P entries (3 byt5-tiny ONNX) were also
+    // removed in PR #213 — Russian uses vosk-tts internal G2P now.
+];
 
 pub fn cache_dir() -> PathBuf {
     if let Ok(p) = std::env::var("KESHA_CACHE_DIR") {
@@ -1069,7 +1068,7 @@ mod tts_tests {
 
     #[test]
     fn vosk_ru_manifest_has_expected_files() {
-        let m = vosk_ru_manifest();
+        let m = VOSK_RU_FILES;
         assert_eq!(m.len(), 5);
         let names: std::collections::HashSet<&str> = m.iter().map(|f| f.rel_path).collect();
         for f in [
@@ -1081,7 +1080,7 @@ mod tts_tests {
         ] {
             assert!(names.contains(f), "missing {f}");
         }
-        for f in &m {
+        for f in m {
             assert!(f.sha256.len() == 64, "sha256 must be 64 hex chars");
             assert!(f.url.starts_with(
                 "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/"
@@ -1314,8 +1313,13 @@ mod tts_tests {
 /// same hash-verify + retry path as the rest.
 #[cfg(feature = "system_diarize")]
 pub fn download_diarize(no_cache: bool) -> Result<()> {
+    download_manifest(DIARIZE_FILES, no_cache)
+}
+
+/// Hash-verified parallel download of a static manifest into the cache dir.
+fn download_manifest(files: &[ModelFile], no_cache: bool) -> Result<()> {
     let cache = cache_dir();
-    let refs: Vec<&ModelFile> = DIARIZE_FILES.iter().collect();
+    let refs: Vec<&ModelFile> = files.iter().collect();
     parallel_download(&cache, &refs, no_cache)
 }
 
@@ -1377,9 +1381,7 @@ fn is_compiled_mlpackage_sidecar(path: &Path) -> bool {
 /// Single-file manifest, so `parallel_download` reduces to one HTTP round
 /// trip — keeps the uniform hash-verify + retry path.
 pub fn download_vad(no_cache: bool) -> Result<()> {
-    let cache = cache_dir();
-    let refs: Vec<&ModelFile> = VAD_FILES.iter().collect();
-    parallel_download(&cache, &refs, no_cache)
+    download_manifest(VAD_FILES, no_cache)
 }
 
 /// Download the TTS model files needed for `langs` only. Each file is streamed
@@ -1401,7 +1403,7 @@ pub fn download_tts(langs: &[&str], no_cache: bool) -> Result<()> {
         let cache = cache_dir();
         let mut manifest = kokoro_manifest_for(langs);
         if langs.contains(&"ru") {
-            manifest.extend(vosk_ru_manifest());
+            manifest.extend_from_slice(VOSK_RU_FILES);
         }
         let refs: Vec<&ModelFile> = manifest.iter().collect();
         parallel_download(&cache, &refs, no_cache)?;
@@ -1420,12 +1422,7 @@ pub fn download_tts(langs: &[&str], no_cache: bool) -> Result<()> {
     ))]
     {
         if langs.contains(&"ru") {
-            let cache = cache_dir();
-            // `manifest` must outlive `refs` (the borrows point into it), so it
-            // stays a named binding rather than an inlined temporary.
-            let manifest = vosk_ru_manifest();
-            let refs: Vec<&ModelFile> = manifest.iter().collect();
-            parallel_download(&cache, &refs, no_cache)?;
+            download_manifest(VOSK_RU_FILES, no_cache)?;
         }
         stage_ane_kokoro_voices(langs, no_cache)?;
     }

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -43,6 +43,7 @@
 //!   ~934 MB Vosk session is a separate follow-up issue.
 
 use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
 
 use crate::{models, tts};
 
@@ -209,94 +210,7 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
             model_path,
             voice_path,
             ..
-        } => {
-            let sess = match state.kokoro.as_mut() {
-                Some(s) => {
-                    s.ensure_model(&model_path)
-                        .map_err(|e| format!("kokoro reload: {e}"))?;
-                    s
-                }
-                None => state.kokoro.insert(
-                    tts::sessions::KokoroSession::load(&model_path)
-                        .map_err(|e| format!("kokoro load: {e}"))?,
-                ),
-            };
-
-            if req.ssml {
-                let segments = tts::ssml::parse(&req.text).map_err(|e| format!("ssml: {e}"))?;
-                if segments.is_empty() {
-                    return Err("SSML had no speakable content".into());
-                }
-                // Apply English acronym normalization (Spell→letter names,
-                // Text→expand when expand_abbrev) for en-* voices. Mirrors
-                // the one-shot path in tts::synth_segments_kokoro (#244).
-                let segments = if tts::en::is_en(espeak_lang) {
-                    tts::en::normalize_segments(segments, req.expand_abbrev)
-                } else {
-                    segments
-                };
-                tts::synth_segments_kokoro_with(
-                    sess,
-                    &segments,
-                    espeak_lang,
-                    &voice_path,
-                    req.rate,
-                    format,
-                )
-                .map_err(|e| e.to_string())
-            } else if tts::en::is_en(espeak_lang) {
-                // English on Kokoro: route plain text through the segment
-                // pipeline so IPA_LEXICON overrides (EPAM, JSON, Anthropic, …)
-                // emit `Segment::Ipa` and bypass G2P. Mirrors tts::say()'s
-                // English plain-text path. Closes #244.
-                let segments = tts::en::normalize_segments(
-                    vec![tts::ssml::Segment::Text(req.text.clone())],
-                    req.expand_abbrev,
-                );
-                tts::synth_segments_kokoro_with(
-                    sess,
-                    &segments,
-                    espeak_lang,
-                    &voice_path,
-                    req.rate,
-                    format,
-                )
-                .map_err(|e| e.to_string())
-            } else {
-                // Non-English Kokoro: G2P + infer_ipa path.
-                // Romance languages (es/fr/it/pt) use the cached CharsiuG2P
-                // session to avoid reloading ~100 MB of ONNX models per request.
-                // All other languages fall through to the one-shot text_to_ipa
-                // path (which will error with a lang-specific hint for ru etc.).
-                let ipa = if matches!(
-                    crate::tts::charsiu::base_lang(espeak_lang),
-                    "es" | "fr" | "it" | "pt"
-                ) {
-                    state
-                        .charsiu
-                        .to_ipa(
-                            &models::cache_dir().join("models/g2p/byt5-tiny"),
-                            &req.text,
-                            espeak_lang,
-                        )
-                        .map_err(|e| format!("g2p: {e}"))?
-                } else {
-                    tts::g2p::text_to_ipa(&req.text, espeak_lang)
-                        .map_err(|e| format!("g2p: {e}"))?
-                };
-                if ipa.trim().is_empty() {
-                    return Err("no phonemes produced for input (empty after G2P)".into());
-                }
-                let audio = sess
-                    .infer_ipa(&ipa, &voice_path, req.rate)
-                    .map_err(|e| format!("infer: {e}"))?;
-                if audio.is_empty() {
-                    return Err("no recognizable phonemes in input".into());
-                }
-                tts::encode::encode(&audio, tts::kokoro::SAMPLE_RATE, format)
-                    .map_err(|e| format!("encode: {e}"))
-            }
-        }
+        } => handle_kokoro(req, state, &model_path, &voice_path, espeak_lang, format),
         #[cfg(all(
             feature = "system_kokoro",
             target_os = "macos",
@@ -322,35 +236,7 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
         tts::voices::ResolvedVoice::Vosk {
             model_dir,
             speaker_id,
-        } => {
-            if req.ssml {
-                let segments = tts::ssml::parse(&req.text).map_err(|e| format!("ssml: {e}"))?;
-                if segments.is_empty() {
-                    return Err("SSML had no speakable content".into());
-                }
-                let segments = tts::ru::normalize_segments(segments, req.expand_abbrev);
-                tts::synth_segments_vosk_with(
-                    &mut state.vosk,
-                    &segments,
-                    &model_dir,
-                    speaker_id,
-                    req.rate,
-                    format,
-                )
-                .map_err(|e| e.to_string())
-            } else {
-                let text: std::borrow::Cow<'_, str> = if req.expand_abbrev {
-                    std::borrow::Cow::Owned(tts::ru::expand_text(&req.text))
-                } else {
-                    std::borrow::Cow::Borrowed(&req.text)
-                };
-                let (audio, sample_rate) = state
-                    .vosk
-                    .infer(&model_dir, &text, speaker_id, req.rate)
-                    .map_err(|e| format!("vosk: {e}"))?;
-                tts::encode::encode(&audio, sample_rate, format).map_err(|e| format!("encode: {e}"))
-            }
-        }
+        } => handle_vosk(req, state, &model_dir, speaker_id, format),
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         tts::voices::ResolvedVoice::AVSpeech { voice_id } => {
             // AVSpeech is a Swift sidecar — no in-process state to cache.
@@ -369,6 +255,130 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
             })
             .map_err(|e| e.to_string())
         }
+    }
+}
+
+/// Parse SSML for the loop path; an empty parse is the same client error on
+/// every engine.
+fn parse_ssml_or_err(text: &str) -> Result<Vec<tts::ssml::Segment>, String> {
+    let segments = tts::ssml::parse(text).map_err(|e| format!("ssml: {e}"))?;
+    if segments.is_empty() {
+        return Err("SSML had no speakable content".into());
+    }
+    Ok(segments)
+}
+
+/// Kokoro arm of [`handle`]: session reuse + the ssml / English-segment /
+/// G2P-IPA request shapes.
+fn handle_kokoro(
+    req: &LoopRequest,
+    state: &mut LoopState,
+    model_path: &Path,
+    voice_path: &Path,
+    espeak_lang: &str,
+    format: tts::encode::OutputFormat,
+) -> Result<Vec<u8>, String> {
+    let sess = match state.kokoro.as_mut() {
+        Some(s) => {
+            s.ensure_model(model_path)
+                .map_err(|e| format!("kokoro reload: {e}"))?;
+            s
+        }
+        None => state.kokoro.insert(
+            tts::sessions::KokoroSession::load(model_path)
+                .map_err(|e| format!("kokoro load: {e}"))?,
+        ),
+    };
+
+    if req.ssml {
+        let segments = parse_ssml_or_err(&req.text)?;
+        // Apply English acronym normalization (Spell→letter names,
+        // Text→expand when expand_abbrev) for en-* voices. Mirrors
+        // the one-shot path in tts::synth_segments_kokoro (#244).
+        let segments = if tts::en::is_en(espeak_lang) {
+            tts::en::normalize_segments(segments, req.expand_abbrev)
+        } else {
+            segments
+        };
+        tts::synth_segments_kokoro_with(sess, &segments, espeak_lang, voice_path, req.rate, format)
+            .map_err(|e| e.to_string())
+    } else if tts::en::is_en(espeak_lang) {
+        // English on Kokoro: route plain text through the segment
+        // pipeline so IPA_LEXICON overrides (EPAM, JSON, Anthropic, …)
+        // emit `Segment::Ipa` and bypass G2P. Mirrors tts::say()'s
+        // English plain-text path. Closes #244.
+        let segments = tts::en::normalize_segments(
+            vec![tts::ssml::Segment::Text(req.text.clone())],
+            req.expand_abbrev,
+        );
+        tts::synth_segments_kokoro_with(sess, &segments, espeak_lang, voice_path, req.rate, format)
+            .map_err(|e| e.to_string())
+    } else {
+        // Non-English Kokoro: G2P + infer_ipa path.
+        // Romance languages (es/fr/it/pt) use the cached CharsiuG2P
+        // session to avoid reloading ~100 MB of ONNX models per request.
+        // All other languages fall through to the one-shot text_to_ipa
+        // path (which will error with a lang-specific hint for ru etc.).
+        let ipa = if matches!(
+            crate::tts::charsiu::base_lang(espeak_lang),
+            "es" | "fr" | "it" | "pt"
+        ) {
+            state
+                .charsiu
+                .to_ipa(
+                    &models::cache_dir().join("models/g2p/byt5-tiny"),
+                    &req.text,
+                    espeak_lang,
+                )
+                .map_err(|e| format!("g2p: {e}"))?
+        } else {
+            tts::g2p::text_to_ipa(&req.text, espeak_lang).map_err(|e| format!("g2p: {e}"))?
+        };
+        if ipa.trim().is_empty() {
+            return Err("no phonemes produced for input (empty after G2P)".into());
+        }
+        let audio = sess
+            .infer_ipa(&ipa, voice_path, req.rate)
+            .map_err(|e| format!("infer: {e}"))?;
+        if audio.is_empty() {
+            return Err("no recognizable phonemes in input".into());
+        }
+        tts::encode::encode(&audio, tts::kokoro::SAMPLE_RATE, format)
+            .map_err(|e| format!("encode: {e}"))
+    }
+}
+
+/// Vosk arm of [`handle`]: cached-session synth for the ssml and plain paths.
+fn handle_vosk(
+    req: &LoopRequest,
+    state: &mut LoopState,
+    model_dir: &Path,
+    speaker_id: u32,
+    format: tts::encode::OutputFormat,
+) -> Result<Vec<u8>, String> {
+    if req.ssml {
+        let segments = parse_ssml_or_err(&req.text)?;
+        let segments = tts::ru::normalize_segments(segments, req.expand_abbrev);
+        tts::synth_segments_vosk_with(
+            &mut state.vosk,
+            &segments,
+            model_dir,
+            speaker_id,
+            req.rate,
+            format,
+        )
+        .map_err(|e| e.to_string())
+    } else {
+        let text: std::borrow::Cow<'_, str> = if req.expand_abbrev {
+            std::borrow::Cow::Owned(tts::ru::expand_text(&req.text))
+        } else {
+            std::borrow::Cow::Borrowed(&req.text)
+        };
+        let (audio, sample_rate) = state
+            .vosk
+            .infer(model_dir, &text, speaker_id, req.rate)
+            .map_err(|e| format!("vosk: {e}"))?;
+        tts::encode::encode(&audio, sample_rate, format).map_err(|e| format!("encode: {e}"))
     }
 }
 

--- a/rust/src/tts/en/mod.rs
+++ b/rust/src/tts/en/mod.rs
@@ -54,11 +54,7 @@ pub fn normalize_segments(segs: Vec<Segment>, auto_expand: bool) -> Vec<Segment>
                          stripping `+` from content for non-Vosk path",
                     );
                 }
-                let stripped = if content.contains('+') {
-                    content.replace('+', "")
-                } else {
-                    content
-                };
+                let stripped = crate::tts::strip_emphasis_markers(content);
                 vec![Segment::Text(stripped)]
             }
             Segment::Text(t) => acronym::expand_to_segments(&t, auto_expand),

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -40,6 +40,17 @@ pub mod avspeech;
 /// spend minutes on synthesis with poor quality.
 pub const MAX_TEXT_CHARS: usize = 5000;
 
+/// Strip SSML `<emphasis>` `+` stress markers from segment content. Only
+/// ru-vosk-* voices honor `+`; every other synth path strips it before
+/// synthesis (the per-engine callers decide whether to warn first).
+pub(crate) fn strip_emphasis_markers(content: String) -> String {
+    if content.contains('+') {
+        content.replace('+', "")
+    } else {
+        content
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum TtsError {
     #[error("text is empty")]

--- a/rust/src/tts/ru/mod.rs
+++ b/rust/src/tts/ru/mod.rs
@@ -43,11 +43,7 @@ pub fn normalize_segments(segs: Vec<Segment>, auto_expand: bool) -> Vec<Segment>
             Segment::Spell(t) => Segment::Text(letter_table::expand_chars(&t)),
             Segment::Emphasis { content, suppress } => {
                 if suppress {
-                    let stripped = if content.contains('+') {
-                        content.replace('+', "")
-                    } else {
-                        content
-                    };
+                    let stripped = crate::tts::strip_emphasis_markers(content);
                     Segment::Text(stripped)
                 } else {
                     if !content.contains('+') {

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -104,131 +104,118 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         opts.ssml
     );
 
-    #[cfg(all(
-        feature = "system_kokoro",
-        target_os = "macos",
-        target_arch = "aarch64"
-    ))]
-    if let EngineChoice::FluidKokoro { voice_id, speed } = &opts.engine {
-        if opts.ssml {
-            return synth_segments_fluid_kokoro(opts.text, voice_id, *speed, opts.format);
+    // One exhaustive dispatch: each engine arm owns its SSML handling, so no
+    // arm depends on an early return elsewhere and none is unreachable.
+    match &opts.engine {
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        EngineChoice::FluidKokoro { voice_id, speed } => {
+            if opts.ssml {
+                return synth_segments_fluid_kokoro(opts.text, voice_id, *speed, opts.format);
+            }
+            let wav_bytes =
+                super::fluid_kokoro::synthesize(opts.text, voice_id, *speed).map_err(|e| {
+                    TtsError::Coded {
+                        // Preserve a precise code from the engine chain (e.g.
+                        // ScriptUnsupported for native-script input); plain synthesis
+                        // failures carry no CodedError, so code_of falls back to Internal.
+                        code: crate::errors::code_of(&e),
+                        message: format!("fluid-kokoro: {e}"),
+                    }
+                })?;
+            transcode_to(&wav_bytes, opts.format)
         }
-        let wav_bytes =
-            super::fluid_kokoro::synthesize(opts.text, voice_id, *speed).map_err(|e| {
-                TtsError::Coded {
-                    // Preserve a precise code from the engine chain (e.g.
-                    // ScriptUnsupported for native-script input); plain synthesis
-                    // failures carry no CodedError, so code_of falls back to Internal.
-                    code: crate::errors::code_of(&e),
-                    message: format!("fluid-kokoro: {e}"),
-                }
-            })?;
-        return transcode_to(&wav_bytes, opts.format);
-    }
-
-    // AVSpeech does its own G2P + synthesis inside Swift; skip espeak G2P entirely.
-    #[cfg(all(feature = "system_tts", target_os = "macos"))]
-    if let EngineChoice::AVSpeech { voice_id } = &opts.engine {
-        if opts.ssml {
-            return Err(TtsError::Coded {
-                code: crate::errors::ErrorCode::SsmlUnsupported,
-                message: "SSML is not yet supported with macos-* voices (#141 follow-up)".into(),
-            });
+        // AVSpeech does its own G2P + synthesis inside Swift; skip espeak G2P entirely.
+        #[cfg(all(feature = "system_tts", target_os = "macos"))]
+        EngineChoice::AVSpeech { voice_id } => {
+            if opts.ssml {
+                return Err(TtsError::Coded {
+                    code: crate::errors::ErrorCode::SsmlUnsupported,
+                    message: "SSML is not yet supported with macos-* voices (#141 follow-up)"
+                        .into(),
+                });
+            }
+            let wav_bytes = avspeech::synthesize(opts.text, voice_id, None)
+                .map_err(|e| TtsError::SynthesisFailed(format!("avspeech: {e}")))?;
+            // The Swift sidecar always returns WAV. For non-WAV `--format`, decode
+            // back to PCM and re-encode — cheap (a few hundred ms of audio) and
+            // keeps the encoder pipeline single-pathed.
+            transcode_to(&wav_bytes, opts.format)
         }
-        let wav_bytes = avspeech::synthesize(opts.text, voice_id, None)
-            .map_err(|e| TtsError::SynthesisFailed(format!("avspeech: {e}")))?;
-        // The Swift sidecar always returns WAV. For non-WAV `--format`, decode
-        // back to PCM and re-encode — cheap (a few hundred ms of audio) and
-        // keeps the encoder pipeline single-pathed.
-        return transcode_to(&wav_bytes, opts.format);
-    }
-
-    // Vosk-tts owns its own G2P + text normalisation; bypass our espeak/misaki path.
-    if let EngineChoice::Vosk {
-        model_dir,
-        speaker_id,
-        speed,
-    } = &opts.engine
-    {
-        if opts.ssml {
-            return synth_segments_vosk(
+        // Vosk-tts owns its own G2P + text normalisation; bypass our espeak/misaki path.
+        EngineChoice::Vosk {
+            model_dir,
+            speaker_id,
+            speed,
+        } => {
+            if opts.ssml {
+                return synth_segments_vosk(
+                    opts.text,
+                    model_dir,
+                    *speaker_id,
+                    *speed,
+                    opts.format,
+                    opts.expand_abbrev,
+                );
+            }
+            say_with_vosk(
                 opts.text,
                 model_dir,
                 *speaker_id,
                 *speed,
                 opts.format,
                 opts.expand_abbrev,
-            );
+            )
         }
-        return say_with_vosk(
-            opts.text,
-            model_dir,
-            *speaker_id,
-            *speed,
-            opts.format,
-            opts.expand_abbrev,
-        );
-    }
-
-    if opts.ssml {
-        return say_ssml(&opts);
-    }
-
-    // English on Kokoro: route plain text through the segment pipeline so
-    // IPA_LEXICON overrides (EPAM, JSON, Anthropic, Microsoft, …) emit
-    // `Segment::Ipa` and bypass G2P. Letter-spell rule + STOP_LIST run inside
-    // `en::normalize_segments`. Closes #244.
-    if let EngineChoice::Kokoro {
-        model_path,
-        voice_path,
-        speed,
-    } = &opts.engine
-    {
-        if en::is_en(opts.lang) {
-            return synth_segments_kokoro(
-                vec![ssml::Segment::Text(opts.text.to_string())],
-                opts.lang,
-                model_path,
-                voice_path,
-                *speed,
-                opts.format,
-                opts.expand_abbrev,
-            );
-        }
-    }
-
-    // Non-English Kokoro: legacy G2P + say_with_kokoro path.
-    let ipa = g2p::text_to_ipa(opts.text, opts.lang)
-        .map_err(|e| TtsError::SynthesisFailed(format!("g2p: {e}")))?;
-    if ipa.trim().is_empty() {
-        return Err(TtsError::SynthesisFailed(
-            "no phonemes produced for input (empty after G2P)".into(),
-        ));
-    }
-
-    match opts.engine {
         EngineChoice::Kokoro {
             model_path,
             voice_path,
             speed,
-        } => say_with_kokoro(&ipa, model_path, voice_path, speed, opts.format),
-        // Vosk and AVSpeech are handled by early-returns above. Keep guard arms
-        // so the match stays exhaustive when those features are enabled.
-        #[cfg(all(
-            feature = "system_kokoro",
-            target_os = "macos",
-            target_arch = "aarch64"
-        ))]
-        EngineChoice::FluidKokoro { .. } => unreachable!("handled by early return above"),
-        EngineChoice::Vosk { .. } => unreachable!("handled by early return above"),
-        #[cfg(all(feature = "system_tts", target_os = "macos"))]
-        EngineChoice::AVSpeech { .. } => unreachable!("handled by early return above"),
+        } => {
+            if opts.ssml {
+                return say_ssml(&opts, model_path, voice_path, *speed);
+            }
+            // English on Kokoro: route plain text through the segment pipeline so
+            // IPA_LEXICON overrides (EPAM, JSON, Anthropic, Microsoft, …) emit
+            // `Segment::Ipa` and bypass G2P. Letter-spell rule + STOP_LIST run inside
+            // `en::normalize_segments`. Closes #244.
+            if en::is_en(opts.lang) {
+                return synth_segments_kokoro(
+                    vec![ssml::Segment::Text(opts.text.to_string())],
+                    opts.lang,
+                    model_path,
+                    voice_path,
+                    *speed,
+                    opts.format,
+                    opts.expand_abbrev,
+                );
+            }
+            // Non-English Kokoro: legacy G2P + say_with_kokoro path.
+            let ipa = g2p::text_to_ipa(opts.text, opts.lang)
+                .map_err(|e| TtsError::SynthesisFailed(format!("g2p: {e}")))?;
+            if ipa.trim().is_empty() {
+                return Err(TtsError::SynthesisFailed(
+                    "no phonemes produced for input (empty after G2P)".into(),
+                ));
+            }
+            say_with_kokoro(&ipa, model_path, voice_path, *speed, opts.format)
+        }
     }
 }
 
-/// SSML path: parse, then synthesize each text segment through the engine (loaded once),
-/// interleaving silence for `<break>` segments. Concatenate the f32 samples and wrap as WAV.
-fn say_ssml(opts: &SayOptions) -> Result<Vec<u8>, TtsError> {
+/// Kokoro SSML path: parse, then synthesize each text segment through the engine
+/// (loaded once), interleaving silence for `<break>` segments. Concatenate the
+/// f32 samples and wrap as WAV. The other engines handle SSML in their own
+/// `say()` arms (Vosk via `synth_segments_vosk`, AVSpeech rejects it).
+fn say_ssml(
+    opts: &SayOptions,
+    model_path: &Path,
+    voice_path: &Path,
+    speed: f32,
+) -> Result<Vec<u8>, TtsError> {
     let segments = ssml::parse(opts.text).map_err(|e| TtsError::Coded {
         code: crate::errors::code_of(&e),
         message: format!("ssml: {e:#}"),
@@ -239,36 +226,15 @@ fn say_ssml(opts: &SayOptions) -> Result<Vec<u8>, TtsError> {
         ));
     }
 
-    match &opts.engine {
-        EngineChoice::Kokoro {
-            model_path,
-            voice_path,
-            speed,
-        } => synth_segments_kokoro(
-            segments,
-            opts.lang,
-            model_path,
-            voice_path,
-            *speed,
-            opts.format,
-            opts.expand_abbrev,
-        ),
-        #[cfg(all(
-            feature = "system_kokoro",
-            target_os = "macos",
-            target_arch = "aarch64"
-        ))]
-        EngineChoice::FluidKokoro { .. } => {
-            unreachable!("FluidAudio Kokoro + SSML rejected in say() early return")
-        }
-        // Vosk + SSML is handled by the early-return in say(); this arm keeps the match exhaustive.
-        EngineChoice::Vosk { .. } => unreachable!("handled by early return in say()"),
-        // AVSpeech + SSML is rejected up-front in `say()`; this arm keeps the match exhaustive.
-        #[cfg(all(feature = "system_tts", target_os = "macos"))]
-        EngineChoice::AVSpeech { .. } => {
-            unreachable!("AVSpeech + SSML rejected in say() early return")
-        }
-    }
+    synth_segments_kokoro(
+        segments,
+        opts.lang,
+        model_path,
+        voice_path,
+        speed,
+        opts.format,
+        opts.expand_abbrev,
+    )
 }
 
 fn synth_segments_kokoro(

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -297,11 +297,7 @@ fn synth_one_kokoro(
                      stripping `+` from content for non-Vosk path",
                 );
             }
-            let stripped = if content.contains('+') {
-                content.replace('+', "")
-            } else {
-                content.clone()
-            };
+            let stripped = super::strip_emphasis_markers(content.clone());
             let ipa = g2p::text_to_ipa(&stripped, lang)
                 .map_err(|e| TtsError::SynthesisFailed(format!("g2p: {e}")))?;
             sess.infer_ipa(&ipa, voice_path, speed)
@@ -433,11 +429,7 @@ fn synth_one_fluid_kokoro(
                      stripping `+` from content for FluidAudio Kokoro",
                 );
             }
-            let stripped = if content.contains('+') {
-                content.replace('+', "")
-            } else {
-                content.clone()
-            };
+            let stripped = super::strip_emphasis_markers(content.clone());
             out.extend(synth(&stripped, speed)?);
         }
         ssml::Segment::ProsodyRate { rate, content } => {
@@ -577,11 +569,7 @@ fn synth_one_vosk(
                      preprocessing; stripping `+` markers as a fallback",
                 );
             }
-            let stripped = if content.contains('+') {
-                content.replace('+', "")
-            } else {
-                content.clone()
-            };
+            let stripped = super::strip_emphasis_markers(content.clone());
             let (audio, _sr) = cache
                 .infer(model_dir, &stripped, speaker_id, speed)
                 .map_err(|e| TtsError::SynthesisFailed(format!("vosk: {e}")))?;

--- a/rust/src/tts/vosk.rs
+++ b/rust/src/tts/vosk.rs
@@ -22,7 +22,7 @@ pub struct Vosk {
 
 impl Vosk {
     /// Load the model bundle from `model_dir`. Expects the directory layout
-    /// produced by `vosk_ru_manifest()` (model.onnx, dictionary, config.json,
+    /// produced by `models::VOSK_RU_FILES` (model.onnx, dictionary, config.json,
     /// bert/model.onnx, bert/vocab.txt).
     pub fn load(model_dir: &Path) -> Result<Self> {
         let dir_str = model_dir

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -53,6 +53,30 @@ const USER_FORCED_NO_COLOR =
   process.env.NO_COLOR !== undefined && !isFalsey(process.env.NO_COLOR);
 
 /**
+ * Strip a boolean global flag out of rawArgs so citty never sees it. Matches
+ * any of `names` bare (sets the flag) and the `--name=<value>` form for the
+ * long names (`<falsey>` explicitly turns the flag back off).
+ */
+function stripBooleanFlag(
+  rawArgs: string[],
+  names: string[],
+): { value: boolean; rawArgs: string[] } {
+  const valuedPrefixes = names.filter((n) => n.startsWith("--")).map((n) => `${n}=`);
+  let value = false;
+  const cleaned: string[] = [];
+  for (const arg of rawArgs) {
+    if (names.includes(arg)) {
+      value = true;
+    } else if (valuedPrefixes.some((prefix) => arg.startsWith(prefix))) {
+      value = !isFalsey(arg.slice(arg.indexOf("=") + 1));
+    } else {
+      cleaned.push(arg);
+    }
+  }
+  return { value, rawArgs: cleaned };
+}
+
+/**
  * Decide whether ANSI colors should be disabled (#531) and return rawArgs with
  * any `--no-color[=value]` token stripped so citty never sees it.
  *
@@ -65,19 +89,9 @@ export function resolveColorMode(
   rawArgs: string[],
   env: { CI?: string } = process.env as { CI?: string },
 ): { disableColor: boolean; rawArgs: string[] } {
-  let flag = false;
-  const cleaned: string[] = [];
-  for (const arg of rawArgs) {
-    if (arg === "--no-color") {
-      flag = true;
-    } else if (arg.startsWith("--no-color=")) {
-      flag = !isFalsey(arg.slice("--no-color=".length));
-    } else {
-      cleaned.push(arg);
-    }
-  }
+  const { value, rawArgs: cleaned } = stripBooleanFlag(rawArgs, ["--no-color"]);
   const ci = env.CI !== undefined && !isFalsey(env.CI);
-  return { disableColor: flag || ci, rawArgs: cleaned };
+  return { disableColor: value || ci, rawArgs: cleaned };
 }
 
 /**
@@ -87,18 +101,8 @@ export function resolveColorMode(
  * subcommand that doesn't declare it never sees the flag.
  */
 export function resolveQuietMode(rawArgs: string[]): { quiet: boolean; rawArgs: string[] } {
-  let flag = false;
-  const cleaned: string[] = [];
-  for (const arg of rawArgs) {
-    if (arg === "--quiet" || arg === "-q") {
-      flag = true;
-    } else if (arg.startsWith("--quiet=")) {
-      flag = !isFalsey(arg.slice("--quiet=".length));
-    } else {
-      cleaned.push(arg);
-    }
-  }
-  return { quiet: flag, rawArgs: cleaned };
+  const { value, rawArgs: cleaned } = stripBooleanFlag(rawArgs, ["--quiet", "-q"]);
+  return { quiet: value, rawArgs: cleaned };
 }
 
 export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { errorMessage } from "../error-utils";
 import { downloadEngine } from "../engine-install";
 import { getEngineBinPath, getEngineCapabilities } from "../engine";
 import { renderInstallPlan } from "../install-plan";
@@ -111,7 +112,7 @@ function finishInstallDiagnostic(
     });
     diagnosticLog.finish(status);
   } catch (err) {
-    log.debug(`install diagnostic log finish dropped: ${err instanceof Error ? err.message : String(err)}`);
+    log.debug(`install diagnostic log finish dropped: ${errorMessage(err)}`);
   }
 }
 
@@ -161,7 +162,7 @@ export async function performInstall(
     await maybeAskForStar(getEngineBinPath(), packageVersion, log);
     finishInstallDiagnostic(diagnosticLog, startedAt, "success");
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     finishInstallDiagnostic(diagnosticLog, startedAt, "failed", errorKind);
     log.error(message);
     process.exit(1);
@@ -219,7 +220,7 @@ export const installCommand = defineCommand({
     try {
       ttsLangs = resolveTtsLangs({ tts: args.tts === true, positionals }, supported);
     } catch (err) {
-      log.error(err instanceof Error ? err.message : String(err));
+      log.error(errorMessage(err));
       process.exit(1);
     }
     await performInstall(

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { errorMessage } from "../error-utils";
 import { existsSync } from "fs";
 import { detect } from "tinyld";
 import { preflightTranscribeWithSegments, transcribeWithSegments } from "../transcribe";
@@ -435,7 +436,7 @@ export const mainCommand = defineCommand({
       } catch (err: unknown) {
         progress?.stop();
         hasError = true;
-        const stderrText = err instanceof Error ? err.message : String(err);
+        const stderrText = errorMessage(err);
         const code = extractEngineErrorCode(stderrText) ?? ENGINE_CODES.TRANSCRIBE_FAILED;
         stats.recordError("transcribe", err, code);
         diagnosticLog.event("engine.exit", {

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { errorMessage } from "../error-utils";
 import { detectTextLanguageEngine, getEngineBinPath } from "../engine";
 import { log } from "../log";
 import { say, SayError, type SayFormat } from "../synth";
@@ -289,7 +290,7 @@ export const sayCommand = defineCommand({
         log.error(err.stderr.trim() || err.message);
         process.exit(err.exitCode);
       }
-      const message = err instanceof Error ? err.message : String(err);
+      const message = errorMessage(err);
       log.error(message);
       process.exit(4);
     }

--- a/src/cli/support-bundle.ts
+++ b/src/cli/support-bundle.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { errorMessage } from "../error-utils";
 import { createSupportBundle } from "../support-bundle";
 import { log } from "../log";
 
@@ -33,7 +34,7 @@ export const supportBundleCommand = defineCommand({
       log.info(`Entries: ${bundle.entries.length}`);
       log.info(`Size: ${bundle.sizeBytes} bytes`);
     } catch (err) {
-      log.error(err instanceof Error ? err.message : String(err));
+      log.error(errorMessage(err));
       process.exit(1);
     }
   },

--- a/src/diagnostic-log.ts
+++ b/src/diagnostic-log.ts
@@ -1,3 +1,4 @@
+import { errorMessage } from "./error-utils";
 import {
   closeSync,
   existsSync,
@@ -232,7 +233,7 @@ export function createDiagnosticLogSession(): DiagnosticLogSession {
         appendDiagnosticLogLine(line, status);
         return true;
       } catch (err) {
-        log.debug(`diagnostic log event dropped: ${err instanceof Error ? err.message : String(err)}`);
+        log.debug(`diagnostic log event dropped: ${errorMessage(err)}`);
         return false;
       }
     },

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,4 +1,5 @@
 import { existsSync, statSync } from "fs";
+import { errorMessage } from "./error-utils";
 import { dirname, join, sep } from "path";
 import {
   getEngineBinPath,
@@ -194,7 +195,7 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
       capabilities = await getEngineCapabilities();
       if (!capabilities) probeError = "capabilities probe returned no data";
     } catch (err) {
-      probeError = err instanceof Error ? err.message : String(err);
+      probeError = errorMessage(err);
     }
   }
 
@@ -305,7 +306,7 @@ function collectStats(redact: boolean): DoctorReport["stats"] {
       : status;
   } catch (err) {
     return {
-      error: redactString("statsError", err instanceof Error ? err.message : String(err), redact) ?? "unknown",
+      error: redactString("statsError", errorMessage(err), redact) ?? "unknown",
     };
   }
 }
@@ -337,7 +338,7 @@ function collectDiagnosticLogs(redact: boolean): DoctorReport["diagnosticLogs"] 
       maxBytes: 10 * 1024 * 1024,
       retain: 5,
       error:
-        redactString("diagnosticLogsError", err instanceof Error ? err.message : String(err), redact) ??
+        redactString("diagnosticLogsError", errorMessage(err), redact) ??
         "unknown",
     };
   }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from "fs";
 import { errorMessage } from "./error-utils";
+import { humanBytes } from "./format";
 import { dirname, join, sep } from "path";
 import {
   getEngineBinPath,
@@ -81,18 +82,6 @@ export interface DoctorReport {
   stats: StatsStatus | (Partial<StatsStatus> & { error: string });
   diagnosticLogs: DoctorDiagnosticLogStatus;
   env: Record<string, string | null>;
-}
-
-function humanBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  const units = ["KB", "MB", "GB", "TB"];
-  let n = bytes / 1024;
-  let i = 0;
-  while (n >= 1024 && i < units.length - 1) {
-    n /= 1024;
-    i++;
-  }
-  return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
 }
 
 function pathSummary(path: string): PathSummary {

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -1,4 +1,5 @@
 import { dirname, join } from "path";
+import { errorMessage } from "./error-utils";
 import { tmpdir } from "os";
 import { existsSync, mkdirSync, chmodSync, accessSync, constants, rmSync } from "fs";
 import {
@@ -110,7 +111,7 @@ export function cleanupRetiredSidecars(engineDir: string): string[] {
       removed.push(filename);
     } catch (e) {
       log.warn(
-        `Could not remove retired sidecar ${filename} (${e instanceof Error ? e.message : e}); continuing.`,
+        `Could not remove retired sidecar ${filename} (${errorMessage(e)}); continuing.`,
       );
     }
   }
@@ -163,7 +164,7 @@ function darwinTrustBinary(path: string, displayName: string): void {
     }
   } catch (e) {
     log.debug(
-      `codesign on ${displayName} threw: ${e instanceof Error ? e.message : e}`,
+      `codesign on ${displayName} threw: ${errorMessage(e)}`,
     );
   }
   try {
@@ -184,7 +185,7 @@ function darwinTrustBinary(path: string, displayName: string): void {
     }
   } catch (e) {
     log.debug(
-      `xattr -d on ${displayName} threw: ${e instanceof Error ? e.message : e}`,
+      `xattr -d on ${displayName} threw: ${errorMessage(e)}`,
     );
   }
   if (!codesignOk && !xattrOk) {
@@ -222,7 +223,7 @@ async function downloadSidecar(
     res = await fetch(url, { redirect: "follow" });
   } catch (e) {
     log.warn(
-      `Could not fetch ${spec.displayName} (${e instanceof Error ? e.message : e}); ${spec.unavailableHint}.`,
+      `Could not fetch ${spec.displayName} (${errorMessage(e)}); ${spec.unavailableHint}.`,
     );
     return;
   }
@@ -248,7 +249,7 @@ async function downloadSidecar(
     log.success(`${spec.displayName} installed (${spec.availableHint}).`);
   } catch (e) {
     log.warn(
-      `${spec.displayName} install failed (${e instanceof Error ? e.message : e}); ${spec.unavailableHint}.`,
+      `${spec.displayName} install failed (${errorMessage(e)}); ${spec.unavailableHint}.`,
     );
   }
 }
@@ -312,7 +313,7 @@ async function warmDarwinKokoro(binPath: string): Promise<void> {
     );
   } catch (e) {
     log.warn(
-      `FluidAudio Kokoro warmup failed (${e instanceof Error ? e.message : e}); ` +
+      `FluidAudio Kokoro warmup failed (${errorMessage(e)}); ` +
         "first `kesha say en-*` may still be slow.",
     );
   } finally {
@@ -462,7 +463,7 @@ export async function downloadEngine(
     } catch (e) {
       muteSidecarRejections();
       throw new Error(
-        `Failed to fetch engine binary: ${e instanceof Error ? e.message : e}\n  Fix: Check your network connection and try again`,
+        `Failed to fetch engine binary: ${errorMessage(e)}\n  Fix: Check your network connection and try again`,
       );
     }
 

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -7,6 +7,7 @@ import {
   getEngineCapabilities,
   TRANSCRIBE_DIARIZE_FEATURE,
 } from "./engine";
+import { isDarwinArm64 } from "./fluid-kokoro-cache";
 import { log } from "./log";
 import { engineVersion } from "./package-info";
 import { streamResponseToFile } from "./progress";
@@ -62,7 +63,7 @@ interface SidecarSpec {
   unavailableHint: string;
 }
 
-const SIDECARS: SidecarSpec[] = [
+export const SIDECARS: SidecarSpec[] = [
   {
     fileBasename: "say-avspeech",
     assetName: "say-avspeech-darwin-arm64",
@@ -213,7 +214,7 @@ async function downloadSidecar(
   binPath: string,
   engineVersion: string,
 ): Promise<void> {
-  if (process.platform !== "darwin" || process.arch !== "arm64") return;
+  if (!isDarwinArm64()) return;
 
   const sidecarPath = join(dirname(binPath), spec.fileBasename);
   const url = `https://github.com/${GITHUB_REPO}/releases/download/v${engineVersion}/${spec.assetName}`;
@@ -255,7 +256,7 @@ async function downloadSidecar(
 }
 
 async function warmDarwinKokoro(binPath: string): Promise<void> {
-  if (process.platform !== "darwin" || process.arch !== "arm64") return;
+  if (!isDarwinArm64()) return;
   // Kokoro now runs in-engine (FluidAudio CoreML, system_kokoro) — warm it by
   // exercising the engine's own `say`, not a sidecar. The first synthesis
   // compiles/fetches FluidAudio's CoreML Kokoro cache.

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -352,6 +352,120 @@ export interface InstallOptions {
   diarize?: boolean;
 }
 
+/**
+ * Cache-valid path: the binary at binPath already matches engineVersion.
+ * Re-trusts it and tops up any sidecars the cached install is missing.
+ */
+async function refreshCachedEngine(
+  binPath: string,
+  canWriteEngineDir: boolean,
+  noCache: boolean,
+): Promise<void> {
+  const engineDir = dirname(binPath);
+  if (noCache && !canWriteEngineDir) {
+    log.info(
+      `Engine binary at v${engineVersion} is on a read-only filesystem; --no-cache skipped for engine (still forwarded to model installs).`,
+    );
+  } else {
+    log.success(`Engine binary already installed (v${engineVersion}).`);
+  }
+  // Re-run the macOS trust step against the cached binary too. Reason:
+  // a user who upgraded to macOS 15+ Sequoia AFTER installing kesha
+  // would have a v<X> binary on disk with `com.apple.provenance` still
+  // attached, and `kesha install` would normally bail at "already
+  // installed" without healing the SIGKILL. Idempotent — re-signing
+  // an already-correctly-signed binary is a ~10 ms no-op; `xattr -d`
+  // on an absent attr is handled (exit 1 + "No such xattr" treated
+  // as success in `darwinTrustBinary`). Skipped on read-only
+  // filesystems (Nix-store installs) — no write access anyway.
+  if (canWriteEngineDir && existsSync(binPath)) {
+    darwinTrustBinary(binPath, "kesha-engine binary");
+  }
+  // Top up any sidecars missing from this cached install. Pre-#141 / pre-#199
+  // engines never shipped them, so a cache-valid binary may still need
+  // fetching. Run independent fetches concurrently — same shape as the
+  // cold path in fetchEngineBinary.
+  //
+  // Skip the top-up entirely when the engine sits in a read-only
+  // filesystem (e.g., a Nix-store install). Those installs stage the
+  // supported sidecars at build time; writing more is impossible, and
+  // attempting it would emit a confusing "install failed" warning for
+  // a feature the Nix README explicitly documents as unsupported
+  // (diarize on Nix needs network access at build time, which the
+  // sandbox forbids).
+  if (canWriteEngineDir) {
+    const missing = SIDECARS.filter(
+      (s) => !existsSync(join(engineDir, s.fileBasename)),
+    );
+    await Promise.all(missing.map((s) => downloadSidecar(s, binPath, engineVersion)));
+    // The cache-valid branch also re-trusts any sidecars that already
+    // exist alongside the engine — same upgrade-to-Sequoia scenario as
+    // above. The `missing.map` above only handles NEW sidecars; this
+    // loop handles ALREADY-PRESENT ones.
+    for (const s of SIDECARS) {
+      const p = join(engineDir, s.fileBasename);
+      if (existsSync(p)) darwinTrustBinary(p, s.displayName);
+    }
+  }
+}
+
+/** Cold path: download the engine binary (and sidecars, concurrently). */
+async function fetchEngineBinary(
+  binPath: string,
+  installedVersion: string | null,
+): Promise<void> {
+  // Log why we're downloading — helps diagnose surprising re-downloads.
+  if (existsSync(binPath) && installedVersion && installedVersion !== engineVersion) {
+    log.progress(
+      `Upgrading engine v${installedVersion} → v${engineVersion}...`,
+    );
+  }
+  const binaryName = getEngineBinaryName();
+  const url = `https://github.com/${GITHUB_REPO}/releases/download/v${engineVersion}/${binaryName}`;
+
+  mkdirSync(dirname(binPath), { recursive: true });
+
+  // Kick off all sidecar fetches concurrently with the engine fetch. They
+  // target independent github.com release assets, so overlapping the HTTP
+  // round-trips saves ~15-30s on a cold install. Each sidecar is
+  // best-effort (404 on older engines, warn + continue) so a failure
+  // doesn't cascade into the engine path.
+  const sidecarPromises = SIDECARS.map((s) =>
+    downloadSidecar(s, binPath, engineVersion),
+  );
+  // Defense-in-depth: if the engine fetch throws below, attach no-op
+  // rejection handlers so we don't surface unhandledRejection errors
+  // from sidecar paths whose internal try/catch ever drifts. Logs from
+  // sidecars whose own work is still in flight will print when they
+  // complete; the engine error is what the user needs to see now.
+  const muteSidecarRejections = () =>
+    sidecarPromises.forEach((p) => p.catch(() => {}));
+
+  let res: Response;
+  try {
+    res = await fetch(url, { redirect: "follow" });
+  } catch (e) {
+    muteSidecarRejections();
+    throw new Error(
+      `Failed to fetch engine binary: ${errorMessage(e)}\n  Fix: Check your network connection and try again`,
+    );
+  }
+
+  if (!res.ok) {
+    muteSidecarRejections();
+    throw new Error(
+      `Failed to download engine binary (HTTP ${res.status})\n  Fix: Check https://github.com/${GITHUB_REPO}/releases for available versions`,
+    );
+  }
+
+  await streamResponseToFile(res, binPath, "kesha-engine binary");
+  chmodSync(binPath, 0o755);
+  darwinTrustBinary(binPath, "kesha-engine binary");
+  writeInstalledEngineVersion(binPath, engineVersion);
+  log.success(`Engine binary downloaded (v${engineVersion}).`);
+  await Promise.all(sidecarPromises);
+}
+
 export async function downloadEngine(
   noCache = false,
   backend?: string,
@@ -384,102 +498,9 @@ export async function downloadEngine(
   const cacheValid = versionMatches && (!noCache || !canWriteEngineDir);
 
   if (cacheValid) {
-    if (noCache && !canWriteEngineDir) {
-      log.info(
-        `Engine binary at v${engineVersion} is on a read-only filesystem; --no-cache skipped for engine (still forwarded to model installs).`,
-      );
-    } else {
-      log.success(`Engine binary already installed (v${engineVersion}).`);
-    }
-    // Re-run the macOS trust step against the cached binary too. Reason:
-    // a user who upgraded to macOS 15+ Sequoia AFTER installing kesha
-    // would have a v<X> binary on disk with `com.apple.provenance` still
-    // attached, and `kesha install` would normally bail at "already
-    // installed" without healing the SIGKILL. Idempotent — re-signing
-    // an already-correctly-signed binary is a ~10 ms no-op; `xattr -d`
-    // on an absent attr is handled (exit 1 + "No such xattr" treated
-    // as success in `darwinTrustBinary`). Skipped on read-only
-    // filesystems (Nix-store installs) — no write access anyway.
-    if (canWriteEngineDir && existsSync(binPath)) {
-      darwinTrustBinary(binPath, "kesha-engine binary");
-    }
-    // Top up any sidecars missing from this cached install. Pre-#141 / pre-#199
-    // engines never shipped them, so a cache-valid binary may still need
-    // fetching. Run independent fetches concurrently — same shape as the
-    // cold path below.
-    //
-    // Skip the top-up entirely when the engine sits in a read-only
-    // filesystem (e.g., a Nix-store install). Those installs stage the
-    // supported sidecars at build time; writing more is impossible, and
-    // attempting it would emit a confusing "install failed" warning for
-    // a feature the Nix README explicitly documents as unsupported
-    // (diarize on Nix needs network access at build time, which the
-    // sandbox forbids).
-    if (canWriteEngineDir) {
-      const missing = SIDECARS.filter(
-        (s) => !existsSync(join(engineDir, s.fileBasename)),
-      );
-      await Promise.all(missing.map((s) => downloadSidecar(s, binPath, engineVersion)));
-      // The cache-valid branch also re-trusts any sidecars that already
-      // exist alongside the engine — same upgrade-to-Sequoia scenario as
-      // above. The `missing.map` above only handles NEW sidecars; this
-      // loop handles ALREADY-PRESENT ones.
-      for (const s of SIDECARS) {
-        const p = join(engineDir, s.fileBasename);
-        if (existsSync(p)) darwinTrustBinary(p, s.displayName);
-      }
-    }
+    await refreshCachedEngine(binPath, canWriteEngineDir, noCache);
   } else {
-    // Log why we're downloading — helps diagnose surprising re-downloads.
-    if (existsSync(binPath) && installedVersion && installedVersion !== engineVersion) {
-      log.progress(
-        `Upgrading engine v${installedVersion} → v${engineVersion}...`,
-      );
-    }
-    const binaryName = getEngineBinaryName();
-    const url = `https://github.com/${GITHUB_REPO}/releases/download/v${engineVersion}/${binaryName}`;
-
-    mkdirSync(dirname(binPath), { recursive: true });
-
-    // Kick off all sidecar fetches concurrently with the engine fetch. They
-    // target independent github.com release assets, so overlapping the HTTP
-    // round-trips saves ~15-30s on a cold install. Each sidecar is
-    // best-effort (404 on older engines, warn + continue) so a failure
-    // doesn't cascade into the engine path.
-    const sidecarPromises = SIDECARS.map((s) =>
-      downloadSidecar(s, binPath, engineVersion),
-    );
-    // Defense-in-depth: if the engine fetch throws below, attach no-op
-    // rejection handlers so we don't surface unhandledRejection errors
-    // from sidecar paths whose internal try/catch ever drifts. Logs from
-    // sidecars whose own work is still in flight will print when they
-    // complete; the engine error is what the user needs to see now.
-    const muteSidecarRejections = () =>
-      sidecarPromises.forEach((p) => p.catch(() => {}));
-
-    let res: Response;
-    try {
-      res = await fetch(url, { redirect: "follow" });
-    } catch (e) {
-      muteSidecarRejections();
-      throw new Error(
-        `Failed to fetch engine binary: ${errorMessage(e)}\n  Fix: Check your network connection and try again`,
-      );
-    }
-
-    if (!res.ok) {
-      muteSidecarRejections();
-      throw new Error(
-        `Failed to download engine binary (HTTP ${res.status})\n  Fix: Check https://github.com/${GITHUB_REPO}/releases for available versions`,
-      );
-    }
-
-    await streamResponseToFile(res, binPath, "kesha-engine binary");
-    chmodSync(binPath, 0o755);
-    darwinTrustBinary(binPath, "kesha-engine binary");
-    writeInstalledEngineVersion(binPath, engineVersion);
-    log.success(`Engine binary downloaded (v${engineVersion}).`);
-    await Promise.all(sidecarPromises);
+    await fetchEngineBinary(binPath, installedVersion);
   }
 
   if (backend) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,4 +1,5 @@
 import { existsSync, statSync } from "fs";
+import { errorMessage } from "./error-utils";
 import { join } from "path";
 import { installHint } from "./install-hint";
 import { log } from "./log";
@@ -280,7 +281,7 @@ export async function transcribeEngineWithSegments(
   try {
     return parseTranscriptionOutput(stdout);
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     throw new Error(`${message}: ${stdout}`);
   }
 }

--- a/src/error-utils.ts
+++ b/src/error-utils.ts
@@ -1,0 +1,4 @@
+/** Human-readable message from an unknown catch value. */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/format.ts
+++ b/src/format.ts
@@ -60,3 +60,16 @@ export function formatJsonOutput(
     errors === undefined ? results : { results, errors };
   return JSON.stringify(payload, null, 2) + "\n";
 }
+
+/** Render a byte count as a human-readable size (e.g. "1.5 MB"). */
+export function humanBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let n = bytes / 1024;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
+}

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -1,4 +1,5 @@
 import { existsSync, statSync } from "fs";
+import { humanBytes } from "./format";
 import { dirname, join } from "path";
 import { getEngineBinPath } from "./engine";
 import { readInstalledEngineVersion } from "./engine-version-marker";
@@ -128,18 +129,6 @@ const DARWIN_SIDECARS: ReleaseAssetSpec[] = [
 
 function sumFiles(files: PlanFile[]): number {
   return files.reduce((sum, file) => sum + file.sizeBytes, 0);
-}
-
-function humanBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  const units = ["KB", "MB", "GB", "TB"];
-  let n = bytes / 1024;
-  let i = 0;
-  while (n >= 1024 && i < units.length - 1) {
-    n /= 1024;
-    i++;
-  }
-  return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
 }
 
 function engineAssetForPlatform(): ReleaseAssetSpec | null {

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -129,11 +129,17 @@ const SIDECAR_ASSET_SIZES: Record<string, number> = {
   "kesha-textlang-darwin-arm64": 57_648,
 };
 
-const DARWIN_SIDECARS = SIDECARS.map((s) => ({
-  assetName: s.assetName,
-  fileBasename: s.fileBasename,
-  sizeBytes: SIDECAR_ASSET_SIZES[s.assetName] ?? 0,
-}));
+const DARWIN_SIDECARS = SIDECARS.map((s) => {
+  const sizeBytes = SIDECAR_ASSET_SIZES[s.assetName];
+  if (sizeBytes === undefined) {
+    // Fail fast at module load: a sidecar added to SIDECARS without a size
+    // entry here would otherwise silently render as "0 B" in the plan.
+    throw new Error(
+      `install-plan: missing release-asset size for sidecar "${s.assetName}"; add it to SIDECAR_ASSET_SIZES`,
+    );
+  }
+  return { assetName: s.assetName, fileBasename: s.fileBasename, sizeBytes };
+});
 
 function sumFiles(files: PlanFile[]): number {
   return files.reduce((sum, file) => sum + file.sizeBytes, 0);

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from "fs";
 import { humanBytes } from "./format";
 import { dirname, join } from "path";
 import { getEngineBinPath } from "./engine";
+import { SIDECARS } from "./engine-install";
 import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
 import { engineVersion, packageVersion } from "./package-info";
@@ -120,12 +121,19 @@ const DIARIZE_FILES: PlanFile[] = [
   },
 ];
 
-// Kokoro (#207) and diarization (#199) are in-engine now (native fluidaudio-rs),
-// so only AVSpeech and text-lang ship as separate Swift-sidecar assets.
-const DARWIN_SIDECARS: ReleaseAssetSpec[] = [
-  { assetName: "say-avspeech-darwin-arm64", sizeBytes: 63_056 },
-  { assetName: "kesha-textlang-darwin-arm64", sizeBytes: 57_648 },
-];
+// The sidecar list (and the asset-name → installed-filename mapping) lives in
+// SIDECARS in engine-install.ts; only the release-asset sizes are pinned here,
+// like the model tables above.
+const SIDECAR_ASSET_SIZES: Record<string, number> = {
+  "say-avspeech-darwin-arm64": 63_056,
+  "kesha-textlang-darwin-arm64": 57_648,
+};
+
+const DARWIN_SIDECARS = SIDECARS.map((s) => ({
+  assetName: s.assetName,
+  fileBasename: s.fileBasename,
+  sizeBytes: SIDECAR_ASSET_SIZES[s.assetName] ?? 0,
+}));
 
 function sumFiles(files: PlanFile[]): number {
   return files.reduce((sum, file) => sum + file.sizeBytes, 0);
@@ -142,12 +150,6 @@ function engineAssetForPlatform(): ReleaseAssetSpec | null {
     return { assetName: "kesha-engine-windows-x64.exe", sizeBytes: 63_126_528 };
   }
   return null;
-}
-
-function sidecarFilename(assetName: string): string {
-  if (assetName === "say-avspeech-darwin-arm64") return "say-avspeech";
-  if (assetName === "kesha-textlang-darwin-arm64") return "kesha-textlang";
-  return assetName;
 }
 
 function filesCached(cacheRoot: string, files: PlanFile[]): boolean {
@@ -215,7 +217,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
         name: `Sidecar ${sidecar.assetName}`,
         source: `GitHub release v${engineVersion}`,
         sizeBytes: sidecar.sizeBytes,
-        cached: existsSync(join(engineDir, sidecarFilename(sidecar.assetName))),
+        cached: existsSync(join(engineDir, sidecar.fileBasename)),
         refresh: noCache,
       });
     }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,4 +1,5 @@
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { errorMessage } from "../error-utils";
 import { z } from "zod";
 import { chmodSync, existsSync, readFileSync, statSync } from "fs";
 import { basename, join } from "path";
@@ -78,7 +79,7 @@ export function registerTools(server: McpServer): void {
           structuredContent: { uri, path: outPath, format: fmt, voice: resolvedVoice, bytes },
         };
       } catch (err) {
-        return { isError: true, content: [{ type: "text" as const, text: toToolError(err) }] };
+        return { isError: true, content: [{ type: "text" as const, text: errorMessage(err) }] };
       }
     },
   );
@@ -126,7 +127,7 @@ export function registerTools(server: McpServer): void {
           structuredContent: { text, segments: [] },
         };
       } catch (err) {
-        return { isError: true, content: [{ type: "text" as const, text: toToolError(err) }] };
+        return { isError: true, content: [{ type: "text" as const, text: errorMessage(err) }] };
       }
     },
   );
@@ -159,7 +160,7 @@ export function registerTools(server: McpServer): void {
           structuredContent: { voices },
         };
       } catch (err) {
-        return { isError: true, content: [{ type: "text" as const, text: `list_voices failed: ${toToolError(err)}` }] };
+        return { isError: true, content: [{ type: "text" as const, text: `list_voices failed: ${errorMessage(err)}` }] };
       }
     },
   );
@@ -189,12 +190,8 @@ export function registerTools(server: McpServer): void {
           structuredContent: { languages },
         };
       } catch (err) {
-        return { isError: true, content: [{ type: "text" as const, text: `list_languages failed: ${toToolError(err)}` }] };
+        return { isError: true, content: [{ type: "text" as const, text: `list_languages failed: ${errorMessage(err)}` }] };
       }
     },
   );
-}
-
-function toToolError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,4 +1,5 @@
 import { Database } from "bun:sqlite";
+import { errorMessage } from "./error-utils";
 import { existsSync, mkdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { dirname, extname, join } from "path";
@@ -148,7 +149,7 @@ function warnStatsWriteFailed(err: unknown): void {
     log.warn("warning: failed to write Kesha Stats; continuing without stats for this event");
     warnedStatsWriteFailed = true;
   }
-  const message = err instanceof Error ? err.message : String(err);
+  const message = errorMessage(err);
   log.debug(`stats write failed: ${message}`);
 }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -171,23 +171,33 @@ export function createStatsRecorder(command: StatsCommandName): StatsRecorder {
   }
 }
 
-export function enableStats(): void {
+/** Open the stats DB (creating it if needed), run fn, always close. */
+function withStatsDb<T>(fn: (db: Database) => T): T {
   const db = openStatsDatabase(resolveStatsDbPath());
   try {
-    setSetting(db, "enabled", "1");
-    applyStatsRetention(db);
+    return fn(db);
   } finally {
     db.close();
   }
 }
 
+/** Like withStatsDb, but returns fallback() without creating the DB when none exists. */
+function withExistingStatsDb<T>(fallback: () => T, fn: (db: Database) => T): T {
+  if (!existsSync(resolveStatsDbPath())) return fallback();
+  return withStatsDb(fn);
+}
+
+export function enableStats(): void {
+  withStatsDb((db) => {
+    setSetting(db, "enabled", "1");
+    applyStatsRetention(db);
+  });
+}
+
 export function disableStats(): void {
-  const db = openStatsDatabase(resolveStatsDbPath());
-  try {
+  withStatsDb((db) => {
     setSetting(db, "enabled", "0");
-  } finally {
-    db.close();
-  }
+  });
 }
 
 export interface StatsStatus {
@@ -200,27 +210,22 @@ export interface StatsStatus {
 
 export function getStatsStatus(): StatsStatus {
   const dbPath = resolveStatsDbPath();
-  if (!existsSync(dbPath)) {
-    return {
+  return withExistingStatsDb<StatsStatus>(
+    () => ({
       enabled: false,
       dbPath,
       runCount: 0,
       exists: false,
       retentionDays: defaultRetentionDays(),
-    };
-  }
-  const db = openStatsDatabase(dbPath);
-  try {
-    return {
+    }),
+    (db) => ({
       enabled: getStatsEnabled(db),
       dbPath,
       runCount: Number((db.query("select count(*) as n from runs").get() as { n: number }).n),
       exists: true,
       retentionDays: getStatsRetentionDays(db),
-    };
-  } finally {
-    db.close();
-  }
+    }),
+  );
 }
 
 export interface StatsResetResult {
@@ -231,31 +236,27 @@ export interface StatsResetResult {
 }
 
 export function resetStats(): StatsResetResult {
-  const dbPath = resolveStatsDbPath();
-  if (!existsSync(dbPath)) {
-    return { runs: 0, artifacts: 0, stageTimings: 0, errors: 0 };
-  }
-  const db = openStatsDatabase(dbPath);
-  try {
-    let artifacts = 0;
-    let stageTimings = 0;
-    let errors = 0;
-    let runs = 0;
-    db.exec("begin");
-    try {
-      artifacts = runChanges(db, "delete from artifacts");
-      stageTimings = runChanges(db, "delete from stage_timings");
-      errors = runChanges(db, "delete from errors");
-      runs = runChanges(db, "delete from runs");
-      db.exec("commit");
-    } catch (err) {
-      db.exec("rollback");
-      throw err;
-    }
-    return { runs, artifacts, stageTimings, errors };
-  } finally {
-    db.close();
-  }
+  return withExistingStatsDb(
+    () => ({ runs: 0, artifacts: 0, stageTimings: 0, errors: 0 }),
+    (db) => {
+      let artifacts = 0;
+      let stageTimings = 0;
+      let errors = 0;
+      let runs = 0;
+      db.exec("begin");
+      try {
+        artifacts = runChanges(db, "delete from artifacts");
+        stageTimings = runChanges(db, "delete from stage_timings");
+        errors = runChanges(db, "delete from errors");
+        runs = runChanges(db, "delete from runs");
+        db.exec("commit");
+      } catch (err) {
+        db.exec("rollback");
+        throw err;
+      }
+      return { runs, artifacts, stageTimings, errors };
+    },
+  );
 }
 
 export interface StatsVacuumResult {
@@ -274,13 +275,10 @@ export function vacuumStats(): StatsVacuumResult {
       afterBytes: 0,
     };
   }
-  const db = openStatsDatabase(dbPath);
-  try {
+  withStatsDb((db) => {
     db.exec("pragma wal_checkpoint(TRUNCATE)");
     db.exec("vacuum");
-  } finally {
-    db.close();
-  }
+  });
   return {
     dbPath,
     beforeBytes,
@@ -292,13 +290,10 @@ export function setStatsRetentionDays(days: number | null): void {
   if (days !== null && (!Number.isInteger(days) || days < 1)) {
     throw new Error("Stats retention must be a positive whole number of days, or 'off'");
   }
-  const db = openStatsDatabase(resolveStatsDbPath());
-  try {
+  withStatsDb((db) => {
     setSetting(db, "retention_days", days === null ? "off" : String(days));
     applyStatsRetention(db);
-  } finally {
-    db.close();
-  }
+  });
 }
 
 export function exportStats(format: StatsExportFormat): string {
@@ -380,11 +375,8 @@ interface StatsRunTimingRow {
 }
 
 export function getWeekSummary(now = new Date()): StatsWeekSummary {
-  const dbPath = resolveStatsDbPath();
-  if (!existsSync(dbPath)) return emptyWeekSummary();
   const since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
-  const db = openStatsDatabase(dbPath);
-  try {
+  return withExistingStatsDb(emptyWeekSummary, (db) => {
     const stageRows = db.query(
       `select
         run_id as runId,
@@ -433,9 +425,7 @@ export function getWeekSummary(now = new Date()): StatsWeekSummary {
       hasInputDurationData: inputArtifacts.some((row) => typeof row.durationMs === "number"),
       slowestRuns: summarizeSlowestRuns(runRows, stageRows),
     };
-  } finally {
-    db.close();
-  }
+  });
 }
 
 export interface StatsRunExportRow {
@@ -492,11 +482,10 @@ export interface StatsErrorRow {
 }
 
 export function getRecentErrors(limit = 20): StatsErrorRow[] {
-  const dbPath = resolveStatsDbPath();
-  if (!existsSync(dbPath)) return [];
-  const db = openStatsDatabase(dbPath);
-  try {
-    const rows = db.query(
+  return withExistingStatsDb(
+    () => [],
+    (db) => {
+      const rows = db.query(
       `select
         e.occurred_at as occurredAt,
         r.command as command,
@@ -508,11 +497,10 @@ export function getRecentErrors(limit = 20): StatsErrorRow[] {
        left join runs r on r.id = e.run_id
        order by e.occurred_at desc
        limit ?`,
-    ).all(limit) as StatsErrorRow[];
-    return rows;
-  } finally {
-    db.close();
-  }
+      ).all(limit) as StatsErrorRow[];
+      return rows;
+    },
+  );
 }
 
 export function renderWeekSummary(summary: StatsWeekSummary): string {
@@ -780,15 +768,11 @@ function insertRun(db: Database, command: StatsCommandName): number {
 }
 
 function readStatsExport(): StatsExportData {
-  const dbPath = resolveStatsDbPath();
-  if (!existsSync(dbPath)) {
-    return emptyStatsExport(defaultRetentionDays());
-  }
-
-  const db = openStatsDatabase(dbPath);
-  try {
-    applyStatsRetention(db);
-    return {
+  return withExistingStatsDb(
+    () => emptyStatsExport(defaultRetentionDays()),
+    (db) => {
+      applyStatsRetention(db);
+      return {
       schemaVersion: SCHEMA_VERSION,
       exportedAt: new Date().toISOString(),
       retentionDays: getStatsRetentionDays(db),
@@ -840,11 +824,10 @@ function readStatsExport(): StatsExportData {
          from errors e
          left join runs r on r.id = e.run_id
          order by e.occurred_at asc, e.id asc`,
-      ).all() as StatsErrorRow[],
-    };
-  } finally {
-    db.close();
-  }
+        ).all() as StatsErrorRow[],
+      };
+    },
+  );
 }
 
 function emptyStatsExport(retentionDays: number | null): StatsExportData {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { errorMessage } from "./error-utils";
+import { humanBytes } from "./format";
 import { existsSync, mkdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { dirname, extname, join } from "path";
@@ -1182,18 +1183,6 @@ function orderBuckets(buckets: Map<string, number>, order: string[]): StatsCount
   return order
     .filter((label) => buckets.has(label))
     .map((label) => ({ label, count: buckets.get(label) ?? 0 }));
-}
-
-function humanBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  const units = ["KB", "MB", "GB", "TB"];
-  let n = bytes / 1024;
-  let i = 0;
-  while (n >= 1024 && i < units.length - 1) {
-    n /= 1024;
-    i++;
-  }
-  return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
 }
 
 function humanDuration(ms: number): string {

--- a/tests/unit/error-utils.test.ts
+++ b/tests/unit/error-utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { errorMessage } from "../../src/error-utils";
+
+describe("errorMessage", () => {
+  test("returns .message for Error instances", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+    expect(errorMessage(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  test("stringifies non-Error throwables", () => {
+    expect(errorMessage("plain string")).toBe("plain string");
+    expect(errorMessage(42)).toBe("42");
+    expect(errorMessage(null)).toBe("null");
+    expect(errorMessage(undefined)).toBe("undefined");
+  });
+});

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatTextOutput,
+  formatTranscriptOutput,
+  formatVerboseOutput,
+  humanBytes,
+} from "../../src/format";
+import type { TranscribeResult } from "../../src/types";
+
+function result(overrides: Partial<TranscribeResult>): TranscribeResult {
+  return { file: "a.ogg", text: "hello", ...overrides } as TranscribeResult;
+}
+
+describe("humanBytes", () => {
+  test("bytes below 1024 stay in B", () => {
+    expect(humanBytes(0)).toBe("0 B");
+    expect(humanBytes(1023)).toBe("1023 B");
+  });
+
+  test("scales through KB/MB/GB/TB", () => {
+    expect(humanBytes(1024)).toBe("1.0 KB");
+    expect(humanBytes(1536)).toBe("1.5 KB");
+    expect(humanBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(humanBytes(1024 ** 3)).toBe("1.0 GB");
+    expect(humanBytes(1024 ** 4)).toBe("1.0 TB");
+  });
+
+  test("drops decimals at 100+ of a unit", () => {
+    expect(humanBytes(150 * 1024)).toBe("150 KB");
+    expect(humanBytes(99.4 * 1024)).toBe("99.4 KB");
+  });
+
+  test("caps at TB instead of inventing units", () => {
+    expect(humanBytes(1024 ** 5)).toBe("1024 TB");
+  });
+});
+
+describe("formatTextOutput", () => {
+  test("single result is bare text", () => {
+    expect(formatTextOutput([result({})])).toBe("hello\n");
+  });
+
+  test("multiple results get file headers", () => {
+    const out = formatTextOutput([
+      result({ file: "a.ogg", text: "one" }),
+      result({ file: "b.ogg", text: "two" }),
+    ]);
+    expect(out).toBe("=== a.ogg ===\none\n\n=== b.ogg ===\ntwo\n");
+  });
+});
+
+describe("formatTranscriptOutput", () => {
+  test("appends lang line with confidence", () => {
+    const out = formatTranscriptOutput([
+      result({ textLanguage: { code: "ru", confidence: 0.987 } }),
+    ]);
+    expect(out).toBe("hello\n[lang: ru, confidence: 0.99]\n");
+  });
+
+  test("omits lang line when no language fields are present", () => {
+    expect(formatTranscriptOutput([result({})])).toBe("hello\n");
+  });
+});
+
+describe("formatVerboseOutput", () => {
+  test("includes language, timing, and separator lines", () => {
+    const out = formatVerboseOutput([
+      result({
+        audioLanguage: { code: "en", confidence: 0.5 },
+        textLanguage: { code: "en", confidence: 0.75 },
+        sttTimeMs: 120,
+      }),
+    ]);
+    expect(out).toBe(
+      "Audio language: en (confidence: 0.50)\n" +
+        "Text language: en (confidence: 0.75)\n" +
+        "STT time: 120ms\n" +
+        "---\n" +
+        "hello\n",
+    );
+  });
+
+  test("falls back to legacy lang field without confidence", () => {
+    const out = formatVerboseOutput([result({ lang: "fr" })]);
+    expect(out).toBe("Text language: fr\n---\nhello\n");
+  });
+
+  test("multiple results get file headers", () => {
+    const out = formatVerboseOutput([
+      result({ file: "a.ogg", text: "one" }),
+      result({ file: "b.ogg", text: "two" }),
+    ]);
+    expect(out).toBe("=== a.ogg ===\n---\none\n\n=== b.ogg ===\n---\ntwo\n");
+  });
+});


### PR DESCRIPTION
Closes #538

Ten behavior-preserving "Tidy First?" structural cleanups, one commit each, ranked by churn × repetition (Pareto pass over the 6-month git log). No functional changes intended anywhere — existing tests pass unmodified.

## TypeScript

1. **`errorMessage()` helper** — replaces 20 inline `err instanceof Error ? err.message : String(err)` ternaries across 10 files; folds `mcp/tools.ts`'s private `toToolError()` into it (`src/error-utils.ts`).
2. **`withStatsDb()` / `withExistingStatsDb()`** — the resolve-path → existsSync guard → open → try/finally close idiom repeated in 9 exported functions in `src/stats.ts` now lives in two helpers.
3. **`downloadEngine` chunked** — the ~200-line body split into `refreshCachedEngine()` (cache-valid path) and `fetchEngineBinary()` (cold path); comments moved with the code.
4. **`humanBytes()` deduped** — identical implementations in `stats.ts` / `doctor.ts` / `install-plan.ts` → one exported copy in `format.ts`.
5. **Sidecar table unified** — `install-plan.ts` re-encoded the asset-name → installed-filename mapping already in `SIDECARS`; it now derives `DARWIN_SIDECARS` from the exported spec (only release-asset sizes stay pinned locally). Also: three inline `process.platform/arch` checks in `engine-install.ts` → existing `isDarwinArm64()`.
6. **`stripBooleanFlag()`** — `resolveColorMode` / `resolveQuietMode` in `cli/dispatch.ts` shared ~18 of 20 lines; a third global flag is now one entry.

## Rust

7. **`say()` flattened** — the mixed cfg-gated if-let early returns + bottom match (with `unreachable!()` leftovers) is now a single exhaustive match where each engine arm owns its SSML handling. `say_ssml()` was only reachable with a Kokoro engine, so it takes the Kokoro params directly and loses its own `unreachable!()` match.
8. **`say_loop::handle()` chunked** — extracted `handle_kokoro()` / `handle_vosk()`; the dispatcher reads as validation + routing. The verbatim SSML parse + "no speakable content" check duplicated in both arms is now `parse_ssml_or_err()`.
9. **`strip_emphasis_markers()`** — the `+` stress-marker strip was inlined five times (three `synth_one_*` engine arms, plus `en`/`ru` `normalize_segments`); one `pub(crate)` helper in `tts/mod.rs`, per-engine `warn_once` messages stay at call sites.
10. **`models.rs` manifests normalized** — `vosk_ru_manifest()` (a `Vec` of `'static` literals allocated per call) is now `const VOSK_RU_FILES`, matching every other manifest; the repeated cache/collect/`parallel_download` dance collapses into `download_manifest()`.

## Verification

- `bun test && bunx tsc --noEmit`
- `cargo fmt && cargo clippy --all-targets --features tts -- -D warnings && cargo nextest run --features tts`
- `cargo check --features coreml,tts,system_tts,system_kokoro --no-default-features` (cfg-gated TTS arms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
