### PR TITLE
test: widen CLI-spawn budget for the diagnostics contract test

### DIFF
--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -711,6 +711,9 @@ describe("CLI contracts", () => {
     expect(existsSync(langPidPath)).toBe(false);
   });
 
+  // Two cold `bun bin/kesha.js` spawns (full TS transpile each) — the default
+  // 4s per-spawn budget flakes under CPU contention, so both calls get a wide
+  // budget. The assertions themselves are deterministic.
   test("diagnostic and support commands return parseable/readable contracts without leaking temp home", async () => {
     const dir = makeTempDir("kesha-cli-contract-diagnostics-");
     const enginePath = createFakeEngine(dir);
@@ -719,7 +722,7 @@ describe("CLI contracts", () => {
       KESHA_ENGINE_BIN: enginePath,
     };
 
-    const doctor = await runCli(["doctor", "--json", "--redact"], { env });
+    const doctor = await runCli(["doctor", "--json", "--redact"], { env, timeoutMs: 15_000 });
     expectContract(doctor, {
       exitCode: 0,
       stderrEmpty: true,
@@ -738,6 +741,7 @@ describe("CLI contracts", () => {
     const bundlePath = join(dir, "bundle.tar.gz");
     const bundle = await runCli(["support-bundle", "--output", bundlePath], {
       env,
+      timeoutMs: 15_000,
       artifacts: [bundlePath],
     });
     expectContract(bundle, {
@@ -751,7 +755,7 @@ describe("CLI contracts", () => {
       exists: true,
     });
     expect(bundle.artifacts[0]?.sizeBytes).toBeGreaterThan(0);
-  });
+  }, 30_000);
 
   test("read-only planning and stats commands keep user data on stdout", async () => {
     const dir = makeTempDir("kesha-cli-contract-readonly-");


### PR DESCRIPTION
Follow-up from #539's verification runs (refs #538).

The `diagnostic and support commands return parseable/readable contracts` test in `tests/integration/cli-contracts.test.ts` cold-spawns `bun bin/kesha.js` twice (full TS transpile each) inside the harness's default 4s-per-spawn budget plus bun's 5s per-test timeout. Under CPU contention (e.g. cargo building in parallel locally) the spawn gets SIGTERM'd at 4s → exit 143 → flaky failure that never reflects a real regression.

Fix: give both `runCli` calls a 15s budget and the test an explicit 30s timeout. The assertions it pins — `--redact` privacy redaction, stdout/stderr contract discipline, support-bundle integrity — stay fully deterministic; a regression there still fails regardless of the wider timeout.

Verified: 3 consecutive green runs locally (previously flaked ~1 in 3 under load); reproduced the flake on unmodified main before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)