### PR TITLE
chore(release): v1.24.1 (CLI-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
CLI-only patch release. Engine: v1.23.0 (unchanged).

Ships:
- #539 — Tidy First: top-10 Pareto tidyings (TS CLI + Rust engine source; the Rust refactors are source-only until the next engine release)
- #540 — widen CLI-spawn budget for the diagnostics contract test (deflakes local runs)

Refs #538. After merge: `gh release create v1.24.1-cli` marker → automated npm publish.

Smoke-tested the refactored CLI surface (status, doctor --json --redact, install --plan, stats, say) against the published v1.23.0 engine per the CLI-only release rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)