### PR TITLE
chore(release): v1.24.2 (engine + CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ binary.
 
 ## [Unreleased]
 
+## [1.24.2] — 2026-06-12
+
+Engine release. Ships the [#539](https://github.com/drakulavich/kesha-voice-kit/pull/539) Rust refactors in isolation — binaries are intended to be functionally identical to v1.23.0, so any future regression bisects cleanly to this refactor set. CLI and engine versions move together to 1.24.2.
+
+### Changed
+- **Internal (engine):** TTS dispatch in `say()` flattened to one exhaustive engine match (no more `unreachable!()` arms); `--stdin-loop` handler chunked into per-engine helpers with a shared SSML parse guard; SSML `<emphasis>` `+`-stripping deduplicated into one helper; the Vosk-RU model manifest normalized to a `const` plus a shared `download_manifest()` ([#539](https://github.com/drakulavich/kesha-voice-kit/pull/539), refs [#538](https://github.com/drakulavich/kesha-voice-kit/issues/538)). No behavior change intended.
+
+## [1.24.1] — 2026-06-12
+
+CLI-only release. Engine binary unchanged at v1.23.0. Marker tag `v1.24.1-cli`.
+
+### Changed
+- **Internal (CLI):** ten Tidy First refactors — shared `errorMessage()` / `humanBytes()` helpers, `downloadEngine` split into cached/cold-path helpers, stats-DB open/close scaffolding deduplicated, the install-plan sidecar table derived from the canonical `SIDECARS` spec (with a fail-fast guard for missing asset sizes), and generic global boolean-flag parsing ([#539](https://github.com/drakulavich/kesha-voice-kit/pull/539), closes [#538](https://github.com/drakulavich/kesha-voice-kit/issues/538)). No behavior change intended.
+
+### Fixed
+- **Flaky diagnostics contract test** — the doctor/support-bundle test now has a 15 s per-spawn / 30 s per-test budget instead of flaking with SIGTERM under CPU contention; assertions unchanged ([#540](https://github.com/drakulavich/kesha-voice-kit/pull/540)).
+
 ## [1.24.0] — 2026-06-09
 
 CLI-only release. Engine binary unchanged at v1.23.0. Marker tag `v1.24.0-cli` (the `-cli` suffix excludes it from `build-engine.yml`'s tag filter — no Rust rebuild fires).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.23.0"
+    "version": "1.24.2"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.23.0"
+version = "1.24.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.23.0"
+version = "1.24.2"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Engine release. Bumps `rust/Cargo.toml`, `Cargo.lock`, `package.json#version`, and `package.json#keshaEngine.version` together to **1.24.2**.

Ships the #539 Rust refactors (refs #538) in an isolated engine release — binaries are functionally identical to v1.23.0 by design, so any future regression bisects cleanly to the refactor set.

Post-merge: tag `v1.24.2` → build-engine → draft validation (sha256 + sigstore + darwin binary exercise) → undraft → npm publish.

Note: `integration-tests` is expected to skip on `release/*` (engine tag doesn't exist yet — see runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)