### PR TITLE
docs(openspec): baseline specs for all existing features

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,155 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,160 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,172 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,107 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,143 @@
+---
+name: "OPSX: Sync"
+description: Sync delta specs from a change to main specs
+category: Workflow
+tags: [workflow, specs, experimental]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,21 @@
+schema: spec-driven
+
+context: |
+  Kesha Voice Kit: local-only multilingual voice toolkit. CLI `kesha` (Bun/TypeScript)
+  wraps a Rust binary `kesha-engine` (subprocess, never linked in-process).
+  Capabilities: speech-to-text (Parakeet TDT 0.6B; CoreML on Apple Silicon, ONNX elsewhere),
+  audio/text language detection, TTS (Kokoro / Vosk-TTS / AVSpeech), MCP server, OpenClaw plugin.
+  Conventions: conventional commits; engine and models are NEVER auto-downloaded
+  (explicit `kesha install` only); default TTS voices must be male (brand rule);
+  stdout stays pipe-friendly (progress/errors on stderr); user-facing install
+  instructions use bun, never npm.
+  Baseline specs live in openspec/specs/ — one capability per directory; see
+  openspec/specs/README.md for personas and reading order, GLOSSARY.md for canonical terms.
+
+rules:
+  proposal:
+    - Always include a "Non-goals" section
+  specs:
+    - Use glossary terms from openspec/specs/GLOSSARY.md verbatim
+    - Every requirement needs at least one happy-path and one error/edge scenario
+    - State outcomes, not implementation mechanisms, in requirement text

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -19,3 +19,6 @@ rules:
     - Use glossary terms from openspec/specs/GLOSSARY.md verbatim
     - Every requirement needs at least one happy-path and one error/edge scenario
     - State outcomes, not implementation mechanisms, in requirement text
+    - Reference named personas (Ira/Maks/Sona), never a generic "user"
+    - Record anything uncertain or where spec and code disagree under "Open Issues" — never invent a resolution
+    - Trace each requirement to code with file:line refs in a Technical Note

--- a/openspec/specs/GLOSSARY.md
+++ b/openspec/specs/GLOSSARY.md
@@ -1,0 +1,42 @@
+# Glossary
+
+Canonical terms for the Kesha Voice Kit spec corpus. Specs use these terms
+verbatim; if you need a new term, add it here first.
+
+| Term | Definition |
+|---|---|
+| **CLI** | The `kesha` command — a Bun/TypeScript program installed from npm as `@drakulavich/kesha-voice-kit`. |
+| **Engine** | The `kesha-engine` Rust binary, downloaded from GitHub Releases by `kesha install` and invoked by the CLI as a subprocess. Never linked in-process. |
+| **Backend** | The compile-time ASR implementation inside the Engine: **CoreML** (Apple Silicon, FluidAudio/ANE) or **ONNX** (Linux/Windows/fallback, `ort`). Exactly one per Engine binary; no runtime fallback. |
+| **Model cache** | `~/.cache/kesha/` (override: `KESHA_CACHE_DIR`) where the Engine binary and all models live. |
+| **Pinned hash** | The SHA-256 recorded for every model file in `rust/src/models.rs`; downloads that don't match are rejected, never cached. |
+| **Capabilities JSON** | The machine-readable self-description printed by `kesha-engine --capabilities-json` (protocol version 3); the CLI validates flags against it instead of blindly forwarding them. |
+| **Error code** | A stable `E_*` identifier (e.g. `E_MODEL_MISSING`) printed by the Engine on stderr as `error [E_CODE]: message`; the full taxonomy comes from `--error-codes-json`. |
+| **Exit code** | Process status: 0 success, 1 runtime failure, 2 invalid arguments; `kesha say` additionally uses 4 (synthesis/internal) and 5 (text too long). |
+| **Transcription** | Speech-to-text of an audio file via the Backend (Parakeet TDT 0.6B v3). The CLI's default command. |
+| **Segment** | A time-bounded slice of a Transcription: `{start, end, text}` seconds, optionally with a Speaker label. |
+| **Diarization** | Assigning Speaker labels (cluster indices) to Segments; requires darwin-arm64 and the Sortformer model installed via `kesha install --diarize`. |
+| **Speaker** | An unsigned integer cluster index, stable within one Transcription only. |
+| **VAD** | Voice-activity detection (Silero v5) used to split long audio before Transcription. Modes: **auto** (default), **on** (`--vad`), **off** (`--no-vad`). |
+| **Language detection (audio)** | Identifying the spoken language of audio (ECAPA-TDNN VoxLingua107, first 10 s), returning `{code, confidence}`. |
+| **Language detection (text)** | Identifying the language of a string (macOS `NLLanguageRecognizer`; `tinyld` fallback in the CLI). |
+| **TTS** | Text-to-speech via `kesha say` or the `say()` API. |
+| **TTS engine** | One of **Kokoro** (Kokoro-82M, 24 kHz), **Vosk** (Vosk-TTS Russian, multi-speaker), or **AVSpeech** (macOS system voices via Swift sidecar). Selected by Voice id prefix. |
+| **Voice id** | `<lang>-<name>` identifier such as `en-am_michael`, `ru-vosk-m02`, `macos-com.apple.voice.compact.ru-RU.Milena`. The prefix routes to a TTS engine. |
+| **Default voice** | The voice chosen when none is given. Must be male (brand rule); documented exception: `fr-ff_siwis`. |
+| **Voice routing** | Choosing a Voice id from `--voice`, `--lang`, or detected text language (`pickVoiceForLang`), in that precedence order. |
+| **SSML** | Speech Synthesis Markup Language subset accepted by `kesha say --ssml` (`<speak>`, `<break>`, `<say-as>`, `<phoneme>`, `<emphasis>`, `<prosody>`). |
+| **Normalization** | Pre-synthesis text rewriting: acronym letter-spelling, number-to-words expansion, IPA lexicon overrides; per-language stop-lists exempt word-like acronyms. |
+| **Sidecar** | A helper binary shipped next to the Engine (`say-avspeech`, `kesha-textlang`), resolved sibling-of-exe first. |
+| **Output format (transcribe)** | One of **text** (default), **verbose**, **transcript**, **json**, **toon** — selected by `--format`/`--json`/`--toon`. |
+| **TOON** | Token-oriented object notation (`@toon-format/toon`): compact tabular encoding of the same data as `--json`, losslessly decodable. |
+| **Output format (TTS)** | One of **wav** (default, IEEE-float mono), **ogg-opus**, **flac**. |
+| **Install plan** | The dry-run preview (`--plan`) listing components, sizes, and cache status before any download. |
+| **Never-auto-download rule** | The Engine and models download only during explicit `kesha install` / `kesha init`; every other command fails with an actionable hint when something is missing. |
+| **Diagnostic log** | Privacy-safe local NDJSON event log managed by `kesha logs` (modes: off / on / retain-on-failure). No transcript content or file paths. |
+| **Stats DB** | Local SQLite database of anonymous performance metrics managed by `kesha stats`. |
+| **Support bundle** | Redacted `.tar.gz` diagnostics archive produced by `kesha support-bundle`. |
+| **Redaction** | Removing secrets (TOKEN/KEY/SECRET/… values), home-directory paths, and URL credentials from diagnostic output. |
+| **MCP server** | The Model Context Protocol stdio server started by `kesha mcp`, exposing transcribe/synthesize/list tools to LLM clients. |
+| **Core API** | The programmatic interface exported from `@drakulavich/kesha-voice-kit/core` (`transcribe`, `say`, `downloadModel`, …). |
+| **Model mirror** | `KESHA_MODEL_MIRROR` base URL that rewrites HuggingFace download URLs (GitHub release URLs are never rewritten); safe because of Pinned hashes. |

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -1,0 +1,64 @@
+# Kesha Voice Kit — Baseline Specifications
+
+This directory is the **baseline spec corpus**: it captures how Kesha Voice Kit
+*actually behaves today*, one capability per directory, so future work can be
+proposed as OpenSpec change deltas against a trustworthy reference instead of
+tribal knowledge.
+
+> **Disclaimer (living document).** These specs describe the current release and
+> are updated whenever behavior changes. If a spec and the code disagree, the code
+> is the bug *or* the spec is stale — either way, open an issue; don't silently
+> trust one side.
+
+## How to read these specs
+
+Every spec follows the same shape:
+
+- **Purpose** — what the capability does and for whom.
+- **Non-Goals** — what it deliberately does *not* do (so nobody "fixes" that).
+- **Requirements** — verifiable contracts (`SHALL`), each with at least one
+  happy-path and one error/edge **Scenario** in Given/When/Then form.
+- **Technical Notes** — constants, tables, and `file:line` traceability refs,
+  kept out of the requirement text so contracts stay readable.
+- **Open Issues** — known gaps, tracked by GitHub issue where one exists.
+
+Terminology is canonical: every capitalized term of art (Engine, Backend,
+Voice id, Model cache, …) is defined once in [GLOSSARY.md](GLOSSARY.md) and used
+verbatim everywhere else.
+
+## Personas
+
+Specs reference these named personas instead of a generic "user":
+
+- **Ira, the CI engineer** — runs `kesha` headless in pipelines and scripts.
+  Cares about exit codes, stdout purity, `--quiet`, JSON/TOON output, and that
+  nothing ever triggers a surprise multi-gigabyte download.
+- **Maks, the macOS power user** — Apple Silicon laptop, voice-notes in Telegram
+  through the OpenClaw plugin, listens to `kesha say` replies. Cares about fast
+  local transcription, Russian + English TTS quality, and diarized meeting notes.
+- **Sona, the agent author** — embeds Kesha in an LLM agent via the MCP server
+  and the `./core` programmatic API. Cares about stable tool schemas, structured
+  errors, and resource cleanup.
+
+## Capabilities
+
+| Spec | Covers |
+|---|---|
+| [transcription](transcription/spec.md) | Default `kesha <file>` command: batch, output formats, VAD, exit codes |
+| [speaker-diarization](speaker-diarization/spec.md) | `--speakers` labels on transcription segments |
+| [language-detection](language-detection/spec.md) | Audio and text language identification |
+| [tts-synthesis](tts-synthesis/spec.md) | `kesha say`: voices, engines, formats, SSML, normalization |
+| [installation](installation/spec.md) | `kesha install` / `kesha init`: engine + model downloads, integrity |
+| [audio-recording](audio-recording/spec.md) | `kesha record`: microphone capture to WAV |
+| [diagnostics](diagnostics/spec.md) | `doctor`, `status`, `logs`, `stats`, `support-bundle` |
+| [cli-shell-integration](cli-shell-integration/spec.md) | Global flags, color/quiet rules, completions, manpage |
+| [mcp-server](mcp-server/spec.md) | `kesha mcp`: MCP tools and audio resources |
+| [programmatic-api](programmatic-api/spec.md) | `@drakulavich/kesha-voice-kit/core` exports |
+| [engine-contract](engine-contract/spec.md) | CLI ↔ `kesha-engine` boundary: capabilities, error codes, env vars |
+
+## Validation
+
+```bash
+openspec spec list                    # enumerate capabilities
+openspec validate --specs --strict    # structural validation — must exit 0
+```

--- a/openspec/specs/audio-recording/spec.md
+++ b/openspec/specs/audio-recording/spec.md
@@ -1,0 +1,202 @@
+# Audio Recording Specification
+
+## Purpose
+
+`kesha record` captures microphone audio to a WAV file so Maks can record a
+voice note or meeting directly from the command line, then immediately pipe it
+into `kesha` for transcription. The recording is entirely local: the Engine
+opens the default system microphone via CPAL, mixes all input channels to
+mono, and writes an IEEE-float 32-bit WAV at the device's native sample rate.
+
+## Non-Goals
+
+- `kesha record` is macOS-only. Linux and Windows receive a clear
+  `E_UNSUPPORTED_PLATFORM` error.
+- Device selection is not supported; only the OS default input device is used.
+- Live streaming of audio to stdout is not supported; the WAV is written when
+  recording stops.
+- No transcription or language detection is performed during recording;
+  `kesha record` is a capture-only command.
+- The output sample rate is whatever the device reports; no resampling is
+  applied by the recorder itself.
+
+## Requirements
+
+### Requirement: --out is required
+
+The CLI SHALL reject invocations that omit `--out` and exit 2 with a message
+naming the missing flag. The exit 2 happens in the CLI before the Engine is
+spawned.
+
+#### Scenario: Ira forgets --out
+
+- WHEN Ira runs `kesha record`
+- THEN the CLI prints `kesha record requires --out <path>.` to stderr
+- AND the process exits 2
+
+#### Scenario: Maks records to a specific path
+
+- GIVEN the microphone is available and recording is allowed by macOS
+- WHEN Maks runs `kesha record --out ~/notes/standup.wav`
+- THEN recording begins immediately and `standup.wav` is created when it stops
+- AND the process exits 0
+
+> *Technical Note — validation: `resolveRecordArgs` in
+> `src/cli/record.ts` lines 18–38. Exit 2: `src/cli/record.ts` line 68.*
+
+### Requirement: --max-seconds defaults to 120 and must be 1–3600
+
+The CLI SHALL default `--max-seconds` to 120 when omitted. It SHALL reject
+values that are not positive integers in the range 1–3600 and exit 2 with a
+message stating the valid range. The Engine stops recording when the elapsed
+time reaches `max-seconds`, even if stdin remains open.
+
+#### Scenario: Default recording stops at 120 s
+
+- GIVEN no `--max-seconds` is passed
+- WHEN Maks runs `kesha record --out note.wav` and lets it run
+- THEN recording stops automatically after 120 seconds
+- AND `note.wav` is written and the process exits 0
+
+#### Scenario: Value out of range is rejected
+
+- WHEN Ira runs `kesha record --out out.wav --max-seconds 9999`
+- THEN the CLI prints an error stating `--max-seconds must be an integer
+  between 1 and 3600.`
+- AND the process exits 2 without spawning the Engine
+
+#### Scenario: Non-integer value is rejected
+
+- WHEN Maks runs `kesha record --out out.wav --max-seconds 30.5`
+- THEN the CLI exits 2 with a message about the valid range
+
+> *Technical Note — constants: `DEFAULT_MAX_SECONDS = 120`,
+> `MAX_RECORD_SECONDS = 3600`. Source: `src/cli/record.ts` lines 15–16.
+> Integer check: `src/cli/record.ts` line 30 (`Number.isInteger`).*
+
+### Requirement: macOS-only at runtime
+
+The Engine SHALL return `E_UNSUPPORTED_PLATFORM` immediately when
+`record` is invoked on a non-macOS platform. The CLI surfaces this as a
+runtime exit 1.
+
+#### Scenario: Ira runs kesha record on Linux CI
+
+- GIVEN `kesha-engine` is the Linux ONNX build
+- WHEN Ira runs `kesha record --out out.wav`
+- THEN the Engine reports that microphone recording is supported on macOS only
+- AND the process exits 1
+
+> *Technical Note — non-macOS gate: `rust/src/record.rs` lines 48–56
+> (`#[cfg(not(target_os = "macos"))]` returns `E_UNSUPPORTED_PLATFORM` with
+> message `"microphone recording is currently supported on macOS only"`).*
+
+### Requirement: Records the default microphone, mixes to mono
+
+The Engine SHALL open the OS default input device via CPAL and accept any
+device sample format (F32, I16, U16). Multi-channel input SHALL be mixed down
+to mono by averaging all channels in each frame. The resulting mono samples
+are clamped to `[-1.0, 1.0]` before writing.
+
+#### Scenario: Maks uses a stereo USB microphone
+
+- GIVEN the default input device reports 2 channels
+- WHEN Maks runs `kesha record --out stereo-mic.wav --max-seconds 5`
+- THEN `stereo-mic.wav` is a valid mono WAV (1 channel) at the device's native
+  sample rate
+- AND the process exits 0
+
+#### Scenario: No microphone is available
+
+- GIVEN no default input device exists on the system
+- WHEN Maks runs `kesha record --out out.wav`
+- THEN the Engine reports `no default microphone input device found`
+- AND the process exits 1
+
+> *Technical Note — channel mix: `mix_frame_to_mono` in `rust/src/record.rs`
+> line 207 (frame average). Clamp: `rust/src/record.rs` line 110
+> (`.clamp(-1.0, 1.0)`). Sample format dispatch: `rust/src/record.rs`
+> lines 83–87 (F32/I16/U16 branches).*
+
+### Requirement: Recording stops on stdin EOF or max-seconds elapsed
+
+The Engine SHALL stop recording when either `--max-seconds` elapsed time is
+reached or stdin reaches EOF (pipe closed by the caller), whichever comes
+first. If stdin is a terminal, the EOF stop is not available; only
+`--max-seconds` applies.
+
+#### Scenario: Sona stops recording by closing the pipe
+
+- GIVEN Sona's script opens `kesha record --out captured.wav` and closes stdin
+  after 3 s
+- WHEN stdin EOF is detected
+- THEN the Engine stops recording immediately and writes `captured.wav`
+- AND the process exits 0
+
+#### Scenario: Interactive terminal relies on max-seconds
+
+- GIVEN Maks runs `kesha record --out note.wav --max-seconds 10` in a terminal
+- WHEN 10 seconds elapse
+- THEN recording stops automatically and `note.wav` is written
+
+> *Technical Note — stdin EOF stop: `spawn_stdin_stop_thread` in
+> `rust/src/record.rs` lines 131–139; the thread is only spawned when stdin is
+> not a terminal (`!io::stdin().is_terminal()`). Max-seconds check:
+> `rust/src/record.rs` lines 96 and 106.*
+
+### Requirement: Output is a WAV file — IEEE-float 32-bit mono at native device rate
+
+The Engine SHALL write the recording as a RIFF WAV file with format tag
+`0x0003` (IEEE float), 1 channel, 32 bits per sample, at the native device
+sample rate. The file SHALL include a `fact` chunk as required by the
+IEEE-float WAV format. Parent directories are created if they do not exist.
+
+#### Scenario: Output file is a valid IEEE-float WAV
+
+- GIVEN recording completes normally
+- WHEN Maks opens `note.wav` in any standard audio tool (e.g. Audacity, sox)
+- THEN the tool reads it as a 32-bit float mono WAV at the device sample rate
+
+#### Scenario: Output directory does not exist
+
+- WHEN Maks runs `kesha record --out /tmp/new-dir/note.wav`
+  and `/tmp/new-dir` does not exist
+- THEN the Engine creates `/tmp/new-dir/` and writes `note.wav` there
+- AND the process exits 0
+
+> *Technical Note — WAV format tag: `FORMAT_IEEE_FLOAT = 0x0003`
+> (`rust/src/record.rs` line 23). The writer uses plain `WAVE_FORMAT_IEEE_FLOAT`
+> (not `WAVE_FORMAT_EXTENSIBLE`) to avoid CoreAudio interpreting a stereo
+> layout that does not apply to mono files. `fact` chunk is always written.
+> Source: `write_plain_mono_float_wav` in `rust/src/record.rs` lines 234–276.*
+
+### Requirement: Success message on stderr names recording details
+
+When recording completes successfully, the Engine SHALL print a single line to
+stderr of the form:
+
+```
+Recorded <path> (<sample_rate> Hz, <channels> channel, <frames> frames)
+```
+
+Stdout remains empty so the caller can detect the silent completion without
+parsing.
+
+#### Scenario: Maks reads the confirmation
+
+- GIVEN `kesha record --out note.wav --max-seconds 5` completes normally
+- THEN stderr contains exactly one line matching
+  `Recorded note.wav (44100 Hz, 1 channel, <N> frames)`
+- AND stdout is empty
+- AND the process exits 0
+
+> *Technical Note — success message: `rust/src/cli/record.rs` lines 9–14.
+> Pluralization: `"channel"` (singular) when `channels == 1`.*
+
+## Open Issues
+
+- Device selection (`--device`) is not implemented; only the OS default input
+  is used. Feature request tracked separately.
+- The output sample rate is device-native (commonly 44100 Hz or 48000 Hz).
+  The transcription pipeline resamples to 16 kHz internally; no explicit
+  `--rate` flag exists on `kesha record`.

--- a/openspec/specs/cli-shell-integration/spec.md
+++ b/openspec/specs/cli-shell-integration/spec.md
@@ -1,0 +1,240 @@
+# CLI Shell Integration Specification
+
+## Purpose
+
+This spec covers the surface of `kesha` that makes it pleasant to use in shells
+and pipelines: global flags that apply to every subcommand (`--quiet`,
+`--no-color`), color-disable rules tied to environment variables, the
+unknown-command handler that suggests corrections, `kesha completions` for
+shell tab-completion, and `kesha manpage` for the bundled man page. Ira relies
+on these for scriptable, colorless output in CI. Maks relies on them for a clean
+terminal experience on his Mac.
+
+## Non-Goals
+
+- Per-subcommand flag parsing is handled by citty inside each subcommand, not
+  by this layer.
+- `KESHA_DEBUG` and debug-log output are not covered here; they are detailed in
+  the diagnostics spec.
+- Color/quiet semantics inside the Engine subprocess are the Engine contract's
+  concern; this spec covers propagation from the CLI.
+
+## Requirements
+
+### Requirement: `--quiet` / `-q` suppresses progress output globally
+
+The CLI SHALL strip `--quiet` and `-q` (and `--quiet=<value>`) from `rawArgs`
+before passing them to citty, so the flag is effective for every subcommand
+without each one declaring it. When quiet is active, `log.progress` and
+`log.status` calls produce no output. `log.warn` and `log.error` always print
+regardless of quiet.
+
+#### Scenario: Ira runs a transcription in quiet mode
+
+- GIVEN the Engine and models are installed
+- WHEN Ira runs `kesha --quiet standup.ogg`
+- THEN stdout contains only the transcript text
+- AND no spinner or progress lines appear on stderr
+- AND the process exits 0
+
+#### Scenario: Quiet applied to a subcommand
+
+- WHEN Ira runs `kesha -q say --voice en-am_michael "hello"`
+- THEN no progress lines appear on stderr
+- AND the synthesized audio still goes to stdout
+
+#### Scenario: Warnings still appear under quiet
+
+- GIVEN a language mismatch warning would normally be emitted
+- WHEN Ira runs `kesha --quiet --lang en ru.ogg`
+- THEN the language-mismatch warning still appears on stderr
+- AND the process exits 0
+
+> *Technical Note — `resolveQuietMode` in `src/cli/dispatch.ts:103` strips
+> `--quiet` / `-q` from `rawArgs` pre-parse and sets `log.quietEnabled`.
+> `log.progress` and `log.status` check `log.quietEnabled` before writing;
+> `log.warn` and `log.error` do not. Source: `src/log.ts:48-68`.*
+
+### Requirement: `--no-color` disables ANSI color universally
+
+The CLI SHALL resolve color mode from `--no-color`, the `CI` environment
+variable, and the `NO_COLOR` environment variable before any subcommand runs.
+Two distinct mechanisms cooperate:
+
+1. Per-invocation resolution (`resolveColorMode`): `--no-color` (bare) or
+   `--no-color=<truthy>` in `rawArgs` → disable; otherwise `CI` set to a
+   non-falsey value → disable (covers GitHub Actions, GitLab, CircleCI, and any
+   CI system that sets `CI=true`).
+2. Process-start preference: `NO_COLOR` set to a non-falsey value is honored by
+   the colorizer library at import time (user-level preference; never cleared
+   by the CLI). Because that decision is made at import, a later
+   `--no-color=false` cannot override a user-exported `NO_COLOR`.
+
+Falsey values for both flags and env vars are: the empty string, `"0"`,
+`"false"`, `"no"`, `"off"` (case-insensitive, trimmed). Any other non-empty
+value is truthy.
+
+`--no-color=false` explicitly re-enables color even when `CI=true`.
+
+When the CLI disables color, it sets `NO_COLOR=1` in `process.env` so that
+Engine subprocesses spawned later in the same process also see it. When the CLI
+re-enables color, it clears `NO_COLOR` from `process.env` — but only when the
+CLI itself set it; a user-exported `NO_COLOR` is never cleared.
+
+#### Scenario: Ira pipes output in CI
+
+- GIVEN `CI=true` is set in the environment
+- WHEN Ira runs `kesha status`
+- THEN all output is plain text with no ANSI escape codes
+- AND `process.env.NO_COLOR` is `"1"` when the Engine is spawned
+
+#### Scenario: Developer explicitly re-enables color in CI
+
+- GIVEN `CI=true` in the environment
+- WHEN Maks runs `kesha --no-color=false say "hello"`
+- THEN ANSI color sequences appear in the output
+- AND `NO_COLOR` is cleared from the process environment
+
+#### Scenario: User-exported NO_COLOR is never cleared
+
+- GIVEN `NO_COLOR=1` was exported before the process started
+- WHEN a subcommand completes and the CLI processes a second invocation with
+  `--no-color=false`
+- THEN `process.env.NO_COLOR` is still set (not deleted by the CLI)
+
+#### Scenario: `--no-color=0` re-opts in from a flag value
+
+- WHEN Maks runs `kesha --no-color=0 say "hello"`
+- THEN color is enabled (falsey grammar treats `"0"` as false)
+
+> *Technical Note — `resolveColorMode` in `src/cli/dispatch.ts:88` evaluates
+> only the `--no-color` flag and `CI`; the `NO_COLOR` env var is honored by
+> picocolors at import time (`src/log.ts:1-12`), not inside `resolveColorMode`.
+> The `FALSEY_VALUES` set (`src/cli/dispatch.ts:44`) is `{"", "0", "false",
+> "no", "off"}`. `USER_FORCED_NO_COLOR` is captured once at module import
+> (`src/cli/dispatch.ts:52`) and is used only to decide whether re-enabling may
+> clear `NO_COLOR` from `process.env`. The `setColorEnabled` toggle in
+> `src/log.ts:15` swaps picocolors between its full and no-op colorizers.
+> `--no-color` is stripped from `rawArgs` so citty never sees it.*
+
+### Requirement: Unknown non-path tokens produce a Levenshtein suggestion and exit 1
+
+The CLI SHALL print an "unknown command" error when the first non-flag,
+non-path argument does not match any known subcommand, optionally suggest the
+closest known command by Levenshtein distance (threshold: distance ≤ 3 AND
+≤ 40% of the candidate length), always print a hint that audio files need a
+path-like form, and exit 1 without spawning the Engine.
+
+A token is path-like if it contains `.` or `/`, or if it names an existing file
+on disk. Path-like first arguments route to transcription instead of triggering
+the unknown-command handler.
+
+#### Scenario: Maks typos a subcommand
+
+- WHEN Maks runs `kesha instal`
+- THEN stderr contains `unknown command 'instal'`
+- AND stderr contains `(Did you mean install?)`
+- AND stderr contains `If this is an audio file, pass a path like './instal'.`
+- AND the process exits 1
+
+#### Scenario: Completely unrecognised token with no close match
+
+- WHEN Ira runs `kesha xyzzy`
+- THEN stderr contains `unknown command 'xyzzy'`
+- AND no "Did you mean" line appears (distance exceeds threshold)
+- AND the path hint still appears
+- AND the process exits 1
+
+#### Scenario: Extensionless file that exists routes to transcription
+
+- GIVEN a file named `meeting` exists in the working directory
+- WHEN Maks runs `kesha meeting`
+- THEN the CLI routes to the main transcription command (not the unknown-command
+  handler)
+
+#### Scenario: Path-like token with extension routes to transcription
+
+- WHEN Ira runs `kesha standup.ogg`
+- THEN the CLI routes to the main transcription command (not the unknown-command
+  handler), even though `standup.ogg` is not a known subcommand
+
+> *Technical Note — `isPathLike` in `src/cli/dispatch.ts:38`: returns true when
+> the token contains `.` or `/` or `existsSync` returns true. `suggestCommand`
+> in `src/suggest-command.ts:3` uses `fastest-levenshtein`; threshold is
+> `Math.min(3, Math.ceil(match.length * 0.4))` (`src/suggest-command.ts:16`).
+> The suggestion is suppressed when `suggestion === firstArg` (exact case-fold
+> match already returned by the handler).*
+
+### Requirement: `kesha completions <shell>` prints a bundled completion script
+
+The CLI SHALL print the bundled shell completion script for `bash`, `zsh`, or
+`fish` to stdout and exit 0. An unknown shell argument SHALL print a usage
+error to stderr and exit 2. The script is read from the bundled
+`completions/kesha.<shell>` file at runtime.
+
+#### Scenario: Maks installs zsh completions
+
+- WHEN Maks runs `kesha completions zsh`
+- THEN stdout contains the zsh completion script
+- AND the process exits 0
+
+#### Scenario: Unknown shell
+
+- WHEN Ira runs `kesha completions powershell`
+- THEN stderr contains `usage: kesha completions <bash|zsh|fish>`
+- AND the process exits 2
+
+> *Technical Note — `completionsCommand` in `src/cli/completions.ts:20`.
+> `SHELL_FILES` maps `bash → kesha.bash`, `zsh → kesha.zsh`,
+> `fish → kesha.fish` (`src/cli/completions.ts:4`). The file is loaded via
+> `new URL("../../completions/<file>", import.meta.url)`. Unknown shell exits 2
+> at `src/cli/completions.ts:35`.*
+
+### Requirement: `kesha manpage` prints the bundled kesha(1) man page
+
+The CLI SHALL print the content of the bundled `man/kesha.1` file to stdout
+and exit 0. No arguments are accepted.
+
+#### Scenario: Maks reads the man page
+
+- WHEN Maks runs `kesha manpage`
+- THEN stdout contains the kesha(1) man-page in troff/groff format
+- AND the process exits 0
+
+> *Technical Note — `manpageCommand` in `src/cli/manpage.ts:3`. File loaded
+> via `new URL("../../man/kesha.1", import.meta.url)`. Written directly to
+> `process.stdout` — no colorization.*
+
+### Requirement: Result-producing commands follow the stdout-purity principle
+
+The CLI SHALL write only the primary result to stdout for commands whose
+stdout is the deliverable (transcription, `say` without `--out`, JSON/TOON
+output, completion scripts, the man page); spinner, status, warning, error,
+and debug output SHALL go to stderr so the result can be piped without
+filtering.
+
+#### Scenario: Ira pipes a JSON transcript to jq
+
+- WHEN Ira runs `kesha --json call.ogg | jq '.[] | .text'`
+- THEN `jq` receives clean JSON on stdin with no interleaved progress text
+- AND stderr carries any spinner or warning lines
+
+> *Technical Note — `log.info`, `log.success`, and `log.progress` use
+> `console.log` (stdout); `log.warn`, `log.error`, and `log.status` use
+> `process.stderr.write` to avoid Bun's startup-frozen TTY auto-red that
+> `console.error` would apply. `log.progress` (stdout) is used only in install
+> flows (`src/progress.ts:146`, `src/engine-install.ts`), which produce no
+> machine-readable stdout result. Source: `src/log.ts:46-68`.*
+
+## Open Issues
+
+- `--no-color` is not forwarded to the Engine subprocess explicitly; it relies
+  on `process.env.NO_COLOR` propagation. If the Engine is spawned via a shell
+  wrapper that resets the environment, the Engine may still produce ANSI codes.
+- Install-flow progress lines (`log.progress`) print to stdout, not stderr.
+  Harmless today because install has no machine-readable stdout, but it breaks
+  the corpus-wide "progress goes to stderr" intuition — candidate for moving to
+  `log.status` (stderr).
+- There is no `--color` flag to force color on when stdout is not a TTY (e.g.
+  inside tmux with `TERM=dumb`); `FORCE_COLOR` from picocolors is the current
+  workaround.

--- a/openspec/specs/diagnostics/spec.md
+++ b/openspec/specs/diagnostics/spec.md
@@ -1,0 +1,359 @@
+# Diagnostics Specification
+
+## Purpose
+
+Diagnostics is a family of read-oriented (or carefully scoped write) commands that
+let Ira debug a broken installation, Maks understand what is installed, and Sona
+package evidence for a support request — all without touching audio data or
+transcripts. The five commands are `kesha doctor`, `kesha status`, `kesha logs`,
+`kesha stats`, and `kesha support-bundle`. Every one of them respects the privacy
+contract: no transcript content, no raw file paths beyond the user's own Model cache,
+no credentials.
+
+## Non-Goals
+
+- None of these commands download the Engine or models; `kesha doctor` and
+  `kesha status` are read-only even if the Engine is missing.
+- The Stats DB records anonymous performance metrics only; it never records
+  transcript text, audio bytes, input file names, or full paths.
+- `kesha support-bundle` does not upload anything; it writes a local `.tar.gz` that
+  the user attaches manually.
+
+## Requirements
+
+### Requirement: `kesha doctor` produces a read-only diagnostic report
+
+`kesha doctor` SHALL collect and print a structured diagnostic report covering: CLI
+package name and version; Bun runtime version, platform, and architecture; Engine
+binary path, install status, version marker, and Capabilities JSON (obtained by
+probing the Engine); Model cache path, existence, total size, and per-component
+breakdown; optional-component install status (VAD, TTS Kokoro, TTS Vosk, FluidAudio
+Kokoro cache, Diarization, Sidecars); Stats DB status; Diagnostic log status; and a
+snapshot of known `KESHA_*` environment variables.
+
+`kesha doctor` SHALL always exit 0, even when components are missing or the Engine
+probe fails. It SHALL never download or modify any file.
+
+`--json` outputs the same data as 2-space-indented JSON to stdout.
+
+`--redact` replaces secret-pattern key values (keys containing TOKEN, KEY, SECRET,
+PASSWORD, CREDENTIAL, or AUTH) with `[REDACTED]`, rewrites home-directory path
+prefixes to `~`, and strips URL credentials and query strings. Redaction is opt-in
+for `kesha doctor`; it is always-on for `kesha support-bundle`.
+
+#### Scenario: Ira probes a broken CI image
+
+- GIVEN the Engine binary is missing
+- WHEN Ira runs `kesha doctor`
+- THEN the report shows `Binary: <path> (missing)` and `not available` for
+  capabilities
+- AND all other sections are still present
+- AND the process exits 0
+
+#### Scenario: Maks checks a healthy install in JSON
+
+- GIVEN the Engine and ASR models are installed
+- WHEN Maks runs `kesha doctor --json`
+- THEN stdout is a JSON object with `package`, `runtime`, `engine`, `cache`,
+  `optionalComponents`, `stats`, `diagnosticLogs`, and `env` keys
+- AND the process exits 0
+
+#### Scenario: Sona redacts before sharing
+
+- GIVEN `KESHA_MODEL_MIRROR=https://user:pass@mirror.example.com/models` is set
+- WHEN Sona runs `kesha doctor --redact`
+- THEN the mirror value in the env snapshot is printed as
+  `https://mirror.example.com/models` (credentials stripped)
+- AND home-directory paths appear as `~/…`
+- AND the process exits 0
+
+> *Technical Note — sources: `src/doctor.ts::collectDoctorReport`,
+> `src/doctor.ts::formatDoctorReport`, `src/cli/doctor.ts::doctorCommand`.
+> Known env keys snapshot: `KESHA_ENGINE_BIN`, `KESHA_CACHE_DIR`,
+> `KESHA_MODEL_MIRROR`, `KESHA_STATS_DB`, `KESHA_DEBUG`, `KESHA_DEBUG_FD`
+> (from `KNOWN_ENV_KEYS`). Secret-pattern detection splits the key on
+> non-alphanumeric characters and checks each part against
+> `["TOKEN","KEY","SECRET","PASSWORD","CREDENTIAL","AUTH"]`. URL redaction strips
+> `username`, `password`, `search`, and `hash`. Home-path redaction rewrites the
+> exact home prefix to `~`; case-insensitive on Windows.*
+
+### Requirement: `kesha status` shows engine and voice install state
+
+`kesha status` SHALL print a concise install summary: Engine binary path and install
+status; Backend, protocol version, and features (from Capabilities JSON); Bun runtime
+version and platform; active Model mirror (when `KESHA_MODEL_MIRROR` is set); and the
+list of installed TTS Voice ids.
+
+`--disk` SHALL additionally print a per-component disk-usage table (Engine, ASR,
+Language ID, VAD, TTS Kokoro, TTS Vosk) and the grand total. The FluidAudio Kokoro
+external cache is reported separately when it exists, because it lives outside
+Kesha's Model cache.
+
+When the Engine is not installed, `kesha status` prints a `kesha install` hint and
+exits 0.
+
+#### Scenario: Ira checks install state in a script
+
+- GIVEN the Engine and ASR models are installed with TTS English
+- WHEN Ira runs `kesha status`
+- THEN the output shows a green check for the Engine binary and its backend
+- AND lists `en-am_michael` (and other installed Kokoro voices) under TTS voices
+- AND the process exits 0
+
+#### Scenario: Maks sees disk usage
+
+- WHEN Maks runs `kesha status --disk`
+- THEN a disk-usage table appears with per-component sizes and a bold Total
+- AND if FluidAudio Kokoro cache exists it is listed under "External caches"
+
+#### Scenario: Engine missing
+
+- GIVEN no Engine is installed
+- WHEN Ira runs `kesha status`
+- THEN the output shows a red cross for the Engine binary
+- AND a hint to run `kesha install` is printed
+- AND the process exits 0
+
+> *Technical Note — sources: `src/status.ts::showStatus`, `src/status.ts::showDiskUsage`,
+> `src/cli/status.ts::statusCommand`. TTS voice enumeration reads `kokoro-82m/voices/*.bin`
+> (prefixed `en-`) and checks `vosk-ru/model.onnx` + `vosk-ru/bert/model.onnx` presence
+> (voices `ru-vosk-f01`, `ru-vosk-f02`, `ru-vosk-f03`, `ru-vosk-m01`, `ru-vosk-m02`).
+> `activeModelMirror()` trims and strips trailing slashes from `KESHA_MODEL_MIRROR`;
+> returns null when unset or empty.*
+
+### Requirement: `kesha logs` manages privacy-safe NDJSON Diagnostic logs
+
+`kesha logs` SHALL manage the local NDJSON Diagnostic log with the following actions:
+`status` (default), `enable`, `disable`, `mode <off|on|retain-on-failure>`, `path`,
+and `reset`.
+
+The three log modes are:
+- **off**: no events are written.
+- **on**: events are appended to the active log file immediately.
+- **retain-on-failure**: events are buffered in memory per CLI session and flushed to
+  disk only if the session ends with status `failed`; on success the buffer is
+  discarded.
+
+The default mode is `retain-on-failure`.
+
+`--json` is only valid with the `status` action; combining it with any other action
+SHALL exit 2.
+
+The Diagnostic log allowlist enforces privacy at write time: field names matching
+path, file, filename, message, text, transcript, stdout, stderr, env, token, secret,
+password, key, url, prompt, content, or raw are rejected; string values containing
+path separators, file extensions, domain names, or URL schemes are rejected. Events
+are NDJSON lines with fixed fields `ts`, `level`, `event`, `app_version`, `pid`.
+
+Log files rotate when the active file would exceed `maxBytes` (default 10 MB); up to
+`retain` rotated files are kept (default 5). Rotation naming: `kesha.1.ndjson`,
+`kesha.2.ndjson`, etc.
+
+Log directory: `~/Library/Logs/kesha` (macOS), `%LOCALAPPDATA%\kesha\logs` (Windows),
+`$XDG_STATE_HOME/kesha/logs` (Linux; override: `KESHA_LOG_DIR`).
+
+#### Scenario: Ira checks log status
+
+- WHEN Ira runs `kesha logs status`
+- THEN the mode, active path, total size, rotated file count, and rotation settings
+  are printed to stderr/info
+- AND the process exits 0
+
+#### Scenario: Enable and then disable
+
+- WHEN Ira runs `kesha logs enable` then `kesha logs disable`
+- THEN after `enable` the mode is `on` and the path is reported
+- AND after `disable` the mode is `off`
+- AND both commands exit 0
+
+#### Scenario: `--json` with non-status action is rejected
+
+- WHEN Ira runs `kesha logs enable --json`
+- THEN the CLI prints `usage: kesha logs status --json` to stderr
+- AND exits 2
+
+#### Scenario: Invalid mode value is rejected
+
+- WHEN Ira runs `kesha logs mode always`
+- THEN the CLI prints `usage: kesha logs mode <off|on|retain-on-failure>` to stderr
+- AND exits 2
+
+#### Scenario: `reset` deletes log files
+
+- GIVEN two rotated log files exist alongside the active log
+- WHEN Maks runs `kesha logs reset`
+- THEN all log files are deleted
+- AND the output reports the number of files and bytes deleted
+- AND the process exits 0
+
+> *Technical Note — sources: `src/diagnostic-log.ts`, `src/cli/logs.ts::logsCommand`.
+> Active log file: `kesha.ndjson`. Rotated files match `/^kesha\.\d+\.ndjson$/`.
+> Field name blocklist: `DISALLOWED_FIELD_NAME` regex; string value safety:
+> `SAFE_STRING_VALUE = /^[A-Za-z0-9_.@+-]{1,120}$/` AND NOT `UNSAFE_STRING_VALUE`
+> (path separators, file extensions, domain-like patterns, URL schemes).
+> Reserved field names: `ts`, `level`, `event`, `app_version`, `pid`.*
+
+### Requirement: `kesha stats` manages local anonymous SQLite metrics
+
+`kesha stats` SHALL manage the local SQLite Stats DB with the following actions:
+`status` (default), `enable`, `disable`, `week`, `errors`, `export`, `reset`,
+`vacuum`, and `retention`.
+
+Stats are disabled by default (the DB is not created until `kesha stats enable` is
+called). The Stats DB records command name, timing stages, artifact metadata
+(format, size in bytes, duration, sample rate, channels), and sanitized error
+messages — never transcript text, audio bytes, input file names, or raw paths.
+
+`export` requires a format argument: `json` or `csv`; any other value or omitting
+the format SHALL exit 2. `retention <days>` accepts a positive integer of days or
+`off` for no expiry; any other value SHALL exit 2. Unknown action names SHALL exit 2.
+
+Default retention is 90 days. The DB path defaults to
+`~/Library/Application Support/kesha/stats.sqlite` (macOS),
+`%APPDATA%\kesha\stats.sqlite` (Windows), or
+`$XDG_DATA_HOME/kesha/stats.sqlite` (Linux); override: `KESHA_STATS_DB`.
+
+#### Scenario: Ira checks stats status when disabled
+
+- GIVEN `kesha stats enable` has never been run
+- WHEN Ira runs `kesha stats status`
+- THEN the output shows `Kesha Stats: disabled` and `Runs: 0`
+- AND the process exits 0
+
+#### Scenario: Maks enables stats and checks the week summary
+
+- WHEN Maks runs `kesha stats enable`
+- THEN the output shows `Kesha Stats enabled` and the DB path
+- AND `kesha stats week` then shows the last-7-days summary including runs, input
+  files, STT time, and stage breakdown
+- AND both commands exit 0
+
+#### Scenario: Export with missing format is rejected
+
+- WHEN Ira runs `kesha stats export`
+- THEN the CLI prints `usage: kesha stats export --format json|csv` to stderr
+- AND exits 2
+
+#### Scenario: Invalid retention value is rejected
+
+- WHEN Ira runs `kesha stats retention 0`
+- THEN the CLI prints `usage: kesha stats retention <days|off>` to stderr
+- AND exits 2
+
+#### Scenario: Unknown action is rejected
+
+- WHEN Ira runs `kesha stats purge`
+- THEN the CLI lists supported actions to stderr
+- AND exits 2
+
+> *Technical Note — sources: `src/stats.ts`, `src/cli/stats.ts::statsCommand`.
+> Stats DB schema v1: tables `settings`, `runs`, `artifacts`, `stage_timings`,
+> `errors`. Privacy contract (in every export): `contentFree: true`,
+> `neverStored: ["audio bytes","transcripts","input text","output text","file names",
+> "full file paths","raw stdout","raw stderr","environment variables","model files"]`.
+> Error sanitization: strips stack frames, replaces home/cwd paths with `<path>`,
+> redacts URL query strings, redacts JSON text/transcript/stdout/stderr field values,
+> truncates to 300 chars. `export` writes to stdout (not stderr). `vacuum` runs
+> `pragma wal_checkpoint(TRUNCATE)` then `vacuum`.*
+
+### Requirement: `kesha support-bundle` creates a redacted diagnostics archive
+
+`kesha support-bundle` SHALL write a `.tar.gz` archive containing:
+- `README.txt` — description and privacy notice
+- `doctor.json` — redacted JSON doctor report
+- `doctor.txt` — redacted human-readable doctor report
+- `manifest.json` — archive metadata (entries, generation time, package, format)
+
+When `--include-logs` is passed, three additional entries are added under
+`diagnostic-logs/`: `README.txt`, `kesha.ndjson` (a bounded tail of the active log,
+default 64 KB), and `status.json`.
+
+The archive SHALL never contain audio files, transcripts, model files, the Stats DB,
+or any file not in the list above. Redaction is always-on (equivalent to
+`kesha doctor --redact`).
+
+`--output <path>` sets the archive path; the default is
+`kesha-support-bundle-<ISO-timestamp>.tar.gz` in the current directory.
+
+On success the CLI reports the archive path, entry count, and size in bytes to stderr.
+On failure it exits 1 with the error message.
+
+#### Scenario: Sona creates a bundle for a GitHub issue
+
+- GIVEN the Engine is installed and logs exist
+- WHEN Sona runs `kesha support-bundle`
+- THEN a `.tar.gz` is written in the current directory
+- AND the output shows the path, `Entries: 4`, and the file size
+- AND the archive contains `README.txt`, `doctor.json`, `doctor.txt`,
+  `manifest.json`
+- AND the process exits 0
+
+#### Scenario: Ira includes logs for a failing install report
+
+- WHEN Ira runs `kesha support-bundle --include-logs`
+- THEN the archive contains 7 entries including `diagnostic-logs/kesha.ndjson`
+- AND the log tail is bounded (≤64 KB by default)
+- AND the process exits 0
+
+#### Scenario: Custom output path
+
+- WHEN Maks runs `kesha support-bundle --output /tmp/kesha-diag.tar.gz`
+- THEN the archive is written to `/tmp/kesha-diag.tar.gz`
+- AND the success message includes that exact path
+
+> *Technical Note — sources: `src/support-bundle.ts::createSupportBundle`,
+> `src/cli/support-bundle.ts::supportBundleCommand`. Redaction is always applied
+> (`redact: true` is hardcoded in `createSupportBundle`; the `--redact` flag exists
+> on `kesha doctor` but not `kesha support-bundle`). Log tail default:
+> `DEFAULT_TAIL_BYTES = 64 * 1024` from `src/diagnostic-log.ts`. The tar format is
+> a hand-written ustar implementation (no external dependency); archives are
+> gzip-compressed with Node's `zlib.gzipSync`. The manifest `entries` array lists
+> bare entry names (without the archive root prefix).*
+
+### Requirement: Privacy framing — redaction, allowlists, and size-bucketing are always enforced
+
+Across all diagnostic commands, the CLI SHALL enforce the following privacy boundaries
+as invariants, not options:
+
+1. Diagnostic log field names and values are validated against an allowlist at write
+   time; invalid fields cause the event to be dropped, not silently truncated.
+2. Stats error messages have home and cwd paths replaced with `<path>`, URL query
+   strings redacted, and content-bearing JSON fields redacted before storage;
+   messages are truncated to 300 characters.
+3. Stats artifact records store audio size in bytes and duration — never file names,
+   full paths, or content.
+4. Support bundles are always redacted and never include audio, transcripts, model
+   files, or the Stats DB, regardless of flags.
+
+#### Scenario: Diagnostic log rejects a path-like field value
+
+- GIVEN the Diagnostic log mode is `on`
+- WHEN a CLI command attempts to log an event with a field value containing `/tmp/audio.wav`
+- THEN the event is dropped (logged to debug only) and no NDJSON line is written
+- AND the command continues normally
+
+#### Scenario: Stats export privacy contract is present in every export
+
+- GIVEN stats are enabled and some runs are recorded
+- WHEN Ira runs `kesha stats export --format json`
+- THEN the JSON output contains a `privacy` key with `contentFree: true` and
+  a `neverStored` array
+- AND no transcript or file-path data appears anywhere in the export
+
+> *Technical Note — sources: `src/diagnostic-log.ts` (`DISALLOWED_FIELD_NAME`,
+> `UNSAFE_STRING_VALUE`, `SAFE_STRING_VALUE`, `validateField`);
+> `src/stats.ts::sanitizeStatsError`, `src/stats.ts::statsPrivacyContract`,
+> `src/stats.ts::artifactFromFile` (records `extname(path)` and `st.size`, not the
+> path itself). Audio size bucketing in `stats.ts::summarizeSizeBuckets`:
+> `<1 MB`, `1-10 MB`, `10-100 MB`, `100 MB+`.*
+
+## Open Issues
+
+- `kesha doctor` does not surface the FluidAudio Kokoro external cache size in the
+  plain-text format (it is included in the JSON and in the cache components list, but
+  the human-readable section omits it); the `--disk` flag on `kesha status` does show
+  it correctly.
+- `kesha logs` has no `tail` or `cat` action for reading log contents from the CLI;
+  the only way to include log contents is via `kesha support-bundle --include-logs`.
+- `kesha stats` has no `--json` flag on `status`; machine-readable stats output
+  requires `export --format json`.

--- a/openspec/specs/diagnostics/spec.md
+++ b/openspec/specs/diagnostics/spec.md
@@ -89,7 +89,8 @@ Language ID, VAD, TTS Kokoro, TTS Vosk) and the grand total. The FluidAudio Koko
 external cache is reported separately when it exists, because it lives outside
 Kesha's Model cache.
 
-When the Engine is not installed, `kesha status` prints a `kesha install` hint and
+When the Engine is not installed, `kesha status` prints an actionable setup hint
+(`kesha init` on an interactive TTY, `kesha install` when stderr is piped) and
 exits 0.
 
 #### Scenario: Ira checks install state in a script
@@ -111,7 +112,8 @@ exits 0.
 - GIVEN no Engine is installed
 - WHEN Ira runs `kesha status`
 - THEN the output shows a red cross for the Engine binary
-- AND a hint to run `kesha install` is printed
+- AND an actionable setup hint is printed — `kesha init` on an interactive TTY,
+  `kesha install` when stderr is piped (`installHint()`, `src/status.ts:86`)
 - AND the process exits 0
 
 > *Technical Note — sources: `src/status.ts::showStatus`, `src/status.ts::showDiskUsage`,

--- a/openspec/specs/engine-contract/spec.md
+++ b/openspec/specs/engine-contract/spec.md
@@ -1,0 +1,333 @@
+# Engine Contract Specification
+
+## Purpose
+
+The Engine (`kesha-engine`) is a self-contained Rust binary downloaded during
+`kesha install` and invoked by the CLI as a subprocess — never linked
+in-process. This spec defines the boundary between the CLI and the Engine: the
+Capabilities JSON protocol, the error-code taxonomy and stderr format, the
+`KESHA_*` environment variables that both sides honour, and the rule that the
+CLI validates flags against Capabilities JSON instead of forwarding them
+blindly. Ira depends on stable exit codes and error codes in scripts. Sona
+depends on the capabilities contract to feature-gate her agent code. Maks
+depends on the Engine being available and well-behaved on his Apple Silicon Mac.
+
+## Non-Goals
+
+- This spec does not cover the internals of ASR inference, TTS synthesis, or
+  model download; those are Engine implementation details.
+- The Engine's audio decode pipeline (symphonia + rubato) is not specified here.
+- Model hash pinning and download mechanics are covered in the installation
+  spec.
+
+## Requirements
+
+### Requirement: The Engine is always a subprocess, never linked in-process
+
+The CLI SHALL spawn `kesha-engine` as a child process via `Bun.spawn`. It SHALL
+never import or `require` Engine code. The Engine binary path comes from
+`KESHA_ENGINE_BIN` when set, otherwise from the default location inside the
+Model cache (`~/.cache/kesha/`).
+
+#### Scenario: Ira overrides the engine binary for testing
+
+- GIVEN `KESHA_ENGINE_BIN=/tmp/kesha-engine-dev` is set in the environment
+- WHEN Ira runs any `kesha` command that spawns the Engine
+- THEN the CLI uses the binary at `/tmp/kesha-engine-dev` instead of the
+  cached default
+
+#### Scenario: Engine not installed
+
+- GIVEN the Engine binary does not exist at the resolved path
+- WHEN Ira runs `kesha standup.ogg`
+- THEN the CLI prints an actionable error with a `kesha install` hint
+- AND exits 1 without attempting to spawn a missing binary
+
+> *Technical Note — `getEngineBinPath()` in `src/engine.ts:46` returns
+> `process.env.KESHA_ENGINE_BIN ?? defaultEngineBinPath()`.
+> `isEngineInstalled()` at `src/engine.ts:50` uses `existsSync`.*
+
+### Requirement: `--capabilities-json` describes the Engine's feature set
+
+Running `kesha-engine --capabilities-json` SHALL print a single-line JSON
+object to stdout (protocol version 3) and exit 0. The object contains:
+
+- `protocolVersion`: `3` (integer constant).
+- `backend`: `"coreml"` on Apple Silicon builds, `"onnx"` on all others.
+- `features`: array of capability-flag strings (see Technical Note below for
+  the full set and their compile-time gates).
+- `tts`: present only on `tts`-feature builds; an object with `languages` — an
+  array of `{ code, engines }` objects, one per supported TTS language, with
+  the default engine first.
+
+The CLI caches the Capabilities JSON in-process keyed by binary path and
+`mtimeMs`; the cache invalidates automatically when `kesha install` overwrites
+the binary.
+
+#### Scenario: Sona probes capabilities before calling `say`
+
+- GIVEN the Engine is a `tts`-feature build
+- WHEN the CLI calls `getEngineCapabilities()`
+- THEN the result has `protocolVersion: 3` and `features` contains `"tts"`
+- AND `tts.languages` contains at least `{ code: "en", engines: ["kokoro"] }`
+  and `{ code: "ru", engines: ["vosk"] }`
+
+#### Scenario: CoreML backend on Apple Silicon
+
+- GIVEN an `aarch64-apple-darwin` Engine binary
+- WHEN the CLI calls `getEngineCapabilities()`
+- THEN `backend` is `"coreml"`
+
+#### Scenario: Engine with no subcommand prints usage and exits 1
+
+- WHEN Ira runs `kesha-engine` with no arguments
+- THEN stderr contains `Usage: kesha-engine <command>`
+- AND the process exits 1
+
+> *Technical Note — Capability flag strings and their compile-time gates
+> (`rust/src/capabilities.rs:37`):*
+>
+> | Flag | Gate |
+> |---|---|
+> | `"transcribe"` | always |
+> | `"transcribe.segments"` | always |
+> | `"detect-lang"` | always |
+> | `"vad"` | always |
+> | `"detect-text-lang"` | `target_os = "macos"` |
+> | `"tts"` | `feature = "tts"` |
+> | `"tts.ru_acronym_expansion"` | `feature = "tts"` |
+> | `"tts.en_acronym_expansion"` | `feature = "tts"` |
+> | `"tts.ru_emphasis_marker"` | `feature = "tts"` |
+> | `"tts.prosody_rate"` | `feature = "tts"` |
+> | `"transcribe.diarize"` | `feature = "system_diarize"` + `target_os = "macos"` |
+>
+> `protocolVersion: 3` asserted in `rust/src/capabilities.rs:128`.
+> Cache in `src/engine.ts:356`; invalidates when `mtimeMs` changes.*
+
+### Requirement: The CLI validates flags against Capabilities JSON instead of forwarding blindly
+
+Before spawning the Engine for a capability-gated operation, the CLI SHALL
+check the relevant feature flag in the cached Capabilities JSON. It SHALL NOT
+forward flags to subcommands that do not accept them.
+
+Specifically: `kesha-engine install` accepts only `--no-cache` (plus
+`--tts`/`--vad`/`--diarize`/`--no-warmup`); the CLI must not forward
+transcription or TTS flags to the install subcommand. `--speakers` requires
+`transcribe.diarize` in `features`; the CLI throws a clear error when the flag
+is unavailable instead of letting the Engine reject it.
+
+#### Scenario: Diarization requested on a non-diarize build
+
+- GIVEN the Engine does not advertise `transcribe.diarize` in its features
+- WHEN Ira calls `transcribe("meeting.ogg", { speakers: true })`
+- THEN the CLI throws with a message stating diarization is darwin-arm64 only
+- AND no Engine subprocess is spawned
+
+#### Scenario: Unknown flag not forwarded to install
+
+- GIVEN the CLI's install command is invoked
+- WHEN the CLI constructs the Engine argv for `kesha-engine install`
+- THEN the argv contains only `install` plus at most
+  `--no-cache`, `--tts <langs>`, `--vad`, `--diarize`, `--no-warmup`
+- AND no CLI-level flags (e.g. `--format`, `--lang`) appear in the Engine argv
+
+> *Technical Note — `preflightTranscribeEngineWithSegments` in
+> `src/engine.ts:193` checks `TRANSCRIBE_DIARIZE_FEATURE` against capabilities
+> before building the argv. Engine install argv is constructed in
+> `src/engine-install.ts`; the CLAUDE.md rule "DO NOT BLINDLY FORWARD CLI FLAGS
+> TO SUBCOMMANDS" is the governing design constraint.*
+
+### Requirement: `--error-codes-json` prints the full error-code taxonomy
+
+Running `kesha-engine --error-codes-json` SHALL print a JSON array to stdout
+and exit 0. Each element SHALL be an object with `code` (string), `title`
+(string), `category` (lowercase string), and `retryable` (boolean).
+
+The taxonomy SHALL contain exactly 19 codes. Only `E_MODEL_DOWNLOAD` and
+`E_DIARIZE_TIMEOUT` SHALL be marked retryable.
+
+The CLI SHALL read error codes from Engine stderr using the regex
+`/^error \[([A-Z0-9_]+)\]:/m`; when no match is found, it SHALL fall back to
+`E_INTERNAL`. The drift test in the test suite verifies that the TS-native code
+registry and the Engine taxonomy do not diverge.
+
+#### Scenario: Ira inspects the taxonomy from a script
+
+- WHEN Ira runs `kesha-engine --error-codes-json`
+- THEN stdout is a JSON array of exactly 19 objects
+- AND each object has `code`, `title`, `category`, and `retryable` fields
+- AND the process exits 0
+
+#### Scenario: Only retryable codes are model-download and diarize-timeout
+
+- WHEN Ira parses the `--error-codes-json` output
+- THEN exactly `E_MODEL_DOWNLOAD` and `E_DIARIZE_TIMEOUT` have `retryable: true`
+- AND all other 17 codes have `retryable: false`
+
+> *Technical Note — Full E_* taxonomy (`rust/src/errors.rs:12`):*
+>
+> | Code | Category | Retryable | Title |
+> |---|---|---|---|
+> | `E_INPUT_NOT_FOUND` | input | no | Input file not found |
+> | `E_BAD_AUDIO` | input | no | Unreadable or unsupported audio |
+> | `E_INVALID_ARG` | input | no | Invalid command-line argument |
+> | `E_MODEL_MISSING` | model | no | Model or voice not installed |
+> | `E_MODEL_DOWNLOAD` | model | **yes** | Model download failed |
+> | `E_CACHE_CORRUPT` | model | no | Cached model failed verification |
+> | `E_MODEL_LOAD` | model | no | Model failed to load |
+> | `E_UNSUPPORTED_PLATFORM` | platform | no | Feature unsupported on this platform |
+> | `E_SIDECAR_MISSING` | platform | no | Helper sidecar missing or failed |
+> | `E_NO_BACKEND` | platform | no | No ASR backend compiled in |
+> | `E_TEXT_EMPTY` | tts | no | Empty synthesis text |
+> | `E_TEXT_TOO_LONG` | tts | no | Synthesis text too long |
+> | `E_VOICE_UNKNOWN` | tts | no | Unknown voice id |
+> | `E_SSML_INVALID` | tts | no | Malformed SSML |
+> | `E_SSML_UNSUPPORTED` | tts | no | SSML not supported for this engine |
+> | `E_SCRIPT_UNSUPPORTED` | tts | no | Text script not supported for this voice |
+> | `E_TRANSCRIBE_FAILED` | transcribe | no | Transcription failed |
+> | `E_DIARIZE_TIMEOUT` | transcribe | **yes** | Speaker diarization timed out |
+> | `E_INTERNAL` | internal | no | Unexpected internal error |
+>
+> `extractEngineErrorCode` regex: `src/error-codes.ts:9`.
+> Fallback to `E_INTERNAL` in `engineErrorCode` at `src/error-codes.ts:42`.*
+
+### Requirement: Engine stderr format is `error [E_CODE]: <message>`
+
+When the Engine encounters a fatal error it SHALL print a single line to stderr
+in the form `error [E_CODE]: <human-readable message>` and exit 1. The `E_CODE`
+token consists only of uppercase letters, digits, and underscores.
+
+The CLI extracts the code with the regex `^error \[([A-Z0-9_]+)\]:` applied
+multiline to the captured stderr. Non-fatal warnings (e.g. VAD hints, model
+mirror notices) may also appear on stderr; they do not carry the `error [...]`
+prefix.
+
+#### Scenario: Missing model produces a parseable error code
+
+- GIVEN the ASR model is not installed
+- WHEN Ira runs `kesha standup.ogg`
+- THEN stderr contains a line matching `error [E_MODEL_MISSING]: ...`
+- AND the CLI surfaces `E_MODEL_MISSING` to the user
+- AND the process exits 1
+
+#### Scenario: Engine stderr with no error code
+
+- GIVEN the Engine crashes without printing an `error [...]` line
+- WHEN the CLI captures stderr
+- THEN `engineErrorCode(stderr)` returns `"E_INTERNAL"`
+
+> *Technical Note — `report` in `rust/src/errors.rs:200` calls
+> `eprintln!("error [{}]: {:#}", code.as_str(), err)` and always returns exit
+> code 1. Exception: the `say` subcommand maps structured TTS errors through
+> `exit_code_for_tts_err` (`rust/src/cli/say.rs:132-136`) to exit codes 2
+> (empty text), 4 (synthesis/SSML/internal), and 5 (text too long) — see the
+> tts-synthesis spec. All other Engine fatal exits go through `report` or
+> `process::exit(errors::report(&err))`.*
+
+### Requirement: TS-native codes cover CLI-side failures
+
+The CLI SHALL define four TS-native error codes for failures that occur before
+or around the Engine (never inside it):
+
+- `E_INPUT_NOT_FOUND` — input file not found (checked by the CLI before spawn).
+- `E_ENGINE_SPAWN` — Engine binary not installed or failed to start.
+- `E_INVALID_ARG` — invalid argument detected by the CLI.
+- `E_INTERNAL` — unexpected internal error in the CLI.
+
+These codes SHALL appear in `SayError.code` and in structured error records. A
+drift test SHALL verify that every value in `KNOWN_TS_CODES` also appears in
+the Engine taxonomy (or is explicitly TS-only).
+
+#### Scenario: Engine binary missing surfaces E_ENGINE_SPAWN
+
+- GIVEN the Engine binary is absent
+- WHEN Sona calls `await say({ text: "hello" })`
+- THEN `SayError.code` is `"E_ENGINE_SPAWN"` (the value of
+  `TS_NATIVE_CODES.ENGINE_SPAWN`)
+
+> *Technical Note — `TS_NATIVE_CODES` at `src/error-codes.ts:18`.
+> `KNOWN_TS_CODES` at `src/error-codes.ts:39`. `SayError` default code
+> `"E_INTERNAL"` in `src/synth.ts:103`; engine-spawn path uses
+> `TS_NATIVE_CODES.ENGINE_SPAWN` at `src/synth.ts:131`.*
+
+### Requirement: `KESHA_*` environment variables configure both CLI and Engine
+
+Both the CLI and the Engine SHALL honour the `KESHA_*` environment variables
+listed below. The CLI SHALL read them at startup; the Engine SHALL read them at
+spawn time (inheriting `process.env` from the CLI).
+
+> *Technical Note — Full `KESHA_*` env var table:*
+>
+> | Variable | Read by | Effect |
+> |---|---|---|
+> | `KESHA_ENGINE_BIN` | CLI | Override Engine binary path (`src/engine.ts:47`). |
+> | `KESHA_CACHE_DIR` | CLI + Engine | Override Model cache root (default `~/.cache/kesha/`). CLI: `src/paths.ts:5`. Engine: `rust/src/models.rs:614`. |
+> | `KESHA_MODEL_MIRROR` | Engine | Rewrite HuggingFace download base URLs; GitHub release URLs are never rewritten. Safe because of Pinned hashes (`rust/src/models.rs:628`). |
+> | `KESHA_DEBUG` | CLI + Engine | Enable debug trace output. Falsey values: `""`, `"0"`, `"false"`, `"no"`, `"off"` (case-insensitive). Truthy: any other non-empty value. CLI: `src/log.ts:30`. Engine: `rust/src/debug.rs:57`. |
+> | `KESHA_DEBUG_FD` | CLI + Engine | Forward a file descriptor number to the Engine for NDJSON debug event output. Values 0/1/2 are rejected (covered by stdin/stdout/stderr). Values above 1024 (`MAX_FORWARDED_FD`) are rejected. Must be a non-negative integer ≥ 3. CLI: `src/engine.ts:92`. Engine: `rust/src/debug.rs:159`. |
+> | `KESHA_DIARIZE_TIMEOUT_SECS` | Engine | Override the adaptive diarization timeout (seconds). CLI checks `KESHA_DIARIZE_MODEL_PATH` before spawn. Engine: `rust/src/transcribe/diarize.rs:103`. |
+> | `KESHA_DIARIZE_MODEL_PATH` | CLI + Engine | Override the Sortformer model path. CLI: `src/engine.ts:212`. Engine: `rust/src/transcribe/mod.rs:747`. |
+> | `KESHA_STATS_DB` | CLI | Override the Stats DB path (`src/stats.ts:580`). |
+> | `KESHA_LOG_DIR` | CLI | Override the Diagnostic log directory (`src/diagnostic-log.ts:73`). |
+
+#### Scenario: Ira points the cache at a network share in CI
+
+- GIVEN `KESHA_CACHE_DIR=/mnt/ci-cache/kesha` is set
+- WHEN Ira runs `kesha standup.ogg`
+- THEN the CLI resolves the Engine binary from `/mnt/ci-cache/kesha/`
+- AND the Engine reads models from `/mnt/ci-cache/kesha/models/`
+
+#### Scenario: KESHA_DEBUG_FD rejects stdin/stdout/stderr numbers
+
+- WHEN `KESHA_DEBUG_FD=1` is set
+- THEN `spawnStdioWithDebugFd` returns the base stdio array unchanged (fd 1 is
+  rejected)
+- AND no extra fd is forwarded to the Engine
+
+#### Scenario: KESHA_DEBUG_FD rejects out-of-range values
+
+- WHEN `KESHA_DEBUG_FD=2000` is set
+- THEN `spawnStdioWithDebugFd` returns the base stdio array unchanged
+  (2000 > `MAX_FORWARDED_FD` = 1024)
+
+> *Technical Note — `MAX_FORWARDED_FD = 1024` at `src/engine.ts:66`. The
+> guard condition at `src/engine.ts:95`:
+> `!Number.isInteger(fd) || fd < 3 || fd > MAX_FORWARDED_FD`.*
+
+### Requirement: Capabilities JSON cache invalidates on Engine binary change
+
+The CLI SHALL cache the Capabilities JSON in-process, keyed by the Engine
+binary path and its `mtimeMs`. The cache invalidates automatically when the
+binary is replaced (e.g. after `kesha install`), ensuring the CLI never uses
+stale feature flags after an upgrade.
+
+#### Scenario: Cache hit — no extra subprocess spawned
+
+- GIVEN `getEngineCapabilities()` was called once successfully
+- WHEN the CLI calls `getEngineCapabilities()` again with the same binary and
+  same `mtimeMs`
+- THEN no new subprocess is spawned
+- AND the cached result is returned immediately
+
+#### Scenario: Cache miss after install overwrites the binary
+
+- GIVEN `getEngineCapabilities()` was called before `kesha install` ran
+- WHEN `kesha install` overwrites the Engine binary (changing its `mtimeMs`)
+- THEN the next call to `getEngineCapabilities()` re-spawns the Engine and
+  refreshes the cache
+
+> *Technical Note — Cache logic at `src/engine.ts:356`. Cache key:
+> `{ binPath, mtime }`. `statSync(binPath).mtimeMs` at `src/engine.ts:368`;
+> `statSync` throwing (missing binary) causes `getEngineCapabilities` to
+> return `null`.*
+
+## Open Issues
+
+- Protocol version is hardcoded to `3`; there is no negotiation mechanism if
+  the CLI and Engine are on incompatible versions. The CLI currently falls back
+  to `null` (capabilities unavailable) rather than erroring on version mismatch.
+- `KESHA_DEBUG_FD` NDJSON event schema is not yet stable and is not specified
+  here; callers should treat the format as internal.
+- `E_ENGINE_SPAWN` is a TS-native code that has no corresponding entry in the
+  Engine's `--error-codes-json` output; the drift test exempts TS-only codes
+  explicitly.

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -1,0 +1,391 @@
+# Installation Specification
+
+## Purpose
+
+Installation is how Kesha acquires the Engine binary and all models. `kesha install`
+downloads and verifies them explicitly; `kesha init` guides a first-time user through
+the same process interactively. Nothing ever downloads automatically — every other
+command fails with an actionable hint if a required component is missing. This is the
+path Ira relies on in CI pipelines (reproducible, hash-verified, no surprises) and the
+path Maks follows when setting up a new machine.
+
+## Non-Goals
+
+- No automatic downloads during transcription, TTS, or any other command
+  (Never-auto-download rule). Missing components fail with a `kesha install` hint.
+- `kesha install` does not manage the Bun/npm CLI package itself — use
+  `bun add -g @drakulavich/kesha-voice-kit` for that.
+- No model pruning or cleanup of previously installed optional components; installs
+  are additive.
+
+## Requirements
+
+### Requirement: Only `kesha install` downloads the Engine and models
+
+The CLI SHALL download the Engine binary and ASR/lang-id models only when `kesha install`
+(or `kesha init` leading to an install) is explicitly invoked. Every other command
+(`kesha`, `kesha say`, `kesha doctor`, etc.) SHALL fail immediately with an actionable
+error message telling the user to run `kesha install` when a required component is
+missing.
+
+#### Scenario: Ira runs transcription before installing
+
+- GIVEN no Engine binary is present in the Model cache
+- WHEN Ira runs `kesha standup.ogg`
+- THEN the CLI prints an error naming the missing component and including a
+  `kesha install` hint to stderr
+- AND the process exits 1 without attempting a download
+
+#### Scenario: Maks installs for the first time
+
+- GIVEN no Engine is installed
+- WHEN Maks runs `kesha install`
+- THEN the Engine binary and required ASR/lang-id models are downloaded and verified
+- AND the process exits 0
+- AND subsequent `kesha audio.ogg` invocations succeed
+
+> *Technical Note — sources: `src/engine-install.ts::downloadEngine`,
+> `src/cli/install.ts::performInstall`. The Engine binary is fetched from
+> `https://github.com/drakulavich/kesha-voice-kit/releases/download/v<version>/<asset>`.
+> The version is pinned in `package.json#keshaEngine.version`. Required models are
+> installed by delegating `kesha-engine install` to the Rust binary after the binary
+> download completes.*
+
+### Requirement: Backend selection is mutex and platform-validated
+
+The CLI SHALL accept `--coreml` and `--onnx` flags to override the auto-detected
+backend. Passing both SHALL fail immediately with exit 1. Requesting a backend that
+does not match the platform's release Engine (e.g. `--coreml` on Linux) SHALL also
+fail with exit 1.
+
+Auto-detection defaults: darwin-arm64 → CoreML; linux-x64 → ONNX. Any other
+platform is unsupported and fails.
+
+#### Scenario: Both flags given
+
+- WHEN Ira runs `kesha install --coreml --onnx`
+- THEN the CLI prints `Choose only one backend: "--coreml" or "--onnx".` to stderr
+- AND the process exits 1 without downloading anything
+
+#### Scenario: Wrong backend for platform
+
+- GIVEN the machine is linux-x64 (ONNX release)
+- WHEN Ira runs `kesha install --coreml`
+- THEN the CLI prints an error explaining the platform uses the ONNX backend
+- AND the process exits 1
+
+#### Scenario: Auto-detection on darwin-arm64
+
+- GIVEN the machine is darwin-arm64 and `--coreml`/`--onnx` are not passed
+- WHEN Maks runs `kesha install`
+- THEN the CoreML Engine binary is downloaded
+- AND no backend error is emitted
+
+> *Technical Note — sources: `src/cli/install.ts::resolveBackendFlag`,
+> `src/cli/install.ts::defaultBackendForPlatform`,
+> `src/engine-install.ts::downloadEngine` (post-download backend mismatch check via
+> Capabilities JSON). Windows x64 is temporarily unsupported in the current release
+> (issue #216).*
+
+### Requirement: TTS install is opt-in and requires `--tts`
+
+The CLI SHALL install TTS models only when `--tts` is passed. Bare `--tts` installs
+English only. `--tts <lang>…` installs the listed languages. Positional language codes
+without `--tts` SHALL fail with exit 1 explaining the required flag. Unsupported
+language codes SHALL fail with exit 1 listing the supported set.
+
+The supported TTS language sets are:
+- ONNX build (linux-x64, macOS ONNX): `en`, `es`, `fr`, `it`, `pt`, `ru`
+- darwin-arm64 (CoreML): additionally `hi`, `ja`, `zh`
+
+Installs are additive; re-running `kesha install --tts ru` on a system with English
+already installed leaves English in place.
+
+#### Scenario: Ira installs English TTS
+
+- WHEN Ira runs `kesha install --tts`
+- THEN the Kokoro-82M model graph (~326 MB) and the `am_michael` voice file are
+  downloaded
+- AND the process exits 0
+
+#### Scenario: Maks installs English and Russian TTS
+
+- WHEN Maks runs `kesha install --tts en ru`
+- THEN Kokoro files for English and Vosk-TTS Russian files (~937 MB total) are
+  downloaded
+- AND the process exits 0
+
+#### Scenario: Language code without `--tts` flag
+
+- WHEN Ira runs `kesha install ru`
+- THEN the CLI prints an error: language codes require the `--tts` flag, e.g.
+  `kesha install --tts ru`
+- AND the process exits 1 without downloading anything
+
+#### Scenario: Unsupported language code
+
+- GIVEN the machine is linux-x64 (ONNX build)
+- WHEN Ira runs `kesha install --tts zh`
+- THEN the CLI prints an error listing supported languages for this platform
+- AND the process exits 1
+
+> *Technical Note — sources: `src/cli/install.ts::resolveTtsLangs`,
+> `src/install-plan.ts` (KOKORO_GRAPH_FILE ~325 MB, per-language KOKORO_VOICE_FILES
+> ~522 KB each, VOSK_RU_FILES ~937 MB total, G2P_CHARSIU_FILES ~30 MB for es/fr/it/pt
+> on ONNX). Supported language list comes from `getEngineCapabilities()` when the
+> Engine is already installed; falls back to `TTS_LANG_FALLBACK` = `["en", "es", "fr",
+> "it", "pt", "ru"]` when the Engine is not yet installed (hi/ja/zh excluded as they
+> require darwin-arm64 capabilities to confirm).*
+
+### Requirement: VAD and Diarize install are separate opt-in flags
+
+The CLI SHALL install the Silero VAD model only when `--vad` is passed (~2.3 MB).
+The CLI SHALL install the Sortformer diarization model only when `--diarize` is passed
+(~245 MB). `--diarize` SHALL fail with exit 1 on any platform other than darwin-arm64.
+
+#### Scenario: Ira installs VAD for long-audio CI jobs
+
+- WHEN Ira runs `kesha install --vad`
+- THEN the Silero VAD model (~2.3 MB) is downloaded to the Model cache
+- AND the process exits 0
+
+#### Scenario: Diarize on a non-darwin-arm64 machine
+
+- GIVEN the machine is linux-x64
+- WHEN Ira runs `kesha install --diarize`
+- THEN the CLI prints an error that `--diarize` is currently darwin-arm64 only
+- AND the process exits 1 without downloading anything
+
+#### Scenario: Maks installs diarization on Apple Silicon
+
+- GIVEN the machine is darwin-arm64
+- WHEN Maks runs `kesha install --diarize`
+- THEN the Sortformer model files (~245 MB) are downloaded
+- AND the process exits 0
+
+> *Technical Note — sources: `src/cli/install.ts::performInstall` (darwin-arm64 guard),
+> `rust/src/cli/install.rs::run` (`#[cfg(feature = "system_diarize")]`),
+> `src/install-plan.ts` (VAD_FILES ~2.3 MB, DIARIZE_FILES ~245 MB).*
+
+### Requirement: Every model file has a Pinned hash; mismatches are rejected, not cached
+
+The Engine SHALL verify the SHA-256 hash of every downloaded model file against the
+Pinned hash recorded in `rust/src/models.rs`. A file whose hash does not match SHALL
+be deleted and the install SHALL fail with an error. The file SHALL NOT be left in the
+Model cache.
+
+Activating `KESHA_MODEL_MIRROR` rewrites HuggingFace model download URLs to a
+user-supplied base URL; GitHub release asset URLs (Engine binary, Sidecars) are never
+rewritten. Hash verification applies identically whether the mirror is active or not.
+When `KESHA_MODEL_MIRROR` is set, a banner is printed to stderr before any downloads
+begin.
+
+#### Scenario: Corrupted download is rejected
+
+- GIVEN `KESHA_MODEL_MIRROR` points to a mirror that serves a modified model file
+- WHEN Ira runs `kesha install`
+- THEN the install fails with an error indicating the hash mismatch
+- AND no corrupted file remains in the Model cache
+
+#### Scenario: Mirror banner is shown
+
+- GIVEN `KESHA_MODEL_MIRROR=https://mirror.example.com/models`
+- WHEN Maks runs `kesha install`
+- THEN a banner noting the active mirror is printed to stderr before downloads begin
+- AND all HuggingFace model URLs are rewritten to use the mirror base
+- AND the Engine binary URL is not rewritten
+
+> *Technical Note — sources: `rust/src/models.rs` (SHA-256 per `ModelFile` entry,
+> `download_verified` function, `init_mirror_logging`, `model_mirror()`).
+> Error code `E_CACHE_CORRUPT` is used when a cached file fails hash verification.*
+
+### Requirement: `--plan` shows the download plan without changing local state
+
+The CLI SHALL print a human-readable Install plan when `--plan` is passed, listing all
+components with their sizes, cache status (cached / needed / refresh), source, and the
+expected network bytes for the current run. No files SHALL be downloaded or modified.
+The plan also includes warm-up steps and ends with the equivalent `kesha install …`
+command.
+
+#### Scenario: Ira previews a fresh install
+
+- GIVEN no Engine or models are installed
+- WHEN Ira runs `kesha install --plan`
+- THEN the plan lists Engine, ASR, and lang-id components with sizes, all marked
+  `needed`
+- AND states `Expected Kesha-managed network for this run` in bytes
+- AND ends with `Run: kesha install`
+- AND the process exits 0 with no downloads having occurred
+
+#### Scenario: Plan with TTS and VAD
+
+- WHEN Maks runs `kesha install --plan --tts en ru --vad`
+- THEN the plan additionally lists TTS Kokoro, TTS Vosk RU, and VAD Silero components
+- AND already-cached components are marked `cached`
+
+> *Technical Note — sources: `src/install-plan.ts::renderInstallPlan`. The plan is
+> rendered entirely client-side from pinned sizes; no network access is required.
+> Key totals: cold-cache ASR + lang-id ~2.6 GB; VAD ~2.3 MB; Diarize ~245 MB;
+> TTS English only ~326 MB; TTS English + Russian ~937 MB.*
+
+### Requirement: `--no-cache` forces a re-download; silently ignored on read-only engine directories
+
+The CLI SHALL re-download all components when `--no-cache` is passed, even if they
+are already cached and hash-valid. On a read-only engine directory (e.g. a Nix store
+install), `--no-cache` for the Engine binary SHALL be silently ignored with a log
+message; `--no-cache` is still forwarded to the model install step.
+
+#### Scenario: Ira forces a clean re-download
+
+- GIVEN all components are already cached
+- WHEN Ira runs `kesha install --no-cache`
+- THEN all components are re-downloaded and re-verified
+- AND the process exits 0
+
+#### Scenario: Nix store install ignores `--no-cache` for the binary
+
+- GIVEN the Engine binary is on a read-only Nix store path
+- WHEN a user runs `kesha install --no-cache`
+- THEN a message is printed explaining the Engine directory is read-only and
+  `--no-cache` is skipped for the binary
+- AND model downloads still proceed (with `--no-cache` applied)
+
+> *Technical Note — sources: `src/engine-install.ts::downloadEngine`
+> (`canWriteEngineDir` check via `fs.accessSync(engineDir, W_OK)`). The Nix flake
+> build stages models at build time; `--no-cache` reaching the model step is still
+> valid for user-managed cache overrides.*
+
+### Requirement: macOS binaries are ad-hoc codesigned and unquarantined after download
+
+On macOS, the CLI SHALL run `codesign --force --sign -` and
+`xattr -d com.apple.provenance` on every downloaded binary (Engine and Sidecars)
+after writing them to disk. Both steps are best-effort: if both fail, a manual
+recovery hint is printed to stderr. This prevents Gatekeeper SIGKILL on macOS 15+
+Sequoia.
+
+#### Scenario: Maks downloads on macOS 15
+
+- GIVEN the machine is darwin-arm64 running macOS 15 Sequoia
+- WHEN Maks runs `kesha install`
+- THEN the Engine binary and Sidecars are codesigned and unquarantined
+- AND `kesha audio.ogg` runs without a Gatekeeper kill
+
+#### Scenario: Both codesign and xattr fail
+
+- GIVEN neither `codesign` nor `xattr` is available
+- WHEN the install completes
+- THEN the CLI prints a warning with manual `codesign` and `xattr` commands to stderr
+- AND the install itself does not fail (the binary is still on disk)
+
+> *Technical Note — sources: `src/engine-install.ts::darwinTrustBinary`. Two
+> independent fixes run in sequence: `codesign --force --sign - <path>` re-applies
+> the ad-hoc signature; `xattr -d com.apple.provenance <path>` strips the download
+> quarantine marker. The xattr step treats exit 1 + "No such xattr" as success.
+> darwin-arm64 Sidecars: `say-avspeech` (AVSpeech) and `kesha-textlang` (text
+> language detection), downloaded concurrently with the Engine binary.*
+
+### Requirement: Warm-up runs after download; `--no-warmup` skips it; failures are non-fatal
+
+After installing models, the Engine SHALL warm up the ASR Backend by instantiating it
+once, so the expensive cold-start cost (CoreML ANE compile ~20–30 s on darwin-arm64;
+ORT session init ~500 ms on ONNX) is paid during install rather than on the first
+transcription. When `--diarize` is installed, the Sortformer model is also compiled to
+a stable `.mlmodelc` path (first-time compile ~1–2 minutes). Warm-up failures are
+non-fatal: the install still succeeds and a warning is printed.
+
+Passing `--no-warmup` (an Engine-level flag forwarded by the CLI) skips all warm-up.
+
+On darwin-arm64, the CLI also runs a separate Kokoro TTS warm-up by calling
+`kesha-engine say` to prime the FluidAudio CoreML cache. This is skipped when only
+Russian TTS (`--tts ru`) is requested (Vosk does not need it).
+
+#### Scenario: First install on Apple Silicon
+
+- GIVEN a fresh darwin-arm64 install with no CoreML cache
+- WHEN Maks runs `kesha install`
+- THEN the ASR warm-up runs and the Engine prints `ASR backend warmed up (dt=<n>ms).`
+- AND subsequent `kesha audio.ogg` invocations start without the ANE compile delay
+
+#### Scenario: Warm-up failure does not block install
+
+- GIVEN the CoreML ANE is temporarily unavailable
+- WHEN the warm-up step fails
+- THEN a warning is printed to stderr explaining the first real invocation will pay
+  the cold-start cost
+- AND the process still exits 0
+
+#### Scenario: CI install skips warm-up
+
+- WHEN Ira runs `kesha install --no-warmup` in a headless CI image
+- THEN no warm-up step runs
+- AND the install completes faster
+
+> *Technical Note — sources: `rust/src/cli/install.rs::run` (`no_warmup` flag,
+> `backend::create_backend` warm-up, diarize compile via
+> `fa.compile_diarization_model`); `src/engine-install.ts::warmDarwinKokoro`
+> (TTS Kokoro warm-up on darwin-arm64, timeout 180 s). Diarize warm-up note:
+> the e5rt ANE compile cache is keyed by compiled bundle identity, not path —
+> recreating the `.mlmodelc` is still a cache miss (#444).*
+
+### Requirement: `kesha init` is the interactive guided setup
+
+`kesha init` SHALL present an interactive guided setup for new users: a description
+of optional features, a multi-select TTS language picker (English pre-checked), a
+yes/no prompt for VAD, and a yes/no prompt for diarization (darwin-arm64 only). After
+selection, it shows the Install plan and asks for confirmation before running the
+install.
+
+`--yes` accepts all current defaults non-interactively and runs the install
+immediately. `--plan` prints the overview and plan without prompting or downloading.
+
+When stdin or stdout is not a TTY, `kesha init` prints the overview, plan, and a set
+of suggested `kesha install` commands instead of prompting — it never hangs waiting
+for interactive input.
+
+`--diarize` on a non-darwin-arm64 platform is silently dropped with a warning; the
+install proceeds without it.
+
+#### Scenario: Maks runs guided setup on Apple Silicon
+
+- GIVEN the machine is darwin-arm64 with a TTY
+- WHEN Maks runs `kesha init`
+- THEN the CLI displays available optional features, prompts for TTS language
+  selection (English pre-checked), prompts for VAD and diarization
+- AND shows the Install plan for the selected components
+- AND asks for confirmation before starting the download
+
+#### Scenario: Ira runs init in a CI pipeline (no TTY)
+
+- GIVEN stdin is not a TTY
+- WHEN Ira runs `kesha init`
+- THEN the CLI prints the overview, a representative install plan, and a list of
+  suggested `kesha install` commands
+- AND exits 0 without blocking on a prompt
+
+#### Scenario: `--yes` for scripted install with defaults
+
+- WHEN Ira runs `kesha init --yes --tts`
+- THEN the CLI runs `kesha install --tts` immediately with no interactive prompts
+- AND exits 0 on success
+
+#### Scenario: `--diarize` dropped on non-darwin-arm64
+
+- GIVEN the machine is linux-x64
+- WHEN Ira runs `kesha init --yes --diarize`
+- THEN a warning is printed: `--diarize is currently darwin-arm64 only; omitting it`
+- AND the install proceeds without the diarize model
+
+> *Technical Note — sources: `src/cli/init.ts::initCommand`,
+> `src/cli/init.ts::promptInitSelection`, `src/cli/init.ts::runNonInteractive`,
+> `src/cli/init.ts::canInstallDiarizeOnPlatform`. The TTS language picker uses
+> `@clack/prompts::multiselect` with `required: false` (no-selection = skip TTS).
+> TTY check: `process.stdin.isTTY === true && process.stdout.isTTY === true`.*
+
+## Open Issues
+
+- `kesha install --tts zh` on a darwin-arm64 machine without the Engine installed
+  falls back to `TTS_LANG_FALLBACK` (which excludes `zh`) and rejects the request;
+  the error message says "unsupported" rather than "install the engine first to
+  unlock platform-specific languages" — see the `resolveTtsLangs` fallback path.
+- Windows x64 is temporarily unsupported in the current release (issue #216) due to
+  native Vosk-TTS link-time issues; `kesha install` fails with an explanatory error.

--- a/openspec/specs/language-detection/spec.md
+++ b/openspec/specs/language-detection/spec.md
@@ -1,0 +1,184 @@
+# Language Detection Specification
+
+## Purpose
+
+Language detection answers the question "what language is this?" for both
+audio files and plain text. Ira uses it in pipelines to route transcripts by
+language. Sona uses the JSON output fields to tag structured results. Maks
+gets a `[lang: ru, confidence: 1.00]` trailer on `--format transcript` output
+without thinking about it.
+
+Two independent sub-capabilities exist:
+
+- **Language detection (audio)** — ECAPA-TDNN VoxLingua107 ONNX model;
+  analyzes only the first 10 s of audio; returns `{code, confidence}`.
+- **Language detection (text)** — macOS `NLLanguageRecognizer` via the
+  `kesha-textlang` Sidecar (or legacy `swift -e` fallback); returns
+  `{code, confidence}`; macOS only.
+
+Both sub-capabilities are also called automatically during transcription when
+structured output is requested (see the transcription spec for how results
+surface in JSON/TOON/transcript-format output).
+
+## Non-Goals
+
+- Language detection (text) is not available on Linux or Windows; those
+  platforms return an error.
+- The audio model analyzes only the first 10 s; it does not summarize language
+  across a full recording.
+- Language detection does not translate or re-transcribe in a different
+  language; it only identifies.
+- The CLI-side `tinyld` text fallback is a best-effort safety net when the
+  Engine text-lang call fails; it carries confidence 0 and is not a
+  first-class output.
+
+## Requirements
+
+### Requirement: Audio language detection returns a language code and confidence
+
+The Engine's `detect-lang` subcommand SHALL accept one audio file path, run
+the ECAPA-TDNN VoxLingua107 model on the first 10 s of audio, and print a
+single-line JSON object `{"code":"<BCP-47-ish>","confidence":<float>}` to
+stdout. Progress and errors go to stderr.
+
+#### Scenario: Ira identifies the language of a call recording
+
+- GIVEN the Lang-ID model is installed and `call.ogg` contains Russian speech
+- WHEN Ira runs `kesha-engine detect-lang call.ogg`
+- THEN stdout is `{"code":"ru","confidence":0.97}` (exact value varies)
+- AND the process exits 0
+
+#### Scenario: Audio file does not exist
+
+- WHEN Ira runs `kesha-engine detect-lang missing.ogg`
+- THEN an error naming the missing file is printed to stderr
+- AND the process exits 1
+- AND the error fires before the model is consulted (input validation first)
+
+#### Scenario: Lang-ID model not installed
+
+- GIVEN the Lang-ID model is absent from the Model cache
+- WHEN Ira runs `kesha-engine detect-lang call.ogg` on a valid audio file
+- THEN the Engine reports `E_MODEL_MISSING` and suggests `kesha install`
+- AND the process exits 1
+
+> *Technical Note — model: ECAPA-TDNN VoxLingua107, 107 languages, first-10-s
+> window. Source: `rust/src/lang_id.rs` lines 14 (`MAX_SECONDS = 10.0`) and 43
+> (`load_audio_truncated`). ONNX input: `"waveform"` `[1, samples]` float32;
+> output: `"language_probs"` `[1, 107]` float32. Error code: `E_MODEL_MISSING`
+> from `rust/src/errors.rs`. CLI dispatch: `rust/src/cli/detect_lang.rs`.*
+
+### Requirement: Audio language detection is skipped for long transcripts
+
+During transcription, the CLI SHALL skip the audio Language detection (audio)
+call and log a diagnostic when the estimated transcript duration exceeds
+10 minutes (600 s). The transcription itself still completes; the language
+fields in the output are populated from the text-language result or the
+`tinyld` fallback instead.
+
+#### Scenario: Ira transcribes a 90-minute lecture with --json
+
+- GIVEN a 90-minute audio file
+- WHEN Ira runs `kesha --json lecture.mp3`
+- THEN the Engine audio lang-id call is skipped
+- AND a `skip lang_id_audio` diagnostic is emitted to stderr naming the
+  threshold
+- AND the JSON result still includes a `lang` field (populated from text-lang
+  or `tinyld`)
+- AND the process exits 0
+
+#### Scenario: Short recording triggers audio lang-id normally
+
+- GIVEN a 3-minute voice note
+- WHEN Maks runs `kesha --json note.ogg`
+- THEN the audio lang-id call runs and the result populates the `lang` field
+
+> *Technical Note — threshold: `AUDIO_LANG_ID_LONG_AUDIO_THRESHOLD_SECONDS =
+> 10 * 60` (600 s). Guard function: `shouldRunAudioLanguageDetection` in
+> `src/cli/main.ts` lines 139–145. Audio lang-id is triggered when any of
+> `--lang`, `--verbose`, `--json`, `--toon`, or `--format transcript` is
+> active (`wantsLangId`, `src/cli/main.ts` line 322).*
+
+### Requirement: Text language detection returns a language code and confidence on macOS
+
+The Engine's `detect-text-lang` subcommand SHALL accept a text argument, pass
+it to the `kesha-textlang` Sidecar (or the legacy `swift -e` path when the
+sidecar is absent), and print `{"code":"<code>","confidence":<float>}` to
+stdout. The subcommand SHALL fail with an error on non-macOS platforms. It
+SHALL fail with an error when the text is empty or whitespace-only.
+
+#### Scenario: Sona identifies the language of a transcript fragment
+
+- GIVEN the engine runs on macOS
+- WHEN Sona runs `kesha-engine detect-text-lang "Привет, как дела?"`
+- THEN stdout is `{"code":"ru","confidence":0.99}` (value varies)
+- AND the process exits 0
+
+#### Scenario: Empty text is rejected
+
+- WHEN Ira runs `kesha-engine detect-text-lang "   "`
+- THEN an error `detect-text-lang requires non-empty text` is printed to stderr
+- AND the process exits 1
+
+#### Scenario: Non-macOS platform
+
+- GIVEN `kesha-engine` is the Linux ONNX build
+- WHEN Ira runs `kesha-engine detect-text-lang "hello"`
+- THEN the Engine reports that `detect-text-lang` is only available on macOS
+- AND the process exits 1
+
+> *Technical Note — empty-text guard: `rust/src/cli/detect_text_lang.rs`
+> lines 6–8. Non-macOS error: `rust/src/text_lang.rs` lines 131–133. Sidecar
+> path (`system_text_lang` feature): `rust/src/text_lang.rs` lines 31–51;
+> resolves `kesha-textlang` sibling-of-exe first, then build-time `OUT_DIR`
+> fallback. Legacy `swift -e` path (no feature): `rust/src/text_lang.rs`
+> lines 104–127.*
+
+### Requirement: Language detection results surface in transcription output
+
+The CLI SHALL populate language fields in transcription output whenever any of
+`--lang`, `--verbose`, `--json`, `--toon`, or `--format transcript` is active
+(the `wantsLangId` condition):
+
+- `--format transcript` appends `[lang: <code>, confidence: <n>]` to the
+  transcript text.
+- `--json` / `--toon` include `lang`, and language detection sub-fields in
+  each result object.
+- When the Engine text-lang call succeeds, its result is used; when it fails
+  or is unavailable, the CLI-side `tinyld` result is used as a fallback with
+  `confidence: 0`.
+
+#### Scenario: Maks checks language on a voice note
+
+- WHEN Maks runs `kesha --format transcript note.ogg`
+- THEN the output ends with a `[lang: ru, confidence: 1.00]` trailer
+- AND no error is printed to stderr
+
+#### Scenario: Sona reads language fields from JSON
+
+- WHEN Sona runs `kesha --json call.ogg`
+- THEN the result object includes a `lang` string field and the process exits 0
+
+#### Scenario: --lang mismatch triggers a warning, not a failure
+
+- GIVEN `ru.ogg` contains Russian speech detected with confidence above 0.8
+- WHEN Ira runs `kesha --lang en ru.ogg`
+- THEN the transcript is still printed and the process exits 0
+- AND stderr carries a language-mismatch warning
+
+> *Technical Note — `wantsLangId` trigger: `src/cli/main.ts` line 322.
+> `tinyld` fallback: `detect` imported from `tinyld` package, used at
+> `src/cli/main.ts` line 397. Text-lang engine call: `detectTextLanguageEngine`
+> called at line 401. `tinyld` result carries `confidence: 0` to signal it is
+> the fallback (`src/cli/main.ts` line 420).*
+
+## Open Issues
+
+- The 10 s audio window means accent-switched recordings (language changes
+  after the first 10 s) may be mis-identified. No plan to extend the window
+  today.
+- Audio lang-id is unconditionally skipped for transcripts over 10 minutes;
+  a more precise duration-based gate (based on actual audio duration rather
+  than estimated transcript duration) is a possible future improvement.
+- `tinyld` confidence is always reported as 0, making it indistinguishable
+  from a genuine 0-confidence Engine result in the JSON output.

--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -1,0 +1,249 @@
+# MCP Server Specification
+
+## Purpose
+
+`kesha mcp` starts a Model Context Protocol stdio server that exposes Kesha
+Voice Kit's transcription and TTS capabilities to LLM clients. Sona embeds it
+in agent pipelines to transcribe audio files, synthesize speech, and discover
+available voices — all without shelling out to `kesha` herself. The server
+follows the MCP stdio transport: the client configures
+`{ command: "kesha", args: ["mcp"] }` and communicates via JSON-RPC on
+stdin/stdout.
+
+## Non-Goals
+
+- The MCP server is a thin adapter over the same CLI and Engine paths. It does
+  not implement its own audio codec or TTS engine.
+- No authentication or multi-user isolation: the server runs as the invoking
+  user and inherits the same Model cache and Engine binary.
+- No streaming transcription or partial results.
+- Remote or HTTP MCP transports are not provided; only stdio.
+
+## Requirements
+
+### Requirement: `kesha mcp` starts a named MCP stdio server
+
+The CLI SHALL start an MCP server named `kesha-voice-kit` over stdio and block
+until the client disconnects. The server version matches the CLI package
+version. At server start, audio files older than 24 hours in the MCP audio
+directory are swept.
+
+The server exposes four tools (`transcribe_audio`, `synthesize_speech`,
+`list_voices`, `list_languages`) and one resource template
+(`kesha-audio://{file}`).
+
+#### Scenario: Sona configures kesha mcp in her agent
+
+- GIVEN Sona adds `{ command: "kesha", args: ["mcp"] }` to her MCP client
+- WHEN the client initializes the connection
+- THEN the server announces itself as `kesha-voice-kit`
+- AND the four tools appear in the tools list
+- AND the kesha-audio resource template appears in the resources list
+- AND the server remains running until the client closes the connection
+
+> *Technical Note — `mcpCommand` in `src/cli/mcp.ts:5` creates the server via
+> `createKeshaMcpServer()` (`src/mcp/server.ts:6`) and connects a
+> `StdioServerTransport`. `sweepOldAudio()` runs at server creation
+> (`src/mcp/server.ts:7`). Server name is `"kesha-voice-kit"` at
+> `src/mcp/server.ts:8`.*
+
+### Requirement: `transcribe_audio` transcribes a local audio file
+
+The `transcribe_audio` tool SHALL accept a `path` (string, required) and
+`timestamps` (boolean, optional). When the file does not exist, it SHALL return
+`isError: true` without throwing. When transcription succeeds, the tool returns
+`structuredContent` with `text` (string) and `segments` (array). Without
+`timestamps`, `segments` is an empty array. With `timestamps`, each segment
+carries numeric `start`, `end`, and `text`; an optional `speaker` number is
+included when diarization was requested by the engine. The tool's
+`annotations.readOnlyHint` is `true`.
+
+#### Scenario: Sona transcribes a meeting recording
+
+- GIVEN `meeting.ogg` exists and the Engine is installed
+- WHEN Sona calls `transcribe_audio` with `{ path: "/abs/meeting.ogg" }`
+- THEN the response `structuredContent.text` contains the transcript
+- AND `structuredContent.segments` is an empty array
+- AND `isError` is absent (success path)
+
+#### Scenario: Sona requests segment timestamps
+
+- WHEN Sona calls `transcribe_audio` with
+  `{ path: "/abs/meeting.ogg", timestamps: true }`
+- THEN `structuredContent.segments` is a non-empty array of objects each
+  containing numeric `start`, `end`, and `text` fields
+
+#### Scenario: File does not exist
+
+- WHEN Sona calls `transcribe_audio` with `{ path: "/abs/missing.ogg" }`
+- THEN the response has `isError: true`
+- AND the `content[0].text` names the missing file
+
+> *Technical Note — `transcribe_audio` is registered in `src/mcp/tools.ts:87`.
+> Missing-file check at `src/mcp/tools.ts:113` uses `existsSync` before
+> spawning the engine. Segment shape at `src/mcp/tools.ts:96-104`.
+> `readOnlyHint: true` at `src/mcp/tools.ts:107`.*
+
+### Requirement: `synthesize_speech` produces an audio file and returns a resource link
+
+The `synthesize_speech` tool SHALL accept `text` (string, min length 1),
+`voice` (string, optional — auto-routes when omitted, defaulting to
+`en-am_michael` for English and `ru-vosk-m02` for Russian), `rate` (number,
+optional, 0.5–2.0), and `format` (`"wav"` | `"ogg-opus"` | `"flac"`, optional,
+default `"wav"`).
+
+The tool SHALL:
+1. Validate `rate` and return `isError: true` when it is outside `[0.5, 2.0]`.
+2. Synthesize audio via the Engine and write it to a UUID-named file in
+   `<tmpdir>/kesha-mcp/` with permissions `0600`.
+3. Return a `resource_link` content item with URI `kesha-audio://<filename>`
+   and a text summary of the synthesis.
+4. Return `structuredContent` with `uri`, `path`, `format`, `voice`, and
+   `bytes`.
+
+`annotations.readOnlyHint` is `false`.
+
+#### Scenario: Sona synthesizes an English announcement
+
+- GIVEN TTS models are installed
+- WHEN Sona calls `synthesize_speech` with `{ text: "Meeting starts now." }`
+- THEN the response contains a `resource_link` item with a `kesha-audio://`
+  URI
+- AND `structuredContent.bytes` is greater than zero
+- AND the file at `structuredContent.path` exists with permissions `0600`
+
+#### Scenario: Rate out of range
+
+- WHEN Sona calls `synthesize_speech` with `{ text: "hello", rate: 3.0 }`
+- THEN the response has `isError: true`
+- AND `content[0].text` mentions that `3` is out of range `(0.5-2.0)`
+
+#### Scenario: Voice omitted — auto-route applies
+
+- WHEN Sona calls `synthesize_speech` with `{ text: "Hello" }` and no `voice`
+- THEN `structuredContent.voice` is `"(auto)"`
+- AND synthesis succeeds using the Default voice
+
+> *Technical Note — `synthesize_speech` registered at `src/mcp/tools.ts:35`.
+> Rate validation at `src/mcp/tools.ts:61`. `allocAudioPath` in
+> `src/mcp/audio-output.ts:25` creates `<tmpdir>/kesha-mcp/` with mode
+> `0o700` and names the file `<uuid>.<ext>`. `chmodSync(outPath, 0o600)` at
+> `src/mcp/tools.ts:69`. Resolved voice shows `"(auto)"` when `voice` was
+> omitted (`src/mcp/tools.ts:73`).*
+
+### Requirement: `list_voices` returns installed voice metadata
+
+The `list_voices` tool SHALL invoke the Engine's `say --list-voices` and return
+`structuredContent.voices` — an array of objects each containing `voiceId`,
+`modelId` (`"kokoro"` | `"vosk"` | `"avspeech"` | `"unknown"`), `modelName`,
+`languageCode`, `languageName`, and `gender` (`"male"` | `"female"` | `null`).
+`annotations.readOnlyHint` is `true`.
+
+#### Scenario: Sona lists voices to pick one for Russian
+
+- GIVEN the Russian Vosk-TTS model is installed
+- WHEN Sona calls `list_voices`
+- THEN `structuredContent.voices` includes an entry with `voiceId: "ru-vosk-m02"`,
+  `modelId: "vosk"`, `languageCode: "ru"`, and `gender: "male"`
+
+#### Scenario: Engine fails to list voices
+
+- GIVEN the Engine is not installed
+- WHEN Sona calls `list_voices`
+- THEN the response has `isError: true`
+- AND `content[0].text` begins with `list_voices failed:`
+
+> *Technical Note — `list_voices` registered at `src/mcp/tools.ts:135`.
+> `listVoices()` in `src/mcp/voices.ts:110` spawns `kesha-engine say
+> --list-voices`. `parseVoiceInfo` in `src/mcp/voices.ts:31` derives model,
+> language, and gender from the Voice id prefix.*
+
+### Requirement: `list_languages` returns aggregated language counts
+
+The `list_languages` tool SHALL derive its data from `list_voices` and return
+`structuredContent.languages` — an array sorted by `languageCode`, each entry
+carrying `languageCode`, `languageName`, and `voiceCount`.
+
+#### Scenario: Sona checks which languages are available
+
+- GIVEN English (Kokoro) and Russian (Vosk) voices are installed
+- WHEN Sona calls `list_languages`
+- THEN the result contains entries for `"en-US"` (or `"en-GB"`) and `"ru"`
+- AND each entry's `voiceCount` equals the number of installed voices for that
+  language code
+
+> *Technical Note — `list_languages` registered at `src/mcp/tools.ts:168`.
+> `aggregateLanguages` in `src/mcp/voices.ts:126` groups by `languageCode` and
+> sorts with `localeCompare`.*
+
+### Requirement: `kesha-audio://{file}` resource returns base64-encoded audio
+
+The resource template `kesha-audio://{file}` SHALL read the named file from the
+MCP audio directory and return it as a base64-encoded blob with the correct
+MIME type (`audio/wav`, `audio/ogg`, or `audio/flac`). Path traversal SHALL be
+rejected by taking only the `basename` of the supplied `file` parameter.
+Accessing a file that no longer exists (e.g. swept after 24 hours) SHALL throw
+an error naming the file.
+
+#### Scenario: Sona reads back synthesized audio
+
+- GIVEN a previous `synthesize_speech` call returned URI `kesha-audio://abc.wav`
+- WHEN Sona calls `resources/read` on that URI
+- THEN the response contains a blob with `mimeType: "audio/wav"`
+- AND the blob decodes to the same bytes as the file at the path
+
+#### Scenario: Path traversal attempt rejected
+
+- WHEN Sona calls `resources/read` on `kesha-audio://../../../etc/passwd`
+- THEN the request looks up only `passwd` (basename) in the MCP audio directory
+- AND if that file does not exist, an error is returned
+
+#### Scenario: Swept file access
+
+- GIVEN `kesha-audio://old.wav` was produced more than 24 hours ago and swept
+- WHEN Sona attempts `resources/read kesha-audio://old.wav`
+- THEN an error is returned stating the file is not found or already swept
+
+> *Technical Note — resource handler at `src/mcp/tools.ts:18`. Basename
+> sandbox: `basename(String(file))` at `src/mcp/tools.ts:23`. MIME selection
+> by `mimeForExt` at `src/mcp/tools.ts:11`. `sweepOldAudio` in
+> `src/mcp/audio-output.ts:30` deletes files with `mtimeMs < Date.now() - 24h`
+> (`MAX_AGE_MS = 24 * 60 * 60 * 1000` at `src/mcp/audio-output.ts:7`).
+> Audio directory: `join(tmpdir(), "kesha-mcp")` at
+> `src/mcp/audio-output.ts:9`.*
+
+### Requirement: Old MCP audio files are swept at server start
+
+At every `kesha mcp` startup the server SHALL delete files in the MCP audio
+directory whose modification time is more than 24 hours in the past, on a
+best-effort basis (errors for individual files are silently ignored to handle
+races and permission edge cases).
+
+#### Scenario: Stale files cleaned at startup
+
+- GIVEN `<tmpdir>/kesha-mcp/` contains files from 25 hours ago
+- WHEN `kesha mcp` starts
+- THEN those files are deleted before the first tool call is handled
+
+#### Scenario: MCP directory does not yet exist
+
+- GIVEN the MCP audio directory has never been created
+- WHEN `kesha mcp` starts
+- THEN `sweepOldAudio` returns without error (directory absence is silently
+  ignored)
+
+> *Technical Note — `sweepOldAudio()` called in `createKeshaMcpServer()`
+> (`src/mcp/server.ts:7`). The sweep reads the directory with `readdirSync`;
+> if the directory does not exist, the `catch` at `src/mcp/audio-output.ts:36`
+> silently returns. Individual file errors are caught per-file at
+> `src/mcp/audio-output.ts:43`.*
+
+## Open Issues
+
+- `synthesize_speech` returns `voice: "(auto)"` in `structuredContent` when no
+  voice is given, making it impossible for the caller to know which voice was
+  actually used; the engine could return the resolved Voice id in a future
+  protocol revision.
+- `transcribe_audio` does not expose a `lang` hint parameter; callers cannot
+  influence language detection or trigger the expected-language mismatch warning
+  via MCP.

--- a/openspec/specs/programmatic-api/spec.md
+++ b/openspec/specs/programmatic-api/spec.md
@@ -1,0 +1,256 @@
+# Programmatic API Specification
+
+## Purpose
+
+`@drakulavich/kesha-voice-kit/core` is the programmatic interface for embedding
+Kesha Voice Kit in Node.js/Bun applications and agent frameworks without
+invoking the CLI directly. Sona uses it to transcribe audio, synthesize speech,
+and install models inside her agent code. The Core API is a thin TypeScript
+wrapper that spawns the Engine as a subprocess — the same Engine the CLI uses —
+so behavior is identical to the CLI commands.
+
+## Non-Goals
+
+- The Core API does not provide streaming transcription; results are returned
+  when the Engine subprocess exits.
+- No built-in retry logic; callers handle transient failures.
+- The Core API never downloads the Engine or models automatically
+  (Never-auto-download rule); functions throw actionable errors when anything
+  is missing.
+- The CLI's output-format layer (`--json`, `--toon`, `--format`) is separate
+  from the Core API; programmatic callers receive typed objects, not formatted
+  strings (except via `toToon`).
+
+## Requirements
+
+### Requirement: Package exports map exposes `./core` as the programmatic entry point
+
+The package SHALL export the programmatic API at the `"./core"` path, mapping
+to `./src/lib.ts`. The default export (`"."`) maps to `./src/cli.ts` and is the
+CLI entry; importing from `"."` does not give programmatic access to the Core
+API.
+
+#### Scenario: Sona imports the Core API
+
+- WHEN Sona writes `import { transcribe } from "@drakulavich/kesha-voice-kit/core"`
+- THEN the import resolves to `src/lib.ts`
+- AND she receives the `transcribe` function, not the CLI runner
+
+> *Technical Note — `package.json#exports`: `"./core": "./src/lib.ts"`,
+> `".": "./src/cli.ts"`.*
+
+### Requirement: `transcribe(path, opts?)` returns the transcript text
+
+`transcribe` SHALL accept an audio file path and an optional `TranscribeOptions`
+object. It SHALL:
+1. Throw `Error("File not found: <path>")` when the file does not exist (checked
+   before spawning the Engine).
+2. Spawn the Engine with `silent: true` (no progress output to stderr).
+3. Return a `Promise<string>` resolving to the transcript text.
+4. Throw when the Engine fails (non-zero exit).
+
+#### Scenario: Sona transcribes a voice note
+
+- GIVEN the Engine and ASR models are installed and `note.ogg` exists
+- WHEN Sona calls `await transcribe("note.ogg")`
+- THEN the function resolves to the transcript string
+- AND no output appears on stderr
+
+#### Scenario: File does not exist
+
+- WHEN Sona calls `await transcribe("ghost.ogg")`
+- THEN the promise rejects with an Error whose message contains `"File not found: ghost.ogg"`
+
+> *Technical Note — `transcribe` in `src/lib.ts:44`. `existsSync` check at
+> `src/lib.ts:46`. Calls `internalTranscribe` with `{ ...options, silent: true }`.
+> The `silent` flag suppresses the Engine's stderr progress output.*
+
+### Requirement: `transcribeWithTimestamps(path, opts?)` returns text and segments
+
+`transcribeWithTimestamps` SHALL return a `Promise<TranscriptionOutput>` with
+`text` (string) and `segments` (array of `TranscriptionSegment`). Each segment
+has `start` (number, seconds), `end` (number, seconds), `text` (string), and
+optionally `speaker` (number, when diarization was requested). It SHALL throw
+`Error("File not found: <path>")` when the file does not exist.
+
+`transcribeWithSegments` is a deprecated alias for `transcribeWithTimestamps`
+introduced in v1.9.0. Both names MUST remain importable; no removal is
+scheduled before the next major version.
+
+#### Scenario: Sona needs word-level timestamps for a subtitle generator
+
+- GIVEN `lecture.mp3` exists and the Engine supports `transcribe.segments`
+- WHEN Sona calls `await transcribeWithTimestamps("lecture.mp3")`
+- THEN the result has a non-empty `segments` array
+- AND each element has numeric `start`, `end`, and a `text` string
+
+#### Scenario: Deprecated alias still works
+
+- WHEN Sona imports `transcribeWithSegments` from `"@drakulavich/kesha-voice-kit/core"`
+- THEN the import succeeds
+- AND calling it with a valid path returns the same result as `transcribeWithTimestamps`
+
+#### Scenario: File not found throws actionable error
+
+- WHEN Sona calls `await transcribeWithTimestamps("missing.mp3")`
+- THEN the promise rejects with `Error("File not found: missing.mp3")`
+
+> *Technical Note — `transcribeWithTimestamps` in `src/lib.ts:55`. Deprecated
+> alias `transcribeWithSegments` at `src/lib.ts:75`. `TranscriptionSegment`
+> type in `src/engine.ts:28`.*
+
+### Requirement: `say(opts)` synthesizes speech and returns audio bytes
+
+`say` SHALL accept a `SayOptions` object and return a `Promise<Uint8Array>`
+containing the raw audio bytes (WAV IEEE-float mono by default, or the format
+specified by `opts.format`). When `opts.out` is set, the Engine writes to the
+file and the returned `Uint8Array` is empty.
+
+`say` SHALL throw `SayError` — a subclass of `Error` carrying `exitCode`,
+`stderr`, and `code` — on any failure. Specific pre-flight failures:
+- `text` is empty or missing → `SayError` with `exitCode: 2` and
+  `code: "E_TEXT_EMPTY"`.
+- `text` exceeds `MAX_TEXT_CHARS` (5000 Unicode code points) → `SayError`
+  with `exitCode: 5` and `code: "E_TEXT_TOO_LONG"`.
+- Engine not installed → `SayError` with `exitCode: 1` and
+  `code: "E_ENGINE_SPAWN"` (the `TS_NATIVE_CODES.ENGINE_SPAWN` value).
+
+When `opts.noExpandAbbrev` is set and the Engine does not advertise
+`tts.ru_acronym_expansion` or `tts.en_acronym_expansion`, the flag is silently
+dropped and a `log.warn` message is emitted (not a thrown error).
+
+#### Scenario: Sona synthesizes a Russian reply
+
+- GIVEN the Russian Vosk-TTS model is installed
+- WHEN Sona calls `await say({ text: "Привет мир", voice: "ru-vosk-m02" })`
+- THEN the result is a non-empty `Uint8Array` of WAV audio bytes
+
+#### Scenario: Empty text throws immediately
+
+- WHEN Sona calls `await say({ text: "" })`
+- THEN the promise rejects with a `SayError`
+- AND `err.exitCode === 2`
+- AND `err.code === "E_TEXT_EMPTY"`
+
+#### Scenario: Text too long throws immediately
+
+- WHEN Sona calls `await say({ text: "x".repeat(5001) })`
+- THEN the promise rejects with a `SayError`
+- AND `err.exitCode === 5`
+- AND `err.code === "E_TEXT_TOO_LONG"`
+
+#### Scenario: Engine not installed throws actionable error
+
+- GIVEN `kesha install` has not been run
+- WHEN Sona calls `await say({ text: "hello" })`
+- THEN the promise rejects with a `SayError` whose message contains
+  `kesha install --tts`
+
+#### Scenario: Writing to a file
+
+- WHEN Sona calls `await say({ text: "hello", out: "/tmp/hello.wav" })`
+- THEN the file `/tmp/hello.wav` is written with WAV audio
+- AND the returned `Uint8Array` is empty
+
+> *Technical Note — `say` in `src/synth.ts:112`. `MAX_TEXT_CHARS = 5000` at
+> `src/synth.ts:22`. `SayError` at `src/synth.ts:96` carries `exitCode`,
+> `stderr`, `code`. `E_TEXT_EMPTY` exit code 2 at `src/synth.ts:115`;
+> `E_TEXT_TOO_LONG` exit code 5 at `src/synth.ts:118`. Engine-not-installed
+> uses `TS_NATIVE_CODES.ENGINE_SPAWN` at `src/synth.ts:131`. The `noExpandAbbrev`
+> capability check is in `buildSayArgs` at `src/synth.ts:66`.*
+
+### Requirement: `downloadModel` / `downloadEngine` installs the Engine binary
+
+The Core API SHALL expose `downloadModel` (primary export name) and
+`downloadEngine` (the underlying function, also exported) to download and cache
+the Engine binary. They are identical; `downloadModel` is the preferred
+programmatic name. The deprecated `downloadCoreML` alias also resolves to the
+same function.
+
+#### Scenario: Sona installs the Engine from her setup script
+
+- WHEN Sona calls `await downloadModel()`
+- THEN the Engine binary is present at the default location
+- AND subsequent `transcribe` calls succeed
+
+> *Technical Note — `downloadEngine` imported from `src/engine-install.ts`
+> and re-exported as `downloadModel` at `src/lib.ts:11`. `downloadCoreML`
+> deprecated alias at `src/lib.ts:42`.*
+
+### Requirement: `downloadTts(noCache?, langs?)` installs TTS models
+
+`downloadTts` SHALL accept an optional `noCache` flag (default `false`) and an
+optional `langs` array (default `["en"]`). It SHALL install TTS models for the
+specified language codes by delegating to the Engine's `install` subcommand.
+Unsupported-on-platform language codes are rejected by the Engine.
+
+#### Scenario: Sona installs English and Russian TTS in one call
+
+- WHEN Sona calls `await downloadTts(false, ["en", "ru"])`
+- THEN TTS models for both languages are present in the Model cache
+- AND subsequent `say({ text: "hello" })` and
+  `say({ text: "привет", voice: "ru-vosk-m02" })` succeed
+
+> *Technical Note — `downloadTts` at `src/lib.ts:37`. Delegates to
+> `downloadEngine(noCache, undefined, { ttsLangs: langs })`.*
+
+### Requirement: `toToon(results)` encodes a result array as TOON
+
+`toToon` SHALL accept a `TranscribeResult[]` and return a TOON-encoded string
+identical to what `kesha --toon` would produce. The string is losslessly
+decodable via `@toon-format/toon`'s `decode()` back to the same array.
+
+#### Scenario: Sona formats results for an LLM context window
+
+- GIVEN `results` is an array of `TranscribeResult` objects from multiple files
+- WHEN Sona calls `toToon(results)`
+- THEN the returned string is 30–60% shorter than the JSON equivalent
+- AND `decode(toToon(results))` equals the original `results` array
+
+> *Technical Note — `toToon` re-exported as `formatToonOutput` from
+> `src/toon.ts` at `src/lib.ts:19`.*
+
+### Requirement: Exported types cover the full public surface
+
+The Core API SHALL export the following TypeScript types: `TranscribeResult`,
+`TranscribeOptions`, `TranscribeErrorRecord`, `TranscribeJsonOutput`,
+`TranscriptionOutput`, `TranscriptionSegment`, `SayOptions`, `SayError`,
+`VadMode`. These types SHALL not change shape without a major version bump.
+
+#### Scenario: Sona types her wrapper function
+
+- WHEN Sona writes `import type { SayOptions, SayError } from "@drakulavich/kesha-voice-kit/core"`
+- THEN the TypeScript compiler resolves both types without error
+
+> *Technical Note — `TranscribeResult`, `TranscribeErrorRecord`,
+> `TranscribeJsonOutput` re-exported from `src/types.ts` at `src/lib.ts:26`.
+> `TranscriptionOutput`, `TranscriptionSegment` re-exported from `src/engine.ts`
+> at `src/lib.ts:10`. `TranscribeOptions` re-exported from `src/transcribe.ts`
+> at `src/lib.ts:9`. `SayOptions`, `SayError` re-exported from `src/synth.ts`
+> at `src/lib.ts:12`. `VadMode` exported via `src/transcribe.ts`.*
+
+### Requirement: Never-auto-download — all functions throw when prerequisites are missing
+
+No Core API function SHALL silently download the Engine or models. When a
+prerequisite is absent, the function SHALL throw with an actionable error
+message naming the `kesha install` command needed to fix the situation.
+
+#### Scenario: Transcribing without the Engine installed
+
+- GIVEN the Engine binary has never been downloaded
+- WHEN Sona calls `await transcribe("note.ogg")`
+- THEN the promise rejects with an error containing `kesha install`
+
+> *Technical Note — `isEngineInstalled()` in `src/engine.ts:50` gates
+> Engine-dependent calls. `preflightTranscribeWithSegments` in
+> `src/transcribe.ts:32` checks `isEngineInstalled()` and throws with a
+> `bun add -g` + `kesha install` hint when false.*
+
+## Open Issues
+
+- `say()` always passes `text` via stdin to the Engine subprocess; the
+  `SayOptions.text` field is required for programmatic callers because `say()`
+  does not forward the host process's stdin. This asymmetry from the CLI is not
+  surfaced in the type; it is documented only in the JSDoc comment.
+- `downloadTts` does not expose a progress callback; callers cannot observe
+  download progress except via stderr parsing.

--- a/openspec/specs/programmatic-api/spec.md
+++ b/openspec/specs/programmatic-api/spec.md
@@ -143,8 +143,10 @@ dropped and a `log.warn` message is emitted (not a thrown error).
 
 - GIVEN `kesha install` has not been run
 - WHEN Sona calls `await say({ text: "hello" })`
-- THEN the promise rejects with a `SayError` whose message contains
-  `kesha install --tts`
+- THEN the promise rejects with a `SayError` (`err.code === "E_ENGINE_SPAWN"`,
+  `err.exitCode === 1`)
+- AND its message carries an actionable setup hint ending in `--tts` — the verb
+  is `kesha init` on an interactive TTY and `kesha install` when stderr is piped
 
 #### Scenario: Writing to a file
 
@@ -156,7 +158,10 @@ dropped and a `log.warn` message is emitted (not a thrown error).
 > `src/synth.ts:22`. `SayError` at `src/synth.ts:96` carries `exitCode`,
 > `stderr`, `code`. `E_TEXT_EMPTY` exit code 2 at `src/synth.ts:115`;
 > `E_TEXT_TOO_LONG` exit code 5 at `src/synth.ts:118`. Engine-not-installed
-> uses `TS_NATIVE_CODES.ENGINE_SPAWN` at `src/synth.ts:131`. The `noExpandAbbrev`
+> throws `TS_NATIVE_CODES.ENGINE_SPAWN` (`"E_ENGINE_SPAWN"`) with exit code 1 at
+> `src/synth.ts:127-134`; its message embeds `installHint("--tts")`
+> (`src/install-hint.ts:9`) — `kesha init --tts` when `process.stderr.isTTY`,
+> `kesha install --tts` otherwise. The `noExpandAbbrev`
 > capability check is in `buildSayArgs` at `src/synth.ts:66`.*
 
 ### Requirement: `downloadModel` / `downloadEngine` installs the Engine binary

--- a/openspec/specs/programmatic-api/spec.md
+++ b/openspec/specs/programmatic-api/spec.md
@@ -244,12 +244,15 @@ message naming the `kesha install` command needed to fix the situation.
 
 - GIVEN the Engine binary has never been downloaded
 - WHEN Sona calls `await transcribe("note.ogg")`
-- THEN the promise rejects with an error containing `kesha install`
+- THEN the promise rejects with an error carrying an actionable setup hint —
+  `kesha init` on an interactive TTY, `kesha install` when stderr is piped
 
 > *Technical Note — `isEngineInstalled()` in `src/engine.ts:50` gates
 > Engine-dependent calls. `preflightTranscribeWithSegments` in
-> `src/transcribe.ts:32` checks `isEngineInstalled()` and throws with a
-> `bun add -g` + `kesha install` hint when false.*
+> `src/transcribe.ts:32` checks `isEngineInstalled()` and throws a `bun add -g`
+> + `installHint()` block when false (`src/transcribe.ts:34-39`); `installHint()`
+> (`src/install-hint.ts:9`) yields `kesha init` on a TTY, `kesha install`
+> otherwise.*
 
 ## Open Issues
 

--- a/openspec/specs/programmatic-api/spec.md
+++ b/openspec/specs/programmatic-api/spec.md
@@ -45,7 +45,7 @@ API.
 object. It SHALL:
 1. Throw `Error("File not found: <path>")` when the file does not exist (checked
    before spawning the Engine).
-2. Spawn the Engine with `silent: true` (no progress output to stderr).
+2. Not surface the Engine's progress output on the caller's stderr.
 3. Return a `Promise<string>` resolving to the transcript text.
 4. Throw when the Engine fails (non-zero exit).
 
@@ -54,16 +54,19 @@ object. It SHALL:
 - GIVEN the Engine and ASR models are installed and `note.ogg` exists
 - WHEN Sona calls `await transcribe("note.ogg")`
 - THEN the function resolves to the transcript string
-- AND no output appears on stderr
+- AND no Engine progress output appears on the caller's stderr
 
 #### Scenario: File does not exist
 
 - WHEN Sona calls `await transcribe("ghost.ogg")`
 - THEN the promise rejects with an Error whose message contains `"File not found: ghost.ogg"`
 
-> *Technical Note — `transcribe` in `src/lib.ts:44`. `existsSync` check at
-> `src/lib.ts:46`. Calls `internalTranscribe` with `{ ...options, silent: true }`.
-> The `silent` flag suppresses the Engine's stderr progress output.*
+> *Technical Note — `transcribe` in `src/lib.ts:44`; `existsSync` check at
+> `src/lib.ts:46`. The Engine's stderr never reaches the caller's stderr because
+> `runEngine` (`src/engine.ts:106`) spawns it with `stdio: ["ignore", "pipe",
+> "pipe"]` — stderr is captured into a string, surfaced only inside the thrown
+> Error on failure and discarded on success. `lib.ts` also passes `silent: true`,
+> but that option is currently never read downstream — see Open Issues.*
 
 ### Requirement: `transcribeWithTimestamps(path, opts?)` returns text and segments
 
@@ -262,3 +265,8 @@ message naming the `kesha install` command needed to fix the situation.
   surfaced in the type; it is documented only in the JSDoc comment.
 - `downloadTts` does not expose a progress callback; callers cannot observe
   download progress except via stderr parsing.
+- **`silent` is a dead option** — `lib.ts` passes `silent: true` to
+  `internalTranscribe`/`internalTranscribeWithSegments` (`src/lib.ts:52,66`), but
+  `TranscribeOptions.silent` (`src/transcribe.ts:15`) is never read; stderr
+  suppression for the Core API comes solely from `runEngine`'s piped stdio. The
+  flag should either be wired up or removed.

--- a/openspec/specs/speaker-diarization/spec.md
+++ b/openspec/specs/speaker-diarization/spec.md
@@ -56,7 +56,9 @@ timestamps when `--speakers` is set.
 The Engine SHALL reject `--speakers` at runtime on non-darwin-arm64 targets
 with an `E_UNSUPPORTED_PLATFORM` error. On darwin-arm64, the Engine SHALL
 check that the diarize model exists before running ASR, and SHALL fail with an
-actionable `kesha install --diarize` hint if the model is missing.
+actionable setup hint naming `--diarize` (`kesha init --diarize` on an
+interactive TTY, `kesha install --diarize` when stderr is piped) if the model is
+missing.
 
 #### Scenario: Linux CI runs with --speakers
 
@@ -70,7 +72,9 @@ actionable `kesha install --diarize` hint if the model is missing.
 - GIVEN the Engine has the `system_diarize` feature but
   `~/.cache/kesha/models/diarize/SortformerNvidiaLow_v2.mlpackage` is absent
 - WHEN Maks runs `kesha --json --speakers meeting.ogg`
-- THEN the Engine reports the missing model and suggests `kesha install --diarize`
+- THEN the missing model is reported with an actionable setup hint naming
+  `--diarize` — `kesha init --diarize` on a TTY, `kesha install --diarize` when
+  stderr is piped (`installHint("--diarize")`, `src/engine.ts:224`)
 - AND the diarize preflight error fires before ASR model lookup
 - AND the process exits 1
 

--- a/openspec/specs/speaker-diarization/spec.md
+++ b/openspec/specs/speaker-diarization/spec.md
@@ -1,0 +1,212 @@
+# Speaker Diarization Specification
+
+## Purpose
+
+Speaker Diarization labels each Transcription Segment with a Speaker index so
+Maks can read a meeting transcript and see who said what. It runs as a
+post-processing step after ASR: the Engine diarizes the audio with the
+Sortformer CoreML model and projects each span onto the ASR Segments by
+midpoint overlap. The CLI activates it via `--speakers`.
+
+Everything runs locally. No network access is required beyond the initial
+`kesha install --diarize` that stages the model.
+
+## Non-Goals
+
+- Diarization does not identify *who* a speaker is — it assigns cluster indices
+  (`0`, `1`, `2`, …) that have no meaning across separate calls.
+- Diarization is darwin-arm64 only. Other platforms receive a clear error
+  pointing at the tracking issue; there is no ONNX fallback.
+- Speaker count is not configurable. The model determines it automatically.
+- `--speakers` does not improve transcription text quality; it only adds
+  `speaker` fields to the Segment objects.
+
+## Requirements
+
+### Requirement: Speaker labels require structured output and timestamps
+
+The CLI SHALL reject `--speakers` when the output format is not JSON or TOON,
+and SHALL exit 2 with an actionable message before spawning the Engine.
+`--speakers` implies `--timestamps`: the CLI SHALL automatically enable segment
+timestamps when `--speakers` is set.
+
+#### Scenario: Ira runs --speakers without --json
+
+- GIVEN the Engine is installed with diarization support
+- WHEN Ira runs `kesha --speakers meeting.ogg`
+- THEN the CLI prints an error explaining that `--speakers` requires
+  `--json`, `--toon`, or `--format {json,toon}` to stderr
+- AND the process exits 2 without spawning the Engine
+
+#### Scenario: Maks requests diarized JSON
+
+- GIVEN the Engine, ASR models, and the diarize model are installed on
+  darwin-arm64
+- WHEN Maks runs `kesha --json --speakers meeting.ogg`
+- THEN stdout is a JSON result array where each segment object carries a
+  numeric `speaker` field (e.g. `0`, `1`, `2`)
+- AND the process exits 0
+
+> *Technical Note — exit 2 flag check: `src/cli/main.ts` lines 278–279.
+> `--speakers` implies `with_segments = true` via `TranscribeOptionsBuilder`
+> (`rust/src/transcribe/mod.rs`, `rust/src/transcribe/options.rs`).*
+
+### Requirement: Diarization is gated on darwin-arm64 and the installed model
+
+The Engine SHALL reject `--speakers` at runtime on non-darwin-arm64 targets
+with an `E_UNSUPPORTED_PLATFORM` error. On darwin-arm64, the Engine SHALL
+check that the diarize model exists before running ASR, and SHALL fail with an
+actionable `kesha install --diarize` hint if the model is missing.
+
+#### Scenario: Linux CI runs with --speakers
+
+- GIVEN `kesha-engine` is the ONNX build (Linux)
+- WHEN Ira runs `kesha --json --speakers call.ogg`
+- THEN the Engine reports that speaker diarization is darwin-arm64 only
+- AND the process exits 1
+
+#### Scenario: Model not installed on darwin-arm64
+
+- GIVEN the Engine has the `system_diarize` feature but
+  `~/.cache/kesha/models/diarize/SortformerNvidiaLow_v2.mlpackage` is absent
+- WHEN Maks runs `kesha --json --speakers meeting.ogg`
+- THEN the Engine reports the missing model and suggests `kesha install --diarize`
+- AND the diarize preflight error fires before ASR model lookup
+- AND the process exits 1
+
+#### Scenario: KESHA_DIARIZE_MODEL_PATH points to a non-existent path
+
+- GIVEN `KESHA_DIARIZE_MODEL_PATH=/tmp/missing.mlpackage` and that path does
+  not exist
+- WHEN Maks runs `kesha --json --speakers meeting.ogg`
+- THEN the error names the non-existent path from the env var
+- AND the process exits 1 without running ASR
+
+> *Technical Note — platform gate: `rust/src/transcribe/mod.rs` lines 213–219
+> (`#[cfg(not(all(feature = "system_diarize", target_os = "macos")))]`).
+> Model path resolution: `resolve_diarize_model_path` in
+> `rust/src/transcribe/mod.rs` lines 746–768. `system_diarize` feature:
+> `rust/Cargo.toml` line 39.*
+
+### Requirement: Adaptive timeout protects against stalled CoreML calls
+
+The Engine SHALL apply an adaptive timeout to the blocking diarization call.
+The default floor is 150 s; the timeout scales up by audio duration and ASR
+segment count, capped at 1800 s (30 minutes). `KESHA_DIARIZE_TIMEOUT_SECS`
+overrides the adaptive value entirely. On timeout the Engine SHALL report
+`E_DIARIZE_TIMEOUT` with an actionable message that names the elapsed time,
+the audio duration, and suggests `kesha install --diarize` to warm the ANE
+cache.
+
+#### Scenario: Short recording completes well within the floor
+
+- GIVEN a 5-minute meeting recording
+- WHEN Maks runs `kesha --json --speakers meeting.ogg`
+- THEN diarization completes and the timeout never fires
+- AND every Segment in the output carries a `speaker` value
+
+#### Scenario: Diarization stalls on a cold ANE cache
+
+- GIVEN the Apple ANE compile cache has been evicted and `KESHA_DIARIZE_TIMEOUT_SECS=5`
+- WHEN Maks runs `kesha --json --speakers meeting.ogg` on a 10-minute recording
+- THEN the Engine reports `E_DIARIZE_TIMEOUT` on stderr, names the 5 s limit and
+  the audio duration, and suggests re-running `kesha install --diarize`
+- AND the process exits 1
+
+#### Scenario: KESHA_DIARIZE_TIMEOUT_SECS overrides the adaptive limit
+
+- GIVEN `KESHA_DIARIZE_TIMEOUT_SECS=3600`
+- WHEN the Engine computes the adaptive timeout for a 2-hour recording
+- THEN the returned timeout is exactly 3600 s, ignoring the adaptive formula
+
+> *Technical Note — constants: `DEFAULT_DIARIZE_TIMEOUT_SECS = 150`,
+> `MAX_ADAPTIVE_DIARIZE_TIMEOUT_SECS = 1800`,
+> `DIARIZE_TIMEOUT_SECONDS_PER_AUDIO_SECOND = 0.05`,
+> `DIARIZE_TIMEOUT_SECONDS_PER_ASR_SEGMENT = 0.10`.
+> Source: `rust/src/transcribe/diarize.rs` lines 30–33.
+> Error code `E_DIARIZE_TIMEOUT`: `rust/src/errors.rs` line 86.*
+
+### Requirement: Coverage validation prevents silently partial labels
+
+After diarization, the Engine SHALL validate that at least 95 % of ASR
+Segments have been labeled by midpoint overlap, AND that the diarization
+timeline ends no more than 30 s before the final ASR Segment. If either
+check fails, the Engine SHALL report an error with labeled/total counts and
+the span/transcript end times.
+
+#### Scenario: Full meeting is labeled
+
+- GIVEN a 4-speaker meeting where diarization spans cover the full ASR timeline
+- WHEN Maks runs `kesha --json --speakers meeting.ogg`
+- THEN all Segments carry a `speaker` value and the process exits 0
+
+#### Scenario: Diarization stops mid-recording
+
+- GIVEN diarization spans end at 10 s while the ASR transcript runs to 110 s
+- THEN the Engine reports a coverage error naming `spans end at 10.0s while
+  transcript ends at 110.0s`
+- AND the process exits 1
+
+> *Technical Note — constants: `MIN_DIARIZE_SEGMENT_COVERAGE = 0.95`,
+> `MAX_DIARIZE_TAIL_GAP_SECONDS = 30.0`.
+> Source: `rust/src/transcribe/diarize.rs` lines 20–21.
+> Validation function: `validate_coverage` in
+> `rust/src/transcribe/diarize.rs` lines 212–265.*
+
+### Requirement: Speaker ids are cluster indices stable within one call only
+
+The Engine SHALL assign Speaker ids as unsigned integers starting from 0,
+ordered by first appearance. The same physical speaker in two separate
+invocations MAY receive different ids. Distinct FluidAudio speaker labels
+SHALL never collapse onto the same cluster index.
+
+#### Scenario: Four-speaker meeting produces ids 0–3
+
+- GIVEN a recording with four distinct speakers
+- WHEN Maks runs `kesha --json --speakers meeting.ogg`
+- THEN the `speaker` values in the output are drawn from `{0, 1, 2, 3}`,
+  each assigned in first-appearance order
+
+#### Scenario: Re-running the same file may produce different ids
+
+- WHEN Maks runs `kesha --json --speakers meeting.ogg` twice
+- THEN the speaker index for a given physical voice MAY differ between the two
+  runs; Maks MUST NOT rely on cross-run stability
+
+> *Technical Note — id mapping: `speaker_id_to_index` in
+> `rust/src/transcribe/diarize.rs` lines 194–201. The midpoint-overlap merge
+> that projects spans onto ASR Segments: `merge_into` in
+> `rust/src/transcribe/diarize.rs` lines 275–290.*
+
+### Requirement: Output shape — speaker field on segments
+
+JSON and TOON output SHALL include a `speaker` field of type `u32` on each
+`segments[]` entry when `--speakers` is active. Segments whose midpoint falls
+outside every diarization span SHALL omit the `speaker` field entirely.
+
+#### Scenario: Sona parses diarized JSON
+
+- WHEN Sona runs `kesha --json --speakers call.ogg`
+- THEN each object in `results[0].segments` either has a numeric `speaker`
+  field or omits it entirely — there is no `null` or `"unknown"` value
+- AND Sona can group segments by `speaker` value to reconstruct per-speaker
+  turns
+
+#### Scenario: Unlabeled segment has no speaker field
+
+- GIVEN a Segment whose midpoint falls in a gap between diarization spans
+- THEN that Segment is serialized without a `speaker` key in the JSON output
+
+> *Technical Note — Rust struct definition: `TranscriptionSegment.speaker:
+> Option<u32>` with `#[serde(skip_serializing_if = "Option::is_none")]` in
+> `rust/src/transcribe/mod.rs` lines 96–101.*
+
+## Open Issues
+
+- Diarization is darwin-arm64 only; the tracking issue for ONNX-based
+  diarization on Linux/Windows is
+  https://github.com/drakulavich/kesha-voice-kit/issues/199.
+- The first `--speakers` call after OS boot may take longer than the adaptive
+  floor because the Apple ANE compiles the CoreML model from scratch. Re-running
+  `kesha install --diarize` warms the compile cache and makes subsequent calls
+  fast (see #443).

--- a/openspec/specs/transcription/spec.md
+++ b/openspec/specs/transcription/spec.md
@@ -1,0 +1,211 @@
+# Transcription Specification
+
+## Purpose
+
+Transcription is Kesha's default command: `kesha meeting.ogg` prints the spoken
+words as text. It is the path Ira scripts in CI (pipe-friendly stdout, strict
+exit codes, JSON/TOON for machines) and the one Maks uses ad hoc on voice notes.
+Everything runs locally: the CLI spawns the Engine, which decodes the audio,
+runs the Backend (Parakeet TDT 0.6B v3), and returns text — no network access.
+
+## Non-Goals
+
+- Transcription never downloads the Engine or models (Never-auto-download rule);
+  a missing component fails with a `kesha install` hint.
+- No live/streaming transcription — input is a finished audio file (see
+  `audio-recording` for capturing one).
+- No translation; the transcript is in the spoken language.
+- Speaker labels are specified separately in `speaker-diarization`.
+
+## Requirements
+
+### Requirement: Transcribe a single audio file to plain text
+
+The CLI SHALL transcribe a given audio file and print the transcript to stdout
+followed by a newline, keeping all progress and error output on stderr so the
+transcript can be piped.
+
+Supported containers/codecs are those the Engine's decoder handles (MP3, WAV,
+FLAC, AAC, OGG/Vorbis, Opus, AIFF, …); audio is mixed to mono and resampled to
+16 kHz internally.
+
+#### Scenario: Ira pipes a transcript in CI
+
+- GIVEN the Engine and ASR models are installed
+- WHEN Ira runs `kesha standup.ogg > transcript.txt`
+- THEN `transcript.txt` contains only the transcript text and a trailing newline
+- AND the spinner/progress output (if any) went to stderr
+- AND the process exits 0
+
+#### Scenario: Input file does not exist
+
+- WHEN Ira runs `kesha missing.ogg`
+- THEN an error naming the missing file is printed to stderr
+- AND the process exits 1
+
+#### Scenario: File exists but is not decodable audio
+
+- WHEN Maks runs `kesha notes.txt` on a text file
+- THEN the Engine reports an unsupported-format error for that path on stderr
+- AND the process exits 1
+
+#### Scenario: No input files given
+
+- WHEN Ira runs `kesha` with no arguments
+- THEN a usage summary is printed to stderr
+- AND the process exits 1
+
+> *Technical Note — sources: `src/cli/main.ts` (default command),
+> `src/format.ts:3` (text format), `rust/src/audio.rs` (decode + resample),
+> `rust/src/cli/transcribe.rs`. Audio decode errors use messages like
+> `unsupported audio format: <path>` / `no supported audio tracks in: <path>`.*
+
+### Requirement: Batch transcription continues past per-file failures
+
+The CLI SHALL accept multiple audio files in one invocation, transcribe them
+sequentially, label each transcript with a `=== <file> ===` header in text mode,
+and continue after a failing file rather than aborting the batch.
+
+#### Scenario: One of three files is missing
+
+- GIVEN `a.ogg` and `c.ogg` exist but `b.ogg` does not
+- WHEN Ira runs `kesha a.ogg b.ogg c.ogg`
+- THEN transcripts for `a.ogg` and `c.ogg` are printed, each under its
+  `=== <file> ===` header
+- AND the `b.ogg` error goes to stderr
+- AND the process exits 1 (any failure fails the batch)
+
+#### Scenario: All files succeed
+
+- WHEN Maks runs `kesha note1.ogg note2.ogg`
+- THEN both transcripts appear in input order with headers
+- AND the process exits 0
+
+### Requirement: Machine-readable output formats
+
+The CLI SHALL provide JSON (`--json` / `--format json`) and TOON (`--toon` /
+`--format toon`) output: an array of per-file result objects
+(`file`, `text`, `lang`, and detection/timing fields), with TOON losslessly
+round-tripping to the same data as JSON. The CLI SHALL also provide
+`--format transcript` (text plus a `[lang: <code>, confidence: <n>]` trailer)
+and `--verbose` (adds detection details and STT time to stderr-adjacent text
+output).
+
+#### Scenario: Sona requests JSON
+
+- WHEN Sona runs `kesha --json call.ogg`
+- THEN stdout is a 2-space-indented JSON array with one result object containing
+  at least `file`, `text`, and `lang`
+- AND the process exits 0
+
+#### Scenario: TOON for LLM piping
+
+- WHEN Sona runs `kesha --toon call1.ogg call2.ogg`
+- THEN stdout is a TOON document that `@toon-format/toon`'s `decode()` turns
+  back into the same result array `--json` would have printed
+
+#### Scenario: JSON error reporting opt-in
+
+- GIVEN `b.ogg` is missing
+- WHEN Ira runs `kesha --json --include-errors a.ogg b.ogg`
+- THEN stdout is `{ "results": [...], "errors": [...] }` where the error record
+  for `b.ogg` carries a stable error code
+- AND without `--include-errors` stdout would be the plain results array
+
+### Requirement: Conflicting or incomplete flag combinations are rejected
+
+The CLI SHALL validate flag combinations before starting the Engine and exit 2
+with a stderr message when the request is contradictory.
+
+The rejected combinations are: `--json` with `--toon`; `--format transcript`
+combined with `--json` or `--toon`; `--timestamps` or `--speakers` without
+`--json`/`--toon`; `--include-errors` without `--json`; `--vad` with
+`--no-vad`; an unknown `--format` value.
+
+#### Scenario: Both JSON and TOON requested
+
+- WHEN Ira runs `kesha --json --toon call.ogg`
+- THEN an error explaining the flags are mutually exclusive is printed to stderr
+- AND the process exits 2 without spawning the Engine
+
+#### Scenario: Timestamps in plain-text mode
+
+- WHEN Maks runs `kesha --timestamps call.ogg`
+- THEN the CLI exits 2 telling him `--timestamps` requires `--json` or `--toon`
+
+### Requirement: Segment timestamps on demand
+
+The CLI SHALL include per-Segment `start`/`end` times (seconds) in JSON/TOON
+results when `--timestamps` is passed.
+
+#### Scenario: Sona requests timestamps
+
+- WHEN Sona runs `kesha --json --timestamps call.ogg`
+- THEN each result's `segments` array contains objects with numeric `start`,
+  `end`, and `text`
+
+### Requirement: Expected-language mismatch warning
+
+The CLI SHALL accept `--lang <code>` as the expected language and warn on
+stderr — without failing — when confident detection disagrees with it.
+
+#### Scenario: Russian audio declared as English
+
+- GIVEN `ru.ogg` contains Russian speech detected with confidence above 0.8
+- WHEN Ira runs `kesha --lang en ru.ogg`
+- THEN the transcript is still printed and the process exits 0
+- AND stderr carries a language-mismatch warning
+
+### Requirement: Long audio is handled via VAD or chunking, never silently truncated
+
+The CLI SHALL transcribe audio of any length: with VAD installed, audio of
+120 seconds or longer is automatically split on speech boundaries (auto mode);
+`--vad` forces splitting (and fails if the VAD model is not installed);
+`--no-vad` forces a single pass and SHALL fail rather than truncate when the
+file exceeds the single-pass ceiling (24 minutes). Without VAD installed, long
+audio falls back to fixed overlapping windows with boundary deduplication.
+
+#### Scenario: Hour-long recording with VAD installed
+
+- GIVEN the Silero VAD model is installed
+- WHEN Maks runs `kesha lecture.mp3` on a 60-minute file
+- THEN the full lecture is transcribed via VAD-segmented passes
+- AND the process exits 0
+
+#### Scenario: Forcing VAD without the model
+
+- GIVEN the VAD model is not installed
+- WHEN Ira runs `kesha --vad call.ogg`
+- THEN the run fails with an actionable `kesha install --vad` hint
+- AND the process exits 1
+
+#### Scenario: --no-vad on a file over the ceiling
+
+- WHEN Ira runs `kesha --no-vad marathon.mp3` on a 30-minute file
+- THEN the run fails early explaining the single-pass limit instead of
+  returning a truncated transcript
+
+> *Technical Note — VAD auto mode triggers at ≥120 s duration (and file size
+> >200 KB); single-pass ceiling `FULL_FILE_SINGLE_PASS_MAX_SECONDS` = 24 min;
+> fixed-window fallback uses 10-minute windows with 5-second overlap and
+> ≥8-char boundary dedup. Sources: `rust/src/transcribe/mod.rs`,
+> `rust/src/vad.rs`, `src/cli/main.ts` (VAD flag plumbing).*
+
+### Requirement: Exit codes distinguish success, runtime failure, and bad usage
+
+The CLI SHALL exit 0 when every input file transcribed successfully, 1 when any
+file failed at runtime, and 2 for argument-validation errors.
+
+#### Scenario: Exit-code contract in a script
+
+- GIVEN a shell script that branches on `$?`
+- WHEN it runs `kesha good.ogg` / `kesha missing.ogg` / `kesha --json --toon x.ogg`
+- THEN it observes exit codes 0, 1, and 2 respectively
+
+## Open Issues
+
+- VAD auto mode silently skips when the audio file is under 200 KB even if it
+  is long in duration (low-bitrate edge case) — intentional today, revisit if
+  low-bitrate long files surface in support.
+- Audio language detection is skipped for transcripts over 10 minutes; the
+  `--lang` mismatch warning therefore cannot fire on very long files.

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -1,0 +1,558 @@
+# TTS Synthesis Specification
+
+## Purpose
+
+`kesha say` turns text into speech, entirely locally. Maks pipes Russian and
+English replies into Telegram voice notes; Ira scripts batch narration in CI;
+Sona calls the same path through the `say()` Core API and the MCP server. The
+CLI resolves a Voice id, spawns the Engine, and streams audio bytes to stdout
+(or `--out`), keeping stderr for progress and errors. Three TTS engines sit
+behind one flag surface: Kokoro (Kokoro-82M, 24 kHz), Vosk (Vosk-TTS Russian,
+22.05 kHz, multi-speaker), and AVSpeech (macOS system voices via the
+`say-avspeech` Sidecar).
+
+## Non-Goals
+
+- TTS never downloads the Engine or models (Never-auto-download rule); missing
+  models fail with a `kesha install --tts` hint.
+- No streaming synthesis — output is a finished audio file or byte buffer
+  (`--stdin-loop` is an internal Engine mode, not a public contract).
+- No voice cloning or custom voice training.
+- Hindi and Japanese native-script synthesis are explicitly out of scope today
+  (see Script gates below and Open Issues).
+- Audio playback — `kesha say` produces bytes; playing them is the caller's job.
+
+## Requirements
+
+### Requirement: Synthesize text to speech with pipe-friendly output
+
+The CLI SHALL synthesize the given text (positional argument, or stdin when the
+positional is omitted) and write the audio bytes to stdout, unless `--out
+<path>` is given, in which case the audio is written to that file and stdout
+stays empty. All progress and error output SHALL go to stderr. Missing text
+SHALL be rejected before synthesis: no positional argument with a TTY stdin
+exits 2, and empty (or whitespace-only) text exits 2 with `E_TEXT_EMPTY`. Text
+longer than 5000 Unicode characters SHALL be rejected with `E_TEXT_TOO_LONG`
+and exit code 5, before any model is loaded.
+
+#### Scenario: Maks pipes a voice note to a file
+
+- GIVEN the Engine and English TTS models are installed
+- WHEN Maks runs `kesha say "Hello from Kesha" > hello.wav`
+- THEN `hello.wav` contains a playable WAV file
+- AND nothing but audio bytes went to stdout
+- AND the process exits 0
+
+#### Scenario: Ira pipes text via stdin in CI
+
+- WHEN Ira runs `echo "Build passed" | kesha say --out status.wav`
+- THEN the text is read from stdin and synthesized into `status.wav`
+- AND the `Synthesizing default voice -> status.wav...` progress line (voice
+  label or `default voice`) goes to stderr
+- AND the process exits 0
+
+#### Scenario: No text and interactive stdin
+
+- WHEN Maks runs `kesha say` in a terminal with no piped input
+- THEN stderr explains that text or piped stdin is required
+- AND the process exits 2 without spawning the Engine
+
+#### Scenario: Text over the 5000-character limit
+
+- WHEN Sona calls `say()` with a 5001-character string
+- THEN the call fails with Error code `E_TEXT_TOO_LONG` naming the limit and
+  the actual length
+- AND the Exit code is 5 (CLI path) — distinct from generic invalid input
+
+#### Scenario: Empty text after trimming
+
+- WHEN Ira runs `printf '   ' | kesha say`
+- THEN the run fails with `E_TEXT_EMPTY` and exits 2
+
+> *Technical Note — the limit is `MAX_TEXT_CHARS = 5000`, counted in Unicode
+> code points (`Array.from(text).length` / `chars().count()`), enforced in both
+> the CLI (`src/synth.ts:22,117-125`) and the Engine
+> (`rust/src/tts/mod.rs:41`). TTY guard: `src/cli/say.ts:54-59`
+> (`shouldRejectMissingSayText`). Stdin is trimmed before the empty check
+> (`src/cli/say.ts:38-52`, `rust/src/cli/say.rs:185-201`).*
+
+### Requirement: Voice routing resolves --voice, then --lang, then detected language, then the engine default
+
+Voice routing SHALL apply this precedence: an explicit `--voice` wins
+unconditionally; otherwise `--lang` maps the stated language to its default
+voice via `pickVoiceForLang` without running text-language detection;
+otherwise Language detection (text) runs and its result (when confidence is at
+least 0.5) is mapped the same way; otherwise the voice is left unset and the
+Engine uses its Default voice, `en-am_michael`. A `--lang` value with no
+mapped voice SHALL resolve to the engine default rather than re-running
+detection. The Voice id scheme is `<lang>-<name>`; the `<lang>` prefix routes
+to a TTS engine (Kokoro, Vosk, or AVSpeech), and an unparseable or unsupported
+Voice id SHALL fail with `E_VOICE_UNKNOWN` and exit 1.
+
+#### Scenario: Explicit voice beats explicit language
+
+- WHEN Maks runs `kesha say --voice ru-vosk-f01 --lang en "привет"`
+- THEN synthesis uses `ru-vosk-f01` (the `--voice` wins)
+- AND `--lang` is still forwarded to the Engine as the G2P language override
+
+#### Scenario: --lang skips detection on Linux
+
+- GIVEN Ira's Linux runner, where macOS text-language detection is unavailable
+- WHEN Ira runs `kesha say --lang ru "Сборка прошла успешно"`
+- THEN the voice resolves to `ru-vosk-m02` without any detection call
+- AND the process exits 0
+
+#### Scenario: Auto-detection routes Russian to AVSpeech on macOS
+
+- GIVEN Maks's Mac with no `--voice` or `--lang` given
+- WHEN Maks runs `kesha say "Привет, это Кеша"`
+- THEN text-language detection identifies `ru`
+- AND the voice resolves to `macos-com.apple.voice.compact.ru-RU.Milena`
+  (zero-install AVSpeech path; `--voice ru-vosk-m02` opts into Vosk quality)
+
+#### Scenario: Low-confidence detection falls back to the engine default
+
+- WHEN Sona synthesizes a short ambiguous string detected with confidence 0.3
+- THEN `pickVoiceForLang` returns no voice
+- AND the Engine synthesizes with its Default voice `en-am_michael`
+
+#### Scenario: Unknown voice id
+
+- WHEN Ira runs `kesha say --voice gibberish "test"`
+- THEN the Engine reports that a Voice id must be in `lang-name` form, with
+  Error code `E_VOICE_UNKNOWN`
+- AND the process exits 1
+
+#### Scenario: Unsupported voice language
+
+- WHEN Maks runs `kesha say --voice de-something "Hallo"`
+- THEN the run fails with `E_VOICE_UNKNOWN` listing the supported prefixes
+- AND the process exits 1
+
+> *Technical Note — precedence: `src/cli/say.ts:27-35` (`resolveSayVoice`);
+> mapping: `src/voice-routing.ts:31-53` (`pickVoiceForLang`). The full map
+> (confidence < 0.5 → none; base code is lowercased and split on `-`/`_`):*
+>
+> | Detected/stated lang | darwin (any arch) | darwin-arm64 extra | Linux/Windows/Intel macOS |
+> |---|---|---|---|
+> | `en` | `en-am_michael` | — | `en-am_michael` |
+> | `ru` | `macos-com.apple.voice.compact.ru-RU.Milena` | — | `ru-vosk-m02` |
+> | `es` | — | `es-em_alex` | `es-em_alex` |
+> | `fr` | — | *(unmapped → engine default)* | `fr-ff_siwis` |
+> | `hi` | — | `hi-hm_omega` | *(unmapped)* |
+> | `it` | — | `it-im_nicola` | `it-im_nicola` |
+> | `ja` | — | `ja-jm_kumo` | *(unmapped)* |
+> | `pt` | — | `pt-pm_alex` | `pt-pm_alex` |
+> | `zh` | — | `zh-zm_yunjian` (see Open Issues — engine ships `zh-zm_050`) | *(unmapped)* |
+>
+> *Engine-side routing (`rust/src/tts/voices.rs:99-148`): `en-*` → Kokoro;
+> `es/fr/hi/it/ja/pt/zh-*` → FluidAudio Kokoro on the darwin-arm64
+> `system_kokoro` build, `es/fr/it/pt-*` → ONNX Kokoro elsewhere; `ru-*` →
+> Vosk (the `vosk-` infix is optional; speakers map `f01→0, f02→1, f03→2,
+> m01→3, m02→4`, `rust/src/tts/voices.rs:295-300`); `macos-*` → AVSpeech
+> (suffix forwarded as identifier or language code; empty suffix rejected).
+> Engine default: `DEFAULT_VOICE_ID = "en-am_michael"`
+> (`rust/src/tts/voices.rs:45`).*
+
+### Requirement: Default voices are male
+
+Every Default voice SHALL be male — Kesha is a male brand voice. The English
+default is `en-am_michael`; the Russian Vosk default is `ru-vosk-m02`; Spanish,
+Italian, and Portuguese default to `es-em_alex`, `it-im_nicola`, and
+`pt-pm_alex`. The single documented exception is French: Kokoro v1.0 ships no
+male French voice, so `fr` defaults to `fr-ff_siwis` (female) until a male
+French voice exists.
+
+#### Scenario: Default English voice is male
+
+- WHEN Maks runs `kesha say "Good morning"` with no voice flags and English
+  detected
+- THEN synthesis uses `en-am_michael` (American male)
+
+#### Scenario: French falls back to the documented female exception
+
+- WHEN Ira runs `kesha say --voice fr- "Bonjour"` on a Linux runner
+- THEN the Engine resolves the empty name to the language default `ff_siwis`
+- AND this is the documented brand-rule exception, not a regression
+
+> *Technical Note — per-language defaults: `rust/src/tts/voices.rs:221-233`
+> (`default_voice_for_lang`), with the brand-rule exception comment inline.
+> Female Vosk voices `ru-vosk-f01/f02/f03` stay selectable via explicit
+> `--voice`.*
+
+### Requirement: TTS models are never auto-downloaded
+
+Synthesis SHALL fail loudly — never download — when the required TTS model is
+not in the Model cache. The failure carries Error code `E_MODEL_MISSING` and an
+actionable `kesha install --tts` hint, and exits 1.
+
+#### Scenario: Synthesis with installed models stays offline
+
+- GIVEN the English Kokoro model is installed
+- WHEN Ira runs `kesha say "ready" --out ready.wav` on an air-gapped runner
+- THEN synthesis succeeds with no network access
+
+#### Scenario: Missing Russian model
+
+- GIVEN the Vosk Russian model is not installed
+- WHEN Maks runs `kesha say --voice ru-vosk-m02 "привет"`
+- THEN stderr reads `voice 'ru-vosk-m02' not installed. run: kesha install --tts`
+  with Error code `E_MODEL_MISSING`
+- AND the process exits 1 without downloading anything
+
+> *Technical Note — model presence gates: `rust/src/tts/voices.rs:192-204`
+> (ONNX Kokoro), `:307-313` (Vosk). `macos-*` voices need no model download;
+> FluidAudio Kokoro voices are fetched only by `kesha install --tts`.*
+
+### Requirement: Output formats — wav, ogg-opus, flac
+
+The CLI SHALL produce one of three Output formats (TTS): **wav** (default;
+IEEE-float mono at the engine's native sample rate), **ogg-opus** (mono Opus in
+an OGG container; `--bitrate` 6000–510000 bps, default 32000; `--sample-rate`
+one of 8000/12000/16000/24000/48000 Hz, default 24000), and **flac** (lossless
+16-bit, native rate, no encoder knobs). When `--format` is omitted the format
+SHALL be inferred from the `--out` extension (`.wav` → wav; `.ogg`/`.opus`/
+`.oga` → ogg-opus; `.flac` → flac; anything else → wav). `opus` and `ogg`
+SHALL be accepted as aliases for `ogg-opus`. An unknown `--format` value exits
+2, and `--bitrate`/`--sample-rate` with any non-opus format also exit 2.
+
+#### Scenario: Maks makes a Telegram-ready voice note
+
+- WHEN Maks runs `kesha say --format ogg-opus "Уже еду" --out note.ogg`
+- THEN `note.ogg` is a mono OGG/Opus file at 24 kHz, 32 kbps
+- AND Telegram renders it as a native voice message
+
+#### Scenario: Format inferred from the --out extension
+
+- WHEN Ira runs `kesha say "done" --out done.opus`
+- THEN the output is ogg-opus without any `--format` flag
+
+#### Scenario: Alias accepted
+
+- WHEN Sona passes `--format opus`
+- THEN it is treated exactly as `--format ogg-opus`
+
+#### Scenario: Unknown format
+
+- WHEN Ira runs `kesha say --format mp3 "test"`
+- THEN stderr lists the supported formats (wav, ogg-opus, flac)
+- AND the process exits 2 without spawning the Engine
+
+#### Scenario: Opus knobs rejected for WAV
+
+- WHEN Maks runs `kesha say --bitrate 64000 "test" --out test.wav`
+- THEN stderr explains `--bitrate` and `--sample-rate` are only valid with
+  `--format ogg-opus`
+- AND the process exits 2
+
+#### Scenario: Bitrate out of the Opus range
+
+- WHEN Ira runs `kesha say --format ogg-opus --bitrate 1000 "test"`
+- THEN the Engine rejects it (`--bitrate must be 6000..=510000 bps`)
+- AND the run fails rather than producing degraded audio
+
+> *Technical Note — format parsing and aliases: `rust/src/tts/encode.rs:82-94`
+> (`FromStr`) mirrored in `src/cli/say.ts:169-180`; extension inference:
+> `rust/src/tts/encode.rs:98-105`, resolution order (`--format` > `--out`
+> extension > wav default): `rust/src/cli/say.rs:36-82`. Opus constraints:
+> `OPUS_VALID_SR = {8000, 12000, 16000, 24000, 48000}`
+> (`rust/src/tts/encode.rs:184`), bitrate `6000..=510000`
+> (`rust/src/tts/encode.rs:218`), defaults 32000 bps / 24000 Hz
+> (`ogg_opus_default`, `rust/src/tts/encode.rs:69-75`). Native rates: Kokoro
+> 24 kHz, Vosk 22.05 kHz (resampled for Opus, kept as-is for wav/flac). FLAC
+> quantizes f32 to 16-bit PCM (`rust/src/tts/encode.rs:138-144`). The CLI
+> pre-validates knob/format combinations (`src/cli/say.ts:186-200`); the
+> Engine repeats the check authoritatively.*
+
+### Requirement: Speaking rate is bounded
+
+The CLI SHALL accept `--rate` between 0.5 and 2.0 inclusive (default 1.0) and
+exit 2 for values outside that range or non-numeric values.
+
+#### Scenario: Slower narration
+
+- WHEN Maks runs `kesha say --rate 0.8 "Read this slowly"`
+- THEN synthesis runs at 0.8× speed and exits 0
+
+#### Scenario: Rate out of range
+
+- WHEN Ira runs `kesha say --rate 3.0 "test"`
+- THEN stderr reads `--rate must be between 0.5 and 2.0.`
+- AND the process exits 2
+
+#### Scenario: Non-numeric rate
+
+- WHEN Ira runs `kesha say --rate fast "test"`
+- THEN stderr reads `--rate must be a finite number.`
+- AND the process exits 2
+
+> *Technical Note — validation: `src/cli/say.ts:72-80`. The CLI omits `--rate`
+> from the Engine argv when it equals 1.0 (`src/synth.ts:71`). An SSML
+> whole-utterance `<prosody rate>` multiplies with `--rate`; the product is
+> clamped to 0.5–2.0 (`rust/src/tts/ssml/rate.rs`). `--rate` is silently
+> ignored for `macos-*` AVSpeech voices — see Open Issues.*
+
+### Requirement: SSML subset with strict root and graceful tag degradation
+
+With `--ssml`, the input SHALL be parsed as SSML and SHALL start with a
+`<speak>` root element; anything else fails with `E_SSML_INVALID` (exit 4).
+Supported tags: `<break time="...">` (silence, default 250 ms, capped at 30 s),
+`<say-as interpret-as="characters">` (letter-by-letter spelling), `<phoneme
+alphabet="ipa" ph="...">` (bypasses G2P; `alphabet` defaults to ipa),
+`<emphasis>` (stress hint; `level="none"` strips `+` stress markers), and
+`<prosody rate="...">` when it wraps the entire utterance. Unknown tags SHALL
+emit one stderr warning per tag name and be stripped with their text content
+preserved. `<!DOCTYPE>` anywhere in the document SHALL be rejected
+(`E_SSML_INVALID`), as SHALL relative-percent prosody rates (`+25%`/`-25%`).
+AVSpeech (`macos-*`) voices SHALL reject `--ssml` entirely with
+`E_SSML_UNSUPPORTED`.
+
+#### Scenario: Maks adds a pause and a phoneme override
+
+- WHEN Maks runs
+  `kesha say --ssml '<speak>Kesha <break time="500ms"/> <phoneme alphabet="ipa" ph="ˈkeʃa">Kesha</phoneme></speak>'`
+- THEN the output contains 500 ms of silence at the break position
+- AND the phoneme content is synthesized from the given IPA, bypassing G2P
+
+#### Scenario: Missing speak root
+
+- WHEN Ira runs `kesha say --ssml 'Hello <break/> world'`
+- THEN the run fails with `E_SSML_INVALID` (`SSML must start with a <speak>
+  element`)
+- AND the process exits 4
+
+#### Scenario: Unknown tag is stripped, text survives
+
+- WHEN Sona passes `<speak><voice name="x">keep this text</voice></speak>`
+- THEN stderr warns once that `<voice>` is not supported
+- AND "keep this text" is still synthesized
+
+#### Scenario: DOCTYPE rejected
+
+- WHEN Ira passes SSML containing `<!DOCTYPE foo [...]>`
+- THEN the run fails with `E_SSML_INVALID` (`DOCTYPE declarations are not
+  supported`) — defense against XXE/billion-laughs
+
+#### Scenario: Relative prosody percentage rejected
+
+- WHEN Maks passes `<speak><prosody rate="+25%">faster</prosody></speak>`
+- THEN the run fails with `E_SSML_INVALID` suggesting an absolute percentage
+  (`125%`) or a named value instead
+
+#### Scenario: AVSpeech rejects SSML
+
+- WHEN Maks runs `kesha say --ssml --voice macos-en-US '<speak>hi</speak>'`
+- THEN the run fails with `E_SSML_UNSUPPORTED`
+- AND the process exits 4
+
+> *Technical Note — parser and hardening: `rust/src/tts/ssml/mod.rs:43-82`
+> (root check :48, DOCTYPE :59, relative rate :73). Tag behavior table:*
+>
+> | Tag | Behavior |
+> |---|---|
+> | `<break time>` | silence; default 250 ms (`segment.rs:38`); capped at `MAX_BREAK_SECS = 30.0` (`rust/src/tts/say.rs:25`) |
+> | `<say-as interpret-as="characters">` | letter-spell; other `interpret-as` values warn-strip |
+> | `<phoneme alphabet="ipa">` | `ph` fed verbatim to the tokenizer; non-ipa alphabets warn-strip |
+> | `<emphasis>` | `+` stress markers honored on `ru-vosk-*` only; `level="none"` suppresses them everywhere |
+> | `<prosody rate>` | whole-utterance only; mid-utterance warn-strips; multiplies `--rate`, clamped 0.5–2.0 |
+> | anything else | warn once per tag name, strip, keep inner text |
+>
+> *Inner structural tags win over an enclosing `<emphasis>` (span-priority
+> sort, `rust/src/tts/ssml/mod.rs:92-111`). AVSpeech rejection:
+> `rust/src/tts/say.rs:136`. FluidAudio Kokoro warn-skips `<phoneme>` (internal
+> G2P only) and reads `<say-as characters>` content as plain text
+> (`rust/src/tts/say.rs:441-455`).*
+
+### Requirement: Text normalization expands acronyms and numbers per language
+
+Normalization SHALL run before G2P. English: uppercase tokens of 2–5
+characters are letter-spelled unless they appear on the English stop-list or in
+the IPA lexicon (which supplies a fixed pronunciation). Russian (`ru-vosk-*`):
+all-caps Cyrillic tokens of 2–5 letters are letter-spelled when they fail the
+pronounceability heuristic (strict consonant-vowel alternation reads as a word)
+and are not on the Russian stop-list. Spanish/French/Italian/Portuguese:
+integers 0–999,999 are expanded to words and 2–5-character uppercase acronyms
+are letter-spelled with that language's letter names, with per-language
+stop-lists exempting word-acronyms. `--no-expand-abbrev` SHALL disable the
+automatic letter-spelling for English and Russian — but the English IPA lexicon
+still fires, and `<say-as interpret-as="characters">` still works.
+
+#### Scenario: English initialism is letter-spelled, lexicon word is not
+
+- WHEN Ira runs `kesha say "Parse the JSON with the IBM SDK"`
+- THEN `JSON` is pronounced "jason" (IPA lexicon hit)
+- AND `IBM` is spelled letter by letter
+- AND `SDK` is spelled letter by letter
+
+#### Scenario: Stop-listed word-acronym reads as a word
+
+- WHEN Maks runs `kesha say "NASA launched it"`
+- THEN `NASA` is read as a word, not "en a es a"
+
+#### Scenario: Russian initialism vs pronounceable acronym
+
+- WHEN Maks runs `kesha say --voice ru-vosk-m02 "ФСБ и ВОЗ"`
+- THEN `ФСБ` is expanded to "эф эс бэ" (no vowels — fails the
+  pronounceability heuristic)
+- AND `ВОЗ` is read as a word (strict consonant-vowel alternation)
+
+#### Scenario: Spanish numbers and acronyms
+
+- WHEN Ira runs `kesha say --voice es-em_alex "El DNI cuesta 12 euros, dice la OTAN"`
+- THEN `12` is expanded to "doce", `DNI` is spelled "de ene i"
+- AND `OTAN` (stop-listed) is read as a word
+
+#### Scenario: --no-expand-abbrev disables spelling but not the lexicon
+
+- WHEN Sona runs `kesha say --no-expand-abbrev "EPAM hired IBM"`
+- THEN `IBM` passes through unspelled
+- AND `EPAM` still uses its IPA lexicon pronunciation
+
+#### Scenario: --no-expand-abbrev on an old engine warns instead of lying
+
+- GIVEN an Engine that does not advertise `tts.ru_acronym_expansion` /
+  `tts.en_acronym_expansion` in its Capabilities JSON
+- WHEN Ira passes `--no-expand-abbrev`
+- THEN the CLI drops the flag from the Engine argv and warns on stderr that it
+  requires kesha-engine ≥ 1.10.0 — never a silent drop
+
+> *Technical Note — English: 30-entry stop-list (OK/NO/GO/…/NASA/NATO/AIDS/
+> OPEC/IKEA/ASCII/NAFTA/LASER/RADAR/SCUBA) and IPA lexicon (EPAM, JSON, JPEG,
+> GIF, SQL, ASAP, CRUD, JWT, OAuth, Microsoft, Anthropic, Claude, Kubernetes,
+> PostgreSQL, GraphQL, Linux, Tokio, macOS, Granola) in
+> `rust/src/tts/en/acronym.rs:23-59`; the lexicon fires even with
+> `--no-expand-abbrev` (`:121-125`, test `ipa_fires_even_without_auto_expand`).
+> Russian: rules and 25-entry stop-list (ВСЁ, ВЫ, ДА, …, ЧТО) in
+> `rust/src/tts/ru/acronym.rs:1-66`; tokens must be 2–5 chars of `[А-ЯЁ]`
+> without Ъ/Ь, and spell only when length ≤ 2 or an adjacent same-type letter
+> pair exists. Romance languages: numbers 0–999,999
+> (`rust/src/tts/normalize/numbers.rs`), letter tables and stop-lists
+> `ES_STOP_LIST` = OTAN, OVNI, SIDA, OPEP, OEA, ONU, FIFA, OMS;
+> `FR_STOP_LIST` = OTAN, OVNI, SIDA, FIFA, OPEP, ONU, OMS;
+> `IT_STOP_LIST` = FIAT, NATO, FIFA, AIDS, ONU;
+> `PT_STOP_LIST` = OTAN, OVNI, SIDA, AIDS, FIFA, ONU, OMS
+> (`rust/src/tts/normalize/acronyms.rs:141-145`) — curated seeds, not
+> exhaustive. Six-plus-character all-caps words (UNESCO) pass through
+> untouched. Capability gating of `--no-expand-abbrev`: `src/synth.ts:76-91`.*
+
+### Requirement: Script gates — unsupported writing systems fail fast
+
+On the darwin-arm64 FluidAudio build, Hindi and Japanese voices SHALL reject
+text in their native scripts (Devanagari; kana/han for Japanese) with
+`E_SCRIPT_UNSUPPORTED` rather than synthesize garbage — romanized text passes
+through. Chinese SHALL be supported natively on darwin-arm64 (Han text,
+tone-aware Mandarin G2P, voice `zh-zm_050`). Castilian Spanish (`--lang es-ES`)
+SHALL synthesize with Latin-American phonology (*seseo*) and print a one-time
+stderr note, because the upstream CharsiuG2P export has no Castilian θ tag.
+
+#### Scenario: Maks synthesizes Mandarin on Apple Silicon
+
+- WHEN Maks runs `kesha say --voice zh-zm_050 "你好，我叫凯沙"`
+- THEN the Han text is synthesized with Mandarin G2P
+- AND the process exits 0
+
+#### Scenario: Devanagari fails fast
+
+- WHEN Maks runs `kesha say --voice hi-hm_omega "नमस्ते"`
+- THEN the run fails with `E_SCRIPT_UNSUPPORTED`
+- AND the process exits 4
+
+#### Scenario: Romanized Hindi passes the gate
+
+- WHEN Maks runs `kesha say --voice hi-hm_omega "Namaste! Mera naam Kesha hai."`
+- THEN synthesis proceeds (the gate checks script, not language)
+
+#### Scenario: Castilian Spanish degrades with a note
+
+- WHEN Ira runs `kesha say --lang es-ES "cielo"`
+- THEN stderr carries a one-time note that Castilian (θ) pronunciation is
+  unavailable and Latin-American phonology is used
+- AND synthesis still succeeds with exit 0
+
+> *Technical Note — script gate: `rust/src/tts/fluid_kokoro.rs:228-234`
+> (`ensure_script_supported`); zh Han is allowed for `zm_050`. Castilian
+> degrade decision (#511 Phase-0 spike found no working θ tag in the klebster
+> CharsiuG2P export): `rust/src/tts/charsiu/mod.rs:46-110`; `es-ES` is detected
+> by `is_castilian_region` while `es`/`es-419`/`es-MX` use the LatAm tag
+> directly. zh voices are fetched by FluidAudio's own `ANE-zh/` bundle, not
+> staged in `rust/src/models.rs`.*
+
+### Requirement: List installed voices
+
+`kesha say --list-voices` SHALL print one installed Voice id per line, sorted,
+to stdout and exit 0. The list covers Kokoro voices (the FluidAudio catalog on
+darwin-arm64; cached `.bin` packs elsewhere), the five Vosk Russian speakers
+when the Vosk model is installed, and the OS-provided `macos-*` voices on
+macOS. With nothing installed it SHALL print a `kesha install --tts` hint and
+still exit 0.
+
+#### Scenario: Maks lists voices on Apple Silicon
+
+- WHEN Maks runs `kesha say --list-voices`
+- THEN stdout lists `en-am_michael`, `es-em_alex`, `zh-zm_050`,
+  `ru-vosk-m02`, and his installed `macos-*` voices, sorted
+- AND the process exits 0
+
+#### Scenario: Nothing installed yet
+
+- GIVEN a fresh machine with no TTS models
+- WHEN Ira runs `kesha say --list-voices`
+- THEN stdout reads `No voices installed. Run: kesha install --tts`
+- AND the process exits 0
+
+> *Technical Note — enumeration: `rust/src/cli/say.rs:140-163`; the CLI relays
+> the Engine's stdout and exit code verbatim (`src/cli/say.ts:157-164`).
+> Partial Vosk installs advertise no `ru-vosk-*` voices (same cache gate as
+> synthesis). AVSpeech enumeration is best-effort: a missing Sidecar still
+> shows Kokoro/Vosk voices.*
+
+### Requirement: Exit codes distinguish failure classes
+
+`kesha say` SHALL exit 0 on success, 1 when the voice is unknown or its model
+is not installed, 2 for invalid input (bad flags, empty text, malformed
+flag combinations), 4 for synthesis/SSML/internal failures, and 5 when the
+text exceeds the length limit. The CLI SHALL propagate the Engine's exit code
+unchanged (`SayError.exitCode`); CLI-side pre-checks use the same map.
+
+#### Scenario: Exit-code contract in a script
+
+- GIVEN a shell script that branches on `$?`
+- WHEN it runs `kesha say "hi"` / `--voice xx-none "hi"` / `--rate 9 "hi"` /
+  `--ssml "no-root"` / a 6000-character input
+- THEN it observes exit codes 0, 1, 2, 4, and 5 respectively
+
+#### Scenario: Unexpected internal error maps to 4
+
+- WHEN the Engine subprocess dies without a structured Error code
+- THEN the CLI reports the stderr text and exits with the Engine's nonzero
+  code, or 4 for non-SayError internal failures
+
+> *Technical Note — Engine map: `rust/src/cli/say.rs:132-138`
+> (`exit_code_for_tts_err`: `EmptyText` → 2, `TextTooLong` → 5,
+> `SynthesisFailed`/`Coded` → 4); voice resolution failures return 1 directly
+> (`rust/src/cli/say.rs:228-235`); format/flag errors return 2
+> (`:169-183`, `:220-226`). CLI side: `SayError` carries the Engine exit code
+> (`src/cli/say.ts:289-292`); pre-flight checks exit 2
+> (`src/cli/say.ts:62-101,204-207`) and 5 (`src/synth.ts:117-125`).
+> `E_SSML_INVALID`, `E_SSML_UNSUPPORTED`, and `E_SCRIPT_UNSUPPORTED` all
+> surface as `Coded` → exit 4.*
+
+## Open Issues
+
+- **French default voice is female** (`fr-ff_siwis`) — documented brand-rule
+  exception; Kokoro v1.0 ships no male French voice. Revisit when one exists.
+- **Castilian θ gap (#511)** — `--lang es-ES` synthesizes Latin-American
+  phonology with a one-time stderr note; the upstream CharsiuG2P export has no
+  Castilian tag.
+- **Hindi/Japanese native scripts** fail fast with `E_SCRIPT_UNSUPPORTED` on
+  the darwin-arm64 FluidAudio build and have no voices at all on ONNX
+  platforms; ja/hi are a future ONNX-CharsiuG2P effort.
+- **zh auto-routing drift** — `src/voice-routing.ts:14` maps detected `zh` to
+  `zh-zm_yunjian`, but the Engine's FluidAudio catalog ships only `zh-zm_050`
+  (`rust/src/tts/fluid_kokoro.rs:169`), so auto-routed Chinese fails with
+  `E_VOICE_UNKNOWN` until the map is fixed; explicit `--voice zh-zm_050`
+  works.
+- **`--rate` is silently ignored for `macos-*` AVSpeech voices** — the
+  `EngineChoice::AVSpeech` variant carries no speed field
+  (`rust/src/tts/mod.rs:103`); the documented 0.5–2.0 contract only holds for
+  Kokoro and Vosk voices.

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -133,17 +133,23 @@ Voice id SHALL fail with `E_VOICE_UNKNOWN` and exit 1.
 > mapping: `src/voice-routing.ts:31-53` (`pickVoiceForLang`). The full map
 > (confidence < 0.5 → none; base code is lowercased and split on `-`/`_`):*
 >
-> | Detected/stated lang | darwin (any arch) | darwin-arm64 extra | Linux/Windows/Intel macOS |
+> | Detected/stated lang | darwin-arm64 | darwin-x64 (Intel macOS) | Linux / Windows |
 > |---|---|---|---|
-> | `en` | `en-am_michael` | — | `en-am_michael` |
-> | `ru` | `macos-com.apple.voice.compact.ru-RU.Milena` | — | `ru-vosk-m02` |
-> | `es` | — | `es-em_alex` | `es-em_alex` |
-> | `fr` | — | *(unmapped → engine default)* | `fr-ff_siwis` |
-> | `hi` | — | `hi-hm_omega` | *(unmapped)* |
-> | `it` | — | `it-im_nicola` | `it-im_nicola` |
-> | `ja` | — | `ja-jm_kumo` | *(unmapped)* |
-> | `pt` | — | `pt-pm_alex` | `pt-pm_alex` |
-> | `zh` | — | `zh-zm_yunjian` (see Open Issues — engine ships `zh-zm_050`) | *(unmapped)* |
+> | `en` | `en-am_michael` | `en-am_michael` | `en-am_michael` |
+> | `ru` | `macos-com.apple.voice.compact.ru-RU.Milena` | `macos-com.apple.voice.compact.ru-RU.Milena` | `ru-vosk-m02` |
+> | `es` | `es-em_alex` | `es-em_alex` | `es-em_alex` |
+> | `fr` | *(unmapped → engine default)* | `fr-ff_siwis` | `fr-ff_siwis` |
+> | `hi` | `hi-hm_omega` | *(unmapped)* | *(unmapped)* |
+> | `it` | `it-im_nicola` | `it-im_nicola` | `it-im_nicola` |
+> | `ja` | `ja-jm_kumo` | *(unmapped)* | *(unmapped)* |
+> | `pt` | `pt-pm_alex` | `pt-pm_alex` | `pt-pm_alex` |
+> | `zh` | `zh-zm_050` | *(unmapped)* | *(unmapped)* |
+>
+> *The platform split differs by row: `ru` routes on `platform === "darwin"`
+> (so Intel macOS gets AVSpeech Milena, not Vosk), while the multilingual rows
+> route on `platform === "darwin" && arch === "arm64"` (so Intel macOS follows
+> the Linux/Windows ONNX column). `*(unmapped)*` means `pickVoiceForLang`
+> returns `undefined` and the Engine default applies.*
 >
 > *Engine-side routing (`rust/src/tts/voices.rs:99-148`): `en-*` → Kokoro;
 > `es/fr/hi/it/ja/pt/zh-*` → FluidAudio Kokoro on the darwin-arm64
@@ -547,11 +553,6 @@ unchanged (`SayError.exitCode`); CLI-side pre-checks use the same map.
 - **Hindi/Japanese native scripts** fail fast with `E_SCRIPT_UNSUPPORTED` on
   the darwin-arm64 FluidAudio build and have no voices at all on ONNX
   platforms; ja/hi are a future ONNX-CharsiuG2P effort.
-- **zh auto-routing drift** — `src/voice-routing.ts:14` maps detected `zh` to
-  `zh-zm_yunjian`, but the Engine's FluidAudio catalog ships only `zh-zm_050`
-  (`rust/src/tts/fluid_kokoro.rs:169`), so auto-routed Chinese fails with
-  `E_VOICE_UNKNOWN` until the map is fixed; explicit `--voice zh-zm_050`
-  works.
 - **`--rate` is silently ignored for `macos-*` AVSpeech voices** — the
   `EngineChoice::AVSpeech` variant carries no speed field
   (`rust/src/tts/mod.rs:103`); the documented 0.5–2.0 contract only holds for


### PR DESCRIPTION
## Summary

Establishes an **OpenSpec baseline corpus**: 11 capability specs that capture how Kesha Voice Kit behaves *today*, validated structurally (`openspec validate --specs --strict`, 11/11 green) and adversarially reviewed against the code. Future changes can now be proposed as OpenSpec deltas against this baseline instead of tribal knowledge.

## What's inside

| Area | Files |
|---|---|
| Specs | `openspec/specs/{transcription, speaker-diarization, language-detection, tts-synthesis, installation, audio-recording, diagnostics, cli-shell-integration, mcp-server, programmatic-api, engine-contract}/spec.md` |
| Shared front matter | `openspec/specs/README.md` (3 named personas, reading order), `openspec/specs/GLOSSARY.md` (canonical terms, used verbatim across specs) |
| OpenSpec scaffolding | `openspec/config.yaml`, `.claude/commands/opsx/*`, `.claude/skills/openspec-*` (from `openspec init --tools claude`) |

## Spec style

Joel Spolsky's painless-functional-spec structure (Purpose / Non-Goals / detail-rich scenarios / Technical Note side-notes / Open Issues as first-class) crossed with Nikita Sobolev's user-story lenses (glossary-consistent terminology, specific roles instead of "user", goal-not-implementation wording, every requirement verifiable with happy + error Given/When/Then scenarios, traceability refs to `file:line`) — on OpenSpec's `### Requirement:` / `#### Scenario:` format. Depth is contract-level: every user-visible flag, output, exit code, error mode, and platform gate is a requirement; fine constants live in Technical Notes.

## Verification

- `openspec validate --specs --strict`: **11 passed, 0 failed**
- Independent adversarial review pass (spec claims vs code): 3 P1 + 3 P2/P3 findings — all fixed in this PR (e.g. `SayError.code` for engine-not-installed is `E_ENGINE_SPAWN`, not `TS_INPUT_NOT_FOUND`; `NO_COLOR` is honored by picocolors at import time, not by `resolveColorMode`; `log.progress` writes to stdout)
- `bunx tsc --noEmit` clean; `bun test` unit suites pass. Two `tests/integration/cli-contracts.test.ts` cases fail locally from environment/timeout flakiness — they also fail on pristine `main` and this PR touches no code.

## Real code drift surfaced by spec-writing (recorded as Open Issues, not spec'd around)

1. ~~**`zh` auto-routing is broken**: routes detected Chinese to `zh-zm_yunjian`, but the engine only ships `zh-zm_050`.~~ **Fixed on `main` by #547** — this branch was rebased onto it, the routing table now shows `zh-zm_050`, and the stale Open Issue was dropped.
2. **`--rate` is silently discarded for `macos-*` AVSpeech voices** (`rust/src/tts/mod.rs` — `EngineChoice::AVSpeech` carries no speed) — same pattern as the #126 P1.
3. **Install-flow progress lines print to stdout** (`log.progress` uses `console.log`), breaking the "progress → stderr" intuition; harmless today since install has no machine-readable stdout.

Happy to file a follow-up issue for #2 after this merges.

## Follow-up (this revision)

- Rebased onto `main` to pick up #547 (zh routing fix); the spec is now consistent with the engine catalog.
- **Greptile P2** (Intel-macOS column ambiguity in the voice routing table): resolved. The table is restructured into an explicit per-platform matrix (`darwin-arm64` / `darwin-x64` / `Linux+Windows`), with a note that the platform split differs by row — `ru` routes on `platform === "darwin"` (Intel macOS → Milena), the multilingual rows on `platform === "darwin" && arch === "arm64"` (Intel macOS → ONNX column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
