### PR TITLE
fix(tts): route zh auto-detection to zh-zm_050 (the voice the engine ships)

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -59,7 +59,7 @@ Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am
 
 **Supported voices:**
 - English: `en-am_michael` (default). Darwin FluidAudio builds expose the supported FluidAudio Kokoro English voices via `kesha say --list-voices`; ONNX builds also see any `.bin` voice you add under `~/.cache/kesha/models/kokoro-82m/voices/`.
-- Apple Silicon Kokoro multilingual voices: `es-em_alex`, `hi-hm_omega`, `it-im_nicola`, `ja-jm_kumo`, `pt-pm_alex`, `zh-zm_yunjian`, and `fr-ff_siwis`. The Spanish, Hindi, Italian, Japanese, Portuguese, and Chinese defaults are male; upstream Kokoro currently has no native male French voice, so French remains explicit-only.
+- Apple Silicon Kokoro multilingual voices: `es-em_alex`, `hi-hm_omega`, `it-im_nicola`, `ja-jm_kumo`, `pt-pm_alex`, `zh-zm_050`, and `fr-ff_siwis`. The Spanish, Hindi, Italian, Japanese, Portuguese, and Chinese defaults are male; upstream Kokoro currently has no native male French voice, so French remains explicit-only.
 - Russian: 5 Vosk-TTS speakers baked into the multi-speaker model — `ru-vosk-m02` (default, male), `ru-vosk-m01` (male), `ru-vosk-f01`/`f02`/`f03` (female).
 - macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
 

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -11,7 +11,7 @@ const DARWIN_KOKORO_DEFAULTS: Record<string, string> = {
   it: "it-im_nicola",
   ja: "ja-jm_kumo",
   pt: "pt-pm_alex",
-  zh: "zh-zm_yunjian",
+  zh: "zh-zm_050",
 };
 
 /**

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -24,7 +24,7 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("it", 0.95, "darwin", "arm64")).toBe("it-im_nicola");
     expect(pickVoiceForLang("ja", 0.95, "darwin", "arm64")).toBe("ja-jm_kumo");
     expect(pickVoiceForLang("pt-BR", 0.95, "darwin", "arm64")).toBe("pt-pm_alex");
-    expect(pickVoiceForLang("zh-Hans", 0.95, "darwin", "arm64")).toBe("zh-zm_yunjian");
+    expect(pickVoiceForLang("zh-Hans", 0.95, "darwin", "arm64")).toBe("zh-zm_050");
   });
 
   it("does not auto-route languages without an ONNX voice pack on non-darwin", () => {


### PR DESCRIPTION
## What

`src/voice-routing.ts` mapped `zh` to `zh-zm_yunjian` in `DARWIN_KOKORO_DEFAULTS`, but the engine catalog (`rust/src/tts/fluid_kokoro.rs:169`) only ships `zh-zm_050`. Auto-routed Chinese on darwin-arm64 therefore exited 1 with `E_VOICE_UNKNOWN` instead of synthesizing.

The unit test (`tests/unit/voice-routing.test.ts:27`) was also pinning the wrong id (`zh-zm_yunjian`), which is why CI stayed green despite the broken routing. This is routing-map drift introduced when zh support landed in #492.

## Changes

- `src/voice-routing.ts:14`: `zh-zm_yunjian` → `zh-zm_050`
- `tests/unit/voice-routing.test.ts:27`: update pinning assertion to match
- `docs/tts.md:62`: update voice list to match

`openspec/` does not yet exist on `main` (it lives on the `openspec-baseline` branch, tracked by #544). The Open Issue about zh routing drift in `openspec/specs/tts-synthesis/spec.md` should be dropped when both PRs merge.

## Verification

Revert-test evidence:
- With fix in place: 10/10 pass
- With `src/voice-routing.ts` reverted to `zh-zm_yunjian` (test still expects `zh-zm_050`): **1 fail** — `Expected: "zh-zm_050" / Received: "zh-zm_yunjian"` — test is not vacuous
- Fix restored: 10/10 pass

Full suite: 406 pass, 1 fail (`cli-contracts.test.ts` timeout — pre-existing environment-dependent failure also present on pristine `main`), type check exit 0.

Fixes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)