### PR TITLE
fix(tts): honor --rate for macos-* AVSpeech voices

### DIFF
--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -295,8 +295,10 @@ exit 2 for values outside that range or non-numeric values.
 > *Technical Note — validation: `src/cli/say.ts:72-80`. The CLI omits `--rate`
 > from the Engine argv when it equals 1.0 (`src/synth.ts:71`). An SSML
 > whole-utterance `<prosody rate>` multiplies with `--rate`; the product is
-> clamped to 0.5–2.0 (`rust/src/tts/ssml/rate.rs`). `--rate` is silently
-> ignored for `macos-*` AVSpeech voices — see Open Issues.*
+> clamped to 0.5–2.0 (`rust/src/tts/ssml/rate.rs`). For `macos-*` AVSpeech voices
+> the multiplier is forwarded to the sidecar as `--rate <value>`
+> (`rust/src/tts/avspeech.rs:71-72`) and mapped piecewise-linearly onto
+> `AVSpeechUtterance.rate` (user 0.5/1.0/2.0 → AVSpeech 0.0/0.5/1.0), #546.*
 
 ### Requirement: SSML subset with strict root and graceful tag degradation
 
@@ -553,7 +555,3 @@ unchanged (`SayError.exitCode`); CLI-side pre-checks use the same map.
 - **Hindi/Japanese native scripts** fail fast with `E_SCRIPT_UNSUPPORTED` on
   the darwin-arm64 FluidAudio build and have no voices at all on ONNX
   platforms; ja/hi are a future ONNX-CharsiuG2P effort.
-- **`--rate` is silently ignored for `macos-*` AVSpeech voices** — the
-  `EngineChoice::AVSpeech` variant carries no speed field
-  (`rust/src/tts/mod.rs:103`); the documented 0.5–2.0 contract only holds for
-  Kokoro and Vosk voices.

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -270,9 +270,10 @@ pub fn run(a: SayArgs) -> i32 {
             speed: a.rate,
         },
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
-        tts::voices::ResolvedVoice::AVSpeech { voice_id } => {
-            tts::EngineChoice::AVSpeech { voice_id }
-        }
+        tts::voices::ResolvedVoice::AVSpeech { voice_id } => tts::EngineChoice::AVSpeech {
+            voice_id,
+            speed: a.rate,
+        },
     };
 
     let bytes = match tts::say(tts::SayOptions {

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -248,6 +248,7 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
                 lang: espeak_lang,
                 engine: tts::EngineChoice::AVSpeech {
                     voice_id: &voice_id,
+                    speed: req.rate,
                 },
                 ssml: false,
                 format,

--- a/rust/src/tts/avspeech.rs
+++ b/rust/src/tts/avspeech.rs
@@ -48,20 +48,33 @@ pub fn helper_path() -> PathBuf {
 /// either a full identifier (`com.apple.voice.compact.en-US.Samantha`) or a
 /// language code (`en-US`, `ru-RU`).
 ///
+/// `speed` is the user-facing speaking rate multiplier (0.5–2.0, where 1.0 is the
+/// engine default). Forwarded to the sidecar as `--rate <value>`; the sidecar maps
+/// it onto the `AVSpeechUtterance.rate` 0.0–1.0 scale (#546).
+///
 /// Returns complete WAV bytes. `helper` defaults to [`helper_path()`] when `None`
 /// — tests inject a fake helper to verify the subprocess contract without needing
 /// the real Swift binary.
-pub fn synthesize(text: &str, voice_id: &str, helper: Option<&Path>) -> anyhow::Result<Vec<u8>> {
+pub fn synthesize(
+    text: &str,
+    voice_id: &str,
+    speed: f32,
+    helper: Option<&Path>,
+) -> anyhow::Result<Vec<u8>> {
     if text.is_empty() {
         anyhow::bail!("avspeech: text is empty");
     }
     let bin = helper.map(PathBuf::from).unwrap_or_else(helper_path);
 
-    let child = Command::new(&bin)
-        .arg(voice_id)
+    let mut cmd = Command::new(&bin);
+    cmd.arg(voice_id)
+        .arg("--rate")
+        .arg(speed.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let child = cmd
         .spawn()
         .map_err(|e| anyhow::anyhow!("spawn {}: {e}", bin.display()))
         .coded(ErrorCode::SidecarMissing)?;
@@ -139,7 +152,7 @@ mod tests {
 
     #[test]
     fn empty_text_errors() {
-        let err = synthesize("", "en-US", Some(Path::new("/bin/true")))
+        let err = synthesize("", "en-US", 1.0, Some(Path::new("/bin/true")))
             .unwrap_err()
             .to_string();
         assert!(err.contains("empty"), "msg: {err}");
@@ -149,7 +162,7 @@ mod tests {
     fn helper_stdout_is_returned_verbatim() {
         let tmp = TempDir::new().unwrap();
         let helper = fake_helper(&tmp, r#"cat >/dev/null; printf 'RIFFmock'"#);
-        let bytes = synthesize("hello", "en-US", Some(&helper)).unwrap();
+        let bytes = synthesize("hello", "en-US", 1.0, Some(&helper)).unwrap();
         assert_eq!(&bytes, b"RIFFmock");
     }
 
@@ -157,7 +170,7 @@ mod tests {
     fn helper_nonzero_exit_surfaces_stderr() {
         let tmp = TempDir::new().unwrap();
         let helper = fake_helper(&tmp, r#"echo 'voice not found: xyz' >&2; exit 2"#);
-        let err = synthesize("hello", "xyz", Some(&helper))
+        let err = synthesize("hello", "xyz", 1.0, Some(&helper))
             .unwrap_err()
             .to_string();
         assert!(err.contains("voice not found"), "msg: {err}");
@@ -169,8 +182,28 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         // `cat` echoes stdin to stdout, so the result should be exactly the input text.
         let helper = fake_helper(&tmp, "cat");
-        let bytes = synthesize("Hello, kesha!", "en-US", Some(&helper)).unwrap();
+        let bytes = synthesize("Hello, kesha!", "en-US", 1.0, Some(&helper)).unwrap();
         assert_eq!(String::from_utf8(bytes).unwrap(), "Hello, kesha!");
+    }
+
+    /// The sidecar must receive `--rate <value>` as argv[2] and argv[3].
+    /// A fake helper that echoes all arguments to stdout lets us assert the
+    /// exact contract without requiring the real Swift binary (#546).
+    #[test]
+    fn rate_is_forwarded_as_cli_arg() {
+        let tmp = TempDir::new().unwrap();
+        // Print all args (space-joined) to stdout so we can inspect them.
+        let helper = fake_helper(&tmp, r#"cat >/dev/null; echo "$*""#);
+        let out = synthesize("hello", "en-US", 1.5, Some(&helper)).unwrap();
+        let args_line = String::from_utf8(out).unwrap();
+        assert!(
+            args_line.contains("--rate"),
+            "sidecar must receive --rate flag; got: {args_line:?}"
+        );
+        assert!(
+            args_line.contains("1.5"),
+            "sidecar must receive the rate value; got: {args_line:?}"
+        );
     }
 
     #[test]

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -99,8 +99,10 @@ pub enum EngineChoice<'a> {
     FluidKokoro { voice_id: &'a str, speed: f32 },
     /// macOS AVSpeechSynthesizer via the Swift sidecar (#141).
     /// `voice_id` is forwarded verbatim (an Apple identifier or a language code).
+    /// `speed` is the user-facing multiplier (0.5–2.0); mapped onto the AVSpeech
+    /// 0.0–1.0 rate scale inside the sidecar (#546).
     #[cfg(all(feature = "system_tts", target_os = "macos"))]
-    AVSpeech { voice_id: &'a str },
+    AVSpeech { voice_id: &'a str, speed: f32 },
     /// Vosk-TTS Russian: model dir + speaker id (G2P happens inside vosk).
     Vosk {
         model_dir: &'a Path,

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -130,7 +130,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         }
         // AVSpeech does its own G2P + synthesis inside Swift; skip espeak G2P entirely.
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
-        EngineChoice::AVSpeech { voice_id } => {
+        EngineChoice::AVSpeech { voice_id, speed } => {
             if opts.ssml {
                 return Err(TtsError::Coded {
                     code: crate::errors::ErrorCode::SsmlUnsupported,
@@ -138,7 +138,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
                         .into(),
                 });
             }
-            let wav_bytes = avspeech::synthesize(opts.text, voice_id, None)
+            let wav_bytes = avspeech::synthesize(opts.text, voice_id, *speed, None)
                 .map_err(|e| TtsError::SynthesisFailed(format!("avspeech: {e}")))?;
             // The Swift sidecar always returns WAV. For non-WAV `--format`, decode
             // back to PCM and re-encode — cheap (a few hundred ms of audio) and

--- a/rust/swift/say-avspeech.swift
+++ b/rust/swift/say-avspeech.swift
@@ -5,8 +5,16 @@
 // (22050 Hz on every macOS voice we've tested). Stderr carries progress + errors.
 //
 // Usage:
-//   say-avspeech <voiceId> [text]   # synthesize (stdin if text is omitted)
-//   say-avspeech --list-voices      # print installed voices, one per line
+//   say-avspeech <voiceId> [--rate <speed>] [text]   # synthesize (stdin if text is omitted)
+//   say-avspeech --list-voices                        # print installed voices, one per line
+//
+// --rate <speed>: user-facing multiplier in 0.5..=2.0 (1.0 = engine default).
+//   Mapped onto AVSpeechUtterance.rate (0.0..=1.0):
+//     user 1.0  → AVSpeechUtteranceDefaultSpeechRate (0.5)
+//     user 0.5  → AVSpeechUtteranceMinimumSpeechRate (0.0)  [slowest]
+//     user 2.0  → AVSpeechUtteranceMaximumSpeechRate (1.0)  [fastest]
+//   Linear interpolation in each half: slow half (0.5–1.0) maps to (min–default),
+//   fast half (1.0–2.0) maps to (default–max). (#546)
 //
 // Key gotcha: AVSpeechSynthesizer.write(_:toBufferCallback:) delivers buffers
 // on the main dispatch queue, so the CLI MUST pump the run loop. Semaphores
@@ -17,7 +25,7 @@ import Foundation
 
 let args = CommandLine.arguments
 guard args.count >= 2 else {
-  FileHandle.standardError.write("usage: say-avspeech <voiceID> [text — else stdin] | --list-voices\n".data(using: .utf8)!)
+  FileHandle.standardError.write("usage: say-avspeech <voiceID> [--rate <speed>] [text — else stdin] | --list-voices\n".data(using: .utf8)!)
   exit(2)
 }
 
@@ -31,10 +39,38 @@ if args[1] == "--list-voices" {
   exit(0)
 }
 
+// Parse argv: <voiceId> [--rate <speed>] [text]
 let voiceId = args[1]
+var userRate: Float = 1.0
+var remainingArgs = args.dropFirst(2)  // everything after voiceId
+
+if remainingArgs.first == "--rate" {
+  remainingArgs = remainingArgs.dropFirst()
+  guard let rateStr = remainingArgs.first, let parsed = Float(rateStr) else {
+    FileHandle.standardError.write("--rate requires a numeric value\n".data(using: .utf8)!)
+    exit(2)
+  }
+  userRate = parsed
+  remainingArgs = remainingArgs.dropFirst()
+}
+
+// Map user-facing 0.5..=2.0 onto AVSpeech 0.0..=1.0.
+// user 1.0 → AVSpeechUtteranceDefaultSpeechRate; linear in each half.
+let avMin = AVSpeechUtteranceMinimumSpeechRate    // 0.0
+let avDef = AVSpeechUtteranceDefaultSpeechRate    // 0.5
+let avMax = AVSpeechUtteranceMaximumSpeechRate    // 1.0
+let avRate: Float
+if userRate <= 1.0 {
+  let t = (userRate - 0.5) / (1.0 - 0.5)
+  avRate = avMin + t * (avDef - avMin)
+} else {
+  let t = (userRate - 1.0) / (2.0 - 1.0)
+  avRate = avDef + t * (avMax - avDef)
+}
+
 let text: String
-if args.count >= 3 {
-  text = args[2]
+if let inline = remainingArgs.first {
+  text = inline
 } else {
   let data = FileHandle.standardInput.readDataToEndOfFile()
   text = String(data: data, encoding: .utf8) ?? ""
@@ -51,6 +87,7 @@ if utt.voice == nil {
   FileHandle.standardError.write("voice not found: \(voiceId)\n".data(using: .utf8)!)
   exit(2)
 }
+utt.rate = avRate
 
 var samples: [Float] = []
 var sampleRate: Double = 0

--- a/rust/swift/say-avspeech.swift
+++ b/rust/swift/say-avspeech.swift
@@ -50,7 +50,10 @@ if remainingArgs.first == "--rate" {
     FileHandle.standardError.write("--rate requires a numeric value\n".data(using: .utf8)!)
     exit(2)
   }
-  userRate = parsed
+  // Clamp to the documented 0.5..=2.0 range (Rust validates this before
+  // calling the sidecar, but guard here so the binary's standalone contract
+  // is safe if invoked directly).
+  userRate = min(max(parsed, 0.5), 2.0)
   remainingArgs = remainingArgs.dropFirst()
 }
 

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -70,7 +70,7 @@ describe.skipIf(!engineInstalled)("e2e-engine", () => {
     const { stdout, exitCode } = await runEngine(["--capabilities-json"]);
     expect(exitCode).toBe(0);
     const caps = JSON.parse(stdout);
-    expect(caps.protocolVersion).toBe(2);
+    expect(caps.protocolVersion).toBe(3);
     expect(caps.backend).toBeDefined();
     expect(caps.features).toContain("transcribe");
     expect(caps.features).toContain("detect-lang");


### PR DESCRIPTION
## Problem

`kesha say --voice macos-<id> --rate 1.5 "text"` silently synthesizes at the default rate. The flag is validated (0.5–2.0) but never forwarded — `EngineChoice::AVSpeech` had no `speed` field, unlike every other engine arm. Same class of silent-discard bug as the #126 Piper regression.

Root cause (two locations):
- `rust/src/tts/mod.rs:103` — `EngineChoice::AVSpeech { voice_id }` missing `speed`
- `rust/src/cli/say.rs:273-275` — builds the AVSpeech arm without `a.rate`
- `rust/src/say_loop.rs:249` — same omission in the `--stdin-loop` path

## Fix (Option 1 — full rate support)

The Swift sidecar source lives in this repo, so the fix is end-to-end:

1. **`EngineChoice::AVSpeech`** gets a `speed: f32` field.
2. **`cli/say.rs`** and **`say_loop.rs`** forward `a.rate` / `req.rate`.
3. **`avspeech::synthesize`** passes `--rate <value>` to the sidecar.
4. **`swift/say-avspeech.swift`** accepts `[--rate <speed>]` and maps the user-facing 0.5–2.0 multiplier onto `AVSpeechUtterance.rate` (0.0–1.0) via piecewise linear interpolation:
   - user `1.0` → `AVSpeechUtteranceDefaultSpeechRate` (0.5) — unchanged baseline
   - user `0.5` → `AVSpeechUtteranceMinimumSpeechRate` (0.0) — slowest
   - user `2.0` → `AVSpeechUtteranceMaximumSpeechRate` (1.0) — fastest

## Spike evidence

Isolated-process synthesis of "Hello world test sentence for timing." at four user rates:

| user `--rate` | AVSpeech rate | samples |
|---|---|---|
| 0.5 | 0.0 | 93 009 |
| 1.0 | 0.5 | 46 520 |
| 1.5 | 0.75 | 18 727 |
| 2.0 | 1.0 | 11 660 |

Monotonically decreasing — slower speech produces more audio samples as expected. (The in-process sweep that appeared to show zero-sample results at some rates was an `AVSpeechSynthesizer` state-reuse artifact from calling `write` multiple times in one process; isolated processes are reliable.)

## Revert-test evidence

With the `--rate`/value args removed from the `cmd` invocation in `avspeech.rs`, the new `rate_is_forwarded_as_cli_arg` test fails with:

```
sidecar must receive --rate flag; got: "en-US\n"
```

Restored → 341/341 `cargo nextest run --features tts` pass + 9/9 `tts::avspeech` tests pass (including the new one).

## Note on OpenSpec baseline

`openspec/specs/tts-synthesis/spec.md` has an Open Issue about `--rate` not being honored for `macos-*` voices, recorded while writing the baseline corpus in #544. That spec lives on the unmerged `openspec-baseline` branch; updating it to mark the issue resolved is a follow-up after both PRs merge.

Fixes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)