### PR TITLE
chore(release): v1.24.3 (engine + CLI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.2"
+    "version": "1.24.3"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.2"
+version = "1.24.3"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.2"
+version = "1.24.3"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## Release v1.24.3 (engine + CLI)

Engine release — #548 touched `rust/`, so the `kesha-engine` binary is rebuilt and republished. All four version sources bumped 1.24.2 → 1.24.3 (`package.json#version`, `package.json#keshaEngine.version`, `rust/Cargo.toml`, `rust/Cargo.lock`); `bun run check:versions` passes.

### Shipped since v1.24.2
- **fix(tts): honor `--rate` for `macos-*` AVSpeech voices** (#548) — the rate multiplier is now forwarded to the AVSpeech sidecar and mapped onto `AVSpeechUtterance.rate`, instead of being silently discarded.
- **fix(tts): route `zh` auto-detection to `zh-zm_050`** (#547) — auto-routed Chinese previously hit a non-existent voice.
- **docs(openspec): baseline spec corpus** (#544) — no shipped-code change.

### Release mechanics
- `integration-tests` auto-skips on `release/*` (engine tag doesn't exist yet — runbook chicken-and-egg guard).
- On merge + tag `v1.24.3`, `build-engine.yml` builds the 3 platform binaries + draft release; draft assets are validated (SHA256SUMS, Sigstore, SBOM) and the binary exercised before un-drafting fires npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)