### PR TITLE
fix(tts): FluidKokoro say stdout leak on --stdin-loop + punctuation-only SSML (#543)

### DIFF
--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -41,7 +41,17 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
                 // uses a separate buffer, so framed output is unaffected.
                 // SAFETY: fflush(NULL) flushes all open C output streams; it takes no
                 // borrows and is safe to call from a Drop impl.
-                unsafe { libc::fflush(std::ptr::null_mut()) };
+                if unsafe { libc::fflush(std::ptr::null_mut()) } != 0 {
+                    // Flush failed — residual Swift-bridge output may still flush onto
+                    // the restored stdout below, recreating the #543 corruption. Writing
+                    // to /dev/null should never fail, so this is a very low-probability
+                    // path; warn on stderr to match the dup2 handling below.
+                    let errno = std::io::Error::last_os_error();
+                    let _ = writeln!(
+                        std::io::stderr(),
+                        "warning: failed to flush stdout before restore after FluidAudio call: {errno}"
+                    );
+                }
                 // SAFETY: saved is a dup'd stdout fd we own. as_raw_fd
                 // borrows it for the dup2 call (atomic in the kernel);
                 // `saved` is then dropped at end of this block, closing
@@ -87,7 +97,15 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
             // Flush the C stdio buffer to the *real* stdout before redirecting, so
             // any legitimately pre-buffered output isn't swallowed by /dev/null.
             // SAFETY: fflush(NULL) flushes all open C output streams; no borrows.
-            unsafe { libc::fflush(std::ptr::null_mut()) };
+            if unsafe { libc::fflush(std::ptr::null_mut()) } != 0 {
+                // Flush failed before the redirect — pre-buffered output may be lost to
+                // /dev/null on the next flush. Warn on stderr to match the dup2 handling.
+                let errno = std::io::Error::last_os_error();
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "warning: failed to flush stdout before silencing for FluidAudio call: {errno}"
+                );
+            }
             // SAFETY: devnull is owned by the caller; dup2 atomically replaces
             // fd 1 with a duplicate of devnull, and the caller's fd stays valid.
             let rc = unsafe { libc::dup2(devnull.as_raw_fd(), libc::STDOUT_FILENO) };

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -31,6 +31,17 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
     impl Drop for StdoutGuard {
         fn drop(&mut self) {
             if let Some(saved) = self.saved.take() {
+                // Drain the C stdio buffer to /dev/null *before* restoring fd 1.
+                // When stdout is a pipe/file (e.g. `say --stdin-loop`), libc makes
+                // the FILE* fully buffered, so a synchronous Swift `print` from the
+                // FluidAudio bridge sits in that buffer during the guarded scope and
+                // would otherwise flush onto the *restored* real stdout afterwards —
+                // corrupting the binary frame stream (#543). Flushing here, while fd 1
+                // still points at /dev/null, discards that noise. Rust's own stdout
+                // uses a separate buffer, so framed output is unaffected.
+                // SAFETY: fflush(NULL) flushes all open C output streams; it takes no
+                // borrows and is safe to call from a Drop impl.
+                unsafe { libc::fflush(std::ptr::null_mut()) };
                 // SAFETY: saved is a dup'd stdout fd we own. as_raw_fd
                 // borrows it for the dup2 call (atomic in the kernel);
                 // `saved` is then dropped at end of this block, closing
@@ -73,6 +84,10 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
     // swallowing the engine's final JSON for the rest of the process.
     if have_save {
         if let Some(devnull) = devnull {
+            // Flush the C stdio buffer to the *real* stdout before redirecting, so
+            // any legitimately pre-buffered output isn't swallowed by /dev/null.
+            // SAFETY: fflush(NULL) flushes all open C output streams; no borrows.
+            unsafe { libc::fflush(std::ptr::null_mut()) };
             // SAFETY: devnull is owned by the caller; dup2 atomically replaces
             // fd 1 with a duplicate of devnull, and the caller's fd stays valid.
             let rc = unsafe { libc::dup2(devnull.as_raw_fd(), libc::STDOUT_FILENO) };

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -279,15 +279,25 @@ pub fn synthesize(text: &str, voice_id: &str, speed: f32) -> Result<Vec<u8>> {
 ///
 /// Used by the SSML segment walker (`tts::say::synth_segments_fluid_kokoro`),
 /// which decodes/concatenates per-segment audio and interleaves `<break>`
-/// silence before encoding once. Empty/whitespace-only text returns an empty
-/// buffer (the walker skips it) rather than erroring the whole utterance.
+/// silence before encoding once. Text with no alphanumeric content
+/// (whitespace- or punctuation-only) returns an empty buffer (the walker skips
+/// it) rather than erroring the whole utterance.
 ///
 /// Each call re-inits the FluidAudio bridge: the dominant SSML case is a single
 /// `<prosody>`-wrapped utterance (one call), and the `.mlmodelc` is disk-cached
 /// after the first compile so multi-segment re-inits load the compiled model
 /// rather than recompiling.
 pub fn synthesize_pcm(text: &str, voice_id: &str, speed: f32) -> Result<Vec<f32>> {
-    if text.trim().is_empty() {
+    // A segment with no alphanumeric content (whitespace, or bare punctuation
+    // like the trailing "." in `<speak>Loop <emphasis>ssml</emphasis>.</speak>`)
+    // has nothing to phonemize. FluidAudio's internal G2P *errors* on such input
+    // ("G2P produced no phonemes for input '.'", #543), which would fail the whole
+    // SSML utterance; the ONNX path instead yields empty audio (misaki returns an
+    // empty IPA string → `sessions::infer_ipa` early-returns on empty token ids).
+    // Mirror that tolerance so a punctuation-only segment contributes silence and
+    // the walker's final "no audio produced" guard still catches a fully-empty
+    // utterance.
+    if !text.chars().any(char::is_alphanumeric) {
         return Ok(Vec::new());
     }
     ensure_script_supported(voice_id, text)?;
@@ -444,6 +454,25 @@ mod tests {
         let err = synthesize("नमस्ते मेरा नाम केशा है", "hm_omega", 1.0)
             .expect_err("native-script synth must fail fast");
         assert_eq!(crate::errors::code_of(&err), ErrorCode::ScriptUnsupported);
+    }
+
+    #[test]
+    fn synthesize_pcm_skips_no_phoneme_text_before_model_init() {
+        // Bare-punctuation / whitespace-only segments (e.g. the trailing "." in
+        // `<speak>Loop <emphasis>ssml</emphasis>.</speak>`, #543) have nothing to
+        // phonemize. They must short-circuit to an empty buffer *before* model init:
+        // FluidAudio's internal G2P otherwise errors ("G2P produced no phonemes for
+        // input '.'") and fails the whole SSML utterance, whereas the ONNX path yields
+        // empty audio. No model download needed — the guard returns first.
+        for text in [".", "   ", "...", "—", "?!", "“”", ", ."] {
+            let pcm = synthesize_pcm(text, "am_michael", 1.0)
+                .unwrap_or_else(|e| panic!("no-phoneme synth must not error for {text:?}: {e}"));
+            assert!(
+                pcm.is_empty(),
+                "expected empty PCM for no-phoneme text {text:?}, got {} samples",
+                pcm.len()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes the two pre-existing CoreML/`system_kokoro` bugs in #543 (both reproduce byte-for-byte on v1.23.0), surfacing when synthesizing SSML through `kesha-engine say` on Apple Silicon.

## Part 1 — stdout leak corrupts `--stdin-loop` framing
`with_silenced_stdout` (`rust/src/fluid_stdout.rs`) `dup2`'d fd 1 → `/dev/null` for the FluidAudio call and restored it on `Drop`, **but never flushed the C stdio buffer**. With `--stdin-loop`, stdout is a pipe/file so libc makes it *fully buffered* — the Swift bridge's synchronous `print("Kesha synthesize error: …")` sits in that buffer during the guarded scope and flushes onto the **restored** real stdout afterwards, landing after the binary frame (`<status:u8><id:u32><len:u32><payload>`) and desyncing any client parsing the protocol.

Fix: `fflush(NULL)` at guard **entry** (before the redirect, so legit pre-buffered output isn't swallowed) and in **`Drop` before restoring fd 1** (so the noise drains to `/dev/null`). Rust's own stdout uses a separate buffer, so framed output is unaffected. Also hardens the transcribe/diarize paths.

## Part 2 — a bare-punctuation SSML segment failed G2P
`<speak>Loop <emphasis>ssml</emphasis>.</speak>` splits into a trailing `Text(".")` segment; FluidAudio's G2P throws `G2P produced no phonemes for input '.'`, failing the whole utterance — even though the sentence synthesizes fine as plain text. The ONNX path tolerates it (misaki returns empty IPA → `infer_ipa` early-returns → empty audio).

Fix: `synthesize_pcm` now short-circuits to an empty buffer when the text has **no alphanumeric character** (was `trim().is_empty()`), mirroring the ONNX tolerance. The walker's existing "no audio produced from SSML input" guard still fails a *fully*-empty utterance loudly.

The two are linked: Part 2 is the trigger that produces the failing synth; Part 1 is why that failure corrupted the wire. Each is fixed independently (defense-in-depth).

## Tests
- `synthesize_pcm_skips_no_phoneme_text_before_model_init` — asserts `.`, whitespace, `...`, `—`, etc. return empty PCM **without touching the model** (the guard returns before init), directly covering Part 2.

## Verification
- `cargo check` / `clippy --all-targets` / `fmt` under `--features system_kokoro --no-default-features` — **0 warnings** (matches CI's `system_kokoro` compile-check).
- `cargo nextest run --features tts` (ONNX) green; `bun test` + `bunx tsc --noEmit` green.
- ⚠️ A full **CoreML binary build**, the `--stdin-loop` **E2E repro**, and *running* the gated `system_kokoro` tests require full **Xcode** (this dev box has only Command Line Tools). They're compile-checked under `system_kokoro` here and built by the `build-engine` workflow; the runtime repro should be confirmed on an Xcode machine.

Closes #543