### PR TITLE
ci(tts-e2e): pin macos-14 + Xcode 16.2 to fix flaky clang_rt link failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,7 +537,10 @@ jobs:
           !startsWith(github.event.head_commit.message, 'chore(release):')
         )
       )
-    runs-on: macos-latest
+    # Pinned (matches build-engine.yml): this is the only CI lane that
+    # builds the engine from source on macOS, and macos-latest's floating
+    # Xcode 16.4 fails to link (`clang_rt.osx not found`).
+    runs-on: macos-14
     timeout-minutes: 20
     permissions:
       contents: read
@@ -547,6 +550,11 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v7
+
+      - name: 🍎 Pin Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.2"
 
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun


### PR DESCRIPTION
## Why

The `tts-e2e` lane is the **only** CI job that compiles `kesha-engine` from source on macOS (`cargo build --release`). It ran on `macos-latest`, which floats to newer runner images. On an image whose default Xcode is **16.4**, the clang resource directory is incomplete and linking fails:

```
ld: library 'clang_rt.osx' not found
ld: warning: search path '/Applications/Xcode_16.4.app/.../clang/17/lib/darwin' not found
error: linking with `cc` failed: exit status: 1
```

Observed in [run 28081448706](https://github.com/drakulavich/kesha-voice-kit/actions/runs/28081448706): the **same commit** built and linked fine on the first attempt (only the artifact upload then hit a transient `ETIMEDOUT`), but the rerun landed on a runner with the broken Xcode 16.4 toolchain and failed to link. Pure environment flake — no code change involved.

The other macOS CI jobs (`integration-tests`, `integration-tests-full`, `published-engine-smoke`) download the published engine or use stubs, so they never exercise this from-source link path — which is why only `tts-e2e` is affected.

## Fix

Pin the lane to `macos-14` + `maxim-lobanov/setup-xcode@v1` `16.2` — the **same proven toolchain the canonical engine build (`build-engine.yml`) already uses** (per the COREML BUILD TRIPLE rule in CLAUDE.md). The job no longer depends on the floating `macos-latest` default Xcode.

## Notes

- This lane builds the `onnx,tts` default feature set (not `coreml`), so it doesn't strictly need 16.2 — but matching the released-binary toolchain keeps macOS engine builds consistent across CI.
- No functional change to the engine or tests; CI-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)