### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs via pinact

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: 🍞 Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         # Single source of truth for the Bun version: the repo-root .bun-version
         # file. The repo is always checked out before this composite runs (it

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
 

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -129,17 +129,18 @@ jobs:
       - uses: actions/checkout@v7
       - name: Select Xcode 16 (Swift 6)
         if: matrix.os == 'macos-14'
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: "16.2"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         if: matrix.os == 'windows-latest'
 
       - name: Pin MSVC linker (Windows)
@@ -373,7 +374,7 @@ jobs:
           fi
 
       - name: Generate source SBOM
-        uses: anchore/sbom-action@v0.24.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
           format: spdx-json
@@ -426,7 +427,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign release assets
         shell: bash
@@ -438,7 +439,7 @@ jobs:
           done < <(find . -maxdepth 1 -type f ! -name '*.sigstore.json' -print0 | sort -z)
 
       - name: Create draft release with binaries
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           body_path: release-notes.md
           files: release-assets/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,7 +474,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
 
@@ -565,7 +565,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
           # Flush caches poisoned before #554, when this lane ran on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,12 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
+          # Flush caches poisoned before #554, when this lane ran on
+          # macos-latest/Xcode 16.4: their build-script `rustc-link-search`
+          # hardcoded that Xcode's clang resource dir, so the link step failed
+          # with `clang_rt.osx not found` even after the Xcode 16.2 pin. Bump
+          # this discriminator if the stale path ever resurfaces.
+          key: xcode-16.2
 
       - name: 💾 Cache Kokoro models
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 🔍 Detect changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # Filter design (post-#280):
@@ -470,9 +470,11 @@ jobs:
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
 
@@ -552,16 +554,18 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 🍎 Pin Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: "16.2"
 
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
 
@@ -679,7 +683,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: ❄️  Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       # No remote Nix cache: DeterminateSystems retired the free
       # `magic-nix-cache-action` backend (the macos-14 row of this job hung

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: 🔍 Detect Docker-relevant changes
         if: github.ref_type == 'branch'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -25,7 +25,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -42,8 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
 
@@ -80,11 +82,13 @@ jobs:
       - uses: actions/checkout@v7
       - name: Select Xcode 16 (Swift 6)
         if: matrix.os == 'macos-14'
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: "16.2"
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
 
@@ -93,11 +97,11 @@ jobs:
       # JUnit XML via the `ci` profile (see rust/.config/nextest.toml).
       # taiki-e/install-action caches a prebuilt binary per OS/arch so
       # the install is ~1s on warm cache.
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: nextest
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         if: runner.os == 'Windows'
 
       - name: Pin MSVC linker (Windows)
@@ -186,7 +190,7 @@ jobs:
       # platform-specific curl installer it covers windows-latest too.
       # Setup-bun is a no-op when bun is already on PATH (cached on warm
       # runs).
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         if: always()
         with:
           bun-version-file: .bun-version
@@ -217,23 +221,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
+          toolchain: stable
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: nextest
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: cargo-llvm-cov
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -315,15 +320,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust
       - name: Install system audio deps (Opus)
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: nextest
       - name: Check formatting

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
 
@@ -88,7 +88,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
 
@@ -226,7 +226,7 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
 
@@ -323,7 +323,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
       - name: Install system audio deps (Opus)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
       deps: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -89,7 +89,7 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
       - name: Install deps (frozen lockfile)

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,23 @@
+# https://github.com/suzuki-shunsuke/pinact — pin third-party Actions to commit SHAs.
+# actions/*, github/*, docker/* are trusted first-party owners (GitHub, Docker) and are
+# kept on readable version tags; everything else is pinned to an immutable SHA to defend
+# against tag-hijack supply-chain attacks.
+version: 3
+files:
+  - pattern: .github/workflows/*.yml
+  - pattern: .github/workflows/*.yaml
+  - pattern: .github/actions/*/action.yml
+  - pattern: .github/actions/*/action.yaml
+rules:
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionRepoOwner in ["actions", "github", "docker"]
+  # dtolnay/rust-toolchain selects the toolchain from its ref, and its channel
+  # refs (stable/nightly/1.xx) are branches — pinact can't pin a branch, and the
+  # only tag (v1) is stale. It's pinned manually to a master-history commit SHA
+  # (with `toolchain: stable`); Dependabot keeps the `# master` SHA current.
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionRepoFullName == "dtolnay/rust-toolchain"


### PR DESCRIPTION
## Why

Mutable action version tags (`@v2`, `@v4`…) can be force-moved by a compromised maintainer to point at attacker code — the `tj-actions/changed-files` (March 2025) class of supply-chain attack. This repo has **privileged workflows**: `npm-publish.yml` holds `id-token: write` (npm provenance OIDC) and `build-engine.yml` holds `contents: write` (release tag creation), so a hijacked action in those jobs is a high-value target — the same surface CLAUDE.md already hardens against shell/prompt injection.

## What

Introduce [`pinact`](https://github.com/suzuki-shunsuke/pinact) and pin every **third-party** action to an immutable commit SHA (keeping a `# vX.Y.Z` comment so Dependabot still bumps them). **Trusted first-party owners — `actions/*`, `github/*`, `docker/*` (GitHub, Docker) — stay on readable version tags**, configured via `.pinact.yaml` rules.

Pinned: `dorny/paths-filter`, `oven-sh/setup-bun`, `maxim-lobanov/setup-xcode`, `Swatinem/rust-cache`, `ilammy/msvc-dev-cmd`, `taiki-e/install-action`. (`EmbarkStudios/cargo-deny-action` was already SHA-pinned.)

### `dtolnay/rust-toolchain` — special case

It selects the Rust toolchain from its ref, and its channel refs (`stable`/`nightly`/`1.xx`) are **branches** that pinact can't pin, while its only tag (`v1`) is stale (2025-08). So it's pinned **manually** to a current master-history commit (`67ef31d…`, 2026-06-20) with an explicit `with: toolchain: stable` input across all 7 usages, and **exempted** in `.pinact.yaml`. Dependabot keeps the `# master` SHA current. (Please don't revert these to `@stable` — the SHA pin is intentional.)

## Notes

- **No CI gate** in this PR (deliberate, for a small-maintainer repo) — Dependabot + ad-hoc `pinact run` keep pins fresh. Re-pin with `GITHUB_TOKEN=$(gh auth token) pinact run`.
- Compatible with the existing `github-actions` Dependabot ecosystem — it updates SHA pins via the version comment.
- `actionlint` clean (only pre-existing `SC2086` shellcheck info notes on unrelated `>> $GITHUB_STEP_SUMMARY` lines).
- CI exercises the rust lanes, so `dtolnay/rust-toolchain@<sha> + toolchain: stable` is proven to still install the toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)