### PR TITLE
fix(deps): override hono to >=4.12.25 (GHSA-88fw-hqm2-52qc)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,9 @@
       },
     },
   },
+  "overrides": {
+    "hono": "^4.12.25",
+  },
   "packages": {
     "@clack/core": ["@clack/core@1.4.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw=="],
 
@@ -148,7 +151,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -99,5 +99,8 @@
     "picocolors": "^1.1.1",
     "tinyld": "^1.3.4",
     "zod": "^4.4.3"
+  },
+  "overrides": {
+    "hono": "^4.12.25"
   }
 }


### PR DESCRIPTION
## What

`bun audit --audit-level=high` (the `🛡️ Security Audit` gate) flags one high-severity advisory:

```
hono  <4.12.25
  @modelcontextprotocol/sdk › @hono/node-server › hono
  high: CORS Middleware reflects any Origin with credentials when origin defaults to wildcard
  https://github.com/advisories/GHSA-88fw-hqm2-52qc
```

`hono@4.12.23` is pulled in **transitively** by `@modelcontextprotocol/sdk` (our only path to it). Fixed in **hono 4.12.25**.

## Fix

Add a package.json `overrides` entry forcing every `hono` resolution to `^4.12.25` — bun dedupes the tree to **hono 4.12.27**. The MCP SDK's own range (`hono: ^4.11.4`) already permits this, so it's a lockfile-level change with no API impact.

```jsonc
"overrides": { "hono": "^4.12.25" }
```

> Note: `bun update hono` was the wrong tool — it adds hono as a *direct* dep and leaves the SDK's nested `hono@4.12.23` in place, so the vulnerable path survives. `overrides` is the correct mechanism for a transitive pin.

## Exploitability in Kesha

**Not reachable.** Kesha never uses hono's CORS middleware — hono only exists inside the MCP SDK, and `kesha mcp` runs over stdio, not an HTTP server with CORS + credentials. This is hygiene / unblocking the audit gate, not a live vulnerability.

## Verification

- `bun audit --audit-level=high` → **No vulnerabilities found** (was 1 high)
- `bunx tsc --noEmit` → clean
- `bun test` → 334 pass / 0 fail
- Single resolution in `bun.lock` (`hono@4.12.27`); no stray direct dependency in `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)