### PR TITLE
refactor(cli): reduce complexity & duplication in 8 low-health TS modules

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -5,13 +5,8 @@ import { multiselect, isCancel, cancel } from "@clack/prompts";
 import { renderInstallPlan } from "../install-plan";
 import { log } from "../log";
 import { getEngineCapabilities } from "../engine";
-import {
-  performInstall,
-  resolveBackendFlag,
-  resolveNoCacheFlag,
-  TTS_LANG_FALLBACK,
-  type SharedInstallArgs,
-} from "./install";
+import { performInstall, resolveBackendFlag, resolveNoCacheFlag, TTS_LANG_FALLBACK } from "./install";
+import type { SharedInstallArgs } from "./types";
 
 const TTS_LANG_LABELS: Record<string, string> = {
   en: "English (Kokoro)",

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -10,6 +10,7 @@ import {
   resolveBackendFlag,
   resolveNoCacheFlag,
   TTS_LANG_FALLBACK,
+  type SharedInstallArgs,
 } from "./install";
 
 const TTS_LANG_LABELS: Record<string, string> = {
@@ -44,16 +45,7 @@ async function promptTtsLangs(preselect: string[]): Promise<string[]> {
   return selected as string[];
 }
 
-export interface InitCommandArgs {
-  coreml: boolean;
-  onnx: boolean;
-  "no-cache": boolean;
-  noCache?: boolean;
-  no_cache?: boolean;
-  tts: boolean;
-  vad: boolean;
-  diarize: boolean;
-  plan: boolean;
+export interface InitCommandArgs extends SharedInstallArgs {
   yes: boolean;
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -7,23 +7,7 @@ import { maybeAskForStar } from "../star";
 import { log } from "../log";
 import { packageVersion } from "../package-info";
 import { createDiagnosticLogSession, type DiagnosticLogSession } from "../diagnostic-log";
-
-/**
- * Fields shared between `install` and `init` command args. Both commands
- * accept the same backend/cache/model flags; extracting them here avoids
- * duplicating the declarations in `init.ts`.
- */
-export interface SharedInstallArgs {
-  coreml: boolean;
-  onnx: boolean;
-  "no-cache": boolean;
-  noCache?: boolean;
-  no_cache?: boolean;
-  tts: boolean;
-  vad: boolean;
-  diarize: boolean;
-  plan: boolean;
-}
+import type { SharedInstallArgs } from "./types";
 
 export interface InstallCommandArgs extends SharedInstallArgs {
   /** Positional args after `install` — candidate TTS language codes. */

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -8,9 +8,12 @@ import { log } from "../log";
 import { packageVersion } from "../package-info";
 import { createDiagnosticLogSession, type DiagnosticLogSession } from "../diagnostic-log";
 
-export interface InstallCommandArgs {
-  /** Positional args after `install` — candidate TTS language codes. */
-  _?: string[];
+/**
+ * Fields shared between `install` and `init` command args. Both commands
+ * accept the same backend/cache/model flags; extracting them here avoids
+ * duplicating the declarations in `init.ts`.
+ */
+export interface SharedInstallArgs {
   coreml: boolean;
   onnx: boolean;
   "no-cache": boolean;
@@ -20,6 +23,11 @@ export interface InstallCommandArgs {
   vad: boolean;
   diarize: boolean;
   plan: boolean;
+}
+
+export interface InstallCommandArgs extends SharedInstallArgs {
+  /** Positional args after `install` — candidate TTS language codes. */
+  _?: string[];
 }
 
 /**

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -100,6 +100,69 @@ function parseSampleRateFlag(value: unknown): number | undefined {
   return sampleRate;
 }
 
+/** Parse and validate --format; exits with code 2 on unknown value. */
+function parseFormatFlag(raw: string | undefined): SayFormat | undefined {
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase();
+  if (lower === "wav" || lower === "ogg-opus" || lower === "flac") return lower;
+  if (lower === "opus" || lower === "ogg") return "ogg-opus";
+  log.error(`unknown --format '${raw}'. supported: wav, ogg-opus, flac`);
+  process.exit(2);
+}
+
+/**
+ * Validate that --bitrate / --sample-rate are only used with ogg-opus output.
+ * Exits with code 2 when the resolved format is not ogg-opus.
+ */
+function assertOpusOnlyFlags(
+  bitrate: number | undefined,
+  sampleRate: number | undefined,
+  format: SayFormat | undefined,
+  outArg: string | undefined,
+): void {
+  if (bitrate === undefined && sampleRate === undefined) return;
+  const outExt = typeof outArg === "string" ? outArg.split(".").pop()?.toLowerCase() : undefined;
+  const impliesOpus = outExt && ["ogg", "opus", "oga"].includes(outExt);
+  // --bitrate / --sample-rate are Opus-only. Reject for wav and flac
+  // (both lossless / no encoder knobs) and for any non-Opus extension.
+  const resolvesToOpus = format === "ogg-opus" || (format === undefined && impliesOpus);
+  if (!resolvesToOpus) {
+    log.error("--bitrate and --sample-rate are only valid with --format ogg-opus");
+    process.exit(2);
+  }
+}
+
+type SayOpts = {
+  text: string;
+  voice: string | undefined;
+  lang: string | undefined;
+  out: string | undefined;
+  rate: number | undefined;
+  ssml: boolean;
+  format: SayFormat | undefined;
+  bitrate: number | undefined;
+  sampleRate: number | undefined;
+  noExpandAbbrev: boolean;
+};
+
+/** Record output artifact stats; returns resolved format and size for diagnostics. */
+function recordOutputArtifact(
+  stats: ReturnType<typeof createStatsRecorder>,
+  audio: Uint8Array,
+  opts: SayOpts,
+): { outputFormat: string; outputSizeBytes: number | null | undefined } {
+  if (opts.out) {
+    const outputArtifact = artifactFromFile(opts.out, "output_audio");
+    if (outputArtifact) stats.recordArtifact(outputArtifact);
+    return {
+      outputFormat: outputArtifact?.format || opts.format || "auto",
+      outputSizeBytes: outputArtifact?.sizeBytes,
+    };
+  }
+  stats.recordArtifact(artifactFromBytes(audio.byteLength, "output_audio", opts.format ?? "wav"));
+  return { outputFormat: opts.format ?? "wav", outputSizeBytes: audio.byteLength };
+}
+
 export const sayCommand = defineCommand({
   meta: {
     name: "say",
@@ -166,38 +229,14 @@ export const sayCommand = defineCommand({
     // Validate --format up front so we surface a clear error before spawning
     // the engine subprocess. The engine repeats the check authoritatively, but
     // catching it here gives the user a faster failure mode in scripts.
-    const fmtArg = typeof args.format === "string" ? args.format.toLowerCase() : undefined;
-    let format: SayFormat | undefined;
-    if (fmtArg) {
-      if (fmtArg === "wav" || fmtArg === "ogg-opus" || fmtArg === "flac") {
-        format = fmtArg;
-      } else if (fmtArg === "opus" || fmtArg === "ogg") {
-        format = "ogg-opus";
-      } else {
-        log.error(`unknown --format '${args.format}'. supported: wav, ogg-opus, flac`);
-        process.exit(2);
-      }
-    }
+    const format = parseFormatFlag(typeof args.format === "string" ? args.format : undefined);
 
     const rate = parseRateFlag(args.rate);
     const bitrate = parseBitrateFlag(args.bitrate);
     const sampleRate = parseSampleRateFlag(args["sample-rate"]);
 
     // Reject --bitrate / --sample-rate with WAV up front to surface the error fast.
-    const hasOpusOnlyFlag = bitrate !== undefined || sampleRate !== undefined;
-    if (hasOpusOnlyFlag) {
-      const outExt = typeof args.out === "string"
-        ? args.out.split(".").pop()?.toLowerCase()
-        : undefined;
-      const impliesOpus = outExt && ["ogg", "opus", "oga"].includes(outExt);
-      // --bitrate / --sample-rate are Opus-only. Reject for wav and flac
-      // (both lossless / no encoder knobs) and for any non-Opus extension.
-      const resolvesToOpus = format === "ogg-opus" || (format === undefined && impliesOpus);
-      if (!resolvesToOpus) {
-        log.error("--bitrate and --sample-rate are only valid with --format ogg-opus");
-        process.exit(2);
-      }
-    }
+    assertOpusOnlyFlags(bitrate, sampleRate, format, typeof args.out === "string" ? args.out : undefined);
 
     const inlineText = typeof args.text === "string" ? args.text : undefined;
     const stdinIsTty = (process.stdin as { isTTY?: boolean }).isTTY;
@@ -210,7 +249,7 @@ export const sayCommand = defineCommand({
     const langHint = typeof args.lang === "string" ? args.lang : undefined;
     const voice = await resolveSayVoice(explicitVoice, langHint, text);
 
-    const opts = {
+    const opts: SayOpts = {
       text,
       voice,
       lang: langHint,
@@ -251,16 +290,7 @@ export const sayCommand = defineCommand({
         // stderr — stdout may carry raw audio bytes when --out is omitted.
         log.status(`TTS time: ${ttsTimeMs}ms`);
       }
-      let outputFormat: string = opts.format ?? "wav";
-      let outputSizeBytes: number | null | undefined = audio.byteLength;
-      if (opts.out) {
-        const outputArtifact = artifactFromFile(opts.out, "output_audio");
-        if (outputArtifact) stats.recordArtifact(outputArtifact);
-        outputFormat = outputArtifact?.format || opts.format || "auto";
-        outputSizeBytes = outputArtifact?.sizeBytes;
-      } else {
-        stats.recordArtifact(artifactFromBytes(audio.byteLength, "output_audio", opts.format ?? "wav"));
-      }
+      const { outputFormat, outputSizeBytes } = recordOutputArtifact(stats, audio, opts);
       diagnosticLog.event("command.finish", {
         command: "say",
         status: "success",

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -121,7 +121,7 @@ function assertOpusOnlyFlags(
   outArg: string | undefined,
 ): void {
   if (bitrate === undefined && sampleRate === undefined) return;
-  const outExt = typeof outArg === "string" ? outArg.split(".").pop()?.toLowerCase() : undefined;
+  const outExt = outArg?.split(".").pop()?.toLowerCase();
   const impliesOpus = outExt && ["ogg", "opus", "oga"].includes(outExt);
   // --bitrate / --sample-rate are Opus-only. Reject for wav and flac
   // (both lossless / no encoder knobs) and for any non-Opus extension.

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Fields shared between the `install` and `init` command args. Both commands
+ * accept the same backend/cache/model flags; defining the shape here (rather
+ * than in either command module) keeps `init` from importing a type out of its
+ * sibling `install` command just to extend it.
+ */
+export interface SharedInstallArgs {
+  coreml: boolean;
+  onnx: boolean;
+  "no-cache": boolean;
+  noCache?: boolean;
+  no_cache?: boolean;
+  tts: boolean;
+  vad: boolean;
+  diarize: boolean;
+  plan: boolean;
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -368,6 +368,63 @@ function formatInstalled(installed: boolean): string {
   return installed ? "installed" : "missing";
 }
 
+function formatCapabilities(engine: DoctorReport["engine"]): string {
+  if (!engine.capabilities) return engine.probeError ?? "not available";
+  const { backend, protocolVersion, features } = engine.capabilities;
+  return `${backend}, protocol v${protocolVersion}, ${features.join(", ")}`;
+}
+
+function formatCacheSection(cache: DoctorReport["cache"]): string[] {
+  const header = `Cache: ${cache.path} (${cache.exists ? humanBytes(cache.totalBytes) : "missing"})`;
+  const rows = cache.components.map(
+    (c) => `  ${c.label}: ${c.exists ? humanBytes(c.sizeBytes) : "missing"}`,
+  );
+  return [header, ...rows];
+}
+
+function formatOptionalSection(components: DoctorReport["optionalComponents"]): string[] {
+  const lines = ["", "Optional components:"];
+  for (const c of components) {
+    const note = c.note ? ` - ${c.note}` : "";
+    lines.push(`  ${c.name}: ${formatInstalled(c.exists)}${note}`);
+  }
+  return lines;
+}
+
+function formatStatsSection(stats: DoctorReport["stats"]): string[] {
+  const lines = ["", "Stats:"];
+  if ("error" in stats) {
+    lines.push(`  Error: ${stats.error}`);
+  } else {
+    lines.push(`  Enabled: ${stats.enabled ? "yes" : "no"}`);
+    lines.push(`  Database: ${stats.dbPath}`);
+    lines.push(`  Runs: ${stats.runCount}`);
+  }
+  return lines;
+}
+
+function formatDiagnosticLogsSection(logs: DoctorReport["diagnosticLogs"]): string[] {
+  const lines = [
+    "",
+    "Diagnostic logs:",
+    `  Mode: ${logs.mode}`,
+    `  Path: ${logs.activePath}`,
+    `  Size: ${humanBytes(logs.totalSizeBytes)}`,
+    `  Rotated files: ${logs.rotatedFiles.length}`,
+    `  Rotation: ${humanBytes(logs.maxBytes)}, keep ${logs.retain}`,
+  ];
+  if (logs.error) lines.push(`  Error: ${logs.error}`);
+  return lines;
+}
+
+function formatEnvSection(env: DoctorReport["env"]): string[] {
+  const lines = ["", "Environment:"];
+  for (const [key, value] of Object.entries(env)) {
+    lines.push(`  ${key}: ${value ?? "unset"}`);
+  }
+  return lines;
+}
+
 export function formatDoctorReport(report: DoctorReport): string {
   const lines = [
     "Kesha Doctor",
@@ -380,46 +437,14 @@ export function formatDoctorReport(report: DoctorReport): string {
     "Engine:",
     `  Binary: ${report.engine.path} (${formatInstalled(report.engine.installed)})`,
     `  Version marker: ${report.engine.versionMarker ?? "missing"}`,
-    `  Capabilities: ${
-      report.engine.capabilities
-        ? `${report.engine.capabilities.backend}, protocol v${report.engine.capabilities.protocolVersion}, ${report.engine.capabilities.features.join(", ")}`
-        : report.engine.probeError ?? "not available"
-    }`,
+    `  Capabilities: ${formatCapabilities(report.engine)}`,
     "",
-    `Cache: ${report.cache.path} (${report.cache.exists ? humanBytes(report.cache.totalBytes) : "missing"})`,
+    ...formatCacheSection(report.cache),
+    ...formatOptionalSection(report.optionalComponents),
+    ...formatStatsSection(report.stats),
+    ...formatDiagnosticLogsSection(report.diagnosticLogs),
+    ...formatEnvSection(report.env),
   ];
-
-  for (const component of report.cache.components) {
-    lines.push(`  ${component.label}: ${component.exists ? humanBytes(component.sizeBytes) : "missing"}`);
-  }
-
-  lines.push("", "Optional components:");
-  for (const component of report.optionalComponents) {
-    const note = component.note ? ` - ${component.note}` : "";
-    lines.push(`  ${component.name}: ${formatInstalled(component.exists)}${note}`);
-  }
-
-  lines.push("", "Stats:");
-  if ("error" in report.stats) {
-    lines.push(`  Error: ${report.stats.error}`);
-  } else {
-    lines.push(`  Enabled: ${report.stats.enabled ? "yes" : "no"}`);
-    lines.push(`  Database: ${report.stats.dbPath}`);
-    lines.push(`  Runs: ${report.stats.runCount}`);
-  }
-
-  lines.push("", "Diagnostic logs:");
-  lines.push(`  Mode: ${report.diagnosticLogs.mode}`);
-  lines.push(`  Path: ${report.diagnosticLogs.activePath}`);
-  lines.push(`  Size: ${humanBytes(report.diagnosticLogs.totalSizeBytes)}`);
-  lines.push(`  Rotated files: ${report.diagnosticLogs.rotatedFiles.length}`);
-  lines.push(`  Rotation: ${humanBytes(report.diagnosticLogs.maxBytes)}, keep ${report.diagnosticLogs.retain}`);
-  if (report.diagnosticLogs.error) lines.push(`  Error: ${report.diagnosticLogs.error}`);
-
-  lines.push("", "Environment:");
-  for (const [key, value] of Object.entries(report.env)) {
-    lines.push(`  ${key}: ${value ?? "unset"}`);
-  }
 
   return `${lines.join("\n")}\n`;
 }

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -6,6 +6,7 @@ import {
   getEngineBinPath,
   getEngineCapabilities,
   TRANSCRIBE_DIARIZE_FEATURE,
+  type EngineCapabilities,
 } from "./engine";
 import { isDarwinArm64 } from "./fluid-kokoro-cache";
 import { log } from "./log";
@@ -487,8 +488,7 @@ function checkEngineWritable(engineDir: string): boolean {
  * Validates that the installed engine matches the requested backend.
  * Throws if the engine advertises a different backend.
  */
-async function validateBackend(backend: string): Promise<void> {
-  const caps = await getEngineCapabilities();
+function validateBackend(backend: string, caps: EngineCapabilities | null): void {
   if (caps && caps.backend !== backend) {
     throw new Error(
       `Requested backend "${backend}" is not available: the installed engine for this platform uses "${caps.backend}".\n  Fix: omit --${backend} to use the auto-detected backend, or run on a platform that ships the "${backend}" build.`,
@@ -506,8 +506,7 @@ async function validateBackend(backend: string): Promise<void> {
  * Nix sandbox forbids it. Without this guard, `kesha-engine install
  * --diarize` would fail with clap's generic "unexpected argument" error.
  */
-async function validateDiarize(): Promise<void> {
-  const caps = await getEngineCapabilities();
+function validateDiarize(caps: EngineCapabilities | null): void {
   // Treat null (pre-capabilities-JSON engine, or capability probe failed)
   // the same as an engine that advertised features but omitted ours —
   // forwarding `--diarize` to a binary that doesn't understand it would
@@ -585,12 +584,13 @@ export async function downloadEngine(
     await fetchEngineBinary(binPath, installedVersion);
   }
 
-  if (backend) {
-    await validateBackend(backend);
-  }
-
-  if (options.diarize) {
-    await validateDiarize();
+  if (backend || options.diarize) {
+    // One capabilities probe shared by both validators (getEngineCapabilities
+    // is cached, but a single explicit gate reads clearer than two helpers
+    // each fetching independently).
+    const caps = await getEngineCapabilities();
+    if (backend) validateBackend(backend, caps);
+    if (options.diarize) validateDiarize(caps);
   }
 
   runEngineModelInstall(binPath, noCache, options);

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -467,75 +467,71 @@ async function fetchEngineBinary(
   await Promise.all(sidecarPromises);
 }
 
-export async function downloadEngine(
-  noCache = false,
-  backend?: string,
-  options: InstallOptions = {},
-): Promise<string> {
-  const binPath = getEngineBinPath();
-  const installedVersion = readInstalledEngineVersion(binPath);
-  const engineDir = dirname(binPath);
-
-  // Detect a read-only engine directory (e.g., a Nix-store install —
-  // `KESHA_ENGINE_BIN` points into `/nix/store/.../bin/`). Used twice
-  // below: to honor `--no-cache` only when the engine is writable, and
-  // to skip the sidecar top-up that would otherwise emit confusing
-  // "install failed" warnings for paths we physically can't write to.
-  let canWriteEngineDir = true;
-  if (existsSync(engineDir)) {
-    try {
-      accessSync(engineDir, constants.W_OK);
-    } catch {
-      canWriteEngineDir = false;
-    }
+/**
+ * Returns true when the engine directory is writable by the current process.
+ *
+ * A false result indicates a read-only install (e.g. Nix store) — callers
+ * should skip download/sidecar steps rather than emitting confusing errors.
+ */
+function checkEngineWritable(engineDir: string): boolean {
+  if (!existsSync(engineDir)) return true; // dir will be created on cold install
+  try {
+    accessSync(engineDir, constants.W_OK);
+    return true;
+  } catch {
+    return false;
   }
+}
 
-  const versionMatches =
-    existsSync(binPath) && installedVersion === engineVersion;
-  // When the engine sits on a read-only filesystem at the matching
-  // version, `--no-cache` can't re-download it without an EROFS crash
-  // and there's nothing to refresh anyway — treat as cache-valid and
-  // forward `--no-cache` to the model install step below.
-  const cacheValid = versionMatches && (!noCache || !canWriteEngineDir);
-
-  if (cacheValid) {
-    await refreshCachedEngine(binPath, canWriteEngineDir, noCache);
-  } else {
-    await fetchEngineBinary(binPath, installedVersion);
+/**
+ * Validates that the installed engine matches the requested backend.
+ * Throws if the engine advertises a different backend.
+ */
+async function validateBackend(backend: string): Promise<void> {
+  const caps = await getEngineCapabilities();
+  if (caps && caps.backend !== backend) {
+    throw new Error(
+      `Requested backend "${backend}" is not available: the installed engine for this platform uses "${caps.backend}".\n  Fix: omit --${backend} to use the auto-detected backend, or run on a platform that ships the "${backend}" build.`,
+    );
   }
+}
 
-  if (backend) {
-    const caps = await getEngineCapabilities();
-    if (caps && caps.backend !== backend) {
-      throw new Error(
-        `Requested backend "${backend}" is not available: the installed engine for this platform uses "${caps.backend}".\n  Fix: omit --${backend} to use the auto-detected backend, or run on a platform that ships the "${backend}" build.`,
-      );
-    }
+/**
+ * Guards against forwarding `--diarize` to an engine built without it.
+ *
+ * Catches the case where the platform check passed (darwin-arm64) but the
+ * engine itself was built without `system_diarize` — e.g., the Nix build,
+ * which compiles `coreml,tts,system_tts` and intentionally omits diarize
+ * because the FluidAudio CoreML weights need network at build time and the
+ * Nix sandbox forbids it. Without this guard, `kesha-engine install
+ * --diarize` would fail with clap's generic "unexpected argument" error.
+ */
+async function validateDiarize(): Promise<void> {
+  const caps = await getEngineCapabilities();
+  // Treat null (pre-capabilities-JSON engine, or capability probe failed)
+  // the same as an engine that advertised features but omitted ours —
+  // forwarding `--diarize` to a binary that doesn't understand it would
+  // surface as clap's generic "unexpected argument" error.
+  if (!caps || !caps.features.includes(TRANSCRIBE_DIARIZE_FEATURE)) {
+    throw new Error(
+      "--diarize is not supported by the installed engine: it was built " +
+        "without the 'system_diarize' feature (the Nix build is one such " +
+        "case — see docs/nix-install.md).\n" +
+        "  Fix: install via the npm release with `bun add -g @drakulavich/kesha-voice-kit`, " +
+        "which ships the diarize-enabled engine on darwin-arm64.",
+    );
   }
+}
 
-  // Catch the case where the platform check passed (darwin-arm64) but the
-  // engine itself was built without `system_diarize` — e.g., the Nix build,
-  // which compiles `coreml,tts,system_tts` and intentionally omits diarize
-  // because the FluidAudio CoreML weights need network at build time and the
-  // Nix sandbox forbids it. Without this guard, `kesha-engine install
-  // --diarize` would fail with clap's generic "unexpected argument" error.
-  if (options.diarize) {
-    const caps = await getEngineCapabilities();
-    // Treat null (pre-capabilities-JSON engine, or capability probe failed)
-    // the same as an engine that advertised features but omitted ours —
-    // forwarding `--diarize` to a binary that doesn't understand it would
-    // surface as clap's generic "unexpected argument" error.
-    if (!caps || !caps.features.includes(TRANSCRIBE_DIARIZE_FEATURE)) {
-      throw new Error(
-        "--diarize is not supported by the installed engine: it was built " +
-          "without the 'system_diarize' feature (the Nix build is one such " +
-          "case — see docs/nix-install.md).\n" +
-          "  Fix: install via the npm release with `bun add -g @drakulavich/kesha-voice-kit`, " +
-          "which ships the diarize-enabled engine on darwin-arm64.",
-      );
-    }
-  }
-
+/**
+ * Runs `kesha-engine install` to download/verify models.
+ * Streams stderr to the process and throws on non-zero exit.
+ */
+function runEngineModelInstall(
+  binPath: string,
+  noCache: boolean,
+  options: InstallOptions,
+): void {
   log.progress("Installing models...");
   const installArgs = buildEngineInstallArgs({
     noCache,
@@ -557,6 +553,47 @@ export async function downloadEngine(
     const detail = stderr.trim();
     throw new Error(detail ? `Failed to install models: ${detail}` : "Failed to install models");
   }
+}
+
+export async function downloadEngine(
+  noCache = false,
+  backend?: string,
+  options: InstallOptions = {},
+): Promise<string> {
+  const binPath = getEngineBinPath();
+  const installedVersion = readInstalledEngineVersion(binPath);
+  const engineDir = dirname(binPath);
+
+  // Detect a read-only engine directory (e.g., a Nix-store install —
+  // `KESHA_ENGINE_BIN` points into `/nix/store/.../bin/`). Used twice
+  // below: to honor `--no-cache` only when the engine is writable, and
+  // to skip the sidecar top-up that would otherwise emit confusing
+  // "install failed" warnings for paths we physically can't write to.
+  const canWriteEngineDir = checkEngineWritable(engineDir);
+
+  const versionMatches =
+    existsSync(binPath) && installedVersion === engineVersion;
+  // When the engine sits on a read-only filesystem at the matching
+  // version, `--no-cache` can't re-download it without an EROFS crash
+  // and there's nothing to refresh anyway — treat as cache-valid and
+  // forward `--no-cache` to the model install step below.
+  const cacheValid = versionMatches && (!noCache || !canWriteEngineDir);
+
+  if (cacheValid) {
+    await refreshCachedEngine(binPath, canWriteEngineDir, noCache);
+  } else {
+    await fetchEngineBinary(binPath, installedVersion);
+  }
+
+  if (backend) {
+    await validateBackend(backend);
+  }
+
+  if (options.diarize) {
+    await validateDiarize();
+  }
+
+  runEngineModelInstall(binPath, noCache, options);
 
   // Warm the FluidAudio Kokoro CoreML cache only when a Kokoro language is
   // requested. Russian (`ru`) routes through Vosk-TTS, not Kokoro, so a

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -229,8 +229,8 @@ function buildTtsComponents(
   cacheRoot: string,
   ttsLangs: string[],
   noCache: boolean,
-): { components: PlanComponent[]; warmups: PlanWarmup[] } {
-  if (ttsLangs.length === 0) return { components: [], warmups: [] };
+): { components: PlanComponent[]; warmups: PlanWarmup[]; wantsAnyKokoro: boolean } {
+  if (ttsLangs.length === 0) return { components: [], warmups: [], wantsAnyKokoro: false };
 
   // Darwin ANE serves every non-ru language through Kokoro (en/es/fr/it/pt + the
   // ANE-only hi/ja/zh), so the warm-up gate mirrors engine-install.ts's
@@ -285,7 +285,7 @@ function buildTtsComponents(
     );
   }
 
-  return { components, warmups };
+  return { components, warmups, wantsAnyKokoro };
 }
 
 // ---------------------------------------------------------------------------
@@ -352,8 +352,6 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     );
   }
 
-  const wantsAnyKokoro = ttsLangs.some((l) => l !== "ru");
-
   const coldBytes = components.reduce((sum, component) => sum + component.sizeBytes, 0);
   const expectedNetworkBytes = components.reduce((sum, component) => {
     if (component.cached && !component.refresh) return sum;
@@ -406,7 +404,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     "  - install warms the ASR backend after downloads; CoreML warm-up is typically 20-30 s, ONNX warm-up is about 500 ms.",
   );
 
-  if (ttsLangs.length > 0 && wantsAnyKokoro && isDarwinArm64()) {
+  if (ttsLangs.length > 0 && tts.wantsAnyKokoro && isDarwinArm64()) {
     lines.push(
       "  - --tts also warms FluidAudio Kokoro CoreML; FluidAudio may download/compile its own Kokoro cache on first use.",
     );

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -183,19 +183,16 @@ function bundleComponent(
   };
 }
 
-export async function renderInstallPlan(options: InstallPlanOptions = {}): Promise<string> {
-  const cacheRoot = keshaCacheDir();
-  const binPath = getEngineBinPath();
-  const engineDir = dirname(binPath);
-  const noCache = options.noCache === true;
-  const components: PlanComponent[] = [];
-  const warmups: PlanWarmup[] = [];
+// ---------------------------------------------------------------------------
+// Private helpers — build plan sections
+// ---------------------------------------------------------------------------
 
+function buildEngineComponent(binPath: string, noCache: boolean): PlanComponent {
   const engineAsset = engineAssetForPlatform();
   if (engineAsset) {
     const engineCached =
       existsSync(binPath) && readInstalledEngineVersion(binPath) === engineVersion;
-    components.push({
+    return {
       name: `Engine ${engineAsset.assetName}`,
       source: `GitHub release v${engineVersion}`,
       sizeBytes: engineAsset.sizeBytes,
@@ -205,52 +202,36 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
         process.platform === "win32"
           ? "Windows x64 is currently blocked by the install path; see issue #216."
           : undefined,
-    });
-  } else {
-    components.push({
-      name: `Engine for ${process.platform} ${process.arch}`,
-      source: "GitHub release",
-      sizeBytes: 0,
-      cached: false,
-      refresh: false,
-      note: "unsupported platform",
-    });
+    };
   }
+  return {
+    name: `Engine for ${process.platform} ${process.arch}`,
+    source: "GitHub release",
+    sizeBytes: 0,
+    cached: false,
+    refresh: false,
+    note: "unsupported platform",
+  };
+}
 
-  if (isDarwinArm64()) {
-    for (const sidecar of DARWIN_SIDECARS) {
-      components.push({
-        name: `Sidecar ${sidecar.assetName}`,
-        source: `GitHub release v${engineVersion}`,
-        sizeBytes: sidecar.sizeBytes,
-        cached: existsSync(join(engineDir, sidecar.fileBasename)),
-        refresh: noCache,
-      });
-    }
-  }
+function buildSidecarComponents(engineDir: string, noCache: boolean): PlanComponent[] {
+  if (!isDarwinArm64()) return [];
+  return DARWIN_SIDECARS.map((sidecar) => ({
+    name: `Sidecar ${sidecar.assetName}`,
+    source: `GitHub release v${engineVersion}`,
+    sizeBytes: sidecar.sizeBytes,
+    cached: existsSync(join(engineDir, sidecar.fileBasename)),
+    refresh: noCache,
+  }));
+}
 
-  components.push(
-    bundleComponent(
-      cacheRoot,
-      "ASR Parakeet TDT v3",
-      "model cache",
-      ASR_FILES,
-      noCache,
-      "required for speech-to-text",
-    ),
-  );
-  components.push(
-    bundleComponent(
-      cacheRoot,
-      "Audio language ID ECAPA",
-      "model cache",
-      LANG_ID_FILES,
-      noCache,
-      "required for --json, --toon, --format transcript, --lang, and --verbose language metadata",
-    ),
-  );
+function buildTtsComponents(
+  cacheRoot: string,
+  ttsLangs: string[],
+  noCache: boolean,
+): { components: PlanComponent[]; warmups: PlanWarmup[] } {
+  if (ttsLangs.length === 0) return { components: [], warmups: [] };
 
-  const ttsLangs = options.ttsLangs ?? [];
   // Darwin ANE serves every non-ru language through Kokoro (en/es/fr/it/pt + the
   // ANE-only hi/ja/zh), so the warm-up gate mirrors engine-install.ts's
   // `some((l) => l !== "ru")`. The ONNX component, by contrast, only covers the
@@ -260,51 +241,88 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
   const wantsG2p = ttsLangs.some((l) => ["es", "fr", "it", "pt"].includes(l));
   const wantsRu = ttsLangs.includes("ru");
 
-  if (ttsLangs.length > 0) {
-    if (isDarwinArm64()) {
-      if (wantsAnyKokoro) {
-        warmups.push({
-          name: "TTS Kokoro (ANE)",
-          note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoroCachePath()})`,
-        });
-      }
-      if (wantsRu) {
-        components.push(
-          bundleComponent(cacheRoot, "TTS Vosk RU", "model cache", VOSK_RU_FILES, noCache, "Russian ru-vosk-* voices"),
-        );
-      }
-    } else {
-      if (wantsOnnxKokoro) {
-        components.push(
-          bundleComponent(
-            cacheRoot,
-            "TTS Kokoro graph + voices",
-            "model cache",
-            kokoroPlanFiles(ttsLangs),
-            noCache,
-            `voices for ${ttsLangs.filter((l) => l !== "ru").join(", ")}`,
-          ),
-        );
-      }
-      if (wantsG2p) {
-        components.push(
-          bundleComponent(
-            cacheRoot,
-            "G2P CharsiuG2P byt5-tiny",
-            "model cache",
-            G2P_CHARSIU_FILES,
-            noCache,
-            "multilingual G2P for es/fr/it/pt (CC-BY 4.0)",
-          ),
-        );
-      }
-      if (wantsRu) {
-        components.push(
-          bundleComponent(cacheRoot, "TTS Vosk RU", "model cache", VOSK_RU_FILES, noCache, "Russian ru-vosk-* voices"),
-        );
-      }
+  const components: PlanComponent[] = [];
+  const warmups: PlanWarmup[] = [];
+
+  if (isDarwinArm64()) {
+    if (wantsAnyKokoro) {
+      warmups.push({
+        name: "TTS Kokoro (ANE)",
+        note: `${FLUID_KOKORO_CACHE_NOTE} (${fluidKokoroCachePath()})`,
+      });
+    }
+  } else {
+    if (wantsOnnxKokoro) {
+      components.push(
+        bundleComponent(
+          cacheRoot,
+          "TTS Kokoro graph + voices",
+          "model cache",
+          kokoroPlanFiles(ttsLangs),
+          noCache,
+          `voices for ${ttsLangs.filter((l) => l !== "ru").join(", ")}`,
+        ),
+      );
+    }
+    if (wantsG2p) {
+      components.push(
+        bundleComponent(
+          cacheRoot,
+          "G2P CharsiuG2P byt5-tiny",
+          "model cache",
+          G2P_CHARSIU_FILES,
+          noCache,
+          "multilingual G2P for es/fr/it/pt (CC-BY 4.0)",
+        ),
+      );
     }
   }
+
+  // Vosk RU is needed on both darwin and non-darwin builds.
+  if (wantsRu) {
+    components.push(
+      bundleComponent(cacheRoot, "TTS Vosk RU", "model cache", VOSK_RU_FILES, noCache, "Russian ru-vosk-* voices"),
+    );
+  }
+
+  return { components, warmups };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function renderInstallPlan(options: InstallPlanOptions = {}): Promise<string> {
+  const cacheRoot = keshaCacheDir();
+  const binPath = getEngineBinPath();
+  const engineDir = dirname(binPath);
+  const noCache = options.noCache === true;
+
+  const ttsLangs = options.ttsLangs ?? [];
+  const tts = buildTtsComponents(cacheRoot, ttsLangs, noCache);
+
+  const components: PlanComponent[] = [
+    buildEngineComponent(binPath, noCache),
+    ...buildSidecarComponents(engineDir, noCache),
+    bundleComponent(
+      cacheRoot,
+      "ASR Parakeet TDT v3",
+      "model cache",
+      ASR_FILES,
+      noCache,
+      "required for speech-to-text",
+    ),
+    bundleComponent(
+      cacheRoot,
+      "Audio language ID ECAPA",
+      "model cache",
+      LANG_ID_FILES,
+      noCache,
+      "required for --json, --toon, --format transcript, --lang, and --verbose language metadata",
+    ),
+    ...tts.components,
+  ];
+  const warmups: PlanWarmup[] = [...tts.warmups];
 
   if (options.vad) {
     components.push(
@@ -333,6 +351,8 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
       ),
     );
   }
+
+  const wantsAnyKokoro = ttsLangs.some((l) => l !== "ru");
 
   const coldBytes = components.reduce((sum, component) => sum + component.sizeBytes, 0);
   const expectedNetworkBytes = components.reduce((sum, component) => {

--- a/src/status.ts
+++ b/src/status.ts
@@ -35,6 +35,32 @@ export interface ShowStatusOptions {
   disk?: boolean;
 }
 
+async function logEngineCapabilities(): Promise<void> {
+  let caps: Awaited<ReturnType<typeof getEngineCapabilities>> = null;
+  try {
+    caps = await getEngineCapabilities();
+  } catch {
+    caps = null;
+  }
+  if (caps) {
+    log.info(formatStatusLine("Backend", caps.backend, true));
+    log.info(formatStatusLine("Protocol", `v${caps.protocolVersion}`, true));
+    log.info(formatStatusLine("Features", caps.features.join(", "), true));
+  } else {
+    log.info(formatStatusLine("Capabilities", null, false, "probe failed"));
+  }
+}
+
+function logInstalledVoices(): void {
+  const voices = listInstalledVoices();
+  if (voices.length === 0) return;
+  log.info("TTS voices:");
+  for (const v of voices) {
+    log.info(`  ${v}`);
+  }
+  log.info("");
+}
+
 export async function showStatus(options: ShowStatusOptions = {}): Promise<void> {
   const binPath = getEngineBinPath();
   const installed = isEngineInstalled();
@@ -43,19 +69,7 @@ export async function showStatus(options: ShowStatusOptions = {}): Promise<void>
   log.info(formatStatusLine("Binary", installed ? binPath : null, installed));
 
   if (installed) {
-    let caps: Awaited<ReturnType<typeof getEngineCapabilities>> = null;
-    try {
-      caps = await getEngineCapabilities();
-    } catch {
-      caps = null;
-    }
-    if (caps) {
-      log.info(formatStatusLine("Backend", caps.backend, true));
-      log.info(formatStatusLine("Protocol", `v${caps.protocolVersion}`, true));
-      log.info(formatStatusLine("Features", caps.features.join(", "), true));
-    } else {
-      log.info(formatStatusLine("Capabilities", null, false, "probe failed"));
-    }
+    await logEngineCapabilities();
   }
   log.info("");
 
@@ -68,14 +82,7 @@ export async function showStatus(options: ShowStatusOptions = {}): Promise<void>
   log.info("");
 
   if (installed) {
-    const voices = listInstalledVoices();
-    if (voices.length > 0) {
-      log.info("TTS voices:");
-      for (const v of voices) {
-        log.info(`  ${v}`);
-      }
-      log.info("");
-    }
+    logInstalledVoices();
 
     if (options.disk) {
       showDiskUsage(binPath);
@@ -88,6 +95,39 @@ export async function showStatus(options: ShowStatusOptions = {}): Promise<void>
   }
 }
 
+function buildDiskComponents(cache: string, engineDir: string): Array<{ label: string; path: string }> {
+  return [
+    { label: "Engine", path: engineDir },
+    { label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") },
+    { label: "Language ID", path: join(cache, "models/lang-id-ecapa") },
+    { label: "VAD (Silero)", path: join(cache, "models/silero-vad") },
+    { label: "TTS (Kokoro)", path: join(cache, "models/kokoro-82m") },
+    { label: "TTS (Vosk)", path: join(cache, "models/vosk-ru") },
+  ];
+}
+
+function logDiskRows(rows: Array<{ label: string; size: number }>, total: number, componentTotal: number): void {
+  const labelWidth = Math.max(...rows.map((r) => r.label.length), "Total".length);
+  for (const r of rows) {
+    const pad = " ".repeat(labelWidth - r.label.length + 2);
+    log.info(`  ${r.label}:${pad}${humanBytes(r.size)}`);
+  }
+  const totalPad = " ".repeat(labelWidth - "Total".length + 2);
+  log.info(`  ${pc.bold("Total")}:${totalPad}${pc.bold(humanBytes(total))}`);
+  if (total > componentTotal) {
+    const other = total - componentTotal;
+    log.info(pc.dim(`  (includes ${humanBytes(other)} of other cache files)`));
+  }
+}
+
+function logFluidKokoroCache(): void {
+  const fluidKokoro = fluidKokoroCacheInfo();
+  if (!fluidKokoro.exists || fluidKokoro.sizeBytes <= 0) return;
+  log.info("");
+  log.info(`External caches (not included in Kesha total):`);
+  log.info(`  FluidAudio Kokoro: ${humanBytes(fluidKokoro.sizeBytes)} (${fluidKokoro.path})`);
+}
+
 function showDiskUsage(binPath: string): void {
   const cache = keshaCacheDir();
   // Engine binary lives under `<cache>/engine/bin/` (managed by the TS CLI's
@@ -97,14 +137,7 @@ function showDiskUsage(binPath: string): void {
   // counted too.
   const engineDir = join(binPath, "..", "..");
 
-  const components: Array<{ label: string; path: string }> = [
-    { label: "Engine", path: engineDir },
-    { label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") },
-    { label: "Language ID", path: join(cache, "models/lang-id-ecapa") },
-    { label: "VAD (Silero)", path: join(cache, "models/silero-vad") },
-    { label: "TTS (Kokoro)", path: join(cache, "models/kokoro-82m") },
-    { label: "TTS (Vosk)", path: join(cache, "models/vosk-ru") },
-  ];
+  const components = buildDiskComponents(cache, engineDir);
 
   const rows: Array<{ label: string; size: number }> = [];
   for (const c of components) {
@@ -127,23 +160,8 @@ function showDiskUsage(binPath: string): void {
   const total = cacheTotal + engineOutsideCache;
 
   log.info(`Disk usage (${cache}):`);
-  const labelWidth = Math.max(...rows.map((r) => r.label.length), "Total".length);
-  for (const r of rows) {
-    const pad = " ".repeat(labelWidth - r.label.length + 2);
-    log.info(`  ${r.label}:${pad}${humanBytes(r.size)}`);
-  }
-  const totalPad = " ".repeat(labelWidth - "Total".length + 2);
-  log.info(`  ${pc.bold("Total")}:${totalPad}${pc.bold(humanBytes(total))}`);
-  if (total > componentTotal) {
-    const other = total - componentTotal;
-    log.info(pc.dim(`  (includes ${humanBytes(other)} of other cache files)`));
-  }
-  const fluidKokoro = fluidKokoroCacheInfo();
-  if (fluidKokoro.exists && fluidKokoro.sizeBytes > 0) {
-    log.info("");
-    log.info(`External caches (not included in Kesha total):`);
-    log.info(`  FluidAudio Kokoro: ${humanBytes(fluidKokoro.sizeBytes)} (${fluidKokoro.path})`);
-  }
+  logDiskRows(rows, total, componentTotal);
+  logFluidKokoroCache();
   log.info("");
   log.info(pc.dim(`  To reset cache: rm -rf ${cache} — next \`kesha install\` re-downloads.`));
   log.info("");

--- a/src/status.ts
+++ b/src/status.ts
@@ -36,12 +36,7 @@ export interface ShowStatusOptions {
 }
 
 async function logEngineCapabilities(): Promise<void> {
-  let caps: Awaited<ReturnType<typeof getEngineCapabilities>> = null;
-  try {
-    caps = await getEngineCapabilities();
-  } catch {
-    caps = null;
-  }
+  const caps = await getEngineCapabilities().catch(() => null);
   if (caps) {
     log.info(formatStatusLine("Backend", caps.backend, true));
     log.info(formatStatusLine("Protocol", `v${caps.protocolVersion}`, true));

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -62,6 +62,33 @@ export interface SayOptions {
   noExpandAbbrev?: boolean;
 }
 
+/** Returns true when the engine capabilities include acronym expansion support. */
+function supportsAcronymExpansion(capabilities: EngineCapabilities | null | undefined): boolean {
+  return (
+    capabilities?.features?.some(
+      (f) => f === "tts.ru_acronym_expansion" || f === "tts.en_acronym_expansion",
+    ) ?? false
+  );
+}
+
+/**
+ * Appends `--no-expand-abbrev` to `args` when the engine supports it, or
+ * emits a warning and skips the flag on older engines.
+ */
+function applyNoExpandAbbrev(args: string[], capabilities: EngineCapabilities | null | undefined): void {
+  if (supportsAcronymExpansion(capabilities)) {
+    args.push("--no-expand-abbrev");
+  } else {
+    // CLAUDE.md "NEVER SWALLOW ERRORS": the user explicitly passed the flag.
+    // Silent drop with only `log.debug` made the flag look effective on old
+    // engines (#275 D3). Surface it as a warning so a CI script or human
+    // user sees the mismatch on every invocation, not only with --debug.
+    log.warn(
+      "--no-expand-abbrev requires kesha-engine ≥ 1.10.0 (advertises no tts.ru_acronym_expansion / tts.en_acronym_expansion capability); flag ignored",
+    );
+  }
+}
+
 /** Build the argv passed to `kesha-engine say` (pure, unit-testable). */
 export function buildSayArgs(o: SayOptions, capabilities?: EngineCapabilities | null): string[] {
   const args: string[] = ["say"];
@@ -73,22 +100,7 @@ export function buildSayArgs(o: SayOptions, capabilities?: EngineCapabilities | 
   if (o.format) args.push("--format", o.format);
   if (o.bitrate !== undefined) args.push("--bitrate", String(o.bitrate));
   if (o.sampleRate !== undefined) args.push("--sample-rate", String(o.sampleRate));
-  if (o.noExpandAbbrev) {
-    const supportsExpand = capabilities?.features?.some(
-      (f) => f === "tts.ru_acronym_expansion" || f === "tts.en_acronym_expansion",
-    ) ?? false;
-    if (supportsExpand) {
-      args.push("--no-expand-abbrev");
-    } else {
-      // CLAUDE.md "NEVER SWALLOW ERRORS": the user explicitly passed the flag.
-      // Silent drop with only `log.debug` made the flag look effective on old
-      // engines (#275 D3). Surface it as a warning so a CI script or human
-      // user sees the mismatch on every invocation, not only with --debug.
-      log.warn(
-        "--no-expand-abbrev requires kesha-engine ≥ 1.10.0 (advertises no tts.ru_acronym_expansion / tts.en_acronym_expansion capability); flag ignored",
-      );
-    }
-  }
+  if (o.noExpandAbbrev) applyNoExpandAbbrev(args, capabilities);
   if (o.text !== undefined && o.text.length > 0) args.push(o.text);
   return args;
 }
@@ -150,12 +162,8 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
   const stdout = proc.stdout as ReadableStream<Uint8Array>;
   const stderr = proc.stderr as ReadableStream<Uint8Array>;
 
-  if (opts.text !== undefined && opts.text.length > 0) {
-    stdin.write(opts.text);
-    await stdin.end();
-  } else {
-    await stdin.end();
-  }
+  if (opts.text !== undefined && opts.text.length > 0) stdin.write(opts.text);
+  await stdin.end();
 
   let stdoutBuf: ArrayBuffer;
   let stderrText: string;

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -62,21 +62,16 @@ export interface SayOptions {
   noExpandAbbrev?: boolean;
 }
 
-/** Returns true when the engine capabilities include acronym expansion support. */
-function supportsAcronymExpansion(capabilities: EngineCapabilities | null | undefined): boolean {
-  return (
-    capabilities?.features?.some(
-      (f) => f === "tts.ru_acronym_expansion" || f === "tts.en_acronym_expansion",
-    ) ?? false
-  );
-}
-
 /**
  * Appends `--no-expand-abbrev` to `args` when the engine supports it, or
  * emits a warning and skips the flag on older engines.
  */
 function applyNoExpandAbbrev(args: string[], capabilities: EngineCapabilities | null | undefined): void {
-  if (supportsAcronymExpansion(capabilities)) {
+  const supportsAcronymExpansion =
+    capabilities?.features?.some(
+      (f) => f === "tts.ru_acronym_expansion" || f === "tts.en_acronym_expansion",
+    ) ?? false;
+  if (supportsAcronymExpansion) {
     args.push("--no-expand-abbrev");
   } else {
     // CLAUDE.md "NEVER SWALLOW ERRORS": the user explicitly passed the flag.


### PR DESCRIPTION
## What

Behavior-preserving refactors of the 8 lowest-health TypeScript modules flagged by repowise (high CCN / deep nesting / duplication). No public API or CLI-flag changes.

| File | Smell | Change |
|------|-------|--------|
| `src/cli/say.ts` | CCN 38, 16.6% dup | extract `parseFormatFlag`, `assertOpusOnlyFlags`, `recordOutputArtifact` |
| `src/install-plan.ts` | CCN 35, 17.2% dup | extract `build{Engine,Sidecar,Tts}Component*`, dedupe Vosk-RU push |
| `src/engine-install.ts` | CCN 18 | extract `checkEngineWritable`, `validateBackend`, `validateDiarize`, `runEngineModelInstall` |
| `src/doctor.ts` | CCN 11 | 6 section-renderer helpers; top-level CCN → 1 |
| `src/status.ts` | CCN 11 | 5 helpers flattening nested checks |
| `src/synth.ts` | CCN 15 | extract `supportsAcronymExpansion`, `applyNoExpandAbbrev` |
| `src/cli/install.ts` + `src/cli/init.ts` | 25.7% dup | shared `SharedInstallArgs` interface |

## Why

repowise code-health analysis flagged these as the lowest-scoring TS files (alert/warning bands). Pure maintainability cleanup — cutting cyclomatic complexity and duplication without touching behavior.

## Verification

- `bunx tsc --noEmit`: clean
- `bun test`: `405 pass / 6 skip / 2 fail`
- Clean `origin/main` baseline: **identical** `405 / 6 / 2` — the 2 failures (`e2e-engine capabilities-json` protocolVersion 2-vs-3, `install --vad` 4s subprocess timeout) are pre-existing & engine-environment-dependent, present on both branches.
- **Net test delta from this PR: zero.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)