### PR TITLE
refactor: health pass 2 — main.ts decomposition + Rust dedup & characterization tests

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1512,3 +1512,175 @@ fn cleanup_legacy() {
         let _ = fs::remove_file(&old_swift);
     }
 }
+
+#[cfg(test)]
+mod characterization_tests {
+    use super::*;
+
+    // ── ModelKind::subdir table test ─────────────────────────────────────────
+
+    #[test]
+    fn model_kind_subdir_table() {
+        assert_eq!(ModelKind::Asr.subdir(), "models/parakeet-tdt-v3");
+        assert_eq!(ModelKind::LangId.subdir(), "models/lang-id-ecapa");
+        assert_eq!(ModelKind::Vad.subdir(), "models/silero-vad");
+    }
+
+    #[cfg(feature = "tts")]
+    #[test]
+    fn model_kind_subdir_vosk_ru() {
+        assert_eq!(ModelKind::VoskRu.subdir(), "models/vosk-ru");
+    }
+
+    // ── model_dir_at with a fake root ────────────────────────────────────────
+
+    #[test]
+    fn model_dir_at_joins_subdir_to_root() {
+        let root = std::path::Path::new("/fake/cache");
+        assert_eq!(
+            model_dir_at(ModelKind::Asr, root),
+            std::path::PathBuf::from("/fake/cache/models/parakeet-tdt-v3")
+        );
+        assert_eq!(
+            model_dir_at(ModelKind::Vad, root),
+            std::path::PathBuf::from("/fake/cache/models/silero-vad")
+        );
+    }
+
+    // ── is_cached_in with a tempdir ──────────────────────────────────────────
+
+    #[test]
+    fn is_cached_in_asr_true_when_all_files_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/parakeet-tdt-v3");
+        fs::create_dir_all(&dir).unwrap();
+        for f in ASR_FILES {
+            let name = std::path::Path::new(f.rel_path).file_name().unwrap();
+            fs::write(dir.join(name), b"dummy").unwrap();
+        }
+        assert!(is_cached_in(ModelKind::Asr, &dir));
+    }
+
+    #[test]
+    fn is_cached_in_asr_false_when_one_file_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/parakeet-tdt-v3");
+        fs::create_dir_all(&dir).unwrap();
+        // Write all but the last file.
+        for f in &ASR_FILES[..ASR_FILES.len() - 1] {
+            let name = std::path::Path::new(f.rel_path).file_name().unwrap();
+            fs::write(dir.join(name), b"dummy").unwrap();
+        }
+        assert!(!is_cached_in(ModelKind::Asr, &dir));
+    }
+
+    #[test]
+    fn is_cached_in_lang_id_true_when_all_files_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/lang-id-ecapa");
+        fs::create_dir_all(&dir).unwrap();
+        for f in LANG_ID_FILES {
+            let name = std::path::Path::new(f.rel_path).file_name().unwrap();
+            fs::write(dir.join(name), b"dummy").unwrap();
+        }
+        assert!(is_cached_in(ModelKind::LangId, &dir));
+    }
+
+    #[test]
+    fn is_cached_in_vad_true_when_file_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/silero-vad");
+        fs::create_dir_all(&dir).unwrap();
+        for f in VAD_FILES {
+            let name = std::path::Path::new(f.rel_path).file_name().unwrap();
+            fs::write(dir.join(name), b"dummy").unwrap();
+        }
+        assert!(is_cached_in(ModelKind::Vad, &dir));
+    }
+
+    #[test]
+    fn is_cached_in_vad_false_when_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/silero-vad");
+        fs::create_dir_all(&dir).unwrap();
+        assert!(!is_cached_in(ModelKind::Vad, &dir));
+    }
+
+    // ── has_vosk_ru_layout via is_cached_in ──────────────────────────────────
+
+    #[cfg(feature = "tts")]
+    #[test]
+    fn is_cached_in_vosk_ru_true_when_layout_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/vosk-ru");
+        fs::create_dir_all(dir.join("bert")).unwrap();
+        fs::write(dir.join("model.onnx"), b"dummy").unwrap();
+        fs::write(dir.join("dictionary"), b"dummy").unwrap();
+        fs::write(dir.join("bert/model.onnx"), b"dummy").unwrap();
+        assert!(is_cached_in(ModelKind::VoskRu, &dir));
+    }
+
+    #[cfg(feature = "tts")]
+    #[test]
+    fn is_cached_in_vosk_ru_false_when_bert_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/vosk-ru");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("model.onnx"), b"dummy").unwrap();
+        fs::write(dir.join("dictionary"), b"dummy").unwrap();
+        // bert/model.onnx absent
+        assert!(!is_cached_in(ModelKind::VoskRu, &dir));
+    }
+
+    // ── multilang_voice direct ────────────────────────────────────────────────
+
+    #[cfg(all(
+        feature = "tts",
+        not(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))
+    ))]
+    #[test]
+    fn multilang_voice_returns_expected_packs() {
+        // es → em_alex.bin (male ✓)
+        let es = multilang_voice("es").unwrap();
+        assert!(es.rel_path.ends_with("em_alex.bin"), "{}", es.rel_path);
+        // fr → ff_siwis.bin (female, brand-rule exception)
+        let fr = multilang_voice("fr").unwrap();
+        assert!(fr.rel_path.ends_with("ff_siwis.bin"), "{}", fr.rel_path);
+        // it → im_nicola.bin (male ✓)
+        let it = multilang_voice("it").unwrap();
+        assert!(it.rel_path.ends_with("im_nicola.bin"), "{}", it.rel_path);
+        // pt → pm_alex.bin (male ✓)
+        let pt = multilang_voice("pt").unwrap();
+        assert!(pt.rel_path.ends_with("pm_alex.bin"), "{}", pt.rel_path);
+        // ru and de → None (not in multilang Kokoro)
+        assert!(multilang_voice("ru").is_none());
+        assert!(multilang_voice("de").is_none());
+    }
+
+    // ── ane_voice_lang direct ─────────────────────────────────────────────────
+
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    #[test]
+    fn ane_voice_lang_maps_prefixes_correctly() {
+        assert_eq!(ane_voice_lang("am_michael.bin"), Some("en"));
+        assert_eq!(ane_voice_lang("bm_george.bin"), Some("en"));
+        assert_eq!(ane_voice_lang("em_alex.bin"), Some("es"));
+        assert_eq!(ane_voice_lang("ff_siwis.bin"), Some("fr"));
+        assert_eq!(ane_voice_lang("hm_test.bin"), Some("hi"));
+        assert_eq!(ane_voice_lang("im_nicola.bin"), Some("it"));
+        assert_eq!(ane_voice_lang("jm_test.bin"), Some("ja"));
+        assert_eq!(ane_voice_lang("pm_alex.bin"), Some("pt"));
+        assert_eq!(ane_voice_lang("zm_050.bin"), Some("zh"));
+        // Unknown prefix → None
+        assert_eq!(ane_voice_lang("xm_unknown.bin"), None);
+        assert_eq!(ane_voice_lang(""), None);
+    }
+}

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -288,17 +288,34 @@ pub fn transcribe_with_options(
     Ok(output)
 }
 
+/// Load the ASR backend, logging the load time. Shared by the plain and chunked
+/// paths, which contain identical timing+logging+create_backend blocks.
+fn create_timed_backend(model_dir: &str) -> Result<Box<dyn backend::TranscribeBackend>> {
+    let t0 = Instant::now();
+    let be = backend::create_backend(model_dir)?;
+    let dt_ms = t0.elapsed().as_millis() as u64;
+    dtrace!("asr::backend_loaded dt={dt_ms}ms");
+    dtrace_json!("asr.backend_loaded", { "dt_ms": dt_ms });
+    Ok(be)
+}
+
+/// Join segment texts with a single space separator. Used on both the VAD and
+/// chunked paths to stitch per-span transcripts into a single string.
+fn join_segment_texts(segments: &[TranscriptionSegment]) -> String {
+    segments
+        .iter()
+        .map(|s| s.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn transcribe_plain(
     audio_path: &str,
     model_dir: &str,
     duration: Option<f32>,
     timestamps_required: bool,
 ) -> Result<TranscriptionOutput> {
-    let t0 = Instant::now();
-    let mut be = backend::create_backend(model_dir)?;
-    let dt_ms = t0.elapsed().as_millis() as u64;
-    dtrace!("asr::backend_loaded dt={dt_ms}ms");
-    dtrace_json!("asr.backend_loaded", { "dt_ms": dt_ms });
+    let mut be = create_timed_backend(model_dir)?;
     let t1 = Instant::now();
     let text = be.transcribe(audio_path)?;
     dtrace!(
@@ -333,11 +350,7 @@ fn transcribe_chunked(
         samples.len()
     );
 
-    let t0 = Instant::now();
-    let mut be = backend::create_backend(model_dir)?;
-    let dt_ms = t0.elapsed().as_millis() as u64;
-    dtrace!("asr::backend_loaded dt={dt_ms}ms");
-    dtrace_json!("asr.backend_loaded", { "dt_ms": dt_ms });
+    let mut be = create_timed_backend(model_dir)?;
 
     transcribe_chunked_samples(&samples, &mut |slice| be.transcribe_samples(slice)).map(
         |mut output| {
@@ -430,11 +443,7 @@ fn transcribe_via_vad(
             be.transcribe_samples(slice)
         });
 
-    let text = output_segments
-        .iter()
-        .map(|s| s.text.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let text = join_segment_texts(&output_segments);
 
     Ok(TranscriptionOutput {
         text,
@@ -510,11 +519,7 @@ where
         FIXED_CHUNK_OVERLAP_SECONDS,
         transcribe_chunk,
     )?;
-    let text = segments
-        .iter()
-        .map(|s| s.text.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let text = join_segment_texts(&segments);
     Ok(TranscriptionOutput { text, segments })
 }
 
@@ -1309,5 +1314,168 @@ mod tests {
                 },
             }
         }
+    }
+
+    // ── trim_repeated_prefix characterization tests ─────────────────────────
+
+    #[test]
+    fn trim_repeated_prefix_empty_prev_returns_current_unchanged() {
+        assert_eq!(trim_repeated_prefix("", "hello world"), "hello world");
+    }
+
+    #[test]
+    fn trim_repeated_prefix_overlap_below_min_chars_not_stripped() {
+        // CHUNK_DEDUP_MIN_CHARS = 8; a 7-char overlap must NOT be stripped.
+        let prev = "abcdefg";
+        let curr = "abcdefg extra";
+        assert_eq!(trim_repeated_prefix(prev, curr), "abcdefg extra");
+    }
+
+    #[test]
+    fn trim_repeated_prefix_exactly_min_chars_is_stripped() {
+        // CHUNK_DEDUP_MIN_CHARS = 8; an exactly-8-char overlap must be stripped.
+        let prev = "abcdefgh";
+        let curr = "abcdefgh more";
+        assert_eq!(trim_repeated_prefix(prev, curr), "more");
+    }
+
+    #[test]
+    fn trim_repeated_prefix_case_insensitive() {
+        let prev = "Hello World";
+        let curr = "hello world continuation";
+        assert_eq!(trim_repeated_prefix(prev, curr), "continuation");
+    }
+
+    #[test]
+    fn trim_repeated_prefix_multi_byte_boundary_no_panic() {
+        // Cyrillic: each character is 2 bytes. The function must not panic when
+        // scanning char boundaries through a multibyte string.
+        let prev = "привет мир"; // 10 chars, 19 bytes
+        let curr = "привет мир продолжение";
+        // overlap "привет мир" is 10 chars = 19 bytes ≥ CHUNK_DEDUP_MIN_CHARS (8) → stripped
+        let result = trim_repeated_prefix(prev, curr);
+        assert!(
+            !result.contains("привет мир"),
+            "overlap should be stripped: {result}"
+        );
+    }
+
+    // ── fixed_chunk_windows guard tests ─────────────────────────────────────
+
+    #[test]
+    fn fixed_chunk_windows_total_zero_returns_empty() {
+        assert!(fixed_chunk_windows(
+            0,
+            16_000.0,
+            FIXED_CHUNK_SECONDS,
+            FIXED_CHUNK_OVERLAP_SECONDS
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn fixed_chunk_windows_sr_zero_returns_empty() {
+        assert!(fixed_chunk_windows(
+            16_000,
+            0.0,
+            FIXED_CHUNK_SECONDS,
+            FIXED_CHUNK_OVERLAP_SECONDS
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn fixed_chunk_windows_chunk_zero_returns_empty() {
+        assert!(fixed_chunk_windows(16_000, 16_000.0, 0.0, FIXED_CHUNK_OVERLAP_SECONDS).is_empty());
+    }
+
+    #[test]
+    fn fixed_chunk_windows_overlap_ge_chunk_clamped_no_infinite_loop() {
+        // overlap ≥ chunk → step clamped to 1; must terminate and cover all samples.
+        let windows = fixed_chunk_windows(100, 10.0, 1.0, 5.0);
+        assert!(!windows.is_empty(), "should produce at least one window");
+        // last window must reach the end
+        assert_eq!(windows.last().unwrap().input_end, 100);
+    }
+
+    #[test]
+    fn fixed_chunk_windows_single_chunk_when_total_le_chunk_samples() {
+        // 5 samples, chunk = 1.0 s × 10 Hz = 10 samples → only one window needed.
+        let windows = fixed_chunk_windows(5, 10.0, 1.0, 0.0);
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].input_start, 0);
+        assert_eq!(windows[0].input_end, 5);
+    }
+
+    // ── validate_plain_transcribe_safety exact boundary test ─────────────────
+
+    #[test]
+    fn validate_plain_transcribe_safety_exact_boundary_off() {
+        // At exactly FULL_FILE_SINGLE_PASS_MAX_SECONDS with VadMode::Off, must reject.
+        let err = validate_plain_transcribe_safety(
+            VadMode::Off,
+            Some(FULL_FILE_SINGLE_PASS_MAX_SECONDS),
+            false,
+        )
+        .expect_err("exact boundary must be rejected");
+        assert!(err.to_string().contains("refusing --no-vad"), "{err}");
+    }
+
+    // ── decide at exactly AUTO_VAD_MIN_SECONDS without VAD ───────────────────
+
+    #[test]
+    fn decide_at_exactly_auto_vad_min_seconds_without_vad_gives_plain_with_hint() {
+        // At exactly AUTO_VAD_MIN_SECONDS with vad_installed=false → PlainWithHint.
+        assert_eq!(
+            decide(VadMode::Auto, Some(AUTO_VAD_MIN_SECONDS), false),
+            VadDecision::PlainWithHint
+        );
+    }
+
+    // ── TranscriptionOutput JSON round-trip ──────────────────────────────────
+
+    #[test]
+    fn transcription_output_json_round_trip() {
+        let original = TranscriptionOutput {
+            text: "hello world".to_string(),
+            segments: vec![TranscriptionSegment {
+                start: 0.0,
+                end: 1.5,
+                text: "hello world".to_string(),
+                speaker: Some(1),
+            }],
+        };
+        let json = serde_json::to_string(&original).expect("serialise");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["text"], "hello world");
+        assert_eq!(parsed["segments"][0]["start"], 0.0);
+        assert_eq!(parsed["segments"][0]["end"], 1.5);
+        assert_eq!(parsed["segments"][0]["speaker"], 1);
+    }
+
+    // ── join_segment_texts ───────────────────────────────────────────────────
+
+    #[test]
+    fn join_segment_texts_empty_slice() {
+        assert_eq!(join_segment_texts(&[]), "");
+    }
+
+    #[test]
+    fn join_segment_texts_joins_with_space() {
+        let segs = vec![
+            TranscriptionSegment {
+                start: 0.0,
+                end: 1.0,
+                text: "foo".to_string(),
+                speaker: None,
+            },
+            TranscriptionSegment {
+                start: 1.0,
+                end: 2.0,
+                text: "bar".to_string(),
+                speaker: None,
+            },
+        ];
+        assert_eq!(join_segment_texts(&segs), "foo bar");
     }
 }

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -150,11 +150,10 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
 /// Shared Kokoro path-construction + existence-check used by both the English
 /// (`resolve_kokoro`) and the multilingual (`resolve_multilang_kokoro`) paths.
 /// Keeps error messages identical between the two callers.
-#[cfg(not(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-)))]
+///
+/// Unconditional (no cfg gate): `resolve_kokoro` references it even on
+/// `system_kokoro` builds, inside its `#[allow(unreachable_code)]` ONNX
+/// fallback (which still compiles), so gating it out breaks that build.
 fn build_kokoro_voice(
     cache_dir: &Path,
     voice_id: &str,

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -147,6 +147,44 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
     }
 }
 
+/// Shared Kokoro path-construction + existence-check used by both the English
+/// (`resolve_kokoro`) and the multilingual (`resolve_multilang_kokoro`) paths.
+/// Keeps error messages identical between the two callers.
+#[cfg(not(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+)))]
+fn build_kokoro_voice(
+    cache_dir: &Path,
+    voice_id: &str,
+    pack_name: &str,
+    espeak_lang: &'static str,
+) -> anyhow::Result<ResolvedVoice> {
+    let model_path = cache_dir.join("models/kokoro-82m/model.onnx");
+    let voice_path = cache_dir
+        .join("models/kokoro-82m/voices")
+        .join(format!("{pack_name}.bin"));
+    if !voice_path.exists() {
+        coded_bail!(
+            ErrorCode::ModelMissing,
+            "voice '{voice_id}' not installed. run: kesha install --tts"
+        );
+    }
+    if !model_path.exists() {
+        coded_bail!(
+            ErrorCode::ModelMissing,
+            "kokoro model not installed at {}. run: kesha install --tts",
+            model_path.display()
+        );
+    }
+    Ok(ResolvedVoice::Kokoro {
+        model_path,
+        voice_path,
+        espeak_lang,
+    })
+}
+
 /// ONNX Kokoro path for es/fr/it/pt voices. Uses the same model graph as
 /// `resolve_kokoro` but picks the language-appropriate voice pack and passes
 /// the correct espeak language code so CharsiuG2P receives the right language.
@@ -184,30 +222,7 @@ fn resolve_multilang_kokoro(
         _ => unreachable!("resolve_multilang_kokoro called with unexpected lang '{lang}'"),
     };
 
-    let model_path = cache_dir.join("models/kokoro-82m/model.onnx");
-    let voice_path = cache_dir
-        .join("models/kokoro-82m/voices")
-        .join(format!("{resolved_name}.bin"));
-
-    if !voice_path.exists() {
-        coded_bail!(
-            ErrorCode::ModelMissing,
-            "voice '{voice_id}' not installed. run: kesha install --tts"
-        );
-    }
-    if !model_path.exists() {
-        coded_bail!(
-            ErrorCode::ModelMissing,
-            "kokoro model not installed at {}. run: kesha install --tts",
-            model_path.display()
-        );
-    }
-
-    Ok(ResolvedVoice::Kokoro {
-        model_path,
-        voice_path,
-        espeak_lang,
-    })
+    build_kokoro_voice(cache_dir, voice_id, resolved_name, espeak_lang)
 }
 
 /// Default voice pack name (without `.bin`) for each supported non-English
@@ -243,30 +258,7 @@ fn resolve_kokoro(_cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Resu
         return resolve_fluid_kokoro(voice_id);
     }
     #[allow(unreachable_code)]
-    {
-        let model_path = _cache_dir.join("models/kokoro-82m/model.onnx");
-        let voice_path = _cache_dir
-            .join("models/kokoro-82m/voices")
-            .join(format!("{name}.bin"));
-        if !voice_path.exists() {
-            coded_bail!(
-                ErrorCode::ModelMissing,
-                "voice '{voice_id}' not installed. run: kesha install --tts"
-            );
-        }
-        if !model_path.exists() {
-            coded_bail!(
-                ErrorCode::ModelMissing,
-                "kokoro model not installed at {}. run: kesha install --tts",
-                model_path.display()
-            );
-        }
-        Ok(ResolvedVoice::Kokoro {
-            model_path,
-            voice_path,
-            espeak_lang: "en-us",
-        })
-    }
+    build_kokoro_voice(_cache_dir, voice_id, name, "en-us")
 }
 
 #[cfg(all(
@@ -755,80 +747,38 @@ mod tests {
 
     // Test that each language defaults to the expected voice when name is empty.
     // Voice id "es-" splits to lang="es", name="" — triggers default_voice_for_lang.
+    // Also verifies that the resolved espeak_lang matches the language prefix (gap test).
     #[cfg(not(all(
         feature = "system_kokoro",
         target_os = "macos",
         target_arch = "aarch64"
     )))]
     #[test]
-    fn multilang_default_voice_for_lang_es() {
+    fn multilang_default_voice_for_lang() {
+        // (lang_prefix, expected_pack, expected_espeak)
+        let cases: &[(&str, &str, &str)] = &[
+            // em_alex (es, male ✓); espeak "es"
+            ("es", "em_alex", "es"),
+            // ff_siwis (fr, female — brand-rule exception, sole Kokoro v1.0 French voice)
+            ("fr", "ff_siwis", "fr"),
+            // im_nicola (it, male ✓); espeak "it"
+            ("it", "im_nicola", "it"),
+            // pm_alex (pt, male ✓); espeak "pt"
+            ("pt", "pm_alex", "pt"),
+        ];
         let tmp = tempfile::tempdir().unwrap();
         populate_multilang_cache(tmp.path());
-        // "es-" → name="" → default_voice_for_lang("es") = "em_alex"
-        let r = resolve_voice(tmp.path(), "es-").unwrap();
-        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
-        assert!(
-            voice_path.ends_with("em_alex.bin"),
-            "wrong voice_path: {voice_path:?}"
-        );
-        assert_eq!(espeak_lang, "es");
-    }
-
-    #[cfg(not(all(
-        feature = "system_kokoro",
-        target_os = "macos",
-        target_arch = "aarch64"
-    )))]
-    #[test]
-    fn multilang_default_voice_for_lang_fr() {
-        let tmp = tempfile::tempdir().unwrap();
-        populate_multilang_cache(tmp.path());
-        // "fr-" → name="" → default_voice_for_lang("fr") = "ff_siwis"
-        let r = resolve_voice(tmp.path(), "fr-").unwrap();
-        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
-        assert!(
-            voice_path.ends_with("ff_siwis.bin"),
-            "wrong voice_path: {voice_path:?}"
-        );
-        assert_eq!(espeak_lang, "fr");
-    }
-
-    #[cfg(not(all(
-        feature = "system_kokoro",
-        target_os = "macos",
-        target_arch = "aarch64"
-    )))]
-    #[test]
-    fn multilang_default_voice_for_lang_it() {
-        let tmp = tempfile::tempdir().unwrap();
-        populate_multilang_cache(tmp.path());
-        // "it-" → name="" → default_voice_for_lang("it") = "im_nicola"
-        let r = resolve_voice(tmp.path(), "it-").unwrap();
-        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
-        assert!(
-            voice_path.ends_with("im_nicola.bin"),
-            "wrong voice_path: {voice_path:?}"
-        );
-        assert_eq!(espeak_lang, "it");
-    }
-
-    #[cfg(not(all(
-        feature = "system_kokoro",
-        target_os = "macos",
-        target_arch = "aarch64"
-    )))]
-    #[test]
-    fn multilang_default_voice_for_lang_pt() {
-        let tmp = tempfile::tempdir().unwrap();
-        populate_multilang_cache(tmp.path());
-        // "pt-" → name="" → default_voice_for_lang("pt") = "pm_alex"
-        let r = resolve_voice(tmp.path(), "pt-").unwrap();
-        let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
-        assert!(
-            voice_path.ends_with("pm_alex.bin"),
-            "wrong voice_path: {voice_path:?}"
-        );
-        assert_eq!(espeak_lang, "pt");
+        for &(lang, expected_pack, expected_espeak) in cases {
+            let voice_id = format!("{lang}-");
+            let r = resolve_voice(tmp.path(), &voice_id)
+                .unwrap_or_else(|e| panic!("{voice_id} failed: {e}"));
+            let (_, voice_path, espeak_lang) = unwrap_kokoro(r);
+            assert!(
+                voice_path.ends_with(format!("{expected_pack}.bin").as_str()),
+                "{lang}: wrong voice_path {voice_path:?}"
+            );
+            assert_eq!(espeak_lang, expected_espeak, "{lang}: wrong espeak_lang");
+        }
     }
 
     // Test the "voice file present but model.onnx missing" branch in resolve_multilang_kokoro.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,9 +35,6 @@ export {
   shouldRunAudioLanguageDetection,
   shouldReportTranscribeProgress,
   validateTranscribeArgs,
-  detectLanguages,
-  processFile,
-  writeOutput,
 } from "./cli/main";
 export type { ResolvedOutputFormat, ValidatedTranscribeArgs } from "./cli/main";
 export { runCli } from "./cli/dispatch";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,8 +34,12 @@ export {
   resolveOutputFormat,
   shouldRunAudioLanguageDetection,
   shouldReportTranscribeProgress,
+  validateTranscribeArgs,
+  detectLanguages,
+  processFile,
+  writeOutput,
 } from "./cli/main";
-export type { ResolvedOutputFormat } from "./cli/main";
+export type { ResolvedOutputFormat, ValidatedTranscribeArgs } from "./cli/main";
 export { runCli } from "./cli/dispatch";
 
 export type {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -50,7 +50,7 @@ export function detectLanguage(text: string): string {
 /**
  * Pure validation + normalization of the output-format selection. Pulled
  * out of the citty `run` handler so the contract is unit-testable without
- * spawning the CLI binary; the handler just owns the side effects
+ * spawning the CLI binary; the handler just owns the side-effect arms
  * (log.error + process.exit) when this returns `{ ok: false }`.
  *
  * Inputs accept the three knobs the user can flip:
@@ -143,6 +143,270 @@ export function shouldRunAudioLanguageDetection(input: {
   if (!input.wantsLangId) return false;
   if (input.transcriptDurationSeconds === null) return true;
   return input.transcriptDurationSeconds <= AUDIO_LANG_ID_LONG_AUDIO_THRESHOLD_SECONDS;
+}
+
+export type ValidatedTranscribeArgs = {
+  vadMode: "on" | "off" | "auto";
+  outputFormat: "json" | "toon" | "transcript" | "text";
+};
+
+/**
+ * Validates the transcribe-specific flags that require cross-flag consistency
+ * checks beyond what citty can express. Calls `log.error` + `process.exit(2)`
+ * on any violation — matching the original inline behavior byte-for-byte.
+ *
+ * Owns:
+ * - --vad / --no-vad mutex (requires rawArgs to detect the explicit --no-vad)
+ * - --timestamps / --speakers guards (require machine-readable output)
+ * - --include-errors guard (requires --json)
+ * - derivation of `vadMode` and `outputFormat`
+ */
+export function validateTranscribeArgs(
+  args: MainCommandArgs,
+  rawArgs: string[],
+  fmt: ResolvedOutputFormat & { ok: true },
+): ValidatedTranscribeArgs {
+  const { wantsJson, wantsToon, wantsTranscript } = fmt;
+
+  // citty treats --no-vad as the negated form of --vad, so read rawArgs
+  // to distinguish "off" from the default auto mode and to catch both flags.
+  const vad = rawArgs.includes("--vad") || Boolean(args.vad);
+  const noVad = rawArgs.includes("--no-vad") || Boolean(args["no-vad"] ?? args.noVad ?? args.no_vad);
+
+  if (vad && noVad) {
+    log.error("--vad and --no-vad are mutually exclusive.");
+    process.exit(2);
+  }
+  if (args.timestamps && !(wantsJson || wantsToon)) {
+    log.error("--timestamps requires --json, --toon, or --format {json,toon}.");
+    process.exit(2);
+  }
+  if (args.speakers && !(wantsJson || wantsToon)) {
+    log.error("--speakers requires --json, --toon, or --format {json,toon}.");
+    process.exit(2);
+  }
+  if (args["include-errors"] && !wantsJson) {
+    log.error("--include-errors requires --json or --format json.");
+    process.exit(2);
+  }
+
+  const vadMode: ValidatedTranscribeArgs["vadMode"] = vad ? "on" : noVad ? "off" : "auto";
+  const outputFormat: ValidatedTranscribeArgs["outputFormat"] = wantsJson
+    ? "json"
+    : wantsToon
+      ? "toon"
+      : wantsTranscript
+        ? "transcript"
+        : "text";
+
+  return { vadMode, outputFormat };
+}
+
+/**
+ * Runs audio + text language detection for a single transcript, applying the
+ * long-audio skip guard and both checkLanguageMismatch calls.
+ *
+ * Returns `{ audioLanguage, textLanguage, lang }` — the caller owns building
+ * the final `TranscribeResult`.
+ */
+export async function detectLanguages(
+  file: string,
+  text: string,
+  options: {
+    wantsLangId: boolean;
+    expectedLang?: string;
+    progress: ReturnType<typeof createPercentProgress> | null;
+    stats: ReturnType<typeof createStatsRecorder>;
+    transcriptDurationSeconds: number | null;
+  },
+): Promise<{
+  audioLanguage: LangDetectResult | undefined;
+  textLanguage: LangDetectResult | undefined;
+  lang: string;
+  ranAudioLangId: boolean;
+}> {
+  const { wantsLangId, expectedLang, progress, stats, transcriptDurationSeconds } = options;
+
+  let audioResult: LangDetectResult | null = null;
+  if (shouldRunAudioLanguageDetection({ wantsLangId, transcriptDurationSeconds })) {
+    audioResult = await stats.timeStage("lang_id_audio", () => detectAudioLanguageEngine(file));
+  } else if (wantsLangId) {
+    log.debug(
+      `skip lang_id_audio for ${file}: transcript duration ${transcriptDurationSeconds?.toFixed(1)}s exceeds ` +
+        `${AUDIO_LANG_ID_LONG_AUDIO_THRESHOLD_SECONDS}s`,
+    );
+  }
+
+  let audioLanguage: LangDetectResult | undefined;
+  if (audioResult && audioResult.code) {
+    audioLanguage = audioResult;
+  }
+
+  if (audioLanguage && expectedLang && audioLanguage.confidence > 0.8) {
+    const mismatch = checkLanguageMismatch(expectedLang, audioLanguage.code);
+    if (mismatch) {
+      progress?.interrupt(() => log.warn(`${file}: ${mismatch} (from audio)`));
+    }
+  }
+
+  const tinyldLang = wantsLangId ? detectLanguage(text) : "";
+  let textLanguage: LangDetectResult | undefined;
+
+  if (wantsLangId) {
+    const engineTextResult = await stats.timeStage("lang_id_text", () => detectTextLanguageEngine(text));
+    if (engineTextResult && engineTextResult.code) {
+      textLanguage = engineTextResult;
+    }
+  }
+
+  const lang = textLanguage?.code || tinyldLang;
+
+  const mismatchWarning = checkLanguageMismatch(expectedLang, lang);
+  if (mismatchWarning) {
+    progress?.interrupt(() => log.warn(`${file}: ${mismatchWarning}`));
+  }
+
+  return {
+    audioLanguage,
+    textLanguage: textLanguage ?? (tinyldLang ? { code: tinyldLang, confidence: 0 } : undefined),
+    lang,
+    ranAudioLangId: audioResult !== null,
+  };
+}
+
+type ProcessFileOptions = {
+  vadMode: "on" | "off" | "auto";
+  timestamps: boolean;
+  speakers: boolean;
+  wantsLangId: boolean;
+  expectedLang?: string;
+  reportProgress: boolean;
+};
+
+type ProcessFileRecorders = {
+  stats: ReturnType<typeof createStatsRecorder>;
+  diagnosticLog: ReturnType<typeof createDiagnosticLogSession>;
+};
+
+type ProcessFileSuccess = { ok: true; result: TranscribeResult };
+type ProcessFileFailure = { ok: false; error: TranscribeErrorRecord };
+
+/**
+ * Processes a single audio file: existence check, engine call, lang detection,
+ * diagnostic events. Returns a discriminated union so the caller can push to
+ * the appropriate bucket without catching.
+ */
+export async function processFile(
+  file: string,
+  options: ProcessFileOptions,
+  recorders: ProcessFileRecorders,
+): Promise<ProcessFileSuccess | ProcessFileFailure> {
+  const { vadMode, timestamps, speakers, wantsLangId, expectedLang, reportProgress } = options;
+  const { stats, diagnosticLog } = recorders;
+
+  if (!existsSync(file)) {
+    stats.recordError("input", new Error("File not found"), TS_NATIVE_CODES.INPUT_NOT_FOUND);
+    diagnosticLog.event("input.missing", {
+      command: "transcribe",
+      error_code: TS_NATIVE_CODES.INPUT_NOT_FOUND,
+    });
+    log.error(`${file}: File not found`);
+    return { ok: false, error: { file, code: TS_NATIVE_CODES.INPUT_NOT_FOUND, message: "File not found" } };
+  }
+
+  const inputArtifact = artifactFromFile(file, "input_audio");
+  if (inputArtifact) {
+    stats.recordArtifact(inputArtifact);
+    diagnosticLog.event("input.audio", {
+      command: "transcribe",
+      format: inputArtifact.format || null,
+      sizeBucket: diagnosticSizeBucket(inputArtifact.sizeBytes),
+    });
+  }
+
+  const startedAt = performance.now();
+  let progress: ReturnType<typeof createPercentProgress> | null = null;
+  try {
+    await preflightTranscribeWithSegments({ vad: vadMode, timestamps, speakers });
+    progress = reportProgress
+      ? createPercentProgress(`Transcribing ${file}`, {
+          estimatedTotalMs: speakers ? 60 * 60 * 1000 : 30 * 60 * 1000,
+        })
+      : null;
+    const transcript = await stats.timeStage("transcribe", () =>
+      transcribeWithSegments(file, { vad: vadMode, timestamps, speakers }),
+    );
+    const { text, segments } = transcript;
+    const transcriptDurationSeconds = estimateTranscriptDurationSeconds(segments);
+
+    const { audioLanguage, textLanguage, lang, ranAudioLangId } = await detectLanguages(file, text, {
+      wantsLangId,
+      expectedLang,
+      progress,
+      stats,
+      transcriptDurationSeconds,
+    });
+
+    const sttTimeMs = Math.round(performance.now() - startedAt);
+    const result: TranscribeResult = {
+      file,
+      text,
+      lang,
+      audioLanguage,
+      textLanguage,
+      sttTimeMs,
+    };
+    if (timestamps || speakers) {
+      result.segments = segments;
+    }
+
+    diagnosticLog.event("engine.exit", {
+      command: "transcribe",
+      status: "success",
+      durationMs: sttTimeMs,
+      segmentCount: segments.length,
+      ranAudioLangId,
+      ranTxtLangId: textLanguage !== undefined,
+    });
+    progress?.finish(`Transcribed ${file}`);
+    return { ok: true, result };
+  } catch (err: unknown) {
+    progress?.stop();
+    const stderrText = errorMessage(err);
+    const code = extractEngineErrorCode(stderrText) ?? ENGINE_CODES.TRANSCRIBE_FAILED;
+    stats.recordError("transcribe", err, code);
+    diagnosticLog.event("engine.exit", {
+      command: "transcribe",
+      status: "failed",
+      errorKind: "transcribe_failed",
+      error_code: code,
+    });
+    log.error(`${file}: ${stderrText}`);
+    return { ok: false, error: { file, code, message: stderrText } };
+  }
+}
+
+/**
+ * Writes the final output to stdout in the requested format.
+ * The `verbose` flag is only consulted for the plain-text fallback path.
+ */
+export function writeOutput(
+  results: TranscribeResult[],
+  errors: TranscribeErrorRecord[],
+  format: ValidatedTranscribeArgs["outputFormat"],
+  opts: { includeErrors: boolean; verbose: boolean },
+): void {
+  if (format === "json") {
+    process.stdout.write(formatJsonOutput(results, opts.includeErrors ? errors : undefined));
+  } else if (format === "toon") {
+    process.stdout.write(formatToonOutput(results));
+  } else if (format === "transcript") {
+    process.stdout.write(formatTranscriptOutput(results));
+  } else if (opts.verbose) {
+    process.stdout.write(formatVerboseOutput(results));
+  } else {
+    process.stdout.write(formatTextOutput(results));
+  }
 }
 
 export const mainCommand = defineCommand({
@@ -260,31 +524,8 @@ export const mainCommand = defineCommand({
       log.error(fmt.error);
       process.exit(2);
     }
-    const { wantsJson, wantsToon, wantsTranscript } = fmt;
 
-    // citty treats --no-vad as the negated form of --vad, so read rawArgs
-    // to distinguish "off" from the default auto mode and to catch both flags.
-    const vad = rawArgs.includes("--vad") || Boolean(args.vad);
-    const noVad = rawArgs.includes("--no-vad") || Boolean(args["no-vad"] ?? args.noVad ?? args.no_vad);
-
-    if (vad && noVad) {
-      log.error("--vad and --no-vad are mutually exclusive.");
-      process.exit(2);
-    }
-    if (args.timestamps && !(wantsJson || wantsToon)) {
-      log.error("--timestamps requires --json, --toon, or --format {json,toon}.");
-      process.exit(2);
-    }
-    if (args.speakers && !(wantsJson || wantsToon)) {
-      log.error("--speakers requires --json, --toon, or --format {json,toon}.");
-      process.exit(2);
-    }
-    if (args["include-errors"] && !wantsJson) {
-      log.error("--include-errors requires --json or --format json.");
-      process.exit(2);
-    }
-    const vadMode = vad ? "on" : noVad ? "off" : "auto";
-    const outputFormat = wantsJson ? "json" : wantsToon ? "toon" : wantsTranscript ? "transcript" : "text";
+    const { vadMode, outputFormat } = validateTranscribeArgs(args, rawArgs, fmt);
 
     if (files.length === 0) {
       log.info(
@@ -319,7 +560,7 @@ export const mainCommand = defineCommand({
       hasExpectedLang: Boolean(args.lang),
     });
 
-    const wantsLangId = !!(args.lang || args.verbose || wantsJson || wantsToon || wantsTranscript);
+    const wantsLangId = !!(args.lang || args.verbose || fmt.wantsJson || fmt.wantsToon || fmt.wantsTranscript);
     const reportProgress = shouldReportTranscribeProgress({
       stderrIsTty: process.stderr.isTTY === true,
       stdoutIsTty: process.stdout.isTTY === true,
@@ -328,140 +569,30 @@ export const mainCommand = defineCommand({
     });
 
     for (const file of files) {
-      if (!existsSync(file)) {
-        hasError = true;
-        stats.recordError("input", new Error("File not found"), TS_NATIVE_CODES.INPUT_NOT_FOUND);
-        diagnosticLog.event("input.missing", {
-          command: "transcribe",
-          error_code: TS_NATIVE_CODES.INPUT_NOT_FOUND,
-        });
-        errors.push({ file, code: TS_NATIVE_CODES.INPUT_NOT_FOUND, message: "File not found" });
-        log.error(`${file}: File not found`);
-        continue;
-      }
-      const inputArtifact = artifactFromFile(file, "input_audio");
-      if (inputArtifact) {
-        stats.recordArtifact(inputArtifact);
-        diagnosticLog.event("input.audio", {
-          command: "transcribe",
-          format: inputArtifact.format || null,
-          sizeBucket: diagnosticSizeBucket(inputArtifact.sizeBytes),
-        });
-      }
-
-      const startedAt = performance.now();
-      let progress: ReturnType<typeof createPercentProgress> | null = null;
-      try {
-        await preflightTranscribeWithSegments({
-          vad: vadMode,
+      const outcome = await processFile(
+        file,
+        {
+          vadMode,
           timestamps: args.timestamps,
           speakers: args.speakers,
-        });
-        progress = reportProgress
-          ? createPercentProgress(`Transcribing ${file}`, {
-              estimatedTotalMs: args.speakers ? 60 * 60 * 1000 : 30 * 60 * 1000,
-            })
-          : null;
-        const transcript = await stats.timeStage("transcribe", () =>
-          transcribeWithSegments(file, {
-            vad: vadMode,
-            timestamps: args.timestamps,
-            speakers: args.speakers,
-          })
-        );
-        const { text, segments } = transcript;
-        const transcriptDurationSeconds = estimateTranscriptDurationSeconds(segments);
-
-        let audioResult: LangDetectResult | null = null;
-        if (shouldRunAudioLanguageDetection({ wantsLangId, transcriptDurationSeconds })) {
-          audioResult = await stats.timeStage("lang_id_audio", () => detectAudioLanguageEngine(file));
-        } else if (wantsLangId) {
-          log.debug(
-            `skip lang_id_audio for ${file}: transcript duration ${transcriptDurationSeconds?.toFixed(1)}s exceeds ` +
-              `${AUDIO_LANG_ID_LONG_AUDIO_THRESHOLD_SECONDS}s`,
-          );
-        }
-
-        let audioLanguage: LangDetectResult | undefined;
-        if (audioResult && audioResult.code) {
-          audioLanguage = audioResult;
-        }
-
-        if (audioLanguage && args.lang && audioLanguage.confidence > 0.8) {
-          const mismatch = checkLanguageMismatch(args.lang, audioLanguage.code);
-          if (mismatch) {
-            progress?.interrupt(() => log.warn(`${file}: ${mismatch} (from audio)`));
-          }
-        }
-
-        const tinyldLang = wantsLangId ? detectLanguage(text) : "";
-        let textLanguage: LangDetectResult | undefined;
-
-        if (wantsLangId) {
-          const engineTextResult = await stats.timeStage("lang_id_text", () => detectTextLanguageEngine(text));
-          if (engineTextResult && engineTextResult.code) {
-            textLanguage = engineTextResult;
-          }
-        }
-
-        const lang = textLanguage?.code || tinyldLang;
-
-        const mismatchWarning = checkLanguageMismatch(args.lang, lang);
-        if (mismatchWarning) {
-          progress?.interrupt(() => log.warn(`${file}: ${mismatchWarning}`));
-        }
-
-        const sttTimeMs = Math.round(performance.now() - startedAt);
-        const result: TranscribeResult = {
-          file,
-          text,
-          lang,
-          audioLanguage,
-          textLanguage: textLanguage ?? (tinyldLang ? { code: tinyldLang, confidence: 0 } : undefined),
-          sttTimeMs,
-        };
-        if (args.timestamps || args.speakers) {
-          result.segments = segments;
-        }
-        results.push(result);
-        diagnosticLog.event("engine.exit", {
-          command: "transcribe",
-          status: "success",
-          durationMs: sttTimeMs,
-          segmentCount: segments.length,
-          ranAudioLangId: audioResult !== null,
-          ranTxtLangId: textLanguage !== undefined,
-        });
-        progress?.finish(`Transcribed ${file}`);
-      } catch (err: unknown) {
-        progress?.stop();
+          wantsLangId,
+          expectedLang: args.lang,
+          reportProgress,
+        },
+        { stats, diagnosticLog },
+      );
+      if (outcome.ok) {
+        results.push(outcome.result);
+      } else {
         hasError = true;
-        const stderrText = errorMessage(err);
-        const code = extractEngineErrorCode(stderrText) ?? ENGINE_CODES.TRANSCRIBE_FAILED;
-        stats.recordError("transcribe", err, code);
-        diagnosticLog.event("engine.exit", {
-          command: "transcribe",
-          status: "failed",
-          errorKind: "transcribe_failed",
-          error_code: code,
-        });
-        const message = stderrText;
-        errors.push({ file, code, message });
-        log.error(`${file}: ${message}`);
+        errors.push(outcome.error);
       }
     }
 
-    if (wantsJson) {
-      process.stdout.write(formatJsonOutput(results, args["include-errors"] ? errors : undefined));
-    } else if (wantsToon) {
-      process.stdout.write(formatToonOutput(results));
-    } else if (wantsTranscript) {
-      process.stdout.write(formatTranscriptOutput(results));
-    } else if (args.verbose) {
-      process.stdout.write(formatVerboseOutput(results));
-    } else {
-      process.stdout.write(formatTextOutput(results));
-    }
+    writeOutput(results, errors, outputFormat, {
+      includeErrors: args["include-errors"],
+      verbose: args.verbose,
+    });
 
     stats.finish(hasError ? "failed" : "success", files.length);
     diagnosticLog.event("command.finish", {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -209,7 +209,7 @@ export function validateTranscribeArgs(
  * Returns `{ audioLanguage, textLanguage, lang }` — the caller owns building
  * the final `TranscribeResult`.
  */
-export async function detectLanguages(
+async function detectLanguages(
   file: string,
   text: string,
   options: {
@@ -296,7 +296,7 @@ type ProcessFileFailure = { ok: false; error: TranscribeErrorRecord };
  * diagnostic events. Returns a discriminated union so the caller can push to
  * the appropriate bucket without catching.
  */
-export async function processFile(
+async function processFile(
   file: string,
   options: ProcessFileOptions,
   recorders: ProcessFileRecorders,
@@ -390,7 +390,7 @@ export async function processFile(
  * Writes the final output to stdout in the requested format.
  * The `verbose` flag is only consulted for the plain-text fallback path.
  */
-export function writeOutput(
+function writeOutput(
   results: TranscribeResult[],
   errors: TranscribeErrorRecord[],
   format: ValidatedTranscribeArgs["outputFormat"],
@@ -560,7 +560,7 @@ export const mainCommand = defineCommand({
       hasExpectedLang: Boolean(args.lang),
     });
 
-    const wantsLangId = !!(args.lang || args.verbose || fmt.wantsJson || fmt.wantsToon || fmt.wantsTranscript);
+    const wantsLangId = !!(args.lang || args.verbose || outputFormat !== "text");
     const reportProgress = shouldReportTranscribeProgress({
       stderrIsTty: process.stderr.isTTY === true,
       stdoutIsTty: process.stdout.isTTY === true,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -807,17 +807,18 @@ function okFmt(json = false, toon = false, transcript = false): ResolvedOutputFo
 }
 
 describe("validateTranscribeArgs guards", () => {
-  // Suppress log.error side-effects; process.exit is already overridden via expectMainExit
-  // in the existing helper. Here we intercept process.exit directly for synchronous calls.
+  // Suppress log.error side-effects. log.error writes via process.stderr.write
+  // (src/log.ts), NOT console.error, so we stub the former. process.exit is
+  // intercepted directly here for these synchronous validation calls.
   function expectValidateExit(
     argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
     rawArgs: string[],
     fmt: ResolvedOutputFormat & { ok: true },
   ): number {
     const savedExit = process.exit;
-    const savedError = console.error;
+    const savedWrite = process.stderr.write;
     try {
-      console.error = () => {};
+      process.stderr.write = (() => true) as typeof process.stderr.write;
       process.exit = ((code?: string | number | null | undefined) => {
         throw new Error(`exit:${code ?? 0}`);
       }) as typeof process.exit;
@@ -829,7 +830,7 @@ describe("validateTranscribeArgs guards", () => {
       return Number(message.slice("exit:".length));
     } finally {
       process.exit = savedExit;
-      console.error = savedError;
+      process.stderr.write = savedWrite;
     }
   }
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
-import { mainCommand, completionsCommand, doctorCommand, initCommand, installCommand, logsCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, estimateTranscriptDurationSeconds, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress, shouldRunAudioLanguageDetection } from "../../src/cli";
+import { mainCommand, completionsCommand, doctorCommand, initCommand, installCommand, logsCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, estimateTranscriptDurationSeconds, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress, shouldRunAudioLanguageDetection, validateTranscribeArgs } from "../../src/cli";
+import type { ResolvedOutputFormat } from "../../src/cli";
 
 type MainRun = (input: { args: Record<string, unknown>; rawArgs: string[] }) => Promise<void>;
 
@@ -797,5 +798,96 @@ describe("resolveOutputFormat (#300 regression)", () => {
       expect(r.ok).toBe(true);
       if (r.ok) expect(r.wantsToon).toBe(true);
     });
+  });
+});
+
+// Helper: build a ResolvedOutputFormat { ok: true } for a given json/toon/transcript combo.
+function okFmt(json = false, toon = false, transcript = false): ResolvedOutputFormat & { ok: true } {
+  return { ok: true, wantsJson: json, wantsToon: toon, wantsTranscript: transcript };
+}
+
+describe("validateTranscribeArgs guards", () => {
+  // Suppress log.error side-effects; process.exit is already overridden via expectMainExit
+  // in the existing helper. Here we intercept process.exit directly for synchronous calls.
+  function expectValidateExit(
+    argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
+    rawArgs: string[],
+    fmt: ResolvedOutputFormat & { ok: true },
+  ): number {
+    const savedExit = process.exit;
+    const savedError = console.error;
+    try {
+      console.error = () => {};
+      process.exit = ((code?: string | number | null | undefined) => {
+        throw new Error(`exit:${code ?? 0}`);
+      }) as typeof process.exit;
+      validateTranscribeArgs(defaultMainArgs(argsOverrides) as never, rawArgs, fmt);
+      throw new Error("validateTranscribeArgs did not exit");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message.startsWith("exit:")).toBe(true);
+      return Number(message.slice("exit:".length));
+    } finally {
+      process.exit = savedExit;
+      console.error = savedError;
+    }
+  }
+
+  test("--timestamps without machine-readable output exits 2", () => {
+    expect(expectValidateExit({ timestamps: true }, ["--timestamps"], okFmt())).toBe(2);
+  });
+
+  test("--timestamps with --json does not exit", () => {
+    const result = validateTranscribeArgs(
+      defaultMainArgs({ timestamps: true, json: true }) as never,
+      ["--timestamps", "--json"],
+      okFmt(true),
+    );
+    expect(result.outputFormat).toBe("json");
+  });
+
+  test("--speakers without machine-readable output exits 2", () => {
+    expect(expectValidateExit({ speakers: true }, ["--speakers"], okFmt())).toBe(2);
+  });
+
+  test("--speakers with --toon does not exit", () => {
+    const result = validateTranscribeArgs(
+      defaultMainArgs({ speakers: true, toon: true }) as never,
+      ["--speakers", "--toon"],
+      okFmt(false, true),
+    );
+    expect(result.outputFormat).toBe("toon");
+  });
+
+  test("--include-errors without --json exits 2", () => {
+    expect(
+      expectValidateExit({ "include-errors": true }, ["--include-errors"], okFmt()),
+    ).toBe(2);
+  });
+
+  test("--include-errors with --json does not exit", () => {
+    const result = validateTranscribeArgs(
+      defaultMainArgs({ "include-errors": true, json: true }) as never,
+      ["--include-errors", "--json"],
+      okFmt(true),
+    );
+    expect(result.outputFormat).toBe("json");
+  });
+
+  test("--vad and --no-vad mutually exclusive exits 2", () => {
+    expect(
+      expectValidateExit({ vad: true }, ["--vad", "--no-vad"], okFmt()),
+    ).toBe(2);
+  });
+
+  test("vadMode derives correctly from rawArgs", () => {
+    const auto = validateTranscribeArgs(defaultMainArgs() as never, [], okFmt());
+    expect(auto.vadMode).toBe("auto");
+
+    const on = validateTranscribeArgs(defaultMainArgs({ vad: true }) as never, ["--vad"], okFmt());
+    expect(on.vadMode).toBe("on");
+
+    const off = validateTranscribeArgs(defaultMainArgs() as never, ["--no-vad"], okFmt());
+    expect(off.vadMode).toBe("off");
   });
 });


### PR DESCRIPTION
## What

Second repowise health pass, targeting the next tier of low-health files. Behavior-preserving; no public API or CLI-flag changes.

### TypeScript
| File | Smell | Change |
|------|-------|--------|
| `src/cli/main.ts` | health 1.0, **CCN 59** | decompose the ~240-line `run` handler into `validateTranscribeArgs` / `detectLanguages` / `processFile` / `writeOutput`; +8 unit tests |

Exit codes, error messages, and `diagnosticLog.event` ordering are byte-identical.

### Rust (behavior-preserving; manifest arrays left verbose by design)
| File | Smell | Change |
|------|-------|--------|
| `rust/src/tts/voices.rs` | 41% dup | extract `build_kokoro_voice` (collapses `resolve_kokoro`/`resolve_multilang_kokoro` dup); fold 4 clone tests into a data-driven loop; add missing per-lang `espeak_lang` assertions |
| `rust/src/transcribe/mod.rs` | 12% dup | extract `create_timed_backend` + `join_segment_texts`; **+15 model-free tests** (trim_repeated_prefix, fixed_chunk_windows guards, decide/safety boundaries, output round-trip) |
| `rust/src/models.rs` | untested | **+11 characterization tests** (subdir table, model_dir_at, is_cached_in layouts, multilang_voice, ane_voice_lang). No structural change. |

## Why

repowise flagged these as the worst-health files after PR #557. `main.ts` was the highest-CCN file in the repo; the Rust files carried duplication and (per repowise) "no test file" — addressed with dedup + cheap model-free characterization tests that lock current behavior.

## Verification

- `bunx tsc --noEmit`: clean
- `bun test`: 414 pass / 6 skip / 1 fail — the fail is the pre-existing `e2e-engine capabilities-json` protocolVersion test (needs an installed engine; present on `main`)
- `cargo fmt --check`: clean · `cargo clippy --all-targets --features tts -- -D warnings`: no issues
- `cargo nextest run --features tts`: **364 passed / 0 skipped**
- `cargo check --features coreml --no-default-features`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)