### PR TITLE
refactor(ssml): dedup parse()/parse_inner_spans, flatten walker nesting, +7 tests

### DIFF
--- a/rust/src/tts/ssml/mod.rs
+++ b/rust/src/tts/ssml/mod.rs
@@ -20,7 +20,7 @@ mod segment;
 mod walker;
 mod warnings;
 
-use ssml_parser::elements::{EmphasisLevel, ParsedElement, PhonemeAlphabet};
+use ssml_parser::elements::ParsedElement;
 use ssml_parser::parse_ssml;
 
 use crate::coded_bail;
@@ -30,8 +30,7 @@ pub use segment::Segment;
 
 use super::warn::warn_once;
 use rate::{find_relative_rate, has_structural_source_siblings, parse_rate_value};
-use segment::DEFAULT_BREAK;
-use walker::{parse_inner_spans, push_text_slice, span_priority};
+use walker::{emit_span, parse_inner_spans, push_text_slice, span_priority};
 use warnings::{WARN_PROSODY_MID_UTTERANCE, WARN_PROSODY_NO_SUPPORTED_ATTR};
 
 /// Parse an SSML string into a linear segment list.
@@ -113,90 +112,6 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
         match &span.element {
             // `<speak>` covers the whole document; nothing to emit for the wrapper itself.
             ParsedElement::Speak(_) => {}
-            ParsedElement::Break(attrs) => {
-                push_text_slice(&mut segments, &text, cursor, span.start);
-                let dur = attrs
-                    .time
-                    .as_ref()
-                    .map(|t| t.duration())
-                    .unwrap_or(DEFAULT_BREAK);
-                segments.push(Segment::Break(dur));
-                cursor = span.end;
-            }
-            ParsedElement::Phoneme(attrs) => {
-                // IPA override bypasses G2P. Alphabets other than `ipa`
-                // warn-strip (contained text still flows as a Text segment),
-                // so we only consume the span when the alphabet is IPA or
-                // absent (the spec's implementation-defined default, which
-                // we choose to be IPA since that's the only alphabet both
-                // Kokoro's tokenizer and Piper's phoneme-id map speak).
-                let is_ipa = matches!(&attrs.alphabet, None | Some(PhonemeAlphabet::Ipa));
-                if is_ipa {
-                    push_text_slice(&mut segments, &text, cursor, span.start);
-                    if !attrs.ph.is_empty() {
-                        segments.push(Segment::Ipa(attrs.ph.clone()));
-                    }
-                    cursor = span.end;
-                } else {
-                    // `is_ipa` above already filtered `None` and `Some(Ipa)`,
-                    // so the only remaining variant today is `Other(s)`. Future
-                    // `ssml-parser` enum growth falls into the wildcard with a
-                    // synthesized name — warn + strip, never panic on user input.
-                    let alpha = match &attrs.alphabet {
-                        Some(PhonemeAlphabet::Other(s)) => s.clone(),
-                        other => format!("{other:?}"),
-                    };
-                    warn_once(
-                        &format!("phoneme[alphabet={alpha}]"),
-                        &format!(
-                            "SSML <phoneme alphabet=\"{alpha}\"> not supported — only \"ipa\" is recognised; falling back to G2P on contained text"
-                        ),
-                    );
-                }
-            }
-            ParsedElement::SayAs(attrs) => {
-                if attrs.interpret_as == "characters" {
-                    // Emit any pending text up to the tag, then a Spell segment for
-                    // the inner text. Cursor advances past the closing tag so we
-                    // don't double-emit the inner content as a Text fall-through.
-                    push_text_slice(&mut segments, &text, cursor, span.start);
-                    if let Some(inner) = extract_inner_text(&text, span.start, span.end) {
-                        segments.push(Segment::Spell(inner));
-                    }
-                    cursor = span.end;
-                } else {
-                    // Other interpret-as values (cardinal, ordinal, date, telephone, …)
-                    // are out of scope for #232. Keep the established warn+strip
-                    // behavior; the inner text falls through as a Text segment.
-                    warn_once(
-                        &format!("say-as[interpret-as={}]", attrs.interpret_as),
-                        &format!(
-                            "SSML <say-as interpret-as=\"{}\"> is not supported — only \"characters\" is recognised; falling back to plain text",
-                            attrs.interpret_as
-                        ),
-                    );
-                }
-            }
-            ParsedElement::Emphasis(attrs) => {
-                push_text_slice(&mut segments, &text, cursor, span.start);
-                if let Some(content) = extract_inner_text(&text, span.start, span.end) {
-                    // SSML 1.1: missing/empty level == "moderate" (default). Only
-                    // `level="none"` triggers suppression — all other variants
-                    // (Strong, Moderate, Reduced) collapse to "honor `+` markers".
-                    let suppress = matches!(attrs.level, Some(EmphasisLevel::None));
-                    segments.push(Segment::Emphasis { content, suppress });
-                }
-                // Cursor advances past the entire emphasis span. Any structural child
-                // (e.g. <break/>, <say-as>, <phoneme>) whose `start` falls within
-                // [span.start, span.end) will be skipped by the loop-top
-                // `if span.start < cursor { continue; }` guard. For <say-as> /
-                // <phoneme> this is the desired "inner tag wins" behavior (the inner
-                // arm runs first via span_priority sort and consumes its own range);
-                // for <break/> the silence is silently absorbed into the emphasis
-                // content. Out of scope per the #233 spec; tracked separately if a
-                // real user hits it.
-                cursor = span.end;
-            }
             ParsedElement::Prosody(attrs) => {
                 // Whole-utterance detection: the prosody is whole-utterance when
                 // (a) the text outside [span.start, span.end) within the <speak>
@@ -250,13 +165,10 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
                     // Leave cursor unchanged; inner text falls through as Text.
                 }
             }
-            other => {
-                let name = tag_name(other);
-                warn_once(
-                    &format!("unknown-tag-{name}"),
-                    &format!("SSML tag <{name}> is not supported — stripping"),
-                );
-                // Preserve the text content; don't touch cursor.
+            _ => {
+                if let Some(new_cursor) = emit_span(span, &text, &mut segments, cursor) {
+                    cursor = new_cursor;
+                }
             }
         }
     }

--- a/rust/src/tts/ssml/walker.rs
+++ b/rust/src/tts/ssml/walker.rs
@@ -42,6 +42,126 @@ pub(super) fn push_text_slice(out: &mut Vec<Segment>, text: &[char], start: usiz
     }
 }
 
+/// Emit a single IPA or warn-strip a non-IPA phoneme.
+/// Returns `Some(span_end)` when the span was consumed (IPA path), or
+/// `None` when the alphabet is unsupported and the cursor must not move.
+fn emit_phoneme(
+    attrs: &ssml_parser::elements::PhonemeAttributes,
+    text: &[char],
+    segments: &mut Vec<Segment>,
+    cursor: usize,
+    span_start: usize,
+    span_end: usize,
+) -> Option<usize> {
+    let is_ipa = matches!(&attrs.alphabet, None | Some(PhonemeAlphabet::Ipa));
+    if !is_ipa {
+        // `is_ipa` above already filtered `None` and `Some(Ipa)`,
+        // so the only remaining variant today is `Other(s)`. Future
+        // `ssml-parser` enum growth falls into the wildcard with a
+        // synthesized name — warn + strip, never panic on user input.
+        let alpha = match &attrs.alphabet {
+            Some(PhonemeAlphabet::Other(s)) => s.clone(),
+            other => format!("{other:?}"),
+        };
+        warn_once(
+            &format!("phoneme[alphabet={alpha}]"),
+            &format!(
+                "SSML <phoneme alphabet=\"{alpha}\"> not supported — only \"ipa\" is recognised; falling back to G2P on contained text"
+            ),
+        );
+        return None;
+    }
+    push_text_slice(segments, text, cursor, span_start);
+    if !attrs.ph.is_empty() {
+        segments.push(Segment::Ipa(attrs.ph.clone()));
+    }
+    Some(span_end)
+}
+
+/// Emit segments for one span covering Break / Phoneme / SayAs / Emphasis /
+/// unknown-tag arms. The Prosody arm (which recurses into `parse_inner_spans`)
+/// and the Speak root-skip arm are intentionally excluded and handled inline by
+/// the callers.
+///
+/// Returns `Some(new_cursor)` when the span was consumed and the caller should
+/// advance the cursor to that value. Returns `None` for warn-strip cases where
+/// the cursor must not move (non-IPA phoneme, unrecognised say-as, unknown tag).
+pub(super) fn emit_span(
+    span: &ssml_parser::parser::Span,
+    text: &[char],
+    segments: &mut Vec<Segment>,
+    cursor: usize,
+) -> Option<usize> {
+    match &span.element {
+        ParsedElement::Break(attrs) => {
+            push_text_slice(segments, text, cursor, span.start);
+            let dur = attrs
+                .time
+                .as_ref()
+                .map(|t| t.duration())
+                .unwrap_or(DEFAULT_BREAK);
+            segments.push(Segment::Break(dur));
+            Some(span.end)
+        }
+        ParsedElement::Phoneme(attrs) => {
+            emit_phoneme(attrs, text, segments, cursor, span.start, span.end)
+        }
+        ParsedElement::SayAs(attrs) => {
+            if attrs.interpret_as == "characters" {
+                // Emit any pending text up to the tag, then a Spell segment for
+                // the inner text. Cursor advances past the closing tag so we
+                // don't double-emit the inner content as a Text fall-through.
+                push_text_slice(segments, text, cursor, span.start);
+                if let Some(inner) = extract_inner_text(text, span.start, span.end) {
+                    segments.push(Segment::Spell(inner));
+                }
+                Some(span.end)
+            } else {
+                // Other interpret-as values (cardinal, ordinal, date, telephone, …)
+                // are out of scope for #232. Keep the established warn+strip
+                // behavior; the inner text falls through as a Text segment.
+                warn_once(
+                    &format!("say-as[interpret-as={}]", attrs.interpret_as),
+                    &format!(
+                        "SSML <say-as interpret-as=\"{}\"> is not supported — only \"characters\" is recognised; falling back to plain text",
+                        attrs.interpret_as
+                    ),
+                );
+                None
+            }
+        }
+        ParsedElement::Emphasis(attrs) => {
+            push_text_slice(segments, text, cursor, span.start);
+            if let Some(content) = extract_inner_text(text, span.start, span.end) {
+                // SSML 1.1: missing/empty level == "moderate" (default). Only
+                // `level="none"` triggers suppression — all other variants
+                // (Strong, Moderate, Reduced) collapse to "honor `+` markers".
+                let suppress = matches!(attrs.level, Some(EmphasisLevel::None));
+                segments.push(Segment::Emphasis { content, suppress });
+            }
+            // Cursor advances past the entire emphasis span. Any structural child
+            // (e.g. <break/>, <say-as>, <phoneme>) whose `start` falls within
+            // [span.start, span.end) will be skipped by the loop-top
+            // `if span.start < cursor { continue; }` guard. For <say-as> /
+            // <phoneme> this is the desired "inner tag wins" behavior (the inner
+            // arm runs first via span_priority sort and consumes its own range);
+            // for <break/> the silence is silently absorbed into the emphasis
+            // content. Out of scope per the #233 spec; tracked separately if a
+            // real user hits it.
+            Some(span.end)
+        }
+        other => {
+            let name = tag_name(other);
+            warn_once(
+                &format!("unknown-tag-{name}"),
+                &format!("SSML tag <{name}> is not supported — stripping"),
+            );
+            // Preserve the text content; don't touch cursor.
+            None
+        }
+    }
+}
+
 /// Parse the inner content of a whole-utterance `<prosody>` span into segments.
 /// Iterates the sub-spans whose character range falls strictly within
 /// `[prosody_start, prosody_end)`, applying the same rules as the top-level
@@ -64,14 +184,15 @@ pub(super) fn parse_inner_spans(
         if span.start < prosody_start || span.end > prosody_end {
             continue;
         }
-        // Skip the outer prosody span itself — `all_spans` includes it
+        // R3: skip the outer prosody span itself — `all_spans` includes it
         // because its `(start, end)` matches the prosody range. Without this
         // guard, the Prosody match arm below would fire `prosody-nested`
         // for every whole-utterance prosody.
-        if span.start == prosody_start && span.end == prosody_end {
-            if let ParsedElement::Prosody(_) = &span.element {
-                continue;
-            }
+        if span.start == prosody_start
+            && span.end == prosody_end
+            && matches!(&span.element, ParsedElement::Prosody(_))
+        {
+            continue;
         }
         if span.start < cursor {
             continue;
@@ -90,74 +211,226 @@ pub(super) fn parse_inner_spans(
                      supported; inner rate/pitch/volume attributes ignored",
                 );
             }
-            ParsedElement::Break(attrs) => {
-                push_text_slice(&mut segments, text, cursor, span.start);
-                let dur = attrs
-                    .time
-                    .as_ref()
-                    .map(|t| t.duration())
-                    .unwrap_or(DEFAULT_BREAK);
-                segments.push(Segment::Break(dur));
-                cursor = span.end;
-            }
-            ParsedElement::Phoneme(attrs) => {
-                let is_ipa = matches!(&attrs.alphabet, None | Some(PhonemeAlphabet::Ipa));
-                if is_ipa {
-                    push_text_slice(&mut segments, text, cursor, span.start);
-                    if !attrs.ph.is_empty() {
-                        segments.push(Segment::Ipa(attrs.ph.clone()));
-                    }
-                    cursor = span.end;
-                } else {
-                    let alpha = match &attrs.alphabet {
-                        Some(PhonemeAlphabet::Other(s)) => s.clone(),
-                        other => format!("{other:?}"),
-                    };
-                    warn_once(
-                        &format!("phoneme[alphabet={alpha}]"),
-                        &format!(
-                            "SSML <phoneme alphabet=\"{alpha}\"> not supported — \
-                             only \"ipa\" is recognised; falling back to G2P on contained text"
-                        ),
-                    );
+            _ => {
+                if let Some(new_cursor) = emit_span(span, text, &mut segments, cursor) {
+                    cursor = new_cursor;
                 }
-            }
-            ParsedElement::SayAs(attrs) => {
-                if attrs.interpret_as == "characters" {
-                    push_text_slice(&mut segments, text, cursor, span.start);
-                    if let Some(inner) = extract_inner_text(text, span.start, span.end) {
-                        segments.push(Segment::Spell(inner));
-                    }
-                    cursor = span.end;
-                } else {
-                    warn_once(
-                        &format!("say-as[interpret-as={}]", attrs.interpret_as),
-                        &format!(
-                            "SSML <say-as interpret-as=\"{}\"> is not supported — \
-                             only \"characters\" is recognised; falling back to plain text",
-                            attrs.interpret_as
-                        ),
-                    );
-                }
-            }
-            ParsedElement::Emphasis(attrs) => {
-                push_text_slice(&mut segments, text, cursor, span.start);
-                if let Some(content) = extract_inner_text(text, span.start, span.end) {
-                    let suppress = matches!(attrs.level, Some(EmphasisLevel::None));
-                    segments.push(Segment::Emphasis { content, suppress });
-                }
-                cursor = span.end;
-            }
-            other => {
-                let name = tag_name(other);
-                warn_once(
-                    &format!("unknown-tag-{name}"),
-                    &format!("SSML tag <{name}> is not supported — stripping"),
-                );
             }
         }
     }
     // Trailing text inside the prosody span.
     push_text_slice(&mut segments, text, cursor, prosody_end);
     segments
+}
+
+#[cfg(test)]
+#[cfg(feature = "tts")]
+mod tests {
+    use crate::tts::ssml::{parse, Segment};
+
+    // T1: <break> inside a whole-utterance <prosody rate="fast"> produces
+    // [Text, Break(300ms), Text] inside the ProsodyRate content.
+    #[test]
+    fn break_inside_prosody_content_has_text_break_text() {
+        let segs = parse(
+            r#"<speak><prosody rate="fast">Hello <break time="300ms"/> world</prosody></speak>"#,
+        )
+        .unwrap();
+        assert_eq!(segs.len(), 1, "expected single ProsodyRate, got: {segs:?}");
+        let content = match &segs[0] {
+            Segment::ProsodyRate { rate, content } => {
+                assert!((*rate - 1.25).abs() < 1e-6, "rate: {rate}");
+                content
+            }
+            other => panic!("expected ProsodyRate, got {other:?}"),
+        };
+        // Expect Text, Break(300ms), Text — in that order.
+        assert_eq!(content.len(), 3, "inner segments: {content:?}");
+        assert!(
+            matches!(&content[0], Segment::Text(t) if t.contains("Hello")),
+            "content[0]: {:?}",
+            content[0]
+        );
+        assert!(
+            matches!(&content[1], Segment::Break(d) if (d.as_millis() as i64 - 300).abs() <= 1),
+            "content[1]: {:?}",
+            content[1]
+        );
+        assert!(
+            matches!(&content[2], Segment::Text(t) if t.contains("world")),
+            "content[2]: {:?}",
+            content[2]
+        );
+    }
+
+    // T2: IPA <phoneme> inside a whole-utterance <prosody> — the phoneme span
+    // has priority 0 and the prosody has priority 2 in the top-level sort, so
+    // the phoneme arm runs first, advances cursor past the whole prosody range,
+    // and the prosody span is skipped by the cursor guard. Actual output: a
+    // flat [Ipa(...)] with no ProsodyRate wrapper.
+    #[test]
+    fn ipa_phoneme_inside_prosody_emits_ipa_segment() {
+        let segs = parse(
+            r#"<speak><prosody rate="fast"><phoneme alphabet="ipa" ph="həˈloʊ">hello</phoneme></prosody></speak>"#,
+        )
+        .unwrap();
+        // Inner phoneme wins (priority 0 < prosody priority 2); no ProsodyRate wrapper.
+        assert!(
+            segs.iter()
+                .any(|s| matches!(s, Segment::Ipa(p) if p == "həˈloʊ")),
+            "no Ipa segment found in: {segs:?}"
+        );
+        assert!(
+            !segs
+                .iter()
+                .any(|s| matches!(s, Segment::ProsodyRate { .. })),
+            "unexpected ProsodyRate wrapper: {segs:?}"
+        );
+        // Inner "hello" text must NOT leak.
+        assert!(
+            !segs
+                .iter()
+                .any(|s| matches!(s, Segment::Text(t) if t.contains("hello"))),
+            "inner text leaked: {segs:?}"
+        );
+    }
+
+    // T3: non-IPA <phoneme alphabet="x-sampa"> inside prosody → warn-strip,
+    // text flows as Text, no Ipa segment.
+    #[test]
+    fn non_ipa_phoneme_inside_prosody_warn_strips_and_text_flows() {
+        let segs = parse(
+            r#"<speak><prosody rate="fast"><phoneme alphabet="x-sampa" ph="h@_'low">hello</phoneme></prosody></speak>"#,
+        )
+        .unwrap();
+        let content = match &segs[0] {
+            Segment::ProsodyRate { content, .. } => content,
+            other => panic!("expected ProsodyRate, got {other:?}"),
+        };
+        // No Ipa segment.
+        assert!(
+            !content.iter().any(|s| matches!(s, Segment::Ipa(_))),
+            "unexpected Ipa in: {content:?}"
+        );
+        // Inner text still flows through as Text so G2P handles it.
+        assert!(
+            content
+                .iter()
+                .any(|s| matches!(s, Segment::Text(t) if t.contains("hello"))),
+            "inner text missing from: {content:?}"
+        );
+    }
+
+    // T4: <say-as interpret-as="characters"> inside a whole-utterance <prosody>
+    // — SayAs has priority 0 and prosody priority 2; the say-as arm runs first,
+    // advances cursor past the whole prosody range, and prosody is skipped.
+    // Actual output: flat [Spell("ВОЗ")] with no ProsodyRate wrapper.
+    #[test]
+    fn say_as_characters_inside_prosody_emits_spell() {
+        let segs = parse(
+            r#"<speak><prosody rate="slow"><say-as interpret-as="characters">ВОЗ</say-as></prosody></speak>"#,
+        )
+        .unwrap();
+        // Inner say-as wins (priority 0 < prosody priority 2); no ProsodyRate wrapper.
+        assert!(
+            segs.iter()
+                .any(|s| matches!(s, Segment::Spell(t) if t == "ВОЗ")),
+            "no Spell segment found in: {segs:?}"
+        );
+        assert!(
+            !segs
+                .iter()
+                .any(|s| matches!(s, Segment::ProsodyRate { .. })),
+            "unexpected ProsodyRate wrapper: {segs:?}"
+        );
+    }
+
+    // T5: <emphasis level="none"> inside prosody → Emphasis { suppress: true }
+    #[test]
+    fn emphasis_none_inside_prosody_sets_suppress_true() {
+        let segs = parse(
+            r#"<speak><prosody rate="fast"><emphasis level="none">д+ома</emphasis></prosody></speak>"#,
+        )
+        .unwrap();
+        let content = match &segs[0] {
+            Segment::ProsodyRate { content, .. } => content,
+            other => panic!("expected ProsodyRate, got {other:?}"),
+        };
+        assert!(
+            content
+                .iter()
+                .any(|s| matches!(s, Segment::Emphasis { suppress: true, .. })),
+            "no Emphasis{{suppress:true}} in: {content:?}"
+        );
+    }
+
+    // T6: unknown tag (<audio>) inside prosody → warn-strip, text preserved, no panic.
+    #[test]
+    fn unknown_tag_inside_prosody_warn_strips_and_text_preserved() {
+        let segs = parse(
+            r#"<speak><prosody rate="fast">before <audio src="x.mp3"/> after</prosody></speak>"#,
+        )
+        .unwrap();
+        let content = match &segs[0] {
+            Segment::ProsodyRate { content, .. } => content,
+            other => panic!("expected ProsodyRate, got {other:?}"),
+        };
+        // Text should flow through; the <audio> tag is stripped but
+        // surrounding text is preserved.
+        let all_text: String = content
+            .iter()
+            .filter_map(|s| match s {
+                Segment::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("|");
+        assert!(
+            all_text.contains("before") || all_text.contains("after"),
+            "text lost: {all_text:?} from {content:?}"
+        );
+    }
+
+    // T7: two adjacent <break> with only whitespace between inside a whole-utterance
+    // <prosody>. The break spans share the same start position as the prosody span.
+    // Break (priority 1) sorts before Prosody (priority 2) and emits flat Break
+    // segments; cursor does NOT advance past the prosody range (each break only
+    // advances to its own end), so the Prosody arm still fires afterward and emits
+    // a ProsodyRate wrapping the same breaks again. Actual output:
+    // [Break(100ms), Break(200ms), ProsodyRate { content: [Break(100ms), Break(200ms)] }].
+    // No Text segments (whitespace-only chunks are dropped by push_text_slice).
+    #[test]
+    fn two_adjacent_breaks_inside_prosody_emit_exactly_two_breaks() {
+        let segs = parse(
+            r#"<speak><prosody rate="fast"><break time="100ms"/> <break time="200ms"/></prosody></speak>"#,
+        )
+        .unwrap();
+        // Both flat breaks appear at the top level.
+        let flat_break_count = segs
+            .iter()
+            .filter(|s| matches!(s, Segment::Break(_)))
+            .count();
+        assert_eq!(flat_break_count, 2, "expected 2 flat breaks, got: {segs:?}");
+        // The ProsodyRate wrapper also fires and contains the same breaks.
+        let prosody = segs.iter().find_map(|s| match s {
+            Segment::ProsodyRate { rate, content } => Some((rate, content)),
+            _ => None,
+        });
+        let (rate, content) = prosody.expect("expected ProsodyRate segment in output");
+        assert!((*rate - 1.25).abs() < 1e-6, "rate: {rate}");
+        let inner_break_count = content
+            .iter()
+            .filter(|s| matches!(s, Segment::Break(_)))
+            .count();
+        assert_eq!(
+            inner_break_count, 2,
+            "expected 2 inner breaks, got: {content:?}"
+        );
+        // No Text segments anywhere (whitespace-only dropped).
+        let text_count = segs
+            .iter()
+            .filter(|s| matches!(s, Segment::Text(_)))
+            .count();
+        assert_eq!(text_count, 0, "expected no text, got: {segs:?}");
+    }
 }

--- a/rust/src/tts/ssml/walker.rs
+++ b/rust/src/tts/ssml/walker.rs
@@ -386,21 +386,26 @@ mod tests {
             .collect::<Vec<_>>()
             .join("|");
         assert!(
-            all_text.contains("before") || all_text.contains("after"),
+            all_text.contains("before") && all_text.contains("after"),
             "text lost: {all_text:?} from {content:?}"
         );
     }
 
-    // T7: two adjacent <break> with only whitespace between inside a whole-utterance
-    // <prosody>. The break spans share the same start position as the prosody span.
+    // KNOWN QUIRK (BUG, tracked in issue #560): a <break> at the start of a
+    // <prosody> is emitted TWICE — once flat, once again inside ProsodyRate.
+    // This is PRE-EXISTING behavior; this test pins the current output so the
+    // eventual fix is a deliberate, visible change — it is NOT asserting that
+    // double-emission is the desired result.
+    //
+    // Mechanism: the two <break> spans share the prosody span's start position.
     // Break (priority 1) sorts before Prosody (priority 2) and emits flat Break
     // segments; cursor does NOT advance past the prosody range (each break only
-    // advances to its own end), so the Prosody arm still fires afterward and emits
-    // a ProsodyRate wrapping the same breaks again. Actual output:
+    // advances to its own end), so the Prosody arm still fires afterward and
+    // emits a ProsodyRate wrapping the same breaks again. Actual output:
     // [Break(100ms), Break(200ms), ProsodyRate { content: [Break(100ms), Break(200ms)] }].
-    // No Text segments (whitespace-only chunks are dropped by push_text_slice).
+    // Also exercises push_text_slice dropping whitespace-only chunks (no Text).
     #[test]
-    fn two_adjacent_breaks_inside_prosody_emit_exactly_two_breaks() {
+    fn known_quirk_prosody_leading_break_double_emitted() {
         let segs = parse(
             r#"<speak><prosody rate="fast"><break time="100ms"/> <break time="200ms"/></prosody></speak>"#,
         )


### PR DESCRIPTION
## What

Refactor the SSML parser — repowise flagged `ssml/mod.rs` (health **1.0**, CCN 24, ~20% dup) and `walker.rs::parse_inner_spans` (nesting 5, cognitive 62, **no inline tests**). Behavior byte-identical.

**Root cause of both smells:** the 5 tag-handling match arms (Break / Phoneme / SayAs / Emphasis / unknown-fallthrough) were copy-pasted between `parse()` and `parse_inner_spans()`.

| Change | Effect |
|--------|--------|
| Extract `pub(super) emit_span()` for the 5 shared arms, called from both `parse()` and `parse_inner_spans()` | removes the ~20% duplication |
| Extract `emit_phoneme()` with early-return on the non-IPA warn path | removes the depth-5 match nesting |
| Collapse the prosody self-span skip guard to one early-continue | flattens `parse_inner_spans` |
| **+7 characterization tests** (tests-first) on the previously-untested prosody-wrapping paths | locks behavior |

The Prosody/Speak arms stay inlined in their callers (Prosody recurses into `parse_inner_spans`). `warn_once` keys/messages and the `pub parse` / `pub Segment` signatures are unchanged.

## Why

Worst-health remaining file after PRs #557/#558. The duplication and the deep nesting were the same underlying copy-paste; one extraction fixes both, and the 7 new tests give the previously-untested `walker.rs` real coverage. 3 of the 7 tests were corrected during authoring to match actual span-priority behavior (not assumed output).

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --features tts -- -D warnings`: no issues
- `cargo clippy --all-targets --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang --no-default-features -- -D warnings`: no issues (the darwin `system_kokoro` feature-set gate)
- `cargo nextest run --features tts`: **371 passed / 0 skipped**
- `cargo check --features coreml --no-default-features`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)