### PR TITLE
fix(ssml): emit prosody-boundary <break/> once, not twice (#560)

### DIFF
--- a/rust/src/tts/ssml/mod.rs
+++ b/rust/src/tts/ssml/mod.rs
@@ -95,6 +95,26 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
             .then_with(|| span_priority(&a.element).cmp(&span_priority(&b.element)))
     });
 
+    // #560: ranges of whole-utterance <prosody rate> that recurse into parse_inner_spans.
+    let recursed_prosody: Vec<(usize, usize)> = spans
+        .iter()
+        .filter_map(|s| match &s.element {
+            ParsedElement::Prosody(attrs)
+                if prosody_is_whole_utterance(s, &text, input)
+                    && attrs
+                        .rate
+                        .as_ref()
+                        .map(|r| r.to_string())
+                        .as_deref()
+                        .and_then(parse_rate_value)
+                        .is_some() =>
+            {
+                Some((s.start, s.end))
+            }
+            _ => None,
+        })
+        .collect();
+
     let mut segments: Vec<Segment> = Vec::new();
     let mut cursor: usize = 0;
 
@@ -107,6 +127,16 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
         // same character range, so the outer Emphasis is silently absorbed.
         // See #233.
         if span.start < cursor {
+            continue;
+        }
+        // #560: a zero-width <break/> at a recursing-prosody boundary escapes the
+        // cursor guard above (start == end) and would emit flat here AND inside the
+        // ProsodyRate; skip it (Break only — non-zero-width children don't double-emit).
+        if matches!(&span.element, ParsedElement::Break(_))
+            && recursed_prosody
+                .iter()
+                .any(|&(s, e)| span.start >= s && span.end <= e)
+        {
             continue;
         }
         match &span.element {
@@ -124,13 +154,7 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
                 // ssml-parser's text-position spans alone cannot distinguish
                 // `<speak><break/><prosody>x</prosody></speak>` (mid-utterance)
                 // from `<speak><prosody><break/>x</prosody></speak>` (inside).
-                let prefix: String = text[..span.start].iter().collect();
-                let suffix: String = text[span.end..].iter().collect();
-                let is_whole_utterance = prefix.trim().is_empty()
-                    && suffix.trim().is_empty()
-                    && !has_structural_source_siblings(input);
-
-                if is_whole_utterance {
+                if prosody_is_whole_utterance(span, &text, input) {
                     // Attempt to parse the rate attribute.
                     let rate_str = attrs.rate.as_ref().map(|r| r.to_string());
                     let parsed_rate = rate_str.as_deref().and_then(parse_rate_value);
@@ -175,6 +199,19 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
     // Trailing text after the last span.
     push_text_slice(&mut segments, &text, cursor, text.len());
     Ok(segments)
+}
+
+/// True when a `<prosody>` covers the whole utterance (surrounding text + source
+/// both whitespace-only). The source-sibling check disambiguates zero-width tags
+/// that collapse to the prosody's offset. Shared by the Prosody arm and #560 precompute.
+fn prosody_is_whole_utterance(
+    span: &ssml_parser::parser::Span,
+    text: &[char],
+    input: &str,
+) -> bool {
+    let prefix: String = text[..span.start].iter().collect();
+    let suffix: String = text[span.end..].iter().collect();
+    prefix.trim().is_empty() && suffix.trim().is_empty() && !has_structural_source_siblings(input)
 }
 
 /// Collect the inner text of a structural span and trim whitespace.

--- a/rust/src/tts/ssml/walker.rs
+++ b/rust/src/tts/ssml/walker.rs
@@ -391,37 +391,36 @@ mod tests {
         );
     }
 
-    // KNOWN QUIRK (BUG, tracked in issue #560): a <break> at the start of a
-    // <prosody> is emitted TWICE — once flat, once again inside ProsodyRate.
-    // This is PRE-EXISTING behavior; this test pins the current output so the
-    // eventual fix is a deliberate, visible change — it is NOT asserting that
-    // double-emission is the desired result.
-    //
-    // Mechanism: the two <break> spans share the prosody span's start position.
-    // Break (priority 1) sorts before Prosody (priority 2) and emits flat Break
-    // segments; cursor does NOT advance past the prosody range (each break only
-    // advances to its own end), so the Prosody arm still fires afterward and
-    // emits a ProsodyRate wrapping the same breaks again. Actual output:
-    // [Break(100ms), Break(200ms), ProsodyRate { content: [Break(100ms), Break(200ms)] }].
-    // Also exercises push_text_slice dropping whitespace-only chunks (no Text).
+    // #560: boundary <break/> spans must be emitted once (inside the ProsodyRate),
+    // not also flat — they previously double-emitted via the cursor-guard gap.
     #[test]
-    fn known_quirk_prosody_leading_break_double_emitted() {
+    fn prosody_boundary_breaks_emitted_once_inside_prosody() {
         let segs = parse(
             r#"<speak><prosody rate="fast"><break time="100ms"/> <break time="200ms"/></prosody></speak>"#,
         )
         .unwrap();
-        // Both flat breaks appear at the top level.
+        // No flat breaks at the top level — they belong inside the ProsodyRate.
         let flat_break_count = segs
             .iter()
             .filter(|s| matches!(s, Segment::Break(_)))
             .count();
-        assert_eq!(flat_break_count, 2, "expected 2 flat breaks, got: {segs:?}");
-        // The ProsodyRate wrapper also fires and contains the same breaks.
-        let prosody = segs.iter().find_map(|s| match s {
-            Segment::ProsodyRate { rate, content } => Some((rate, content)),
-            _ => None,
-        });
-        let (rate, content) = prosody.expect("expected ProsodyRate segment in output");
+        assert_eq!(
+            flat_break_count, 0,
+            "breaks must not be emitted flat (double-emit #560), got: {segs:?}"
+        );
+        // Exactly one ProsodyRate, carrying both breaks.
+        let prosody_count = segs
+            .iter()
+            .filter(|s| matches!(s, Segment::ProsodyRate { .. }))
+            .count();
+        assert_eq!(prosody_count, 1, "expected one ProsodyRate, got: {segs:?}");
+        let (rate, content) = segs
+            .iter()
+            .find_map(|s| match s {
+                Segment::ProsodyRate { rate, content } => Some((rate, content)),
+                _ => None,
+            })
+            .expect("expected ProsodyRate segment in output");
         assert!((*rate - 1.25).abs() < 1e-6, "rate: {rate}");
         let inner_break_count = content
             .iter()


### PR DESCRIPTION
## What

Fixes the `<break>` double-emission surfaced (and characterization-tested) during the SSML refactor in #559.

A zero-width `<break/>` at the **start or end boundary** of a recursing whole-utterance `<prosody rate=...>` was emitted **twice** — once flat at the top level, once inside the `ProsodyRate`:

```
<speak><prosody rate="fast"><break time="100ms"/> <break time="200ms"/></prosody></speak>
before: [Break(100ms), ProsodyRate{[Break(100ms), Break(200ms)]}, Break(200ms)]   ← pauses heard twice
after:  [ProsodyRate{[Break(100ms), Break(200ms)]}]
```

## Cause

The break's linearized text offset is collapsed (`start == end == boundary`), so the `span.start < cursor` guard can't catch it: the leading break sorts before the Prosody arm (priority 1 < 2) and emits flat *before* prosody recurses; the trailing break sits exactly on `cursor` (`1 < 1` is false).

## Fix

Precompute the ranges of recursing whole-utterance `<prosody>` spans and skip **Break** spans contained in them at the top level — `parse_inner_spans` already emits them inside the `ProsodyRate` exactly once. Scoped to `Break`: non-zero-width children (`<phoneme>`/`<say-as>`/`<emphasis>`) don't double-emit and keep their existing handling. Also extracts `prosody_is_whole_utterance()` (shared by the Prosody arm and the new precompute), and flips the former `known_quirk_*` test to assert the corrected single-emission output.

> Noted for a possible follow-up (out of scope here): `<phoneme>`/`<say-as>` that are the *sole* content of a whole-utterance `<prosody>` are currently emitted flat (the prosody rate is absorbed/lost) rather than wrapped in `ProsodyRate`. Different symptom, not a double-emit; left unchanged to keep this fix surgical.

## Verification

- `cargo clippy --all-targets --features tts -- -D warnings`: clean
- `cargo nextest run --features tts`: **371 passed / 0 skipped** (flipped break test passes; phoneme/say-as/emphasis prosody tests unchanged)
- `cargo clippy --all-targets --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang --no-default-features -- -D warnings`: clean (darwin `system_kokoro` feature-set gate)

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)