### PR TITLE
docs(claude): add terse-comment rule to Code Style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,6 +390,7 @@ const text = await transcribe("audio.ogg");
 - **Imports**: Relative paths (`./engine`, not `src/engine`)
 - **Output**: `console.error()` for progress/errors, `console.log()` for success (stdout stays pipe-friendly)
 - **Rust**: `cargo fmt` + `cargo clippy --all-targets -- -D warnings`
+- **Comments**: explain WHY, not WHAT. Prefer no comment over one that restates the code. No multi-line narration of mechanics. If a comment earns its place (a gotcha, a spec quirk, an issue/PR ref), make it one terse line. Match the comment density of the surrounding code. This applies to agent-generated code too.
 
 ## CI/CD
 


### PR DESCRIPTION
## What

Adds a comment-density rule to the **Code Style** section of `CLAUDE.md`:

> **Comments**: explain WHY, not WHAT. Prefer no comment over one that restates the code. No multi-line narration of mechanics. If a comment earns its place (a gotcha, a spec quirk, an issue/PR ref), make it one terse line. Match the comment density of the surrounding code. This applies to agent-generated code too.

## Why

Subagents (and humans) default to over-commenting — narrating what the code already says. `CLAUDE.md` is injected into every subagent's context, so a rule here is the most durable lever: it reaches all agent-generated code, direct edits, and future sessions, rather than relying on per-spawn prompt reminders.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)