### PR TITLE
refactor: flatten the last 3 complexity hotspots (ssml parse, say.ts run, install-plan)

### DIFF
--- a/rust/src/tts/ssml/mod.rs
+++ b/rust/src/tts/ssml/mod.rs
@@ -108,48 +108,14 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
     let mut cursor: usize = 0;
 
     for span in &spans {
-        // Inner structural tag (priority 0) already consumed this region; skip outer. (#233)
-        if span.start < cursor {
-            continue;
-        }
-        // #560: a zero-width <break/> at a recursing-prosody boundary escapes the
-        // cursor guard above (start == end) and would emit flat here AND inside the
-        // ProsodyRate; skip it (Break only — non-zero-width children don't double-emit).
-        if matches!(&span.element, ParsedElement::Break(_))
-            && recursed_prosody
-                .iter()
-                .any(|&(s, e)| span.start >= s && span.end <= e)
-        {
+        if should_skip_span(span, cursor, &recursed_prosody) {
             continue;
         }
         match &span.element {
             ParsedElement::Speak(_) => {}
             ParsedElement::Prosody(attrs) => {
-                if prosody_is_whole_utterance(span, &text, input) {
-                    let rate_str = attrs.rate.as_ref().map(|r| r.to_string());
-                    let parsed_rate = rate_str.as_deref().and_then(parse_rate_value);
-                    if let Some(rate) = parsed_rate {
-                        push_text_slice(&mut segments, &text, cursor, span.start);
-                        let inner_segs = parse_inner_spans(&spans, &text, span.start, span.end);
-                        segments.push(Segment::ProsodyRate {
-                            rate,
-                            content: inner_segs,
-                        });
-                        cursor = span.end;
-                    } else {
-                        warn_once(
-                            WARN_PROSODY_NO_SUPPORTED_ATTR,
-                            "SSML <prosody> without a parseable rate= attribute \
-                             is not supported (pitch/volume scoped to a follow-up); stripping",
-                        );
-                    }
-                } else {
-                    warn_once(
-                        WARN_PROSODY_MID_UTTERANCE,
-                        "SSML <prosody> mid-utterance is not yet supported \
-                         (whole-utterance only); stripping rate, pitch, and volume",
-                    );
-                }
+                cursor =
+                    handle_prosody_span(span, attrs, &text, input, &spans, &mut segments, cursor);
             }
             _ => {
                 if let Some(new_cursor) = emit_span(span, &text, &mut segments, cursor) {
@@ -160,6 +126,64 @@ pub fn parse(input: &str) -> anyhow::Result<Vec<Segment>> {
     }
     push_text_slice(&mut segments, &text, cursor, text.len());
     Ok(segments)
+}
+
+/// Returns true when the span should be skipped in the top-level walk.
+///
+/// Covers two cases:
+/// - cursor guard: an inner structural tag already consumed this region (#233)
+/// - #560: a zero-width Break at a recursing-prosody boundary would double-emit
+///   (once flat here, once inside the ProsodyRate via `parse_inner_spans`)
+fn should_skip_span(
+    span: &ssml_parser::parser::Span,
+    cursor: usize,
+    recursed_prosody: &[(usize, usize)],
+) -> bool {
+    if span.start < cursor {
+        return true;
+    }
+    matches!(&span.element, ParsedElement::Break(_))
+        && recursed_prosody
+            .iter()
+            .any(|&(s, e)| span.start >= s && span.end <= e)
+}
+
+/// Processes one `<prosody>` span: emits a `ProsodyRate` segment for whole-utterance
+/// prosody with a parseable rate, or warns and strips otherwise.
+/// Returns the updated cursor position.
+fn handle_prosody_span(
+    span: &ssml_parser::parser::Span,
+    attrs: &ssml_parser::elements::ProsodyAttributes,
+    text: &[char],
+    input: &str,
+    spans: &[&ssml_parser::parser::Span],
+    segments: &mut Vec<Segment>,
+    cursor: usize,
+) -> usize {
+    if !prosody_is_whole_utterance(span, text, input) {
+        warn_once(
+            WARN_PROSODY_MID_UTTERANCE,
+            "SSML <prosody> mid-utterance is not yet supported \
+             (whole-utterance only); stripping rate, pitch, and volume",
+        );
+        return cursor;
+    }
+    let rate_str = attrs.rate.as_ref().map(|r| r.to_string());
+    let Some(rate) = rate_str.as_deref().and_then(parse_rate_value) else {
+        warn_once(
+            WARN_PROSODY_NO_SUPPORTED_ATTR,
+            "SSML <prosody> without a parseable rate= attribute \
+             is not supported (pitch/volume scoped to a follow-up); stripping",
+        );
+        return cursor;
+    };
+    push_text_slice(segments, text, cursor, span.start);
+    let inner_segs = parse_inner_spans(spans, text, span.start, span.end);
+    segments.push(Segment::ProsodyRate {
+        rate,
+        content: inner_segs,
+    });
+    span.end
 }
 
 /// True when `<prosody>` is the sole meaningful child of `<speak>`. Source-sibling

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -154,6 +154,58 @@ function recordOutputArtifact(
   return { outputFormat: opts.format ?? "wav", outputSizeBytes: audio.byteLength };
 }
 
+async function synthesizeAndEmit(
+  opts: SayOpts,
+  verbose: boolean,
+  stats: ReturnType<typeof createStatsRecorder>,
+  diagnosticLog: ReturnType<typeof createDiagnosticLogSession>,
+): Promise<void> {
+  try {
+    const startedAt = performance.now();
+    if (opts.out) {
+      const voiceLabel = opts.voice ?? "default voice";
+      log.status(`Synthesizing ${voiceLabel} -> ${opts.out}...`);
+    }
+    const audio = await stats.timeStage("tts", () => say(opts));
+    const ttsTimeMs = Math.round(performance.now() - startedAt);
+    if (opts.out) {
+      log.status(`Saved ${opts.out} (${ttsTimeMs}ms)`);
+    }
+    // stderr — stdout may carry raw audio bytes when --out is omitted.
+    if (verbose && !opts.out) log.status(`TTS time: ${ttsTimeMs}ms`);
+    const { outputFormat, outputSizeBytes } = recordOutputArtifact(stats, audio, opts);
+    diagnosticLog.event("command.finish", {
+      command: "say",
+      status: "success",
+      durationMs: ttsTimeMs,
+      hasOut: Boolean(opts.out),
+      outputFormat,
+      outputSizeBucket: diagnosticSizeBucket(outputSizeBytes),
+    });
+    if (!opts.out) process.stdout.write(audio);
+    stats.finish("success", 1);
+    diagnosticLog.finish("success");
+  } catch (err) {
+    const code = err instanceof SayError ? err.code : "E_INTERNAL";
+    stats.recordError("tts", err, code);
+    stats.finish("failed", 1);
+    diagnosticLog.event("command.finish", {
+      command: "say",
+      status: "failed",
+      errorKind: err instanceof SayError ? "say_error" : "error",
+      exitCode: err instanceof SayError ? err.exitCode : 4,
+      error_code: code,
+    });
+    diagnosticLog.finish("failed");
+    if (err instanceof SayError) {
+      log.error(err.stderr.trim() || err.message);
+      process.exit(err.exitCode);
+    }
+    log.error(errorMessage(err));
+    process.exit(4);
+  }
+}
+
 export const sayCommand = defineCommand({
   meta: {
     name: "say",
@@ -219,7 +271,6 @@ export const sayCommand = defineCommand({
 
     // Validate --format before spawning the engine: faster failure in scripts (engine repeats authoritatively).
     const format = parseFormatFlag(typeof args.format === "string" ? args.format : undefined);
-
     const rate = parseRateFlag(args.rate);
     const bitrate = parseBitrateFlag(args.bitrate);
     const sampleRate = parseSampleRateFlag(args["sample-rate"]);
@@ -264,54 +315,6 @@ export const sayCommand = defineCommand({
       noExpandAbbrev: opts.noExpandAbbrev,
     });
 
-    try {
-      const startedAt = performance.now();
-      if (opts.out) {
-        const voiceLabel = opts.voice ?? "default voice";
-        log.status(`Synthesizing ${voiceLabel} -> ${opts.out}...`);
-      }
-      const audio = await stats.timeStage("tts", () => say(opts));
-      const ttsTimeMs = Math.round(performance.now() - startedAt);
-      if (opts.out) {
-        log.status(`Saved ${opts.out} (${ttsTimeMs}ms)`);
-      }
-      if (args.verbose && !opts.out) {
-        // stderr — stdout may carry raw audio bytes when --out is omitted.
-        log.status(`TTS time: ${ttsTimeMs}ms`);
-      }
-      const { outputFormat, outputSizeBytes } = recordOutputArtifact(stats, audio, opts);
-      diagnosticLog.event("command.finish", {
-        command: "say",
-        status: "success",
-        durationMs: ttsTimeMs,
-        hasOut: Boolean(opts.out),
-        outputFormat,
-        outputSizeBucket: diagnosticSizeBucket(outputSizeBytes),
-      });
-      if (!opts.out) {
-        process.stdout.write(audio);
-      }
-      stats.finish("success", 1);
-      diagnosticLog.finish("success");
-    } catch (err) {
-      const code = err instanceof SayError ? err.code : "E_INTERNAL";
-      stats.recordError("tts", err, code);
-      stats.finish("failed", 1);
-      diagnosticLog.event("command.finish", {
-        command: "say",
-        status: "failed",
-        errorKind: err instanceof SayError ? "say_error" : "error",
-        exitCode: err instanceof SayError ? err.exitCode : 4,
-        error_code: code,
-      });
-      diagnosticLog.finish("failed");
-      if (err instanceof SayError) {
-        log.error(err.stderr.trim() || err.message);
-        process.exit(err.exitCode);
-      }
-      const message = errorMessage(err);
-      log.error(message);
-      process.exit(4);
-    }
+    await synthesizeAndEmit(opts, Boolean(args.verbose), stats, diagnosticLog);
   },
 });

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -282,26 +282,18 @@ function buildTtsComponents(
   return { components, warmups, wantsAnyKokoro };
 }
 
-export async function renderInstallPlan(options: InstallPlanOptions = {}): Promise<string> {
-  const cacheRoot = keshaCacheDir();
-  const binPath = getEngineBinPath();
-  const engineDir = dirname(binPath);
-  const noCache = options.noCache === true;
-
-  const ttsLangs = options.ttsLangs ?? [];
-  const tts = buildTtsComponents(cacheRoot, ttsLangs, noCache);
-
+function assembleComponents(
+  cacheRoot: string,
+  binPath: string,
+  engineDir: string,
+  noCache: boolean,
+  options: InstallPlanOptions,
+  tts: ReturnType<typeof buildTtsComponents>,
+): PlanComponent[] {
   const components: PlanComponent[] = [
     buildEngineComponent(binPath, noCache),
     ...buildSidecarComponents(engineDir, noCache),
-    bundleComponent(
-      cacheRoot,
-      "ASR Parakeet TDT v3",
-      "model cache",
-      ASR_FILES,
-      noCache,
-      "required for speech-to-text",
-    ),
+    bundleComponent(cacheRoot, "ASR Parakeet TDT v3", "model cache", ASR_FILES, noCache, "required for speech-to-text"),
     bundleComponent(
       cacheRoot,
       "Audio language ID ECAPA",
@@ -312,21 +304,11 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     ),
     ...tts.components,
   ];
-  const warmups: PlanWarmup[] = [...tts.warmups];
-
   if (options.vad) {
     components.push(
-      bundleComponent(
-        cacheRoot,
-        "VAD Silero v5",
-        "model cache",
-        VAD_FILES,
-        noCache,
-        "long-audio preprocessing",
-      ),
+      bundleComponent(cacheRoot, "VAD Silero v5", "model cache", VAD_FILES, noCache, "long-audio preprocessing"),
     );
   }
-
   if (options.diarize) {
     components.push(
       bundleComponent(
@@ -341,18 +323,11 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
       ),
     );
   }
+  return components;
+}
 
-  const coldBytes = components.reduce((sum, component) => sum + component.sizeBytes, 0);
-  const expectedNetworkBytes = components.reduce((sum, component) => {
-    if (component.cached && !component.refresh) return sum;
-    return sum + component.sizeBytes;
-  }, 0);
-  const status = (component: PlanComponent) => {
-    if (component.refresh) return "refresh";
-    return component.cached ? "cached" : "needed";
-  };
-
-  const lines = [
+function renderHeader(cacheRoot: string, binPath: string, backend: string | undefined): string[] {
+  return [
     "Kesha install plan",
     "",
     `Package: @drakulavich/kesha-voice-kit ${packageVersion}`,
@@ -360,23 +335,37 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     `Platform: ${process.platform} ${process.arch}`,
     `Cache: ${cacheRoot}`,
     `Engine binary: ${binPath}`,
-    options.backend ? `Requested backend: ${options.backend}` : "Requested backend: auto",
+    backend ? `Requested backend: ${backend}` : "Requested backend: auto",
     "",
     "Components:",
   ];
+}
 
-  for (const component of components) {
-    lines.push(
-      `  - ${component.name}: ${humanBytes(component.sizeBytes)} (${component.sizeBytes} bytes, ${status(component)}, ${component.source})`,
-    );
-    if (component.note) lines.push(`    ${component.note}`);
+function renderComponentLines(components: PlanComponent[]): string[] {
+  const status = (c: PlanComponent) => (c.refresh ? "refresh" : c.cached ? "cached" : "needed");
+  const lines: string[] = [];
+  for (const c of components) {
+    lines.push(`  - ${c.name}: ${humanBytes(c.sizeBytes)} (${c.sizeBytes} bytes, ${status(c)}, ${c.source})`);
+    if (c.note) lines.push(`    ${c.note}`);
   }
+  return lines;
+}
+
+function renderFooter(
+  components: PlanComponent[],
+  warmups: PlanWarmup[],
+  ttsLangs: string[],
+  wantsAnyKokoro: boolean,
+  options: InstallPlanOptions,
+): string[] {
+  const coldBytes = components.reduce((sum, c) => sum + c.sizeBytes, 0);
+  const expectedNetworkBytes = components.reduce((sum, c) => (c.cached && !c.refresh ? sum : sum + c.sizeBytes), 0);
+
+  const lines: string[] = [];
 
   if (warmups.length > 0) {
     lines.push("", "Warm-ups:");
-    for (const warmup of warmups) {
-      lines.push(`  - ${warmup.name}: ${warmup.note}`);
-    }
+    for (const w of warmups) lines.push(`  - ${w.name}: ${w.note}`);
   }
 
   lines.push(
@@ -394,7 +383,7 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     "  - install warms the ASR backend after downloads; CoreML warm-up is typically 20-30 s, ONNX warm-up is about 500 ms.",
   );
 
-  if (ttsLangs.length > 0 && tts.wantsAnyKokoro && isDarwinArm64()) {
+  if (ttsLangs.length > 0 && wantsAnyKokoro && isDarwinArm64()) {
     lines.push(
       "  - --tts also warms FluidAudio Kokoro CoreML; FluidAudio may download/compile its own Kokoro cache on first use.",
     );
@@ -411,6 +400,25 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
     options.diarize ? "--diarize" : "",
   ].filter(Boolean);
   lines.push("", `Run: ${command.join(" ")}`, "");
+
+  return lines;
+}
+
+export async function renderInstallPlan(options: InstallPlanOptions = {}): Promise<string> {
+  const cacheRoot = keshaCacheDir();
+  const binPath = getEngineBinPath();
+  const engineDir = dirname(binPath);
+  const noCache = options.noCache === true;
+  const ttsLangs = options.ttsLangs ?? [];
+
+  const tts = buildTtsComponents(cacheRoot, ttsLangs, noCache);
+  const components = assembleComponents(cacheRoot, binPath, engineDir, noCache, options, tts);
+
+  const lines = [
+    ...renderHeader(cacheRoot, binPath, options.backend),
+    ...renderComponentLines(components),
+    ...renderFooter(components, tts.warmups, ttsLangs, tts.wantsAnyKokoro, options),
+  ];
 
   return `${lines.join("\n")}\n`;
 }


### PR DESCRIPTION
## What

The final structural-complexity cleanup — the only genuine smells left in repowise after filtering out `untested_hotspot` false positives (inline Rust tests; coverage ingestion requested in repowise-dev/repowise#597) and history signals (churn / co-change / change-entropy / prior-defect, which decay with stability). Behavior-preserving.

| File | Smell → change |
|------|----------------|
| `rust/src/tts/ssml/mod.rs` | `parse` nested **5 deep, CCN 18, cognitive 37** → extract `handle_prosody_span` (guard-clause Prosody arm) + `should_skip_span` (cursor-guard + #560 Break-dedup); nesting **5 → 2** |
| `src/cli/say.ts` | `run` **CCN 22** → extract `synthesizeAndEmit`; `run` now a flat ~55-line flow |
| `src/install-plan.ts` | `renderInstallPlan` **120 lines** → ~15; extract `assembleComponents` / `renderHeader` / `renderComponentLines` / `renderFooter` |

`parse`'s segment output + `warn_once` keys + cursor/`#560` semantics, the CLI flags/exit-codes, and the install-plan output string are all byte-identical (tests assert on the latter two).

## Verification

- `bunx tsc --noEmit`: clean
- `bun test`: 450 pass / 6 skip; the 1 failure (`e2e-engine` capabilities-json protocolVersion) is pre-existing & unrelated
- `cargo fmt --check`: clean · `cargo clippy --all-targets` on **`tts`** and the darwin **`system_kokoro`** feature set: no issues
- `cargo nextest run --features tts`: **386 passed**

After this, the remaining repowise flags are all either the coverage-metric false positive or history that self-resolves — no real structural backlog left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)