### PR TITLE
docs(claude): tighten the comment rule to default-deny + allowed-kinds list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,7 +390,7 @@ const text = await transcribe("audio.ogg");
 - **Imports**: Relative paths (`./engine`, not `src/engine`)
 - **Output**: `console.error()` for progress/errors, `console.log()` for success (stdout stays pipe-friendly)
 - **Rust**: `cargo fmt` + `cargo clippy --all-targets -- -D warnings`
-- **Comments**: explain WHY, not WHAT. Prefer no comment over one that restates the code. No multi-line narration of mechanics. If a comment earns its place (a gotcha, a spec quirk, an issue/PR ref), make it one terse line. Match the comment density of the surrounding code. This applies to agent-generated code too.
+- **Comments**: default to NONE — a comment must justify why it exists, and if it only restates what the code says it must be deleted. NEVER narrate mechanics step-by-step, restate a function/field/type name, or add section-banner / separator comments. A comment is allowed ONLY when it carries information the code cannot, and only these kinds qualify: (1) non-obvious WHY / rationale, (2) a gotcha or footgun ("looks wrong but…"), (3) an issue/PR reference, (4) a spec/standard citation, (5) `// SAFETY:` / unsafe-block rationale, (6) a public-API doc contract (`///`, `//!`, JSDoc) — state the contract, not the implementation, (7) `TODO`/`FIXME` with context. Keep it to one line; multi-line is allowed only for SAFETY blocks and public-API doc contracts. Match — and bias below — the comment density of the surrounding code. This applies equally to agent-generated code; in review, delete any comment that doesn't clear this bar rather than letting it land.
 
 ## CI/CD
 


### PR DESCRIPTION
## What

Strengthens the **Code Style → Comments** rule added in #562. The old rule was soft ("prefer no comment", "one terse line"); this makes it **default-deny with an explicit allow-list**.

**Before:** explain WHY not WHAT; prefer no comment; no multi-line narration; one terse line if it earns its place; match surrounding density.

**After:** default to **NONE**; a comment must justify its existence; delete anything that restates code. Never narrate mechanics, restate a name, or add section banners. A comment qualifies **only** if it's one of: (1) non-obvious WHY, (2) gotcha/footgun, (3) issue/PR ref, (4) spec citation, (5) `// SAFETY:`/unsafe rationale, (6) public-API doc contract (state the contract, not the impl), (7) TODO/FIXME with context. One line unless SAFETY or doc contract. Reviewers delete non-conforming comments rather than let them land.

## Why

The softer wording still let borderline narration through. An enumerated allow-list is unambiguous for both humans and agents (it's injected into every subagent's context), and matches the deletion-first approach the repo-wide sweep (#563) already applied in practice.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)