### PR TITLE
chore(release): v1.24.4 (engine + CLI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.3"
+    "version": "1.24.4"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.3"
+version = "1.24.4"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.3"
+version = "1.24.4"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## v1.24.4 — engine release

Bumps all three version sites 1.24.3 → 1.24.4 (`rust/Cargo.toml`, `rust/Cargo.lock`, `package.json#keshaEngine.version`, `package.json#version`). Engine release because `rust/src` changed materially since v1.24.3.

### Shipped since v1.24.3
- **fix(ssml):** emit prosody-boundary `<break/>` once, not twice — #560 / #561
- **fix(deps):** override `hono` to >=4.12.25 (GHSA-88fw-hqm2-52qc) — #556 (closes the weekly JS audit finding #551)
- **ci:** pin third-party Actions to commit SHAs via pinact — #555
- **ci(tts-e2e):** pin macos-14 + Xcode 16.2 to fix flaky clang_rt link failures — #554
- Plus internal refactors / health passes / comment-rule sweeps (#557–#565) — no behavior change.

### Verification
- `bun run check:versions` ✓ (no drift)
- Unit tests: 372 pass / 0 fail
- `bunx tsc --noEmit` ✓
- Feature-matrix invariant: `tts` present in every `build-engine.yml` row ✓

Integration tests are intentionally skipped on `release/*` (the v1.24.4 tag doesn't exist yet — chicken-and-egg guard).

After merge: tag `v1.24.4` → `build-engine.yml` → validate draft assets → publish.