### PR TITLE
perf(cli): lazy-load subcommand modules in dispatch

### DIFF
--- a/bin/kesha.js
+++ b/bin/kesha.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env bun
-import { runCli } from "../src/cli.ts";
+import { runCli } from "../src/cli/dispatch.ts";
 
 await runCli();

--- a/flake.nix
+++ b/flake.nix
@@ -269,7 +269,7 @@
             ln -s ${keshaNodeModules} $out/lib/kesha/node_modules
 
             # bin/kesha.js has a `#!/usr/bin/env bun` shebang and imports
-            # ../src/cli.ts directly — Bun resolves the TS at runtime.
+            # ../src/cli/dispatch.ts directly — Bun resolves the TS at runtime.
             # makeWrapper sets PATH so the shebang's `env bun` resolves to
             # the Nix-built Bun, and pins KESHA_ENGINE_BIN to the flake's
             # engine output so the CLI never falls back to the

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+
+// Runtime entry kept off the ./cli barrel, whose re-exports would eagerly load every command (#568).
+import { runCli } from "./cli/dispatch";
+
+if (import.meta.main) {
+  await runCli();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,9 +61,3 @@ export { createSupportBundle } from "./support-bundle";
 export type { SupportBundleResult } from "./support-bundle";
 export { renderInstallPlan } from "./install-plan";
 export { keshaCacheDir } from "./paths";
-
-import { runCli } from "./cli/dispatch";
-
-if (import.meta.main) {
-  await runCli();
-}

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -2,37 +2,27 @@ import { runMain, type CommandDef } from "citty";
 import { existsSync } from "fs";
 import { log, setColorEnabled } from "../log";
 import { suggestCommand } from "../suggest-command";
-import { completionsCommand } from "./completions";
-import { doctorCommand } from "./doctor";
-import { initCommand } from "./init";
-import { installCommand } from "./install";
-import { logsCommand } from "./logs";
-import { manpageCommand } from "./manpage";
-import { recordCommand } from "./record";
-import { sayCommand } from "./say";
-import { statsCommand } from "./stats";
-import { statusCommand } from "./status";
-import { supportBundleCommand } from "./support-bundle";
-import { mainCommand } from "./main";
-import { mcpCommand } from "./mcp";
 
-// Single source of truth: keyed lookup also feeds the `did you mean` suggester.
-// `CommandDef<any>` is intentional — citty's generic is invariant in the args
-// shape, and each subcommand has its own arg schema; the value here is only
-// passed back to `runMain`, which re-reads the schema from the def itself.
-const SUBCOMMANDS: Record<string, CommandDef<any>> = {
-  doctor: doctorCommand,
-  init: initCommand,
-  install: installCommand,
-  logs: logsCommand,
-  status: statusCommand,
-  record: recordCommand,
-  say: sayCommand,
-  stats: statsCommand,
-  "support-bundle": supportBundleCommand,
-  completions: completionsCommand,
-  manpage: manpageCommand,
-  mcp: mcpCommand,
+// Lazy loaders, not eager imports: a cold `bun run src/cli.ts` spawn transpiles
+// only the command actually invoked instead of the whole CLI graph (`say` pulls
+// in the entire TTS/Kokoro/Vosk/normalize/SSML tree). Keyed names also feed the
+// `did you mean` suggester. `CommandDef<any>` is intentional — citty's generic is
+// invariant in the args shape, and each subcommand has its own arg schema; the
+// value is only passed back to `runMain`, which re-reads the schema from the def.
+type CommandLoader = () => Promise<CommandDef<any>>;
+const SUBCOMMANDS: Record<string, CommandLoader> = {
+  doctor: async () => (await import("./doctor")).doctorCommand,
+  init: async () => (await import("./init")).initCommand,
+  install: async () => (await import("./install")).installCommand,
+  logs: async () => (await import("./logs")).logsCommand,
+  status: async () => (await import("./status")).statusCommand,
+  record: async () => (await import("./record")).recordCommand,
+  say: async () => (await import("./say")).sayCommand,
+  stats: async () => (await import("./stats")).statsCommand,
+  "support-bundle": async () => (await import("./support-bundle")).supportBundleCommand,
+  completions: async () => (await import("./completions")).completionsCommand,
+  manpage: async () => (await import("./manpage")).manpageCommand,
+  mcp: async () => (await import("./mcp")).mcpCommand,
 };
 
 function isPathLike(arg: string): boolean {
@@ -153,7 +143,7 @@ export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
 
   switch (classifyFirstArg(firstArg, subcommandKeys)) {
     case "subcommand":
-      await runMain(SUBCOMMANDS[firstArg!], { rawArgs: restArgs });
+      await runMain(await SUBCOMMANDS[firstArg!]!(), { rawArgs: restArgs });
       return;
 
     case "unknown": {
@@ -169,6 +159,6 @@ export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
     }
 
     default:
-      await runMain(mainCommand, { rawArgs });
+      await runMain((await import("./main")).mainCommand, { rawArgs });
   }
 }

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -3,12 +3,8 @@ import { existsSync } from "fs";
 import { log, setColorEnabled } from "../log";
 import { suggestCommand } from "../suggest-command";
 
-// Lazy loaders, not eager imports: a cold `bun run src/cli.ts` spawn transpiles
-// only the command actually invoked instead of the whole CLI graph (`say` pulls
-// in the entire TTS/Kokoro/Vosk/normalize/SSML tree). Keyed names also feed the
-// `did you mean` suggester. `CommandDef<any>` is intentional — citty's generic is
-// invariant in the args shape, and each subcommand has its own arg schema; the
-// value is only passed back to `runMain`, which re-reads the schema from the def.
+// Lazy loaders so a cold CLI spawn transpiles only the invoked command, not the whole graph (#568).
+// `CommandDef<any>`: citty's generic is invariant in the arg shape and each command has its own schema.
 type CommandLoader = () => Promise<CommandDef<any>>;
 const SUBCOMMANDS: Record<string, CommandLoader> = {
   doctor: async () => (await import("./doctor")).doctorCommand,

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -661,7 +661,7 @@ describe("CLI contracts", () => {
     const mediaPath = join(dir, "workshop.mp4");
     writeFileSync(mediaPath, "fake media");
 
-    const proc = Bun.spawn([process.execPath, "run", "src/cli.ts", mediaPath], {
+    const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", mediaPath], {
       cwd: DEFAULT_CWD,
       stdout: "pipe",
       stderr: "pipe",

--- a/tests/integration/cli-scenario.ts
+++ b/tests/integration/cli-scenario.ts
@@ -68,7 +68,7 @@ export async function runCliScenario(
     FORCE_COLOR: "0",
     ...(opts.env ?? {}),
   };
-  const proc = Bun.spawn([process.execPath, "run", "src/cli.ts", ...args], {
+  const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", ...args], {
     stdout: "pipe",
     stderr: "pipe",
     cwd: opts.cwd ?? DEFAULT_CWD,

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -13,7 +13,7 @@ const FIXTURE_EN = "tests/fixtures/benchmark-en/01-check-email.ogg";
 const engineInstalled = isEngineInstalled();
 
 async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const proc = Bun.spawn([process.execPath, "run", "src/cli.ts", ...args], {
+  const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", ...args], {
     stdout: "pipe",
     stderr: "pipe",
     cwd: CWD,


### PR DESCRIPTION
## Why

The macOS integration runner showed the spawn-heavy read-only test (`tests/integration/cli-contracts.test.ts:755`) trending steadily upward (~1.5s → ~5.4s) while Linux/Windows stayed flat.

Root cause: the CLI has no build step, so every `bun run`-spawned subprocess transpiles the full reachable module graph cold. `dispatch.ts` statically imported **every** command — including `say`, which drags in the whole TTS/Kokoro/Vosk/normalize/SSML tree — so even trivial `stats status` / `logs status` spawns paid for all of it. That graph keeps growing with multilingual TTS work, and the cost surfaces first on the slower, more contended macOS runner, amplified by the test's 6 parallel spawns.

## Change

1. **Lazy command loading** — `dispatch.ts` converts eager command imports into per-command dynamic `import()` loaders, so a cold spawn transpiles only the command actually invoked.
2. **Route the runtime entry off the re-export barrel** — `src/cli.ts` is *also* the public re-export barrel (`exports["."]`), which statically re-exports every command. `bin/kesha.js` and the test helpers spawned `src/cli.ts`, so the whole graph loaded before the lazy loaders ran — making (1) a no-op for the real CLI (caught in codex review). Fix: `src/cli.ts` stays a pure barrel, `bin/kesha.js` calls `runCli` from `./cli/dispatch` directly, and a thin `src/cli-entry.ts` is the spawn target the integration tests use.

## Verification

- `bunx tsc --noEmit` clean.
- Honest same-worktree cold spawn (best of 6), barrel vs lazy entry: `stats status` **0.083s → 0.028s** (~3×). The slow test runs exactly these light commands.
- Eager-vs-lazy `install --vad` timing is identical (~2.6–3.7s) — lazy doesn't regress heavy commands.
- Full `bun test`: 449 pass, 6 skip. Two failures are **pre-existing on `main`** (verified: `main` fails both identically on this machine), unrelated to this PR:
  - `e2e-engine --capabilities-json` (needs a locally installed engine binary)
  - `cli-contracts > diagnostic logs record successful install events` (install ~3s vs a tight 4s `runCli` budget — a pre-existing flake at the timeout boundary; fails 3/3 on unmodified `main` here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)